### PR TITLE
Update version to 0.10.0-beta.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -30,6 +30,17 @@ dependencies = [
  "pgrx",
  "pgrx-tests",
  "serde",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -77,7 +88,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -87,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -108,13 +119,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -155,16 +166,16 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
- "object 0.30.4",
+ "miniz_oxide",
+ "object",
  "rustc-demangle",
 ]
 
@@ -218,7 +229,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -307,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -322,7 +333,7 @@ dependencies = [
  "libloading 0.8.0",
  "nix",
  "num_cpus",
- "object 0.31.1",
+ "object",
  "once_cell",
  "owo-colors",
  "pgrx-pg-config",
@@ -336,7 +347,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_derive",
- "syn 2.0.22",
+ "syn 2.0.23",
  "tempfile",
  "tracing",
  "tracing-error",
@@ -413,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.9"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba77a07e4489fb41bd90e8d4201c3eb246b3c2c9ea2ba0bddd6c1d1df87db7d"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -435,13 +446,12 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.9"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9b4a88bb4bc35d3d6f65a21b0f0bafe9c894fa00978de242c555ec28bea1c0"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
  "once_cell",
  "strsim",
@@ -457,7 +467,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -534,10 +544,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.8"
+name = "core2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -638,6 +657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+
+[[package]]
 name = "datetime"
 version = "0.1.0"
 dependencies = [
@@ -675,7 +700,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -692,22 +717,22 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "enum-map"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988f0d17a0fa38291e5f41f71ea8d46a5d5497b9054d5a759fae2cbb819f2356"
+checksum = "017b207acb4cc917f4c31758ed95c0bc63ddb0f358b22eb38f80a2b2a43f6b1f"
 dependencies = [
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4da76b3b6116d758c7ba93f7ec6a35d2e2cf24feda76c6e38a375f4d5c59f2"
+checksum = "8560b409800a72d2d7860f8e5f4e0b0bd22bea6a352ea2a9ce30ccdef7f16d2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -734,7 +759,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -803,7 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -875,7 +900,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -961,6 +986,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -995,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hmac"
@@ -1059,21 +1093,20 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi 0.3.2",
+ "rustix 0.38.3",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1084,9 +1117,9 @@ checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
@@ -1117,21 +1150,25 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libflate"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
+checksum = "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf"
 dependencies = [
  "adler32",
+ "core2",
  "crc32fast",
+ "dary_heap",
  "libflate_lz77",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+checksum = "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524"
 dependencies = [
+ "core2",
+ "hashbrown 0.13.2",
  "rle-decode-fast",
 ]
 
@@ -1152,7 +1189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1175,6 +1212,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -1204,7 +1247,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1239,15 +1282,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
@@ -1263,7 +1297,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1340,7 +1374,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -1351,15 +1385,6 @@ dependencies = [
  "pgrx",
  "pgrx-tests",
  "rand",
-]
-
-[[package]]
-name = "object"
-version = "0.30.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1402,7 +1427,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1520,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.3",
@@ -1543,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1554,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1570,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1590,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 dependencies = [
  "atty",
  "convert_case",
@@ -1606,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1662,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -1743,12 +1768,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1875,13 +1900,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.2",
+ "regex-syntax 0.7.3",
 ]
 
 [[package]]
@@ -1894,6 +1920,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.3",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,9 +1938,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "ring"
@@ -1958,27 +1995,40 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.1",
  "sct",
 ]
 
@@ -1987,6 +2037,16 @@ name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
 dependencies = [
  "ring",
  "untrusted",
@@ -2005,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "safemem"
@@ -2026,11 +2086,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2116,15 +2176,15 @@ dependencies = [
 
 [[package]]
 name = "seq-macro"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b44e8fc93a14e66336d230954dda83d18b4605ccace8fe09bc7514a71ad0bc"
+checksum = "63134939175b3131fe4d2c131b103fd42f25ccca89423d43b5e4f267920ccf03"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
 ]
@@ -2153,20 +2213,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
  "ryu",
@@ -2235,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -2256,7 +2316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2370,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2404,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.2"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557d0845b86eea8182f7b10dff120214fb6cd9fd937b6f4917714e546a38695"
+checksum = "751e810399bba86e9326f5762b7f32ac5a085542df78da6a78d94e07d14d7c11"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2433,8 +2493,8 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
- "windows-sys 0.48.0",
+ "rustix 0.37.23",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2443,28 +2503,28 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix",
- "windows-sys 0.48.0",
+ "rustix 0.37.23",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2521,9 +2581,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
  "backtrace",
@@ -2532,7 +2592,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2 0.4.9",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2575,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2596,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -2627,7 +2687,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2706,9 +2766,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unescape"
@@ -2724,9 +2784,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -2761,7 +2821,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "rustls",
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
  "url",
  "webpki-roots",
 ]
@@ -2863,7 +2923,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -2885,7 +2945,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2912,7 +2972,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
 ]
 
 [[package]]
@@ -2948,21 +3008,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -2976,20 +3021,14 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2999,21 +3038,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3023,21 +3050,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3047,21 +3062,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3071,9 +3074,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]
@@ -3089,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
+checksum = "5a56c84a8ccd4258aed21c92f70c0f6dea75356b6892ae27c24139da456f9336"
 
 [[package]]
 name = "yaml-rust"

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -27,19 +27,19 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.15.4"
 cargo_toml = "0.15.3"
-clap = { version = "4.3.9", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.3.11", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.10.0", features = [ "cargo_metadata" ] }
 semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.16.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.7" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.7" }
