### PR TITLE
Allow specifying specific release to download to `cargo pgx init`

### DIFF
--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -129,8 +129,7 @@ impl CommandExecute for Init {
                         })?;
                         pgx.push(PgConfig::from(PgVersion { major, minor, url:
                         Url::parse(
-                            &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2",
-                                     major = major, minor = minor))?
+                            &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2"))?
                         }));
                         default_pgx = Some(pgx);
                     }

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -121,8 +121,8 @@ impl CommandExecute for Init {
                         .wrap_err_with(|| format!("{} is not a known Postgres version", pgver))?
                         .clone()
                 } else if pg_config_path.starts_with(&format!("download={major}")) {
-                    let release = pg_config_path.split("=").collect::<Vec<&str>>().pop().unwrap();
-                    let minor = release.split(".").collect::<Vec<&str>>().pop().unwrap().parse()?;
+                    let release = pg_config_path.split("=").last().unwrap();
+                    let minor = release.split(".").last().unwrap().parse()?;
                     if default_pgx.is_none() {
                         let mut pgx = pgx_filtered_default(SUPPORTED_MAJOR_VERSIONS, |version| {
                             version.major != major

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -127,10 +127,10 @@ impl CommandExecute for Init {
                         let mut pgx = pgx_filtered_default(SUPPORTED_MAJOR_VERSIONS, |version| {
                             version.major != major
                         })?;
-                        pgx.push(PgConfig::from(PgVersion { major, minor, url:
+                        pgx.push(PgConfig::from(PgVersion::new(major, minor,
                         Url::parse(
                             &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2"))?
-                        }));
+                        )));
                         default_pgx = Some(pgx);
                     }
                     default_pgx

--- a/cargo-pgx/src/command/init.rs
+++ b/cargo-pgx/src/command/init.rs
@@ -140,7 +140,7 @@ impl CommandExecute for Init {
                         .wrap_err_with(|| format!("{} is not a known Postgres version", pgver))?
                         .clone()
                 } else if pg_config_path.starts_with("download=") {
-                    let release = pg_config_path.split("=").collect::<Vec<&str>>().pop().unwrap();
+                    let release = pg_config_path.split("=").last().unwrap();
                     return Err(eyre::Error::msg(format!(
                         "Invalid release {release} for major version {major}"
                     )));

--- a/cargo-pgx/src/command/version.rs
+++ b/cargo-pgx/src/command/version.rs
@@ -1,9 +1,22 @@
-use pgx_pg_config::{PgConfig, Pgx};
+use pgx_pg_config::{PgConfig, PgVersion, Pgx};
 
 pub(crate) fn pgx_default(supported_major_versions: &[u16]) -> eyre::Result<Pgx> {
     let mut pgx = Pgx::default();
     rss::PostgreSQLVersionRss::new(supported_major_versions)?
         .into_iter()
+        .for_each(|version| pgx.push(PgConfig::from(version)));
+
+    Ok(pgx)
+}
+
+pub(crate) fn pgx_filtered_default<F: Fn(&PgVersion) -> bool>(
+    supported_major_versions: &[u16],
+    filter: F,
+) -> eyre::Result<Pgx> {
+    let mut pgx = Pgx::default();
+    rss::PostgreSQLVersionRss::new(supported_major_versions)?
+        .into_iter()
+        .filter(filter)
         .for_each(|version| pgx.push(PgConfig::from(version)));
 
     Ok(pgx)

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -56,7 +56,7 @@ pub use path_methods::{get_target_dir, prefix_path};
 pub struct PgVersion {
     pub major: u16,
     pub minor: u16,
-    pub url: Url,
+    url: Url,
 }
 
 impl PgVersion {

--- a/pgx-pg-config/src/lib.rs
+++ b/pgx-pg-config/src/lib.rs
@@ -54,9 +54,9 @@ pub use path_methods::{get_target_dir, prefix_path};
 
 #[derive(Clone, Debug)]
 pub struct PgVersion {
-    major: u16,
-    minor: u16,
-    url: Url,
+    pub major: u16,
+    pub minor: u16,
+    pub url: Url,
 }
 
 impl PgVersion {


### PR DESCRIPTION
`--pgVER download` will only download the latest version. However, sometimes an exact version is needed.

Solution: allow specifying the exact release with `download=MAJOR.MINOR`