### PR TITLE
varlena: support bitflag in bigendian format.

### DIFF
--- a/pgrx/src/fcinfo.rs
+++ b/pgrx/src/fcinfo.rs
@@ -285,8 +285,7 @@ mod pg_12_13_14_15 {
         let fcinfo = unsafe { fcinfo.as_mut() }.unwrap();
         unsafe {
             let nargs = fcinfo.nargs;
-            let len = std::mem::size_of::<pg_sys::NullableDatum>() * nargs as usize;
-            fcinfo.args.as_slice(len)[num].clone()
+            fcinfo.args.as_slice(nargs as usize)[num].clone()
         }
     }
 

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -281,7 +281,6 @@ pub fn rust_byte_slice_to_bytea(slice: &[u8]) -> PgBox<pg_sys::bytea> {
     }
 }
 
-#[cfg(target_endian = "little")]
 mod varlena_littleendian {
     use super::*;
 
@@ -375,7 +374,6 @@ mod varlena_littleendian {
     }
 }
 
-#[cfg(target_endian = "big")]
 mod varlena_bigendian {
     use super::*;
 


### PR DESCRIPTION
Postgresql has an endian-dependent format for the bitflag in varlena. currently pgrx only support smallendian. adding bigendian support.

Greenplum uses the bigendian format for all platforms.

----

I will double check if there is some copy&past error tomorrow. :>