-prettyplease = "0.2.9"
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.0" }
+prettyplease = "0.2.10"
 proc-macro2 = { version = "1.0.63", features = [ "span-locations" ] }
 quote = "1.0.29"
 rayon = "1.7.0"
-regex = "1.8.4"
+regex = "1.9.1"
 ureq = "2.7.1"
 url = "2.4.0"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -17,10 +17,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.7"
+pgrx = "=0.10.0-beta.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.7"
+pgrx-tests = "=0.10.0-beta.0"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -27,10 +27,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.7"
+pgrx = "=0.10.0-beta.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.7"
+pgrx-tests = "=0.10.0-beta.0"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-examples/bytea/Cargo.toml
+++ b/pgrx-examples/bytea/Cargo.toml
@@ -28,7 +28,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
-libflate = "1.4.0"
+libflate = "2.0.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -31,7 +31,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.7" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.0" }
 proc-macro2 = "1.0.63"
 quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"
@@ -30,6 +30,6 @@ owo-colors = "3.5.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
-toml = "0.7.5"
+toml = "0.7.6"
 url = "2.4.0"
 cargo_toml = "0.15.3"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-sys"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -40,8 +40,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.9.7" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.9.7" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.10.0-beta.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.10.0-beta.0" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -49,7 +49,7 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.9.7" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.10.0-beta.0" }
 proc-macro2 = "1.0.63"
 quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-sys/src/pg11.rs
+++ b/pgrx-pg-sys/src/pg11.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 #[cfg(any(
     feature = "pg12",
@@ -336,7 +327,6 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
@@ -20563,7 +20553,6 @@ pub struct MemoryContextMethods {
             totals: *mut MemoryContextCounters,
         ),
     >,
