### PR TITLE
Customizable serialization of PostgresType

### DIFF
--- a/pgx-macros/src/lib.rs
+++ b/pgx-macros/src/lib.rs
@@ -781,7 +781,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         de.bounds = bounds;
         lt_generics.params.insert(0, GenericParam::Lifetime(de));
         stream.extend(quote! {
-            impl #lt_generics ::pgx::datum::Serializer<'de> for #name #generics { }
+            impl #generics ::pgx::datum::Serializer for #name #generics { }
+            impl #lt_generics ::pgx::datum::Deserializer<'de> for #name #generics { }
         });
     }
 

--- a/pgx-tests/src/tests/postgres_type_tests.rs
+++ b/pgx-tests/src/tests/postgres_type_tests.rs
@@ -8,8 +8,9 @@ Use of this source code is governed by the MIT license that can be found in the 
 */
 use core::ffi::CStr;
 use pgx::prelude::*;
-use pgx::{InOutFuncs, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
+use pgx::{InOutFuncs, PgVarlena, PgVarlenaInOutFuncs, Serializer, StringInfo};
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 use std::str::FromStr;
 
 #[derive(Copy, Clone, PostgresType)]
@@ -152,6 +153,42 @@ pub enum JsonEnumType {
     E2 { b: f32 },
 }
 
+#[derive(Serialize, Deserialize, PostgresType)]
+#[custom_serializer]
+pub struct CustomSerialized;
+
+impl<'de> Serializer<'de> for CustomSerialized {
+    fn to_writer<W: Write>(&self, mut writer: W) {
+        writer.write(&[1]).expect("can't write");
+    }
+
+    fn from_slice(slice: &'de [u8]) -> Self {
+        if slice != &[1] {
+            panic!("wrong type")
+        } else {
+            CustomSerialized
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PostgresType)]
+#[custom_serializer]
+pub struct AnotherCustomSerialized;
+
+impl<'de> Serializer<'de> for AnotherCustomSerialized {
+    fn to_writer<W: Write>(&self, mut writer: W) {
+        writer.write(&[0]).expect("can't write");
+    }
+
+    fn from_slice(slice: &'de [u8]) -> Self {
+        if slice != &[0] {
+            panic!("wrong type")
+        } else {
+            AnotherCustomSerialized
+        }
+    }
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgx::pg_schema]
 mod tests {
@@ -159,8 +196,8 @@ mod tests {
     use crate as pgx_tests;
 
     use crate::tests::postgres_type_tests::{
-        CustomTextFormatSerializedEnumType, CustomTextFormatSerializedType, JsonEnumType, JsonType,
-        VarlenaEnumType, VarlenaType,
+        AnotherCustomSerialized, CustomSerialized, CustomTextFormatSerializedEnumType,
+        CustomTextFormatSerializedType, JsonEnumType, JsonType, VarlenaEnumType, VarlenaType,
     };
     use pgx::prelude::*;
     use pgx::PgVarlena;
@@ -252,5 +289,25 @@ mod tests {
                 .unwrap();
         assert!(matches!(result, JsonEnumType::E1 { a } if a == 1.0));
         Ok(())
+    }
+
+    #[pg_test]
+    fn custom_serializer() {
+        let s = CustomSerialized;
+        let _ = Spi::get_one_with_args::<CustomSerialized>(
+            r#"SELECT $1"#,
+            vec![(PgOid::Custom(CustomSerialized::type_oid()), s.into_datum())],
+        )
+        .unwrap();
+    }
+
+    #[pg_test(error = "wrong type")]
+    fn custom_serializer_wrong_type() {
+        let s = CustomSerialized;
+        let _ = Spi::get_one_with_args::<AnotherCustomSerialized>(
+            r#"SELECT $1"#,
+            vec![(PgOid::Custom(CustomSerialized::type_oid()), s.into_datum())],
+        )
+        .unwrap();
     }
 }

--- a/pgx/src/datum/mod.rs
+++ b/pgx/src/datum/mod.rs
@@ -65,6 +65,9 @@ use pgx_sql_entity_graph::RustSqlMapping;
 /// Implemented automatically by `#[derive(PostgresType)]`
 pub trait PostgresType {}
 
+/// Serializing to and from datum
+///
+/// Default implementation uses CBOR and Varlena
 pub trait Serializer<'de>: Serialize + Deserialize<'de> {
     /// Serializes the value to Datum
     ///

--- a/pgx/src/datum/mod.rs
+++ b/pgx/src/datum/mod.rs
@@ -65,10 +65,10 @@ use pgx_sql_entity_graph::RustSqlMapping;
 /// Implemented automatically by `#[derive(PostgresType)]`
 pub trait PostgresType {}
 
-/// Serializing to and from datum
+/// Serializing to datum
 ///
 /// Default implementation uses CBOR and Varlena
-pub trait Serializer<'de>: Serialize + Deserialize<'de> {
+pub trait Serializer: Serialize {
     /// Serializes the value to Datum
     ///
     /// Default implementation wraps the output of `Self::to_writer` into a Varlena
@@ -93,7 +93,12 @@ pub trait Serializer<'de>: Serialize + Deserialize<'de> {
     fn to_writer<W: std::io::Write>(&self, writer: W) {
         serde_cbor::to_writer(writer, &self).expect("failed to encode as CBOR");
     }
+}
 
+/// Deserializing from datum
+///
+/// Default implementation uses CBOR and Varlena
+pub trait Deserializer<'de>: Deserialize<'de> {
     /// Deserializes datum into a value
     ///
     /// Default implementation assumes datum to be a varlena and uses `Self::from_slice`
@@ -121,7 +126,7 @@ pub trait Serializer<'de>: Serialize + Deserialize<'de> {
                 let input = datum.cast_mut_ptr();
                 // this gets the varlena Datum copied into this memory context
                 let varlena = pg_sys::pg_detoast_datum_copy(input as *mut pg_sys::varlena);
-                <Self as Serializer<'de>>::deserialize(varlena.into())
+                <Self as Deserializer<'de>>::deserialize(varlena.into())
             })
         }
     }
@@ -134,9 +139,9 @@ pub trait Serializer<'de>: Serialize + Deserialize<'de> {
     }
 }
 
-impl<'de, T> IntoDatum for T
+impl<T> IntoDatum for T
 where
-    T: PostgresType + Serializer<'de>,
+    T: PostgresType + Serializer,
 {
     fn into_datum(self) -> Option<pg_sys::Datum> {
         Some(Serializer::serialize(&self))
@@ -149,7 +154,7 @@ where
 
 impl<'de, T> FromDatum for T
 where
-    T: PostgresType + Serializer<'de>,
+    T: PostgresType + Deserializer<'de>,
 {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
@@ -159,7 +164,7 @@ where
         if is_null {
             None
         } else {
-            Some(<T as Serializer>::deserialize(datum))
+            Some(<T as Deserializer>::deserialize(datum))
         }
     }
 

--- a/pgx/src/datum/mod.rs
+++ b/pgx/src/datum/mod.rs
@@ -50,6 +50,7 @@ pub use json::*;
 pub use numeric::{AnyNumeric, Numeric};
 use once_cell::sync::Lazy;
 pub use range::*;
+use serde::{Deserialize, Serialize};
 use std::any::TypeId;
 pub use time_stamp::*;
 pub use time_stamp_with_timezone::*;
@@ -57,12 +58,121 @@ pub use time_with_timezone::*;
 pub use tuples::*;
 pub use varlena::*;
 
-use crate::PgBox;
+use crate::{pg_sys, PgBox, PgMemoryContexts, StringInfo};
 use pgx_sql_entity_graph::RustSqlMapping;
 
 /// A tagging trait to indicate a user type is also meant to be used by Postgres
 /// Implemented automatically by `#[derive(PostgresType)]`
 pub trait PostgresType {}
+
+pub trait Serializer<'de>: Serialize + Deserialize<'de> {
+    /// Serializes the value to Datum
+    ///
+    /// Default implementation wraps the output of `Self::to_writer` into a Varlena
+    fn serialize(&self) -> pg_sys::Datum {
+        let mut serialized = StringInfo::new();
+
+        serialized.push_bytes(&[0u8; pg_sys::VARHDRSZ]); // reserve space fo the header
+        self.to_writer(&mut serialized);
+
+        let size = serialized.len() as usize;
+        let varlena = serialized.into_char_ptr();
+        unsafe {
+            crate::set_varsize(varlena as *mut pg_sys::varlena, size as i32);
+        }
+
+        (varlena as *const pg_sys::varlena).into()
+    }
+
+    /// Serializes the value to a writer
+    ///
+    /// Default implementation serializes to CBOR
+    fn to_writer<W: std::io::Write>(&self, writer: W) {
+        serde_cbor::to_writer(writer, &self).expect("failed to encode as CBOR");
+    }
+
+    /// Deserializes datum into a value
+    ///
+    /// Default implementation assumes datum to be a varlena and uses `Self::from_slice`
+    /// to deserialize the actual value.
+    fn deserialize(datum: pg_sys::Datum) -> Self {
+        unsafe {
+            let input = datum.cast_mut_ptr();
+            let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
+            let len = crate::varsize_any_exhdr(varlena);
+            let data = crate::vardata_any(varlena);
+            let slice = std::slice::from_raw_parts(data as *const u8, len);
+            Self::from_slice(slice)
+        }
+    }
+
+    /// Deserializes datum into a value into a given context
+    /// Default implementation assumes datum to be a varlena and uses `Self::from_slice`
+    /// to deserialize the actual value.
+    fn deserialize_into_context(
+        mut memory_context: PgMemoryContexts,
+        datum: pg_sys::Datum,
+    ) -> Self {
+        unsafe {
+            memory_context.switch_to(|_| {
+                let input = datum.cast_mut_ptr();
+                // this gets the varlena Datum copied into this memory context
+                let varlena = pg_sys::pg_detoast_datum_copy(input as *mut pg_sys::varlena);
+                <Self as Serializer<'de>>::deserialize(varlena.into())
+            })
+        }
+    }
+
+    /// Deserializes a value from a slice
+    ///
+    /// Default implementation deserializes from CBOR.
+    fn from_slice(slice: &'de [u8]) -> Self {
+        serde_cbor::from_slice(slice).expect("failed to decode CBOR")
+    }
+}
+
+impl<'de, T> IntoDatum for T
+where
+    T: PostgresType + Serializer<'de>,
+{
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        Some(Serializer::serialize(&self))
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        crate::rust_regtypein::<T>()
+    }
+}
+
+impl<'de, T> FromDatum for T
+where
+    T: PostgresType + Serializer<'de>,
+{
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: pg_sys::Oid,
+    ) -> Option<Self> {
+        if is_null {
+            None
+        } else {
+            Some(<T as Serializer>::deserialize(datum))
+        }
+    }
+
+    unsafe fn from_datum_in_memory_context(
+        memory_context: PgMemoryContexts,
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _typoid: pg_sys::Oid,
+    ) -> Option<Self> {
+        if is_null {
+            None
+        } else {
+            Some(T::deserialize_into_context(memory_context, datum))
+        }
+    }
+}
 
 /// A type which can have it's [`core::any::TypeId`]s registered for Rust to SQL mapping.
 ///

--- a/pgx/src/datum/varlena.rs
+++ b/pgx/src/datum/varlena.rs
@@ -9,15 +9,12 @@ Use of this source code is governed by the MIT license that can be found in the 
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
 use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{
-    pg_sys, rust_regtypein, set_varsize, set_varsize_short, vardata_any, varsize_any,
-    varsize_any_exhdr, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts, PostgresType,
-    StringInfo,
+    pg_sys, rust_regtypein, set_varsize, set_varsize_short, vardata_any, varsize_any, void_mut_ptr,
+    FromDatum, IntoDatum, PgMemoryContexts,
 };
-use pgx_pg_sys::varlena;
 use pgx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -333,123 +330,6 @@ where
             })
         }
     }
