### PR TITLE
Add traverse function

### DIFF
--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -12,11 +12,11 @@ use eyre::{eyre, WrapErr};
 use once_cell::sync::Lazy;
 use pgx_pg_config::{prefix_path, PgConfig, PgConfigSelector, Pgx, SUPPORTED_MAJOR_VERSIONS};
 use proc_macro2::Span;
-use quote::{quote, ToTokens, format_ident};
+use quote::{format_ident, quote, ToTokens};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::{Command, Output};
-use syn::{ForeignItem, Item, ItemConst, Type, Ident};
+use syn::{ForeignItem, Ident, Item, ItemConst, Type};
 
 const BLOCKLISTED_TYPES: [&str; 3] = ["Datum", "NullableDatum", "Oid"];
 

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -1082,7 +1082,7 @@ fn impl_pg_node(
                 rtekind_result_handling,
                 quote! {
                     _ => {
-                        unsafe { pre_format_elog_string(ERROR as i32, format!("unrecognized RTE kind: {}", self.rtekind).as_ptr() as *const i8); }
+                        unsafe { pre_format_elog_string(ERROR as i32, format!("unrecognized RTE kind: {}", self.rtekind).as_ptr().cast()); }
                     }
                 },
             ]),

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -268,6 +268,7 @@ fn generate_bindings(
                 #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
                 use crate::NullableDatum;
                 use crate::{Datum, Oid, PgNode};
+                use crate::seal::Sealed;
             },
         )
         .wrap_err_with(|| {
@@ -433,26 +434,14 @@ fn format_builtin_oid_impl<'a>(
         }
     }
 }