-    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20668,10 +20657,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -33082,6 +33067,43 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_language_oid(langname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+        label: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSecurityLabel(object: *const ObjectAddress);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSharedSecurityLabel(objectId: Oid, classId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExecSecLabelStmt(stmt: *mut SecLabelStmt) -> ObjectAddress;
+}
+pub type check_object_relabel_type = ::std::option::Option<
+    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::std::os::raw::c_char),
+>;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn register_label_provider(
+        provider: *const ::std::os::raw::c_char,
+        hook: check_object_relabel_type,
+    );
 }
 extern "C" {
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/pg11_oids.rs
+++ b/pgrx-pg-sys/src/pg11_oids.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::NotBuiltinOid;
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum BuiltinOid {

--- a/pgrx-pg-sys/src/pg12.rs
+++ b/pgrx-pg-sys/src/pg12.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 #[cfg(any(
     feature = "pg12",
@@ -344,7 +335,6 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
@@ -18999,7 +18989,6 @@ pub struct MemoryContextMethods {
             totals: *mut MemoryContextCounters,
         ),
     >,
-    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -19104,10 +19093,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -33130,6 +33115,43 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_language_oid(langname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+        label: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSecurityLabel(object: *const ObjectAddress);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSharedSecurityLabel(objectId: Oid, classId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExecSecLabelStmt(stmt: *mut SecLabelStmt) -> ObjectAddress;
+}
+pub type check_object_relabel_type = ::std::option::Option<
+    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::std::os::raw::c_char),
+>;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn register_label_provider(
+        provider: *const ::std::os::raw::c_char,
+        hook: check_object_relabel_type,
+    );
 }
 extern "C" {
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/pg12_oids.rs
+++ b/pgrx-pg-sys/src/pg12_oids.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::NotBuiltinOid;
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum BuiltinOid {

--- a/pgrx-pg-sys/src/pg13.rs
+++ b/pgrx-pg-sys/src/pg13.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 #[cfg(any(
     feature = "pg12",
@@ -179,7 +170,8 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 109] = b" '--prefix=/home/zombodb/.pgrx/13.11/pgrx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS: &[u8; 73] =
+    b" '--prefix=/home/zombodb/.pgrx/13.11/pgrx-install' '--with-pgport=28813'\0";
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -339,7 +331,6 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
@@ -13390,10 +13381,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn AssertPendingSyncs_RelationCache();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn AtEOXact_RelationCache(isCommit: bool);
 }
 #[pgrx_macros::pg_guard]
@@ -19781,7 +19768,6 @@ pub struct MemoryContextMethods {
             totals: *mut MemoryContextCounters,
         ),
     >,
-    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -19891,10 +19877,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -23593,10 +23575,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn LockHeldByMe(locktag: *const LOCKTAG, lockmode: LOCKMODE) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn GetLockMethodLocalHash() -> *mut HTAB;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -34491,6 +34469,43 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_language_oid(langname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+        label: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSecurityLabel(object: *const ObjectAddress);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSharedSecurityLabel(objectId: Oid, classId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExecSecLabelStmt(stmt: *mut SecLabelStmt) -> ObjectAddress;
+}
+pub type check_object_relabel_type = ::std::option::Option<
+    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::std::os::raw::c_char),
+>;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn register_label_provider(
+        provider: *const ::std::os::raw::c_char,
+        hook: check_object_relabel_type,
+    );
 }
 extern "C" {
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/pg13_oids.rs
+++ b/pgrx-pg-sys/src/pg13_oids.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::NotBuiltinOid;
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum BuiltinOid {

--- a/pgrx-pg-sys/src/pg14.rs
+++ b/pgrx-pg-sys/src/pg14.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 #[cfg(any(
     feature = "pg12",
@@ -179,7 +170,8 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 108] = b" '--prefix=/home/zombodb/.pgrx/14.8/pgrx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS: &[u8; 72] =
+    b" '--prefix=/home/zombodb/.pgrx/14.8/pgrx-install' '--with-pgport=28814'\0";
 pub const DEF_PGPORT: u32 = 28814;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28814\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -347,7 +339,6 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
 pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
@@ -8078,10 +8069,6 @@ extern "C" {
 extern "C" {
     pub fn GetNewObjectId() -> Oid;
 }
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AssertTransactionIdInAllowableRange(xid: TransactionId);
-}
 pub type Item = Pointer;
 pub type Page = Pointer;
 pub type LocationIndex = uint16;
@@ -13715,10 +13702,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RelationCloseSmgrByOid(relationId: Oid);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AssertPendingSyncs_RelationCache();
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -20338,7 +20321,6 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
-    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20452,10 +20434,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -30788,10 +30766,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn GetLockMethodLocalHash() -> *mut HTAB;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn LockHasWaiters(locktag: *const LOCKTAG, lockmode: LOCKMODE, sessionLock: bool) -> bool;
 }
 #[pgrx_macros::pg_guard]