-}
-
-impl<T> IntoDatum for T
-where
-    T: PostgresType + Serialize,
-{
-    fn into_datum(self) -> Option<pg_sys::Datum> {
-        Some(cbor_encode(&self).into())
-    }
-
-    fn type_oid() -> pg_sys::Oid {
-        crate::rust_regtypein::<T>()
-    }
-}
-
-impl<'de, T> FromDatum for T
-where
-    T: PostgresType + Deserialize<'de>,
-{
-    unsafe fn from_polymorphic_datum(
-        datum: pg_sys::Datum,
-        is_null: bool,
-        _typoid: pg_sys::Oid,
-    ) -> Option<Self> {
-        if is_null {
-            None
-        } else {
-            cbor_decode(datum.cast_mut_ptr())
-        }
-    }
-
-    unsafe fn from_datum_in_memory_context(
-        memory_context: PgMemoryContexts,
-        datum: pg_sys::Datum,
-        is_null: bool,
-        _typoid: pg_sys::Oid,
-    ) -> Option<Self> {
-        if is_null {
-            None
-        } else {
-            cbor_decode_into_context(memory_context, datum.cast_mut_ptr())
-        }
-    }
-}
-
-fn cbor_encode<T>(input: T) -> *const pg_sys::varlena
-where
-    T: Serialize,
-{
-    let mut serialized = StringInfo::new();
-
-    serialized.push_bytes(&[0u8; pg_sys::VARHDRSZ]); // reserve space for the header
-    serde_cbor::to_writer(&mut serialized, &input).expect("failed to encode as CBOR");
-
-    let size = serialized.len() as usize;
-    let varlena = serialized.into_char_ptr();
-    unsafe {
-        set_varsize(varlena as *mut pg_sys::varlena, size as i32);
-    }
-
-    varlena as *const pg_sys::varlena
-}
-
-pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
-where
-    T: Deserialize<'de>,
-{
-    let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
-    let len = varsize_any_exhdr(varlena);
-    let data = vardata_any(varlena);
-    let slice = std::slice::from_raw_parts(data as *const u8, len);
-    serde_cbor::from_slice(slice).expect("failed to decode CBOR")
-}
-
-pub unsafe fn cbor_decode_into_context<'de, T>(
-    mut memory_context: PgMemoryContexts,
-    input: *mut pg_sys::varlena,
-) -> T
-where
-    T: Deserialize<'de>,
-{
-    memory_context.switch_to(|_| {
-        // this gets the varlena Datum copied into this memory context
-        let varlena = pg_sys::pg_detoast_datum_copy(input as *mut pg_sys::varlena);
-        cbor_decode(varlena)
-    })
-}
-
-#[allow(dead_code)]
-fn json_encode<T>(input: T) -> *const varlena
-where
-    T: Serialize,
-{
-    let mut serialized = StringInfo::new();
-
-    serialized.push_bytes(&[0u8; pg_sys::VARHDRSZ]); // reserve space for the header
-    serde_json::to_writer(&mut serialized, &input).expect("failed to encode as JSON");
-
-    let size = serialized.len() as usize;
-    let varlena = serialized.into_char_ptr();
-    unsafe {
-        set_varsize(varlena as *mut pg_sys::varlena, size as i32);
-    }
-
-    varlena as *const pg_sys::varlena
-}
-
-#[allow(dead_code)]
-unsafe fn json_decode<'de, T>(input: *mut pg_sys::varlena) -> T
-where
-    T: Deserialize<'de>,
-{
-    let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
-    let len = varsize_any_exhdr(varlena);
-    let data = vardata_any(varlena);
-    let slice = std::slice::from_raw_parts(data as *const u8, len);
-    serde_json::from_slice(slice).expect("failed to decode JSON")
 }
 
 unsafe impl<T> SqlTranslatable for PgVarlena<T>


### PR DESCRIPTION
Problem: CBOR is not the most universal answer to everything

However, all `Serialize/Deserialize` PostgresTypes are forced to use with the blanket implementation of `IntoDatum`/`FromDatum`

Solution: extract a `Serializer` and `Deserializer` traits to abstract this away

By default, it uses CBOR and encodes it into a Varlena, replicating existing behavior.

However, this gives a good amount of flexibility to end-user to determine their encoding needs.

I've also removed JSON-encoding/decoding functions from varlena module, as they don't seem to be used anywhere.

---

A message to pgx users: my ability to actively contribute to pgx largely depends on your support. Please consider [sponsoring my work](https://github.com/sponsors/yrashk)