### PR TITLE
Add security policy

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,0 +1,27 @@
+# Security
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please open a [security advisory][advisory] which notify the maintainers. You should receive a response within 3 working days. If for some reason you do not, please follow up via email to ensure we received your original message. 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you find a vulnerability anywhere in this project, such as the source or scripts,
+then please let the maintainers know ASAP and we will fix it as a critical priority.
+
+Alternatively send an encrypted email to [Secure][mail] to start the secure disclosure process.
+
+[advisory]: https://github.com/pgcentralfoundation/pgrx/security/advisories/new
+[mail]: https://flowcrypt.com/me/pgcentralfoundationsecure

--- a/security.md
+++ b/security.md
@@ -21,7 +21,4 @@ This information will help us triage your report more quickly.
 If you find a vulnerability anywhere in this project, such as the source or scripts,
 then please let the maintainers know ASAP and we will fix it as a critical priority.
 
-Alternatively send an encrypted [email][mail] to start the secure disclosure process.
-
 [advisory]: https://github.com/pgcentralfoundation/pgrx/security/advisories/new
-[mail]: mailto:secure@example.com

--- a/security.md
+++ b/security.md
@@ -4,7 +4,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please open a [security advisory][advisory] which notify the maintainers. You should receive a response within 3 working days. If for some reason you do not, please follow up via email to ensure we received your original message. 
+Instead, please open a [security advisory][advisory] to notify the maintainers. You should receive a response within 3 working days. If for some reason you do not, please follow up via email to ensure we received your original message.
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 

--- a/security.md
+++ b/security.md
@@ -21,7 +21,7 @@ This information will help us triage your report more quickly.
 If you find a vulnerability anywhere in this project, such as the source or scripts,
 then please let the maintainers know ASAP and we will fix it as a critical priority.
 
-Alternatively send an encrypted email to [Secure][mail] to start the secure disclosure process.
+Alternatively send an encrypted [email][mail] to start the secure disclosure process.
 
 [advisory]: https://github.com/pgcentralfoundation/pgrx/security/advisories/new
-[mail]: https://flowcrypt.com/me/pgcentralfoundationsecure
+[mail]: mailto:secure@example.com


### PR DESCRIPTION
This adds a security policy to the repository to report security issues via the github security vulnerability feature. 