@@ -34615,6 +34589,43 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_language_oid(langname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+        label: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSecurityLabel(object: *const ObjectAddress);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSharedSecurityLabel(objectId: Oid, classId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExecSecLabelStmt(stmt: *mut SecLabelStmt) -> ObjectAddress;
+}
+pub type check_object_relabel_type = ::std::option::Option<
+    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::std::os::raw::c_char),
+>;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn register_label_provider(
+        provider: *const ::std::os::raw::c_char,
+        hook: check_object_relabel_type,
+    );
 }
 extern "C" {
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/pg14_oids.rs
+++ b/pgrx-pg-sys/src/pg14_oids.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::NotBuiltinOid;
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum BuiltinOid {

--- a/pgrx-pg-sys/src/pg15.rs
+++ b/pgrx-pg-sys/src/pg15.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate as pg_sys;
 #[cfg(any(
     feature = "pg12",
@@ -179,7 +170,8 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 108] = b" '--prefix=/home/zombodb/.pgrx/15.3/pgrx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert'\0" ;
+pub const CONFIGURE_ARGS: &[u8; 72] =
+    b" '--prefix=/home/zombodb/.pgrx/15.3/pgrx-install' '--with-pgport=28815'\0";
 pub const DEF_PGPORT: u32 = 28815;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28815\0";
 pub const DLSUFFIX: &[u8; 4] = b".so\0";
@@ -350,7 +342,6 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
 pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
@@ -7639,10 +7630,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn StopGeneratingPinnedObjectIds();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn AssertTransactionIdInAllowableRange(xid: TransactionId);
 }
 pub type Item = Pointer;
 pub type Page = Pointer;
@@ -17193,10 +17180,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn AssertPendingSyncs_RelationCache();
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn AtEOXact_RelationCache(isCommit: bool);
 }
 #[pgrx_macros::pg_guard]
@@ -20228,7 +20211,6 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
-    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20342,10 +20324,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -30922,10 +30900,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn GetLockMethodLocalHash() -> *mut HTAB;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn LockHasWaiters(locktag: *const LOCKTAG, lockmode: LOCKMODE, sessionLock: bool) -> bool;
 }
 #[pgrx_macros::pg_guard]