-fn is_node_struct(name: &str, node_types: &HashSet<String>, nodes: &Vec<StructDescriptor>) -> bool {
-    let node = nodes.iter().filter(|n| n.struct_.ident.to_string() == name).next();
-    match node {
-        None => false,
-        Some(n) => {
-            let first_field = n.struct_.fields.iter().next();
-            match first_field {
-                None => false,
-                Some(f) => match &f.ty {
-                    Type::Path(p) => {
-                        let first_field_type_name =
-                            p.path.segments.first().unwrap().ident.to_string();
-                        if first_field_type_name == "NodeTag" {
-                            return true;
-                        }
-                        is_node_struct(first_field_type_name.as_ref(), node_types, nodes)
-                    }
-                    _ => false,
-                },
-            }
+
+/// Produces code which calls `walker_fn` on the given identifier-like field name.
+fn walk_field_definition(field_name: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    quote! {
+        if !#field_name.is_null() {
+            let item = unsafe { &mut *(#field_name as *mut Node) };
+            walker_fn(item, context);
+            Node::traverse::<T>(item, walker_fn, context);
         }
     }
 }
@@ -508,7 +497,7 @@ fn impl_pg_node(
     }
 
     // the set of types which subclass `Node` according to postgres' object system
-    let mut node_set = HashSet::new();
+    let mut node_set = HashMap::new();
     // fill in any children of the roots with a recursive DFS
     // (we are not operating on user input, so it is ok to just
     //  use direct recursion rather than an explicit stack).
@@ -516,14 +505,35 @@ fn impl_pg_node(
         dfs_find_nodes(root, &struct_graph, &mut node_set);
     }
 
-    let mut nodes = node_set.into_iter().collect::<Vec<_>>();
+    let mut nodes = node_set.values().collect::<Vec<_>>();
     if is_for_release {
         // if it's for release we want to sort by struct name to avoid diff churn
         // otherwise we don't care and want to avoid the CPU overhead of sorting
         nodes.sort_by_key(|s| &s.struct_.ident);
     }
+    // Provide a special implementation of PgNode for the Node itself: depending on the `type_` field,
+    // call the override for that type. That way, when we get a `*mut Node` out of a List object, we
+    // can call this function and let it route appropriately.
+    let mut node_traverse_body = proc_macro2::TokenStream::new();
+    let mut node_display_body = proc_macro2::TokenStream::new();
 
-    let node_types = items
+    let mut join_fields_traverse = proc_macro2::TokenStream::new();
+    join_fields_traverse.extend(
+        if std::env::var("CARGO_FEATURE_PG11").is_ok()
+            || std::env::var("CARGO_FEATURE_PG12").is_ok()
+        {
+            vec![]
+        } else if std::env::var("CARGO_FEATURE_PG13").is_ok() {
+            vec![quote! { joinleftcols }, quote! { joinrightcols }]
+        } else {
+            vec![quote! { joinleftcols }, quote! { joinrightcols }, quote! { join_using_alias }]
+        }
+        .into_iter()
+        .map(|f| quote! { self.#f })
+        .map(walk_field_definition),
+    );
+
+    let nodetag_t_values = items
         .iter()
         .filter_map(|i| match i {
             Item::Const(c) if c.ident.to_string().starts_with("NodeTag_T_") => {
@@ -531,73 +541,8 @@ fn impl_pg_node(
             }
             _ => None,
         })
-        .filter(|t| match t.as_ref() {
-            // `NodeTag_T_`s that don't have a corresponding struct we care about. This is a single
-            // list, for convenience, but technically it's different in different versions of
-            // Postgres.
-            "BitString" | "Invalid" | "Null" | "IntList" | "OidList" | "AllocSetContext"
-            | "SlabContext" | "Integer" | "PathKeyInfo" | "GenerationContext" | "Float"
-            | "TsmRoutine" | "String" | "WindowObjectData" | "MemoryContext" | "TIDBitmap" => false,
-            _ => true,
-        })
         .collect::<HashSet<String>>();
 
-    // Provide a special implementation of PgNode for the Node itself: depending on the `type_` field,
-    // call the override for that type. That way, when we get a `*mut Node` out of a List object, we
-    // can call this function and let it route appropriately.
-    let mut node_traverse_body = proc_macro2::TokenStream::new();
-    for node_type in &node_types {
-        let nodetag = format_ident!("NodeTag_T_{}", node_type.to_string());
-        let type_ = format_ident!("{}", node_type);
-        node_traverse_body.extend(quote! {
-            #nodetag => {
-                #type_::traverse(
-                    &mut unsafe { std::ptr::read(self as *mut Node as *mut #type_) },
-                    walker_fn,
-                    context)
-            },
-        });
-    }
-    let mut node_display_body = proc_macro2::TokenStream::new();
-    for node_type in &node_types {
-        let nodetag = format_ident!("NodeTag_T_{}", node_type.to_string());
-        let type_ = format_ident!("{}", node_type);
-        node_display_body.extend(quote! {
-            #nodetag => #type_::fmt(&unsafe { std::ptr::read(self as *const Node as *const #type_) }, f),
-        });
-    }
-
-    let join_fields_traverse = if std::env::var("CARGO_FEATURE_PG11").is_ok()
-        || std::env::var("CARGO_FEATURE_PG12").is_ok()
-    {
-        quote! {}
-    } else if std::env::var("CARGO_FEATURE_PG13").is_ok() {
-        quote! {
-            if !self.joinleftcols.is_null() {
-                walker_fn(self.joinleftcols as *mut Node, context);
-                Node::traverse::<T>(unsafe { &mut *(self.joinleftcols as *mut Node) }, walker_fn, context);
-            }
-            if !self.joinrightcols.is_null() {
-                walker_fn(self.joinrightcols as *mut Node, context);
-                Node::traverse::<T>(unsafe { &mut *(self.joinrightcols as *mut Node) }, walker_fn, context);
-            }
-        }
-    } else {
-        quote! {
-            if !self.joinleftcols.is_null() {
-                walker_fn(self.joinleftcols as *mut Node, context);
-                Node::traverse::<T>(unsafe { &mut *(self.joinleftcols as *mut Node) }, walker_fn, context);
-            }
-            if !self.joinrightcols.is_null() {
-                walker_fn(self.joinrightcols as *mut Node, context);
-                Node::traverse::<T>(unsafe { &mut *(self.joinrightcols as *mut Node) }, walker_fn, context);
-            }
-            if !self.join_using_alias.is_null() {
-                walker_fn(self.join_using_alias as *mut Node, context);
-                Node::traverse::<T>(unsafe { &mut *(self.join_using_alias as *mut Node) }, walker_fn, context);
-            }
-        }
-    };
     let rtekind_result_handling = if std::env::var("CARGO_FEATURE_PG11").is_ok() {
         quote! {}
     } else {
@@ -608,6 +553,7 @@ fn impl_pg_node(
         }
     };
 
+    let walk_item = walk_field_definition(quote! { item });
     // Older Postgres' List is linked.
     let list_fns = if std::env::var("CARGO_FEATURE_PG11").is_ok()
         || std::env::var("CARGO_FEATURE_PG12").is_ok()
@@ -615,14 +561,11 @@ fn impl_pg_node(
         quote! {
             impl pg_sys::PgNode for List {
                 fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                    if self.length == 0 { return; }
+                    if self.type_ != NodeTag_T_List || self.length == 0 { return; }
                     let mut cell = unsafe { *self.head };
                     for _index in 0..self.length {
                         let item = unsafe { cell.data.ptr_value as *mut Node };
-                        if !item.is_null() {
-                            walker_fn(item, context);
-                            Node::traverse::<T>( unsafe { &mut *(item as *mut Node) }, walker_fn, context);
-                        }
+                        #walk_item
                         if !cell.next.is_null() {
                             cell = unsafe { *cell.next };
                         }
@@ -657,27 +600,26 @@ fn impl_pg_node(
         quote! {
             impl pg_sys::PgNode for List {
                 fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                    for index in 0..self.length {
-                        let item = unsafe { (*self.elements.offset(index as isize)).ptr_value as *mut Node };
-                        if !item.is_null() {
-                            walker_fn(item, context);
-                            Node::traverse::<T>( unsafe { &mut *(item as *mut Node) }, walker_fn, context);
-                        }
+                    if self.type_ != NodeTag_T_List { return; }
+                    let slice = unsafe { std::slice::from_raw_parts::<ListCell>(self.elements, self.length as usize) };
+                    for item in slice {
+                        let item = unsafe { item.ptr_value };
+                        #walk_item
                     }
                 }
             }
             impl std::fmt::Display for List {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                     write!(f, "[")?;
-                    for index in 0..self.length {
+                    let slice = unsafe { std::slice::from_raw_parts(self.elements, self.length as usize) };
+                    for (index, item) in slice.iter().enumerate() {
                         if index != 0 {
                             write!(f, ", ")?;
                         }
-                        let item = unsafe { (*self.elements.offset(index as isize)).ptr_value as *mut Node };
-                        if item.is_null() {
+                        if unsafe { item.ptr_value }.is_null() {
                             write!(f, "(null)")?;
                         } else {
-                            write!(f, "{}", unsafe { *item })?;
+                            write!(f, "{}", unsafe { *(item.ptr_value as *mut Node) })?;
                         }
                     }
                     write!(f, "]")
@@ -685,169 +627,6 @@ fn impl_pg_node(
             }
         }
     };
-
-    pgnode_impls.extend(quote! {
-        unsafe fn list_length(list: *mut List) -> i32 {
-            if list.is_null() {
-                0
-            } else {
-                (*list).length
-            }
-        }
-        #list_fns
-
-        impl pg_sys::PgNode for Node {
-            fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                match self.type_ {
-                    #node_traverse_body
-                    _ => {},
-                }
-            }
-        }
-        impl std::fmt::Display for Node {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                match self.type_ {
-                    #node_display_body
-                    _ => write!(f, "[unknown type {}]", self.type_),
-                }
-            }
-        }
-        impl pg_sys::seal::Sealed for Node {}
-        impl pg_sys::seal::Sealed for List {}
-        impl pg_sys::seal::Sealed for RangeTblEntry {}
-        impl pg_sys::PgNode for RangeTblEntry {
-            fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                // Derived from the implementation of `_outRangeTblEntry` in outfuncs.c.
-                // TODO: consider making the if/walk/traverse stanza into a macro?
-                if !self.alias.is_null() {
-                    walker_fn(self.alias as *mut Node, context);
-                    Node::traverse::<T>(unsafe { &mut *(self.alias as *mut Node) }, walker_fn, context);
-                }
-                if !self.eref.is_null() {
-                    walker_fn(self.eref as *mut Node, context);
-                    Node::traverse::<T>(unsafe { &mut *(self.eref as *mut Node) }, walker_fn, context);
-                }
-                // WRITE_ENUM_FIELD(rtekind, RTEKind);
-
-                match self.rtekind {
-                    RTEKind_RTE_RELATION => {
-                        // WRITE_OID_FIELD(relid);
-                        // WRITE_CHAR_FIELD(relkind);
-                        // WRITE_INT_FIELD(rellockmode);
-                        if !self.tablesample.is_null() {
-                            walker_fn(self.tablesample as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.tablesample as *mut Node) }, walker_fn, context);
-                        }
-                    },
-                    RTEKind_RTE_SUBQUERY => {
-                        if !self.subquery.is_null() {
-                            walker_fn(self.subquery as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.subquery as *mut Node) }, walker_fn, context);
-                        }
-                        // WRITE_BOOL_FIELD(security_barrier);
-                    },
-                    RTEKind_RTE_JOIN => {
-                        // WRITE_ENUM_FIELD(jointype, JoinType);
-                        // WRITE_INT_FIELD(joinmergedcols);
-
-                        if !self.joinaliasvars.is_null() {
-                            walker_fn(self.joinaliasvars as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.joinaliasvars as *mut Node) }, walker_fn, context);
-                        }
-                        #join_fields_traverse
-                    }
-                    RTEKind_RTE_FUNCTION => {
-                        if !self.functions.is_null() {
-                            walker_fn(self.functions as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.functions as *mut Node) }, walker_fn, context);
-                        }
-                        // WRITE_BOOL_FIELD(funcordinality);
-                    }
-                    RTEKind_RTE_TABLEFUNC => {
-                        if !self.tablefunc.is_null() {
-                            walker_fn(self.tablefunc as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.tablefunc as *mut Node) }, walker_fn, context);
-                        }
-                    }
-                    RTEKind_RTE_VALUES => {
-                        if !self.values_lists.is_null() {
-                            walker_fn(self.values_lists as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.values_lists as *mut Node) }, walker_fn, context);
-                        }
-                        if !self.coltypes.is_null() {
-                            walker_fn(self.coltypes as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.coltypes as *mut Node) }, walker_fn, context);
-                        }
-                        if !self.coltypmods.is_null() {
-                            walker_fn(self.coltypmods as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.coltypmods as *mut Node)}, walker_fn, context);
-                        }
-                        if !self.colcollations.is_null() {
-                            walker_fn(self.colcollations as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.colcollations as *mut Node) }, walker_fn, context);
-                        }
-                    }
-                    RTEKind_RTE_CTE => {
-                        // WRITE_STRING_FIELD(ctename);
-                        // WRITE_UINT_FIELD(ctelevelsup);
-                        // WRITE_BOOL_FIELD(self_reference);
-                        if !self.coltypes.is_null() {
-                            walker_fn(self.coltypes as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.coltypes as *mut Node) }, walker_fn, context);
-                        }
-                        if !self.coltypmods.is_null() {
-                            walker_fn(self.coltypmods as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.coltypmods as *mut Node) }, walker_fn, context);
-                        }
-                        if !self.colcollations.is_null() {
-                            walker_fn(self.colcollations as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.colcollations as *mut Node) }, walker_fn, context);
-                        }
-                    }
-                    RTEKind_RTE_NAMEDTUPLESTORE => {
-                        // WRITE_STRING_FIELD(enrname);
-                        // WRITE_FLOAT_FIELD(enrtuples, "%.0f");
-                        // WRITE_OID_FIELD(relid);
-                        if !self.coltypes.is_null() {
-                            walker_fn(self.coltypes as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.coltypes as *mut Node) }, walker_fn, context);
-                        }
-                        if !self.coltypmods.is_null() {
-                            walker_fn(self.coltypmods as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.coltypmods as *mut Node) }, walker_fn, context);
-                        }
-                        if !self.colcollations.is_null() {
-                            walker_fn(self.colcollations as *mut Node, context);
-                            Node::traverse::<T>(unsafe { &mut *(self.colcollations as *mut Node) }, walker_fn, context);
-                        }
-                    }
-                    #rtekind_result_handling
-                    _ => {
-                        unsafe { pre_format_elog_string(ERROR as i32, format!("unrecognized RTE kind: {}", self.rtekind).as_ptr() as *const i8); }
-                    }
-                }
-
-                // WRITE_BOOL_FIELD(lateral);
-                // WRITE_BOOL_FIELD(inh);
-                // WRITE_BOOL_FIELD(inFromCl);
-                // WRITE_UINT_FIELD(requiredPerms);
-                // WRITE_OID_FIELD(checkAsUser);
-                // WRITE_BITMAPSET_FIELD(selectedCols);
-                // WRITE_BITMAPSET_FIELD(insertedCols);
-                // WRITE_BITMAPSET_FIELD(updatedCols);
-                // WRITE_BITMAPSET_FIELD(extraUpdatedCols);
-                if !self.securityQuals.is_null() {
-                    walker_fn(self.securityQuals as *mut Node, context);
-                    Node::traverse::<T>(unsafe { &mut *(self.securityQuals as *mut Node) }, walker_fn, context);
-                }
-            }
-        }
-        impl std::fmt::Display for RangeTblEntry {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", self.display_node() )
-            }
-        }
-    });
 
     struct ArrayBoundsInfo {
         n: Option<proc_macro2::TokenStream>,
@@ -870,7 +649,7 @@ fn impl_pg_node(
     in_versions(
         &[14, 15],
         ("AppendState", "as_asyncrequests"),
-        Some(quote! { unsafe { bms_num_members(self.as_valid_asyncplans) } }),
+        Some(quote! { bms_num_members(self.as_valid_asyncplans) }),
     );
     in_versions(
         &[14, 15],
@@ -961,7 +740,7 @@ fn impl_pg_node(
     in_versions(
         &[11, 12, 13, 14, 15],
         ("ResultRelInfo", "ri_ConstraintExprs"),
-        Some(quote! { unsafe { (*(*(*self.ri_RelationDesc).rd_att).constr).num_check } }),
+        Some(quote! { (*(*(*self.ri_RelationDesc).rd_att).constr).num_check }),
     );
     in_versions(&[12, 13, 14, 15], ("ResultRelInfo", "ri_GeneratedExprs"), None);
     in_versions(
@@ -972,7 +751,7 @@ fn impl_pg_node(
     in_versions(
         &[11, 12, 13, 14, 15],
         ("ResultRelInfo", "ri_TrigWhenExprs"),
-        Some(quote! { unsafe { *self.ri_TrigDesc }.numtriggers  }),
+        Some(quote! { (*self.ri_TrigDesc).numtriggers  }),
     );
     in_versions(
         &[14, 15],
@@ -996,27 +775,25 @@ fn impl_pg_node(
     );
 
     fn handle_length_bounded_array(
-        ts: &mut Vec<proc_macro2::TokenStream>,
         n: &proc_macro2::TokenStream,
         array: &str,
-    ) {
+    ) -> proc_macro2::TokenStream {
         let array = Ident::new(array, Span::call_site());
-        ts.push(quote! {
-            for index in 0..(#n) {
-                let item = unsafe { self.#array.offset(index as isize) };
-                if !item.is_null() {
-                    walker_fn(item as *mut Node, context);
-                    Node::traverse::<T>(unsafe { &mut *(item as *mut Node) }, walker_fn, context);
+        quote! {
+            let slice = unsafe { std::slice::from_raw_parts::<*mut Node>(self.#array as *mut *mut Node, (#n) as usize) };
+            for ptr in slice {
+                if !ptr.is_null() {
+                    walker_fn(*ptr, context);
+                    Node::traverse::<T>(unsafe { &mut **ptr }, walker_fn, context);
                 }
             }
-        });
+        }
     }
 
     let mut ptr_problems: Vec<String> = Vec::new();
 
     // now we can finally iterate the Nodes and emit various trait impls
     for node_struct in &nodes {
-        let mut does_walking = false;
         let struct_name = &node_struct.struct_.ident;
         match struct_name.to_string().as_ref() {
             "Node" | "RangeTblEntry" | "List" => {
@@ -1029,18 +806,14 @@ fn impl_pg_node(
 
         for field in node_struct.struct_.fields.iter() {
             let field_name = field.ident.as_ref().unwrap();
-            println!("Handling {} -> {} of type {:?}", struct_name, field_name, &field.ty);
             // Some structures have array fields in them, rather than Lists. Handle those specially.
             match array_fields
                 .get(&(struct_name.to_string().as_ref(), field_name.to_string().as_ref()))
             {
                 Some(abi) => {
                     match &abi.n {
-                        Some(n) => handle_length_bounded_array(
-                            &mut traverse_elements,
-                            n,
-                            field_name.to_string().as_ref(),
-                        ),
+                        Some(n) => traverse_elements
+                            .push(handle_length_bounded_array(n, field_name.to_string().as_ref())),
                         _ => {}
                     }
                     continue;
@@ -1059,17 +832,15 @@ fn impl_pg_node(
                 Type::Array(a) => {
                     if let Type::Ptr(ptr) = a.elem.as_ref() {
                         if let Type::Path(p) = ptr.elem.as_ref() {
-                            if is_node_struct(
-                                &p.path.segments.first().unwrap().ident.to_string(),
-                                &node_types,
-                                &nodes,
-                            ) {
-                                does_walking = true;
-                                traverse_elements.push(quote!{
-                                    for item in self.#field_name.iter() {
-                                        if !item.is_null() {
-                                            walker_fn(item.clone() as *mut Node, context);
-                                            Node::traverse::<T>( unsafe { &mut *(*item as *mut Node) }, walker_fn, context);
+                            if node_set
+                                .contains_key(&p.path.segments.first().unwrap().ident.to_string())
+                            {
+                                traverse_elements.push(quote! {
+                                    for ptr in self.#field_name.iter() {
+                                        if !ptr.is_null() {
+                                            let item = unsafe { &mut *(*ptr as *mut Node) };
+                                            walker_fn(item, context);
+                                            Node::traverse::<T>(item, walker_fn, context);
                                         }
                                     }
                                 });
@@ -1084,18 +855,11 @@ fn impl_pg_node(
                 }
                 Type::Ptr(t) => {
                     if let Type::Path(p) = t.elem.as_ref() {
-                        if is_node_struct(
-                            &p.path.segments.first().unwrap().ident.to_string(),
-                            &node_types,
-                            &nodes,
-                        ) {
-                            does_walking = true;
-                            traverse_elements.push(quote!{
-                                if !self.#field_name.is_null() {
-                                    walker_fn(self.#field_name as *mut Node, context);
-                                    Node::traverse::<T>(unsafe { &mut *(self.#field_name as *mut Node) }, walker_fn, context);
-                                }
-                            });
+                        if node_set
+                            .contains_key(&p.path.segments.first().unwrap().ident.to_string())
+                        {
+                            traverse_elements
+                                .push(walk_field_definition(quote! { self.#field_name }));
                         }
                     } else {
                         ptr_problems.push(format!(
@@ -1105,13 +869,8 @@ fn impl_pg_node(
                     }
                 }
                 Type::Path(p) => {
-                    if is_node_struct(
-                        &p.path.segments.first().unwrap().ident.to_string(),
-                        &node_types,
-                        &nodes,
-                    ) {
+                    if node_set.contains_key(&p.path.segments.first().unwrap().ident.to_string()) {
                         let type_ = &p.path;
-                        does_walking = true;
                         traverse_elements.push(quote! {
                             walker_fn((&mut self.#field_name) as *mut #type_ as *mut Node, context);
                             // Explicitly don't look at _type here - for example, a Result has a concrete Plan as its
@@ -1125,29 +884,41 @@ fn impl_pg_node(
             }
         }
         // impl the PgNode trait for all nodes
-        let mut traversal = proc_macro2::TokenStream::new();
-        for item in traverse_elements {
-            traversal.extend(item);
-        }
-        pgnode_impls.extend(if !does_walking {
+        let traversal_function = if traverse_elements.is_empty() {
             quote! {
-                impl pg_sys::seal::Sealed for #struct_name {}
-                impl pg_sys::PgNode for #struct_name {
-                    fn traverse<T>(&mut self, _walker_fn: fn(*mut Node, &mut T) -> (), _context: &mut T) {
-                        #traversal
-                    }
-                }
             }
         } else {
+            let traversal = proc_macro2::TokenStream::from_iter(traverse_elements.into_iter());
             quote! {
-                impl pg_sys::seal::Sealed for #struct_name {}
-                impl pg_sys::PgNode for #struct_name {
-                    fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                        #traversal
-                    }
+                fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                    #traversal
                 }
             }
-        });
+        };
+
+        if node_set.contains_key(&struct_name.to_string()) {
+            pgnode_impls.extend(quote! {
+                impl pg_sys::seal::Sealed for #struct_name {}
+                impl pg_sys::PgNode for #struct_name {
+                    #traversal_function
+                }
+            });
+            if nodetag_t_values.contains(&struct_name.to_string()) {
+                let nodetag = format_ident!("NodeTag_T_{}", struct_name);
+                let type_ = format_ident!("{}", struct_name);
+                node_traverse_body.extend(quote! {
+                    #nodetag => {
+                        #type_::traverse(
+                            &mut unsafe { std::ptr::read(self as *mut Node as *mut #type_) },
+                            walker_fn,
+                            context)
+                    },
+                });
+                node_display_body.extend(quote! {
+                    #nodetag => #type_::fmt(&unsafe { std::ptr::read(self as *const Node as *const #type_) }, f),
+                });
+            }
+        }
 
         // impl Rust's Display trait for all nodes
         pgnode_impls.extend(quote! {
@@ -1162,6 +933,117 @@ fn impl_pg_node(
         panic!("{}", ptr_problems.join("\n"));
     }
 
+    let rte_traversal = proc_macro2::TokenStream::from_iter(vec![
+        // Order and field names for each case are taken from the implementation of `_outRangeTblEntry` in outfuncs.c.
+        walk_field_definition(quote! { self.alias }),
+        walk_field_definition(quote! { self.eref }),
+        quote! { match self.rtekind },
+        proc_macro2::TokenStream::from(proc_macro2::TokenTree::Group(proc_macro2::Group::new(
+            proc_macro2::Delimiter::Brace,
+            proc_macro2::TokenStream::from_iter(vec![
+                quote! { RTEKind_RTE_RELATION => },
+                walk_field_definition(quote! { self.tablesample }),
+                quote! { RTEKind_RTE_SUBQUERY => },
+                walk_field_definition(quote! { self.subquery }),
+                quote! { RTEKind_RTE_JOIN => },
+                proc_macro2::TokenStream::from(proc_macro2::TokenTree::Group(
+                    proc_macro2::Group::new(
+                        proc_macro2::Delimiter::Brace,
+                        proc_macro2::TokenStream::from_iter(vec![
+                            walk_field_definition(quote! { self.joinaliasvars }),
+                            join_fields_traverse,
+                        ]),
+                    ),
+                )),
+                quote! { RTEKind_RTE_FUNCTION => },
+                walk_field_definition(quote! { self.functions }),
+                quote! { RTEKind_RTE_TABLEFUNC => },
+                walk_field_definition(quote! { self.tablefunc }),
+                quote! { RTEKind_RTE_VALUES => },
+                proc_macro2::TokenStream::from(proc_macro2::TokenTree::Group(
+                    proc_macro2::Group::new(
+                        proc_macro2::Delimiter::Brace,
+                        proc_macro2::TokenStream::from_iter(vec![
+                            walk_field_definition(quote! { self.values_lists }),
+                            walk_field_definition(quote! { self.coltypes }),
+                            walk_field_definition(quote! { self.coltypmods }),
+                            walk_field_definition(quote! { self.colcollations }),
+                        ]),
+                    ),
+                )),
+                quote! { RTEKind_RTE_CTE => },
+                proc_macro2::TokenStream::from(proc_macro2::TokenTree::Group(
+                    proc_macro2::Group::new(
+                        proc_macro2::Delimiter::Brace,
+                        proc_macro2::TokenStream::from_iter(vec![
+                            walk_field_definition(quote! { self.coltypes }),
+                            walk_field_definition(quote! { self.coltypmods }),
+                            walk_field_definition(quote! { self.colcollations }),
+                        ]),
+                    ),
+                )),
+                quote! { RTEKind_RTE_NAMEDTUPLESTORE => },
+                proc_macro2::TokenStream::from(proc_macro2::TokenTree::Group(
+                    proc_macro2::Group::new(
+                        proc_macro2::Delimiter::Brace,
+                        proc_macro2::TokenStream::from_iter(vec![
+                            walk_field_definition(quote! { self.coltypes }),
+                            walk_field_definition(quote! { self.coltypmods }),
+                            walk_field_definition(quote! { self.colcollations }),
+                        ]),
+                    ),
+                )),
+                rtekind_result_handling,
+                quote! {
+                    _ => {
+                        unsafe { pre_format_elog_string(ERROR as i32, format!("unrecognized RTE kind: {}", self.rtekind).as_ptr() as *const i8); }
+                    }
+                },
+            ]),
+        ))),
+        walk_field_definition(quote! { self.securityQuals }),
+    ]);
+
+    pgnode_impls.extend(quote! {
+        impl Sealed for List {}
+        #list_fns
+
+        impl Sealed for Node {}
+        impl pg_sys::PgNode for Node {
+            fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                match self.type_ {
+                    NodeTag_T_List => List::traverse(&mut unsafe { std::ptr::read(self as *mut Node as *mut List) },
+                        walker_fn,
+                        context),
+                    NodeTag_T_RangeTblEntry => RangeTblEntry::traverse(&mut unsafe { std::ptr::read(self as *mut Node as *mut RangeTblEntry) },
+                        walker_fn,
+                        context),
+                    #node_traverse_body
+                    _ => {}, // any types with no explicit traverse method defined will be skipped.
+                }
+            }
+        }
+        impl std::fmt::Display for Node {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.type_ {
+                    #node_display_body
+                    _ => write!(f, "[unknown type {}]", self.type_),
+                }
+            }
+        }
+        impl Sealed for RangeTblEntry {}
+        impl pg_sys::PgNode for RangeTblEntry {
+            fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                #rte_traversal
+            }
+        }
+        impl std::fmt::Display for RangeTblEntry {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.display_node() )
+            }
+        }
+    });
+
     Ok(pgnode_impls)
 }
 
@@ -1169,12 +1051,12 @@ fn impl_pg_node(
 fn dfs_find_nodes<'graph>(
     node: &'graph StructDescriptor<'graph>,
     graph: &'graph StructGraph<'graph>,
-    node_set: &mut HashSet<StructDescriptor<'graph>>,
+    node_set: &mut HashMap<String, StructDescriptor<'graph>>,
 ) {
-    node_set.insert(node.clone());
+    node_set.insert(node.struct_.ident.to_string(), node.clone());
 
     for child in node.children(graph) {
-        if node_set.contains(child) {
+        if node_set.contains_key(&child.struct_.ident.to_string()) {
             continue;
         }
         dfs_find_nodes(child, graph, node_set);

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -11,11 +11,12 @@ use bindgen::callbacks::{DeriveTrait, ImplementsTrait, MacroParsingBehavior};
 use eyre::{eyre, WrapErr};
 use once_cell::sync::Lazy;
 use pgx_pg_config::{prefix_path, PgConfig, PgConfigSelector, Pgx, SUPPORTED_MAJOR_VERSIONS};
-use quote::{quote, ToTokens};
+use proc_macro2::Span;
+use quote::{quote, ToTokens, format_ident};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::{Command, Output};
-use syn::{ForeignItem, Item, ItemConst};
+use syn::{ForeignItem, Item, ItemConst, Type, Ident};
 
 const BLOCKLISTED_TYPES: [&str; 3] = ["Datum", "NullableDatum", "Oid"];
 
@@ -27,9 +28,6 @@ mod build {
 struct PgxOverrides(HashSet<String>);
 
 fn is_nightly() -> bool {
-    if std::env::var_os("CARGO_CFG_PLRUSTC").is_some() {
-        return false;
-    }
     let rustc = std::env::var_os("RUSTC").map(PathBuf::from).unwrap_or_else(|| "rustc".into());
     let output = match std::process::Command::new(rustc).arg("--verbose").output() {
         Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_owned(),
@@ -435,6 +433,29 @@ fn format_builtin_oid_impl<'a>(
         }
     }
 }
+fn is_node_struct(name: &str, node_types: &HashSet<String>, nodes: &Vec<StructDescriptor>) -> bool {
+    let node = nodes.iter().filter(|n| n.struct_.ident.to_string() == name).next();
+    match node {
+        None => false,
+        Some(n) => {
+            let first_field = n.struct_.fields.iter().next();
+            match first_field {
+                None => false,
+                Some(f) => match &f.ty {
+                    Type::Path(p) => {
+                        let first_field_type_name =
+                            p.path.segments.first().unwrap().ident.to_string();
+                        if first_field_type_name == "NodeTag" {
+                            return true;
+                        }
+                        is_node_struct(first_field_type_name.as_ref(), node_types, nodes)
+                    }
+                    _ => false,
+                },
+            }
+        }
+    }
+}
 
 /// Implement our `PgNode` marker trait for `pg_sys::Node` and its "subclasses"
 fn impl_pg_node(
@@ -495,24 +516,684 @@ fn impl_pg_node(
         dfs_find_nodes(root, &struct_graph, &mut node_set);
     }
 
-    let nodes: Box<dyn std::iter::Iterator<Item = StructDescriptor>> = if is_for_release {
+    let mut nodes = node_set.into_iter().collect::<Vec<_>>();
+    if is_for_release {
         // if it's for release we want to sort by struct name to avoid diff churn
-        let mut set = node_set.into_iter().collect::<Vec<_>>();
-        set.sort_by(|a, b| a.struct_.ident.cmp(&b.struct_.ident));
-        Box::new(set.into_iter())
-    } else {
         // otherwise we don't care and want to avoid the CPU overhead of sorting
-        Box::new(node_set.into_iter())
+        nodes.sort_by_key(|s| &s.struct_.ident);
+    }
+
+    let node_types = items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Const(c) if c.ident.to_string().starts_with("NodeTag_T_") => {
+                Some(c.ident.to_string()["NodeTag_T_".len()..].to_string())
+            }
+            _ => None,
+        })
+        .filter(|t| match t.as_ref() {
+            // `NodeTag_T_`s that don't have a corresponding struct we care about. This is a single
+            // list, for convenience, but technically it's different in different versions of
+            // Postgres.
+            "BitString" | "Invalid" | "Null" | "IntList" | "OidList" | "AllocSetContext"
+            | "SlabContext" | "Integer" | "PathKeyInfo" | "GenerationContext" | "Float"
+            | "TsmRoutine" | "String" | "WindowObjectData" | "MemoryContext" | "TIDBitmap" => false,
+            _ => true,
+        })
+        .collect::<HashSet<String>>();
+
+    // Provide a special implementation of PgNode for the Node itself: depending on the `type_` field,
+    // call the override for that type. That way, when we get a `*mut Node` out of a List object, we
+    // can call this function and let it route appropriately.
+    let mut node_traverse_body = proc_macro2::TokenStream::new();
+    for node_type in &node_types {
+        let nodetag = format_ident!("NodeTag_T_{}", node_type.to_string());
+        let type_ = format_ident!("{}", node_type);
+        node_traverse_body.extend(quote! {
+            #nodetag => {
+                emit(format!("Calling specific traverse for item of type {}", stringify!(#type_)));
+                #type_::traverse(
+                    &mut unsafe { std::ptr::read(self as *mut Node as *mut #type_) },
+                    walker_fn,
+                    context)
+            },
+        });
+    }
+    let mut node_display_body = proc_macro2::TokenStream::new();
+    for node_type in &node_types {
+        let nodetag = format_ident!("NodeTag_T_{}", node_type.to_string());
+        let type_ = format_ident!("{}", node_type);
+        node_display_body.extend(quote! {
+            #nodetag => #type_::fmt(&unsafe { std::ptr::read(self as *const Node as *const #type_) }, f),
+        });
+    }
+
+    let join_fields_traverse = if std::env::var("CARGO_FEATURE_PG11").is_ok()
+        || std::env::var("CARGO_FEATURE_PG12").is_ok()
+    {
+        quote! {}
+    } else if std::env::var("CARGO_FEATURE_PG13").is_ok() {
+        quote! {
+            if !self.joinleftcols.is_null() {
+                walker_fn(self.joinleftcols as *mut Node, context);
+                Node::traverse::<T>(unsafe { &mut *(self.joinleftcols as *mut Node) }, walker_fn, context);
+            }
+            if !self.joinrightcols.is_null() {
+                walker_fn(self.joinrightcols as *mut Node, context);
+                Node::traverse::<T>(unsafe { &mut *(self.joinrightcols as *mut Node) }, walker_fn, context);
+            }
+        }
+    } else {
+        quote! {
+            if !self.joinleftcols.is_null() {
+                walker_fn(self.joinleftcols as *mut Node, context);
+                Node::traverse::<T>(unsafe { &mut *(self.joinleftcols as *mut Node) }, walker_fn, context);
+            }
+            if !self.joinrightcols.is_null() {
+                walker_fn(self.joinrightcols as *mut Node, context);
+                Node::traverse::<T>(unsafe { &mut *(self.joinrightcols as *mut Node) }, walker_fn, context);
+            }
+            if !self.join_using_alias.is_null() {
+                walker_fn(self.join_using_alias as *mut Node, context);
+                Node::traverse::<T>(unsafe { &mut *(self.join_using_alias as *mut Node) }, walker_fn, context);
+            }
+        }
+    };
+    let rtekind_result_handling = if std::env::var("CARGO_FEATURE_PG11").is_ok() {
+        quote! {}
+    } else {
+        quote! {
+            RTEKind_RTE_RESULT => {
+                /* no extra fields */
+            },
+        }
     };
 
-    // now we can finally iterate the Nodes and emit out Display impl
-    for node_struct in nodes {
-        let struct_name = &node_struct.struct_.ident;
+    // Older Postgres' List is linked.
+    let list_fns = if std::env::var("CARGO_FEATURE_PG11").is_ok()
+        || std::env::var("CARGO_FEATURE_PG12").is_ok()
+    {
+        quote! {
+            impl pg_sys::PgNode for List {
+                fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                    emit(format!("Preparing to traverse a linked list of {} elements", self.length));
 
+                    if self.length == 0 { return; }
+                    let mut cell = unsafe { *self.head };
+                    for _index in 0..self.length {
+                        let item = unsafe { cell.data.ptr_value as *mut Node };
+                        if !item.is_null() {
+                            emit(format!("Traversing list[{}]: {:?}", _index, item));
+
+                            walker_fn(item, context);
+                            Node::traverse::<T>( unsafe { &mut *(item as *mut Node) }, walker_fn, context);
+                        }
+                        if !cell.next.is_null() {
+                            cell = unsafe { *cell.next };
+                        }
+                    }
+                    emit(format!("Done traversing a list of {} elements", self.length));
+                }
+            }
+            impl std::fmt::Display for List {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "[")?;
+                    if self.length != 0 {
+                        let mut cell = unsafe { *self.head };
+                        for index in 0..self.length {
+                            if index != 0 {
+                                write!(f, ", ")?;
+                            }
+                            let item = unsafe { cell.data.ptr_value as *mut Node };
+                            if item.is_null() {
+                                write!(f, "(null)")?;
+                            } else {
+                                write!(f, "{}", unsafe { *item })?;
+                            }
+                            if !cell.next.is_null() {
+                                cell = unsafe { *cell.next };
+                            }
+                        }
+                    }
+                    write!(f, "]")
+                }
+            }
+        }
+    } else {
+        quote! {
+            impl pg_sys::PgNode for List {
+                fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                    emit(format!("Preparing to traverse an arraylist of {} elements", self.length));
+
+                    for index in 0..self.length {
+                        let item = unsafe { (*self.elements.offset(index as isize)).ptr_value as *mut Node };
+                        if !item.is_null() {
+                            emit(format!("Traversing list[{}]: {:?}", index, item));
+                            walker_fn(item, context);
+                            Node::traverse::<T>( unsafe { &mut *(item as *mut Node) }, walker_fn, context);
+                        }
+                    }
+                    emit(format!("Done traversing a list of {} elements", self.length));
+                }
+            }
+            impl std::fmt::Display for List {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "[")?;
+                    for index in 0..self.length {
+                        if index != 0 {
+                            write!(f, ", ")?;
+                        }
+                        let item = unsafe { (*self.elements.offset(index as isize)).ptr_value as *mut Node };
+                        if item.is_null() {
+                            write!(f, "(null)")?;
+                        } else {
+                            write!(f, "{}", unsafe { *item })?;
+                        }
+                    }
+                    write!(f, "]")
+                }
+            }
+        }
+    };
+
+    pgnode_impls.extend(quote! {
+        pub fn emit(string: std::string::String) {
+            // let mut file = ::std::fs::OpenOptions::new()
+            //     .write(true)
+            //     .append(true)
+            //     .open("/tmp/log")
+            //     .unwrap();
+            // ::std::writeln!(file, "{}", string).unwrap();
+            eprintln!("{}", string);
+        }
+
+        unsafe fn list_length(list: *mut List) -> i32 {
+            if list.is_null() {
+                0
+            } else {
+                (*list).length
+            }
+        }
+        #list_fns
+
+        impl pg_sys::PgNode for Node {
+            fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                match self.type_ {
+                    #node_traverse_body
+                    _ => {},
+                }
+            }
+        }
+        impl std::fmt::Display for Node {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self.type_ {
+                    #node_display_body
+                    _ => write!(f, "[unknown type {}]", self.type_),
+                }
+            }
+        }
+        impl pg_sys::seal::Sealed for Node {}
+        impl pg_sys::seal::Sealed for List {}
+        impl pg_sys::seal::Sealed for RangeTblEntry {}
+        impl pg_sys::PgNode for RangeTblEntry {
+            fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                // Derived from the implementation of `_outRangeTblEntry` in outfuncs.c.
+                // TODO: consider making the if/walk/traverse stanza into a macro?
+                if !self.alias.is_null() {
+                    walker_fn(self.alias as *mut Node, context);
+                    Node::traverse::<T>(unsafe { &mut *(self.alias as *mut Node) }, walker_fn, context);
+                }
+                if !self.eref.is_null() {
+                    walker_fn(self.eref as *mut Node, context);
+                    Node::traverse::<T>(unsafe { &mut *(self.eref as *mut Node) }, walker_fn, context);
+                }
+                // WRITE_ENUM_FIELD(rtekind, RTEKind);
+
+                match self.rtekind {
+                    RTEKind_RTE_RELATION => {
+                        // WRITE_OID_FIELD(relid);
+                        // WRITE_CHAR_FIELD(relkind);
+                        // WRITE_INT_FIELD(rellockmode);
+                        if !self.tablesample.is_null() {
+                            walker_fn(self.tablesample as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.tablesample as *mut Node) }, walker_fn, context);
+                        }
+                    },
+                    RTEKind_RTE_SUBQUERY => {
+                        if !self.subquery.is_null() {
+                            walker_fn(self.subquery as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.subquery as *mut Node) }, walker_fn, context);
+                        }
+                        // WRITE_BOOL_FIELD(security_barrier);
+                    },
+                    RTEKind_RTE_JOIN => {
+                        // WRITE_ENUM_FIELD(jointype, JoinType);
+                        // WRITE_INT_FIELD(joinmergedcols);
+
+                        if !self.joinaliasvars.is_null() {
+                            walker_fn(self.joinaliasvars as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.joinaliasvars as *mut Node) }, walker_fn, context);
+                        }
+                        #join_fields_traverse
+                    }
+                    RTEKind_RTE_FUNCTION => {
+                        if !self.functions.is_null() {
+                            walker_fn(self.functions as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.functions as *mut Node) }, walker_fn, context);
+                        }
+                        // WRITE_BOOL_FIELD(funcordinality);
+                    }
+                    RTEKind_RTE_TABLEFUNC => {
+                        if !self.tablefunc.is_null() {
+                            walker_fn(self.tablefunc as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.tablefunc as *mut Node) }, walker_fn, context);
+                        }
+                    }
+                    RTEKind_RTE_VALUES => {
+                        if !self.values_lists.is_null() {
+                            walker_fn(self.values_lists as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.values_lists as *mut Node) }, walker_fn, context);
+                        }
+                        if !self.coltypes.is_null() {
+                            walker_fn(self.coltypes as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.coltypes as *mut Node) }, walker_fn, context);
+                        }
+                        if !self.coltypmods.is_null() {
+                            walker_fn(self.coltypmods as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.coltypmods as *mut Node)}, walker_fn, context);
+                        }
+                        if !self.colcollations.is_null() {
+                            walker_fn(self.colcollations as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.colcollations as *mut Node) }, walker_fn, context);
+                        }
+                    }
+                    RTEKind_RTE_CTE => {
+                        // WRITE_STRING_FIELD(ctename);
+                        // WRITE_UINT_FIELD(ctelevelsup);
+                        // WRITE_BOOL_FIELD(self_reference);
+                        if !self.coltypes.is_null() {
+                            walker_fn(self.coltypes as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.coltypes as *mut Node) }, walker_fn, context);
+                        }
+                        if !self.coltypmods.is_null() {
+                            walker_fn(self.coltypmods as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.coltypmods as *mut Node) }, walker_fn, context);
+                        }
+                        if !self.colcollations.is_null() {
+                            walker_fn(self.colcollations as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.colcollations as *mut Node) }, walker_fn, context);
+                        }
+                    }
+                    RTEKind_RTE_NAMEDTUPLESTORE => {
+                        // WRITE_STRING_FIELD(enrname);
+                        // WRITE_FLOAT_FIELD(enrtuples, "%.0f");
+                        // WRITE_OID_FIELD(relid);
+                        if !self.coltypes.is_null() {
+                            walker_fn(self.coltypes as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.coltypes as *mut Node) }, walker_fn, context);
+                        }
+                        if !self.coltypmods.is_null() {
+                            walker_fn(self.coltypmods as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.coltypmods as *mut Node) }, walker_fn, context);
+                        }
+                        if !self.colcollations.is_null() {
+                            walker_fn(self.colcollations as *mut Node, context);
+                            Node::traverse::<T>(unsafe { &mut *(self.colcollations as *mut Node) }, walker_fn, context);
+                        }
+                    }
+                    #rtekind_result_handling
+                    _ => {
+                        unsafe { pre_format_elog_string(ERROR as i32, format!("unrecognized RTE kind: {}", self.rtekind).as_ptr() as *const i8); }
+                    }
+                }
+
+                // WRITE_BOOL_FIELD(lateral);
+                // WRITE_BOOL_FIELD(inh);
+                // WRITE_BOOL_FIELD(inFromCl);
+                // WRITE_UINT_FIELD(requiredPerms);
+                // WRITE_OID_FIELD(checkAsUser);
+                // WRITE_BITMAPSET_FIELD(selectedCols);
+                // WRITE_BITMAPSET_FIELD(insertedCols);
+                // WRITE_BITMAPSET_FIELD(updatedCols);
+                // WRITE_BITMAPSET_FIELD(extraUpdatedCols);
+                if !self.securityQuals.is_null() {
+                    walker_fn(self.securityQuals as *mut Node, context);
+                    Node::traverse::<T>(unsafe { &mut *(self.securityQuals as *mut Node) }, walker_fn, context);
+                }
+            }
+        }
+        impl std::fmt::Display for RangeTblEntry {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.display_node() )
+            }
+        }
+    });
+
+    struct ArrayBoundsInfo {
+        n: Option<proc_macro2::TokenStream>,
+    }
+    let mut array_fields: HashMap<(&'static str, &'static str), ArrayBoundsInfo> = HashMap::new();
+    let mut in_versions = |versions: &[u8],
+                           matchable: (&'static str, &'static str),
+                           n: Option<proc_macro2::TokenStream>| {
+        if versions.iter().any(|v| std::env::var(format!("CARGO_FEATURE_PG{}", v)).is_ok()) {
+            array_fields.insert(matchable, ArrayBoundsInfo { n: n });
+        }
+    };
+    in_versions(&[11, 12, 13, 14, 15], ("AggState", "aggcontexts"), Some(quote! { self.numaggs }));
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("AppendState", "appendplans"),
+        Some(quote! { self.as_nplans }),
+    );
+    in_versions(&[14, 15], ("AppendState", "as_asyncplans"), Some(quote! { self.as_nasyncplans }));
+    in_versions(
+        &[14, 15],
+        ("AppendState", "as_asyncrequests"),
+        Some(quote! { unsafe { bms_num_members(self.as_valid_asyncplans) } }),
+    );
+    in_versions(
+        &[14, 15],
+        ("AppendState", "as_asyncresults"),
+        Some(quote! { self.as_nasyncresults }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("BitmapAndState", "bitmapplans"),
+        Some(quote! { self.nplans }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("BitmapOrState", "bitmapplans"),
+        Some(quote! { self.nplans }),
+    );
+    in_versions(
+        &[11, 12, 13],
+        ("EState", "es_result_relations"),
+        Some(quote! { self.es_num_result_relations }),
+    );
+    in_versions(
+        &[14, 15],
+        ("EState", "es_result_relations"),
+        Some(quote! { self.es_range_table_size }),
+    );
+    in_versions(
+        &[12],
+        ("EState", "es_range_table_array"),
+        Some(quote! { self.es_range_table_size }),
+    );
+    in_versions(
+        &[12, 13, 14, 15],
+        ("EState", "es_rowmarks"),
+        Some(quote! { self.es_range_table_size }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("GatherMergeState", "gm_slots"),
+        Some(quote! { self.nreaders + 1 }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("GatherMergeState", "reader"),
+        Some(quote! { self.nreaders }),
+    );
+    in_versions(&[11, 12, 13, 14, 15], ("GatherState", "reader"), Some(quote! { self.nreaders }));
+    in_versions(&[13, 14, 15], ("IndexOptInfo", "opclassoptions"), None); // ignored, just a byte array.
+    in_versions(&[14, 15], ("MemoizeState", "param_exprs"), Some(quote! { self.nkeys }));
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("MergeAppendState", "mergeplans"),
+        Some(quote! { self.ms_nplans }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("MergeAppendState", "ms_slots"),
+        Some(quote! { self.ms_nplans }),
+    );
+    in_versions(&[11, 12, 13], ("ModifyTableState", "mt_plans"), Some(quote! { self.mt_nplans }));
+    in_versions(&[12, 13], ("ModifyTableState", "mt_scans"), Some(quote! { self.mt_nplans }));
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("PlannerInfo", "append_rel_array"),
+        Some(quote! { self.simple_rel_array_size }),
+    );
+    // I couldn't figure out how to traverse this list, I'm not sure how long it is.
+    in_versions(&[11, 12, 13, 14, 15], ("PlannerInfo", "join_rel_level"), None);
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("PlannerInfo", "simple_rel_array"),
+        Some(quote! { self.simple_rel_array_size }),
+    );
+    // in_versions(&[11], ("PlannerInfo", "append_rte_array"), Some(quote! { self.simple_rel_array_size }));
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("PlannerInfo", "simple_rte_array"),
+        Some(quote! { self.simple_rel_array_size }),
+    );
+    in_versions(&[11, 12, 13, 14, 15], ("ProjectSetState", "elems"), Some(quote! { self.nelems }));
+    in_versions(&[11, 12, 13, 14, 15], ("RelOptInfo", "part_rels"), Some(quote! { self.nparts }));
+    in_versions(&[11, 12, 13, 14, 15], ("RelOptInfo", "partexprs"), Some(quote! { self.nparts }));
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("RelOptInfo", "nullable_partexprs"),
+        Some(quote! { self.nparts }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("ResultRelInfo", "ri_ConstraintExprs"),
+        Some(quote! { unsafe { (*(*(*self.ri_RelationDesc).rd_att).constr).num_check } }),
+    );
+    in_versions(&[12, 13, 14, 15], ("ResultRelInfo", "ri_GeneratedExprs"), None);
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("ResultRelInfo", "ri_IndexRelationInfo"),
+        Some(quote! { self.ri_NumIndices }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("ResultRelInfo", "ri_TrigWhenExprs"),
+        Some(quote! { unsafe { *self.ri_TrigDesc }.numtriggers  }),
+    );
+    in_versions(
+        &[14, 15],
+        ("ResultRelInfo", "ri_Slots"),
+        Some(quote! { self.ri_NumSlotsInitialized }),
+    );
+    in_versions(
+        &[14, 15],
+        ("ResultRelInfo", "ri_PlanSlots"),
+        Some(quote! { self.ri_NumSlotsInitialized }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("ValuesScanState", "exprlists"),
+        Some(quote! { self.array_len }),
+    );
+    in_versions(
+        &[11, 12, 13, 14, 15],
+        ("ValuesScanState", "exprstatelists"),
+        Some(quote! { self.array_len }),
+    );
+
+    fn handle_length_bounded_array(
+        ts: &mut Vec<proc_macro2::TokenStream>,
+        n: &proc_macro2::TokenStream,
+        array: &str,
+    ) {
+        let array = Ident::new(array, Span::call_site());
+        ts.push(quote! {
+            for index in 0..(#n) {
+                let item = unsafe { self.#array.offset(index as isize) };
+                if !item.is_null() {
+                    walker_fn(item as *mut Node, context);
+                    Node::traverse::<T>(unsafe { &mut *(item as *mut Node) }, walker_fn, context);
+                }
+            }
+        });
+    }
+
+    let mut ptr_problems: Vec<String> = Vec::new();
+
+    // now we can finally iterate the Nodes and emit various trait impls
+    for node_struct in &nodes {
+        let mut does_walking = false;
+        let struct_name = &node_struct.struct_.ident;
+        match struct_name.to_string().as_ref() {
+            "Node" | "RangeTblEntry" | "List" => {
+                // use the special implementation defined above.
+                continue;
+            }
+            _ => {}
+        }
+        let mut traverse_elements: Vec<proc_macro2::TokenStream> = Vec::new();
+        if struct_name != "A_Const" && struct_name != "Value" {
+            traverse_elements.push(quote!{
+                emit(format!("Preparing to process struct {} {:?} at {}", stringify!(#struct_name), self, &self));
+            });
+        }
+
+        for field in node_struct.struct_.fields.iter() {
+            let field_name = field.ident.as_ref().unwrap();
+            println!("Handling {} -> {} of type {:?}", struct_name, field_name, &field.ty);
+            // Some structures have array fields in them, rather than Lists. Handle those specially.
+            match array_fields
+                .get(&(struct_name.to_string().as_ref(), field_name.to_string().as_ref()))
+            {
+                Some(abi) => {
+                    match &abi.n {
+                        Some(n) => handle_length_bounded_array(
+                            &mut traverse_elements,
+                            n,
+                            field_name.to_string().as_ref(),
+                        ),
+                        _ => {}
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+            // Some structures have fields that we need to handle specially because they're not populated, or are Lists
+            // that don't contain pointers.
+            match (struct_name.to_string().as_ref(), field_name.to_string().as_ref()) {
+                ("ModifyTableState", "mt_arowmarks")
+                | ("ModifyTableState", "mt_per_subplan_tupconv_maps")
+                | (_, "xpr") => continue,
+                _ => {}
+            }
+            match &field.ty {
+                Type::Array(a) => {
+                    if let Type::Ptr(ptr) = a.elem.as_ref() {
+                        if let Type::Path(p) = ptr.elem.as_ref() {
+                            if is_node_struct(
+                                &p.path.segments.first().unwrap().ident.to_string(),
+                                &node_types,
+                                &nodes,
+                            ) {
+                                does_walking = true;
+                                traverse_elements.push(quote!{
+                                    emit(format!("Traversing array {}::{} with value {:?}",
+                                        stringify!(#struct_name), stringify!(#field_name), self.#field_name));
+                                    for (index, item) in self.#field_name.iter().enumerate() {
+                                        if !item.is_null() {
+                                            emit(format!("Traversing array:item {}::{}[{}] with value {:?}",
+                                                stringify!(#struct_name), stringify!(#field_name), index, item));
+                                            walker_fn(item.clone() as *mut Node, context);
+                                            Node::traverse::<T>( unsafe { &mut *(*item as *mut Node) }, walker_fn, context);
+                                        }
+                                    }
+                                });
+                            }
+                        } else {
+                            ptr_problems.push(format!(
+                                "Unexpected type inside array:ptr {} -> field {}: {:?}",
+                                struct_name, field_name, ptr.elem
+                            ));
+                        }
+                    }
+                }
+                Type::Ptr(t) => {
+                    if let Type::Path(p) = t.elem.as_ref() {
+                        if is_node_struct(
+                            &p.path.segments.first().unwrap().ident.to_string(),
+                            &node_types,
+                            &nodes,
+                        ) {
+                            let debug_log = if field_name.to_string() == "extname" {
+                                quote! {}
+                            } else {
+                                quote! {
+                                    emit(format!("Traversing ptr:item {}::{} at {:?}",
+                                        stringify!(#struct_name), stringify!(#field_name), self.#field_name));
+                                }
+                            };
+                            does_walking = true;
+                            traverse_elements.push(quote!{
+                                if !self.#field_name.is_null() {
+                                    #debug_log
+                                    walker_fn(self.#field_name as *mut Node, context);
+                                    Node::traverse::<T>(unsafe { &mut *(self.#field_name as *mut Node) }, walker_fn, context);
+                                }
+                            });
+                        }
+                    } else {
+                        ptr_problems.push(format!(
+                            "Unexpected type inside ptr {} -> field {}: {:?}",
+                            struct_name, field_name, t.elem
+                        ));
+                    }
+                }
+                Type::Path(p) => {
+                    if is_node_struct(
+                        &p.path.segments.first().unwrap().ident.to_string(),
+                        &node_types,
+                        &nodes,
+                    ) {
+                        let type_ = &p.path;
+                        does_walking = true;
+                        if struct_name != "A_Const" {
+                            traverse_elements.push(quote!{
+                                emit(format!("Traversing item {}::{} with value {:?}",
+                                    stringify!(#struct_name), stringify!(#field_name), self.#field_name));
+                            });
+                        }
+                        traverse_elements.push(quote! {
+                            walker_fn((&mut self.#field_name) as *mut #type_ as *mut Node, context);
+                            // Explicitly don't look at _type here - for example, a Result has a concrete Plan as its
+                            // first member, but has _type == NodeTag_T_Result so if we delegated to `Node::traverse`
+                            // we'd be recursing forever.
+                            self.#field_name.traverse(walker_fn, context);
+                        });
+                    }
+                }
+                _ => panic!("In {}: Don't know how to handle {:?}", struct_name, field.ty),
+            }
+        }
         // impl the PgNode trait for all nodes
-        pgnode_impls.extend(quote! {
-            impl pg_sys::seal::Sealed for #struct_name {}
-            impl pg_sys::PgNode for #struct_name {}
+        let mut traversal = proc_macro2::TokenStream::new();
+        for item in traverse_elements {
+            traversal.extend(item);
+        }
+        pgnode_impls.extend(if !does_walking {
+            quote! {
+                impl pg_sys::seal::Sealed for #struct_name {}
+                impl pg_sys::PgNode for #struct_name {
+                    fn traverse<T>(&mut self, _walker_fn: fn(*mut Node, &mut T) -> (), _context: &mut T) {
+                        emit(format!("Empty traverse function for {}", stringify!(#struct_name)));
+                        #traversal
+                    }
+                }
+            }
+        } else {
+            quote! {
+                impl pg_sys::seal::Sealed for #struct_name {}
+                impl pg_sys::PgNode for #struct_name {
+                    fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
+                        emit(format!("Begin traverse function for {}", stringify!(#struct_name)));
+                        #traversal
+                        emit(format!("Finish traverse function for {}", stringify!(#struct_name)));
+                    }
+                }
+            }
         });
 
         // impl Rust's Display trait for all nodes
@@ -523,6 +1204,9 @@ fn impl_pg_node(
                 }
             }
         });
+    }
+    if !ptr_problems.is_empty() {
+        panic!("{}", ptr_problems.join("\n"));
     }
 
     Ok(pgnode_impls)
@@ -829,15 +1513,13 @@ fn build_shim_for_version(
         .unwrap();
     }
 
-    let make = std::env::var("MAKE").unwrap_or_else(|_| "make".to_string());
+    let make = option_env!("MAKE").unwrap_or("make").to_string();
     let rc = run_command(
         Command::new(make)
             .arg("clean")
             .arg(&format!("libpgx-cshim-{}.a", major_version))
             .env("PG_TARGET_VERSION", format!("{}", major_version))
             .env("PATH", path_env)
-            .env_remove("TARGET")
-            .env_remove("HOST")
             .current_dir(shim_dst),
         &format!("shim for PG v{}", major_version),
     )?;
@@ -945,8 +1627,10 @@ fn run_command(mut command: &mut Command, version: &str) -> eyre::Result<Output>
         .env_remove("MFLAGS")
         .env_remove("DYLD_FALLBACK_LIBRARY_PATH")
         .env_remove("OPT_LEVEL")
+        .env_remove("TARGET")
         .env_remove("PROFILE")
         .env_remove("OUT_DIR")
+        .env_remove("HOST")
         .env_remove("NUM_JOBS");
 
     eprintln!("[{}] {:?}", version, command);
@@ -1022,10 +1706,7 @@ fn apply_pg_guard(items: &Vec<syn::Item>) -> eyre::Result<proc_macro2::TokenStre
 }
 
 fn rust_fmt(path: &PathBuf) -> eyre::Result<()> {
-    // We shouldn't hit this path in a case where we care about it, but... just
-    // in case we probably should respect RUSTFMT.
-    let rustfmt = std::env::var_os("RUSTFMT").unwrap_or_else(|| "rustfmt".into());
-    let out = run_command(Command::new(rustfmt).arg(path).current_dir("."), "[bindings_diff]");
+    let out = run_command(Command::new("rustfmt").arg(path).current_dir("."), "[bindings_diff]");
     match out {
         Ok(_) => Ok(()),
         Err(e)

--- a/pgx-pg-sys/build.rs
+++ b/pgx-pg-sys/build.rs
@@ -551,7 +551,6 @@ fn impl_pg_node(
         let type_ = format_ident!("{}", node_type);
         node_traverse_body.extend(quote! {
             #nodetag => {
-                emit(format!("Calling specific traverse for item of type {}", stringify!(#type_)));
                 #type_::traverse(
                     &mut unsafe { std::ptr::read(self as *mut Node as *mut #type_) },
                     walker_fn,
@@ -616,15 +615,11 @@ fn impl_pg_node(
         quote! {
             impl pg_sys::PgNode for List {
                 fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                    emit(format!("Preparing to traverse a linked list of {} elements", self.length));
-
                     if self.length == 0 { return; }
                     let mut cell = unsafe { *self.head };
                     for _index in 0..self.length {
                         let item = unsafe { cell.data.ptr_value as *mut Node };
                         if !item.is_null() {
-                            emit(format!("Traversing list[{}]: {:?}", _index, item));
-
                             walker_fn(item, context);
                             Node::traverse::<T>( unsafe { &mut *(item as *mut Node) }, walker_fn, context);
                         }
@@ -632,7 +627,6 @@ fn impl_pg_node(
                             cell = unsafe { *cell.next };
                         }
                     }
-                    emit(format!("Done traversing a list of {} elements", self.length));
                 }
             }
             impl std::fmt::Display for List {
@@ -663,17 +657,13 @@ fn impl_pg_node(
         quote! {
             impl pg_sys::PgNode for List {
                 fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                    emit(format!("Preparing to traverse an arraylist of {} elements", self.length));
-
                     for index in 0..self.length {
                         let item = unsafe { (*self.elements.offset(index as isize)).ptr_value as *mut Node };
                         if !item.is_null() {
-                            emit(format!("Traversing list[{}]: {:?}", index, item));
                             walker_fn(item, context);
                             Node::traverse::<T>( unsafe { &mut *(item as *mut Node) }, walker_fn, context);
                         }
                     }
-                    emit(format!("Done traversing a list of {} elements", self.length));
                 }
             }
             impl std::fmt::Display for List {
@@ -697,16 +687,6 @@ fn impl_pg_node(
     };
 
     pgnode_impls.extend(quote! {
-        pub fn emit(string: std::string::String) {
-            // let mut file = ::std::fs::OpenOptions::new()
-            //     .write(true)
-            //     .append(true)
-            //     .open("/tmp/log")
-            //     .unwrap();
-            // ::std::writeln!(file, "{}", string).unwrap();
-            eprintln!("{}", string);
-        }
-
         unsafe fn list_length(list: *mut List) -> i32 {
             if list.is_null() {
                 0
@@ -1046,11 +1026,6 @@ fn impl_pg_node(
             _ => {}
         }
         let mut traverse_elements: Vec<proc_macro2::TokenStream> = Vec::new();
-        if struct_name != "A_Const" && struct_name != "Value" {
-            traverse_elements.push(quote!{
-                emit(format!("Preparing to process struct {} {:?} at {}", stringify!(#struct_name), self, &self));
-            });
-        }
 
         for field in node_struct.struct_.fields.iter() {
             let field_name = field.ident.as_ref().unwrap();
@@ -1091,12 +1066,8 @@ fn impl_pg_node(
                             ) {
                                 does_walking = true;
                                 traverse_elements.push(quote!{
-                                    emit(format!("Traversing array {}::{} with value {:?}",
-                                        stringify!(#struct_name), stringify!(#field_name), self.#field_name));
-                                    for (index, item) in self.#field_name.iter().enumerate() {
+                                    for item in self.#field_name.iter() {
                                         if !item.is_null() {
-                                            emit(format!("Traversing array:item {}::{}[{}] with value {:?}",
-                                                stringify!(#struct_name), stringify!(#field_name), index, item));
                                             walker_fn(item.clone() as *mut Node, context);
                                             Node::traverse::<T>( unsafe { &mut *(*item as *mut Node) }, walker_fn, context);
                                         }
@@ -1118,18 +1089,9 @@ fn impl_pg_node(
                             &node_types,
                             &nodes,
                         ) {
-                            let debug_log = if field_name.to_string() == "extname" {
-                                quote! {}
-                            } else {
-                                quote! {
-                                    emit(format!("Traversing ptr:item {}::{} at {:?}",
-                                        stringify!(#struct_name), stringify!(#field_name), self.#field_name));
-                                }
-                            };
                             does_walking = true;
                             traverse_elements.push(quote!{
                                 if !self.#field_name.is_null() {
-                                    #debug_log
                                     walker_fn(self.#field_name as *mut Node, context);
                                     Node::traverse::<T>(unsafe { &mut *(self.#field_name as *mut Node) }, walker_fn, context);
                                 }
@@ -1150,12 +1112,6 @@ fn impl_pg_node(
                     ) {
                         let type_ = &p.path;
                         does_walking = true;
-                        if struct_name != "A_Const" {
-                            traverse_elements.push(quote!{
-                                emit(format!("Traversing item {}::{} with value {:?}",
-                                    stringify!(#struct_name), stringify!(#field_name), self.#field_name));
-                            });
-                        }
                         traverse_elements.push(quote! {
                             walker_fn((&mut self.#field_name) as *mut #type_ as *mut Node, context);
                             // Explicitly don't look at _type here - for example, a Result has a concrete Plan as its
@@ -1178,7 +1134,6 @@ fn impl_pg_node(
                 impl pg_sys::seal::Sealed for #struct_name {}
                 impl pg_sys::PgNode for #struct_name {
                     fn traverse<T>(&mut self, _walker_fn: fn(*mut Node, &mut T) -> (), _context: &mut T) {
-                        emit(format!("Empty traverse function for {}", stringify!(#struct_name)));
                         #traversal
                     }
                 }
@@ -1188,9 +1143,7 @@ fn impl_pg_node(
                 impl pg_sys::seal::Sealed for #struct_name {}
                 impl pg_sys::PgNode for #struct_name {
                     fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T) {
-                        emit(format!("Begin traverse function for {}", stringify!(#struct_name)));
                         #traversal
-                        emit(format!("Finish traverse function for {}", stringify!(#struct_name)));
                     }
                 }
             }

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -177,7 +177,9 @@ pub trait PgNode: seal::Sealed {
     }
 
     /// Traverse the object graph, calling the callback at any `Node`s found as children of this object.
-    fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T);
+    fn traverse<T>(&mut self, _walker_fn: fn(*mut Node, &mut T) -> (), _context: &mut T) {
+        // Do nothing by default, but override for structs that need it.
+    }
 }
 
 mod seal {

--- a/pgx-pg-sys/src/lib.rs
+++ b/pgx-pg-sys/src/lib.rs
@@ -175,6 +175,9 @@ pub trait PgNode: seal::Sealed {
         // this is only implemented for things known to be "Nodes"
         unsafe { display_node_impl(NonNull::from(self).cast()) }
     }
+
+    /// Traverse the object graph, calling the callback at any `Node`s found as children of this object.
+    fn traverse<T>(&mut self, walker_fn: fn(*mut Node, &mut T) -> (), context: &mut T);
 }
 
 mod seal {

--- a/pgx-tests/src/tests/hooks_tests.rs
+++ b/pgx-tests/src/tests/hooks_tests.rs
@@ -28,7 +28,7 @@ mod tests {
             /// Hook before the logs are being processed by PostgreSQL itself
             fn emit_log(
                 &mut self,
-                mut error_data: PgBox<pg_sys::ErrorData>,
+                error_data: PgBox<pg_sys::ErrorData>,
                 prev_hook: fn(error_data: PgBox<pg_sys::ErrorData>) -> HookResult<()>,
             ) -> HookResult<()> {
                 self.events += 1;
@@ -122,7 +122,7 @@ mod tests {
         pgx::hooks::register_hook(&mut HOOK);
         // To trigger the emit_log hook, we need something to log.
         // We therefore ensure the select statement will be logged.
-        Spi::run("SET local log_statement to 'all'; SELECT 1");
+        Spi::run("SET local log_statement to 'all'; SELECT 1").unwrap();
         assert_eq!(8, HOOK.events);
 
         // TODO:  it'd be nice to also test that .commit() and .abort() also get called

--- a/pgx-tests/src/tests/mod.rs
+++ b/pgx-tests/src/tests/mod.rs
@@ -32,6 +32,8 @@ mod lifetime_tests;
 mod log_tests;
 mod memcxt_tests;
 mod name_tests;
+#[cfg(feature = "cshim")]
+mod node_tests;
 mod numeric_tests;
 mod pg_extern_tests;
 mod pg_guard_tests;

--- a/pgx-tests/src/tests/node_tests.rs
+++ b/pgx-tests/src/tests/node_tests.rs
@@ -1,0 +1,172 @@
+/*
+Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+*/
+use pg_sys::{
+    Const, Node, NodeTag_T_Const, ParamListInfoData, PgNode, PlannedStmt, Query, QueryDesc,
+    RangeTblEntry, FLOAT4OID, FLOAT8OID, NUMERICOID,
+};
+use pgx::{
+    cstr_core::c_char, error, hooks::PgHooks, prelude::*, register_hook, warning, FromDatum,
+    HookResult, PgList,
+};
+
+pub struct ExampleHook {}
+impl PgHooks for ExampleHook {
+    fn planner(
+        &mut self,
+        parse: PgBox<Query>,
+        query_string: *const c_char,
+        cursor_options: i32,
+        bound_params: PgBox<ParamListInfoData>,
+        prev_hook: fn(
+            PgBox<Query>,
+            query_string: *const c_char,
+            i32,
+            PgBox<ParamListInfoData>,
+        ) -> HookResult<*mut PlannedStmt>,
+    ) -> HookResult<*mut PlannedStmt> {
+        let planned_stmt = prev_hook(parse, query_string, cursor_options, bound_params);
+        struct Args {
+            has_pi_approximation: bool,
+        }
+        let mut arg = Args { has_pi_approximation: false };
+        fn pi_finder(node: *mut Node, context: &mut Args) -> () {
+            unsafe {
+                if node.is_null() {
+                    return;
+                }
+
+                if (*node).type_ == NodeTag_T_Const {
+                    let constant = *(node as *mut Const);
+
+                    let floatval: Option<f64> = match constant.consttype {
+                        FLOAT4OID => f32::from_polymorphic_datum(
+                            constant.constvalue,
+                            constant.constisnull,
+                            constant.consttype,
+                        )
+                        .map(|v| v as f64),
+                        FLOAT8OID => f64::from_polymorphic_datum(
+                            constant.constvalue,
+                            constant.constisnull,
+                            constant.consttype,
+                        ),
+                        NUMERICOID => AnyNumeric::from_polymorphic_datum(
+                            constant.constvalue,
+                            constant.constisnull,
+                            constant.consttype,
+                        )
+                        .and_then(|s| format!("{}", s).parse().ok()),
+                        _ => None,
+                    };
+
+                    if floatval.is_none() {
+                        return;
+                    }
+                    let floatval = floatval.unwrap();
+                    if 3.14 <= floatval && floatval < 3.142 && floatval != std::f64::consts::PI {
+                        context.has_pi_approximation = true;
+                        error!("Found a bad approximation for pi!");
+                    }
+                }
+            }
+        }
+        warning!("Traversing planned statement {:?}", planned_stmt.inner);
+
+        unsafe { (*planned_stmt.inner).traverse(pi_finder, &mut arg) };
+
+        if arg.has_pi_approximation {
+            error!("Found a bad approximation for pi!",);
+        }
+        planned_stmt
+    }
+    // Just use the upstream behavior for everything but the planner.
+    fn executor_start(
+        &mut self,
+        query_desc: PgBox<QueryDesc>,
+        eflags: i32,
+        prev_hook: fn(PgBox<QueryDesc>, i32) -> HookResult<()>,
+    ) -> HookResult<()> {
+        prev_hook(query_desc, eflags)
+    }
+
+    fn executor_run(
+        &mut self,
+        query_desc: PgBox<QueryDesc>,
+        direction: i32,
+        count: u64,
+        execute_once: bool,
+        prev_hook: fn(PgBox<QueryDesc>, i32, u64, bool) -> HookResult<()>,
+    ) -> HookResult<()> {
+        prev_hook(query_desc, direction, count, execute_once)
+    }
+
+    fn executor_finish(
+        &mut self,
+        query_desc: PgBox<QueryDesc>,
+        prev_hook: fn(PgBox<QueryDesc>) -> HookResult<()>,
+    ) -> HookResult<()> {
+        prev_hook(query_desc)
+    }
+
+    fn executor_end(
+        &mut self,
+        query_desc: PgBox<QueryDesc>,
+        prev_hook: fn(PgBox<QueryDesc>) -> HookResult<()>,
+    ) -> HookResult<()> {
+        prev_hook(query_desc)
+    }
+
+    fn executor_check_perms(
+        &mut self,
+        range_table: PgList<*mut RangeTblEntry>,
+        ereport_on_violation: bool,
+        prev_hook: fn(PgList<*mut RangeTblEntry>, bool) -> HookResult<bool>,
+    ) -> HookResult<bool> {
+        prev_hook(range_table, ereport_on_violation)
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgx_tests;
+    use crate::tests::node_tests::ExampleHook;
+
+    use pgx::{prelude::*, register_hook, warning};
+
+    #[pg_test]
+    fn with_no_pi() {
+        static mut HOOK: ExampleHook = ExampleHook {};
+        unsafe {
+            register_hook(&mut HOOK);
+        }
+        warning!("Registered hook!");
+        Spi::run("SELECT 1 where 3.141 < 4 group by 1 order by 1;");
+    }
+    #[pg_test(error = "Found a bad approximation for pi!")]
+    fn in_targetlist() {
+        static mut HOOK: ExampleHook = ExampleHook {};
+        unsafe {
+            register_hook(&mut HOOK);
+        }
+        Spi::run("SELECT 3.141;");
+    }
+    #[pg_test(error = "Found a bad approximation for pi!")]
+    fn in_with_clause() {
+        static mut HOOK: ExampleHook = ExampleHook {};
+        unsafe {
+            register_hook(&mut HOOK);
+        }
+        Spi::run("with surprise as (SELECT 3.141 as x) select 1 = 2, x from surprise;");
+    }
+    #[pg_test(error = "Found a bad approximation for pi!")]
+    fn in_having_clause() {
+        static mut HOOK: ExampleHook = ExampleHook {};
+        unsafe {
+            register_hook(&mut HOOK);
+        }
+        Spi::run("select count(num) as x FROM generate_series(1, 6) num group by num % 3 having count(*) = 3.141;");
+    }
+}

--- a/pgx-tests/src/tests/node_tests.rs
+++ b/pgx-tests/src/tests/node_tests.rs
@@ -6,7 +6,7 @@ use pg_sys::{
     RangeTblEntry, FLOAT4OID, FLOAT8OID, NUMERICOID,
 };
 use pgx::{
-    cstr_core::c_char, error, hooks::PgHooks, prelude::*, register_hook, warning, FromDatum,
+    cstr_core::c_char, error, hooks::PgHooks, prelude::*, warning, FromDatum,
     HookResult, PgList,
 };
 
@@ -143,7 +143,7 @@ mod tests {
             register_hook(&mut HOOK);
         }
         warning!("Registered hook!");
-        Spi::run("SELECT 1 where 3.141 < 4 group by 1 order by 1;");
+        assert_eq!(Ok(1), Spi::run("SELECT 1 where 3.141 < 4 group by 1 order by 1;"));
     }
     #[pg_test(error = "Found a bad approximation for pi!")]
     fn in_targetlist() {

--- a/pgx-tests/src/tests/node_tests.rs
+++ b/pgx-tests/src/tests/node_tests.rs
@@ -1,13 +1,12 @@
 /*
 Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 */
+use core::ffi::c_char;
 use pg_sys::{
     Const, Node, NodeTag_T_Const, ParamListInfoData, PgNode, PlannedStmt, PointerPath, Query,
     QueryDesc, RangeTblEntry, FLOAT4OID, FLOAT8OID, NUMERICOID,
 };
-use pgx::{
-    cstr_core::c_char, error, hooks::PgHooks, prelude::*, warning, FromDatum, HookResult, PgList,
-};
+use pgx::{error, hooks::PgHooks, prelude::*, warning, FromDatum, HookResult, PgList};
 
 pub struct ExampleHook {}
 impl PgHooks for ExampleHook {


### PR DESCRIPTION
Adds a function which walks a tree of `PgNode` objects, calling a callback at each node. This is useful for things like the planner, where objects of a particular type could occur in many places, and those places change depending on the version of PostgreSQL that's being used. For example, `RTEKind_RTE_RESULT` is only defined and used in version 12+, so the planner would need to handle different layouts of plans depending on the version of PostgreSQL.