### PR TITLE
Try to smartly propagate fs errors

### DIFF
--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -190,7 +190,7 @@ pub(crate) fn init_pgrx(pgrx: &Pgrx, init: &Init) -> eyre::Result<()> {
         } else {
             let datadir = pg_config.data_dir()?;
             let bindir = pg_config.bin_dir()?;
-            if !datadir.exists() {
+            if !datadir.try_exists()? {
                 initdb(&bindir, &datadir)?;
             }
         }

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -110,7 +110,9 @@ pub(crate) fn package_extension(
     is_test: bool,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
-    if !out_dir.exists() {
+    let out_dir_exists =
+        out_dir.try_exists().wrap_err("failed to access out-dir while packaging extension")?;
+    if !out_dir_exists {
         std::fs::create_dir_all(&out_dir)?;
     }
 

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -110,8 +110,9 @@ pub(crate) fn package_extension(
     is_test: bool,
     features: &clap_cargo::Features,
 ) -> eyre::Result<()> {
-    let out_dir_exists =
-        out_dir.try_exists().wrap_err("failed to access out-dir while packaging extension")?;
+    let out_dir_exists = out_dir.try_exists().wrap_err_with(|| {
+        format!("failed to access {} while packaging extension", out_dir.display())
+    })?;
     if !out_dir_exists {
         std::fs::create_dir_all(&out_dir)?;
     }

--- a/cargo-pgrx/src/command/start.rs
+++ b/cargo-pgrx/src/command/start.rs
@@ -71,7 +71,7 @@ pub(crate) fn start_postgres(pg_config: &PgConfig) -> eyre::Result<()> {
     let bindir = pg_config.bin_dir()?;
     let port = pg_config.port()?;
 
-    if !datadir.exists() {
+    if !datadir.try_exists()? {
         initdb(&bindir, &datadir)?;
     }
 

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -15,7 +15,7 @@ use std::error::Error;
 use std::ffi::OsString;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use url::Url;
@@ -321,7 +321,7 @@ impl PgConfig {
     }
 
     pub fn bin_dir(&self) -> eyre::Result<PathBuf> {
-        Ok(Path::new(&self.run("--bindir")?).to_path_buf())
+        Ok(self.run("--bindir")?.into())
     }
 
     pub fn postmaster_path(&self) -> eyre::Result<PathBuf> {
@@ -522,13 +522,13 @@ impl Pgrx {
             Err(_) => {
                 // we'll get what we need from cargo-pgrx' config.toml file
                 let path = Pgrx::config_toml()?;
-                if !path.exists() {
+                if !path.try_exists()? {
                     return Err(eyre!(
                         "{} not found.  Have you run `{}` yet?",
                         path.display(),
                         "cargo pgrx init".bold().yellow()
                     ));
-                }
+                };
 
                 match toml::from_str::<ConfigToml>(&std::fs::read_to_string(&path)?) {
                     Ok(configs) => {
@@ -620,10 +620,10 @@ impl Pgrx {
             |v| Ok(v.into()),
         )?;
 
-        if pgrx_home.exists() {
-            Ok(pgrx_home)
-        } else {
-            Err(PgrxHomeError::MissingPgrxHome(pgrx_home))
+        match pgrx_home.try_exists() {
+            Ok(true) => Ok(pgrx_home),
+            Ok(false) => Err(PgrxHomeError::MissingPgrxHome(pgrx_home)),
+            Err(e) => Err(PgrxHomeError::IoError(e)),
         }
     }
 


### PR DESCRIPTION
Path::exists coerces filesystem errors to "false".
When used in restricted, networked, or other
"interesting" filesystems, like many build environs,
this can lose important error data instead of passing it on.
Try to improve error messaging via propagating errors.

This fixes #1183.