@@ -34851,6 +34825,43 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_language_oid(langname: *const ::std::os::raw::c_char, missing_ok: bool) -> Oid;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn SetSecurityLabel(
+        object: *const ObjectAddress,
+        provider: *const ::std::os::raw::c_char,
+        label: *const ::std::os::raw::c_char,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSecurityLabel(object: *const ObjectAddress);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn DeleteSharedSecurityLabel(objectId: Oid, classId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn ExecSecLabelStmt(stmt: *mut SecLabelStmt) -> ObjectAddress;
+}
+pub type check_object_relabel_type = ::std::option::Option<
+    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::std::os::raw::c_char),
+>;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn register_label_provider(
+        provider: *const ::std::os::raw::c_char,
+        hook: check_object_relabel_type,
+    );
 }
 extern "C" {
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/pg15_oids.rs
+++ b/pgrx-pg-sys/src/pg15_oids.rs
@@ -1,12 +1,3 @@
-//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
-//LICENSE
-//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
-//LICENSE
-//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
-//LICENSE
-//LICENSE All rights reserved.
-//LICENSE
-//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::NotBuiltinOid;
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub enum BuiltinOid {

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-tests"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -48,13 +48,13 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.147"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.7" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.9.7" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.0" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.0" }
 postgres = "0.19.5"
-regex = "1.8.4"
+regex = "1.9.1"
 serde = "1.0"
 serde_json = "1.0"
-sysinfo = "0.29.2"
+sysinfo = "0.29.4"
 eyre = "0.6.8"
 thiserror = "1.0"
 
@@ -64,4 +64,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.9.7"
+version = "=0.10.0-beta.0"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 description = "Standalone tool to update PGRX Cargo.toml versions and dependencies in preparation for a release."
 
 [dependencies]
-clap = { version = "4.3.9", features = [ "env", "derive" ] }
+clap = { version = "4.3.11", features = [ "env", "derive" ] }
 owo-colors = "3.5.0"
-toml_edit = { version = "0.19.11" }
+toml_edit = { version = "0.19.12" }
 walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx"
-version = "0.9.7"
+version = "0.10.0-beta.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -44,15 +44,15 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.9.7" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.9.7" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.9.7" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.0" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.10.0-beta.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.0" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
 seq-macro = "0.3" # impls loops in macros
 uuid = { version = "1.4.0", features = [ "v4" ] } # PgLwLock and shmem
-enum-map = "2.5.0"
+enum-map = "2.6.0"
 
 # error handling and logging
 thiserror = "1.0"


### PR DESCRIPTION
Welcome to pgrx v0.10.0-beta.0.  

This is a big release in that it brings **PostgreSQL 16 Beta 2** support along with a few bug fixes.

🎉 This is also our first release under the stewardship of the PgCentral Foundation 🎉

If you'd like to help beta test please install cargo-pgrx with:

```
# cargo install cargo-pgrx --version 0.10.0-beta.0 --locked`
```
and then run 

```
cargo pgrx init
```

 to get the pgrx-managed version of Postgres 16beta2 locally installed.

This pgrx release is a beta because of the new Postgres 16beta2 support.  There's some new infrastructure in the code for managing Postgres beta releases which will hopefully make it easy down the road when Postgres 17 comes around.  So we'd like to make sure that's working on computers that aren't ours in addition to generally making sure the pgrx-specific changes to support 16beta2 are solid.

However, after a couple of pgrx v0.10.0 beta releases, we'll release the final version regardless of the Postgres 16 state.  We'll simply continue to include the latest 16 beta/rc and publish point releases as 16 progresses.

When 16 is finally GA, we'll add that to whatever the latest pgrx release happens to be at that time.

## Postgres 16 Beta2 Support

pgrx v0.10.0-beta.0 is the first pgrx release to support the new Postgres Beta series.  Note that this release is tied to 16beta2, and a new pgrx release will need to be done for any subsequent 16 betas or release candidates.  We intend to support these in a timely manner.

Note that pgrx only understands `pg16` as the Postgres version feature flag.  It is not possible for pgrx or pgrx-based extensions to support multiple betas at the same time.

You'll want to run a `cargo pgrx init` to get the support, if you want it.

Using pg16beta2 is a simple matter of adding:

```toml
pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
```

to the `[features]` block of your `Cargo.toml` files and then targeting `pg16` instead of any other version.  

In general, there aren't a lot of user-facing internal Postgres API changes between 15 and 16, but there are some, so it's possible you'll need some `#cfg[feature = "pg16"]` directives.

One breaking change that impacts pgrx across all supported versions is that string GUCs are now represented as `GucSetting<Option<&'static CStr>>`.  Previously they were `GucSetting<Option<&'static str>>` which is a) strictly incorrect and b) incompatible with pg16.

If you find any issues with 16beta2 support, please file issues here on GitHub.

* Postgres 16beta1 Support by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1169
* list specific versions in feature gates by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1175

beta1 support was soon replaced by:
* update to pg16beta2 support by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1188


## Bug Fixes

* Support building against macOS universal binaries by @clowder in https://github.com/pgcentralfoundation/pgrx/pull/1166
* fcinfo: fix incorrect length set in unsafe code by @Sasasu in https://github.com/pgcentralfoundation/pgrx/pull/1190
* Array-walking is aligned by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1191

## CI Changes

* Fixes macos-11 tests by @BradyBonnette in https://github.com/pgcentralfoundation/pgrx/pull/1197
* Disable hello_versioned_so test by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1192

This test has been causing our CI some trouble -- we are investigating why

## New Features

* Include security labels header by @daamien in https://github.com/pgcentralfoundation/pgrx/pull/1189
* Implement PGRXSharedMemory for Deque by @feikesteenbergen in https://github.com/pgcentralfoundation/pgrx/pull/1170

## Misc Changes
* doc: fix link broken by @yihong0618 in https://github.com/pgcentralfoundation/pgrx/pull/1181
* PgCentral Foundation copyright updates by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1200

## New Contributors
* @clowder made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1166
* @yihong0618 made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1181
* @Sasasu made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1190
* @daamien made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1189

## Thanks

Thanks to @ChronicallyJD and the @pgcentralfoundation for their stewardship.  We're looking forward to a bright future of extending Postgres with Rust!

**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.9.7...v0.10.0-beta.0