### PR TITLE
Fix issue #1209

### DIFF
--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -27,11 +27,13 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
         BackgroundWorker::transaction(|| {
             Spi::run("CREATE TABLE tests.bgworker_test (v INTEGER);")?;
             Spi::connect(|mut client| {
-                client.update(
-                    "INSERT INTO tests.bgworker_test VALUES ($1);",
-                    None,
-                    Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())]),
-                )
+                client
+                    .update(
+                        "INSERT INTO tests.bgworker_test VALUES ($1);",
+                        None,
+                        Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())]),
+                    )
+                    .map(|_| ())
             })
         })
         .expect("bgworker transaction failed");
@@ -78,6 +80,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
                 None,
                 Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), val.into_datum())]),
             )
+            .map(|_| ())
         })
     })
     .expect("bgworker transaction failed");

--- a/pgrx-tests/src/tests/heap_tuple.rs
+++ b/pgrx-tests/src/tests/heap_tuple.rs
@@ -927,12 +927,12 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_tuple_desc_clone() {
+    fn test_tuple_desc_clone() -> Result<(), spi::Error> {
         let result = Spi::connect(|client| {
             let query = "select * from generate_lots_of_dogs()";
-            client.select(query, None, None)
-        });
-        let table = result.expect("unable to select table result");
-        assert_eq!(table.len(), 10_000);
+            client.select(query, None, None).map(|table| table.len())
+        })?;
+        assert_eq!(result, 10_000);
+        Ok(())
     }
 }

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -179,7 +179,7 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_inserting_null() -> Result<(), Box<dyn Error>> {
+    fn test_inserting_null() -> Result<(), pgrx::spi::Error> {
         Spi::connect(|mut client| {
             client.update("CREATE TABLE tests.null_test (id uuid)", None, None).map(|_| ())
         })?;

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -508,4 +508,28 @@ mod tests {
         assert_eq!("'quoted-with-''quotes'''", spi::quote_literal("quoted-with-'quotes'"));
         assert_eq!("'quoted-string'", spi::quote_literal(String::from("quoted-string")));
     }
+
+    // TODO:  The point of this test is to **not** compile.  How to write a test for that?
+    // #[pg_test]
+    // fn issue1209() -> Result<Option<String>, Box<dyn std::error::Error>> {
+    //     // create the cursor we actually care about
+    //     let mut res = Spi::connect(|c| {
+    //         c.open_cursor("select 'hello' from generate_series(1, 10000)", None)
+    //             .fetch(10000)
+    //             .unwrap()
+    //     });
+    //
+    //     // here we just perform some allocations to make sure that the previous cursor gets invalidated
+    //     for _ in 0..1000 {
+    //         Spi::connect(|c| c.open_cursor("select 1", None).fetch(1).unwrap());
+    //     }
+    //
+    //     // later elements are probably more likely to point to deallocated memory
+    //     for _ in 0..1000 {
+    //         res.next();
+    //     }
+    //
+    //     // segfault
+    //     Ok(res.next().unwrap().get::<String>(1)?)
+    // }
 }

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -522,37 +522,4 @@ mod tests {
         assert_eq!(Some("hello".to_string()), value);
         Ok(())
     }
-
-    // TODO:  The point of this test is to **not** compile.  How to write a test for that?
-    // #[pg_test]
-    // fn issue1209() -> Result<Option<String>, Box<dyn Error>> {
-    //     // create the cursor we actually care about
-    //     let mut res = Spi::connect(|c| {
-    //         c.open_cursor("select 'hello' from generate_series(1, 10000)", None)
-    //             .fetch(10000)
-    //             .unwrap()
-    //     });
-    //
-    //     // here we just perform some allocations to make sure that the previous cursor gets invalidated
-    //     for _ in 0..1000 {
-    //         Spi::connect(|c| c.open_cursor("select 1", None).fetch(1).unwrap());
-    //     }
-    //
-    //     // later elements are probably more likely to point to deallocated memory
-    //     for _ in 0..1000 {
-    //         res.next();
-    //     }
-    //
-    //     // segfault
-    //     Ok(res.next().unwrap().get::<String>(1)?)
-    // }
-    //
-    // #[pg_extern]
-    // fn issue1209_prepared_stmt(q: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    //     use pgrx::spi::Query;
-    //
-    //     let prepared = { Spi::connect(|c| c.prepare(q, None))? };
-    //
-    //     Ok(Spi::connect(|c| prepared.execute(&c, Some(1), None)?.first().get(1))?)
-    // }
 }

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -549,8 +549,10 @@ mod tests {
     //
     // #[pg_extern]
     // fn issue1209_prepared_stmt(q: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    //     use pgrx::spi::Query;
+    //
     //     let prepared = { Spi::connect(|c| c.prepare(q, None))? };
     //
-    //     Ok(Spi::connect(|c| (&prepared).execute(&c, Some(1), None)?.first().get(1))?)
+    //     Ok(Spi::connect(|c| prepared.execute(&c, Some(1), None)?.first().get(1))?)
     // }
 }

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -637,7 +637,7 @@ impl<'conn> SpiClient<'conn> {
     /// Rows may be then fetched using [`SpiCursor::fetch`].
     ///
     /// See [`SpiCursor`] docs for usage details.
-    pub fn open_cursor<Q: Query<'conn>>(&'conn self, query: Q, args: Q::Arguments) -> SpiCursor {
+    pub fn open_cursor<Q: Query<'conn>>(&self, query: Q, args: Q::Arguments) -> SpiCursor<'conn> {
         query.open_cursor(&self, args)
     }
 
@@ -647,10 +647,10 @@ impl<'conn> SpiClient<'conn> {
     ///
     /// See [`SpiCursor`] docs for usage details.
     pub fn open_cursor_mut<Q: Query<'conn>>(
-        &'conn mut self,
+        &mut self,
         query: Q,
         args: Q::Arguments,
-    ) -> SpiCursor {
+    ) -> SpiCursor<'conn> {
         Spi::mark_mutable();
         query.open_cursor(self, args)
     }
@@ -662,7 +662,7 @@ impl<'conn> SpiClient<'conn> {
     /// Returned name can be used with this method to retrieve the open cursor.
     ///
     /// See [`SpiCursor`] docs for usage details.
-    pub fn find_cursor(&self, name: &str) -> Result<SpiCursor> {
+    pub fn find_cursor(&self, name: &str) -> Result<SpiCursor<'conn>> {
         use pgrx_pg_sys::AsPgCStr;
 
         let ptr = NonNull::new(unsafe { pg_sys::SPI_cursor_find(name.as_pg_cstr()) })

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -265,7 +265,7 @@ impl Drop for SpiConnection {
 
 impl SpiConnection {
     /// Return a client that with a lifetime scoped to this connection.
-    fn client<'conn>(&self) -> SpiClient<'conn> {
+    fn client(&self) -> SpiClient<'_> {
         SpiClient { __marker: PhantomData }
     }
 }

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -282,17 +282,13 @@ pub trait Query<'conn> {
     /// Execute a query given a client and other arguments
     fn execute(
         self,
-        client: &SpiClient,
+        client: &SpiClient<'conn>,
         limit: Option<libc::c_long>,
         arguments: Self::Arguments,
     ) -> Self::Result;
 
     /// Open a cursor for the query
-    fn open_cursor(
-        self,
-        client: &'conn SpiClient<'conn>,
-        args: Self::Arguments,
-    ) -> SpiCursor<'conn>;
+    fn open_cursor(self, client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn>;
 }
 
 impl<'conn> Query<'conn> for &String {
@@ -301,18 +297,14 @@ impl<'conn> Query<'conn> for &String {
 
     fn execute(
         self,
-        client: &SpiClient,
+        client: &SpiClient<'conn>,
         limit: Option<libc::c_long>,
         arguments: Self::Arguments,
     ) -> Self::Result {
         self.as_str().execute(client, limit, arguments)
     }
 
-    fn open_cursor(
-        self,
-        client: &'conn SpiClient<'conn>,
-        args: Self::Arguments,
-    ) -> SpiCursor<'conn> {
+    fn open_cursor(self, client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {
         self.as_str().open_cursor(client, args)
     }
 }
@@ -333,7 +325,7 @@ impl<'conn> Query<'conn> for &str {
     /// This function will panic if somehow the specified query contains a null byte.
     fn execute(
         self,
-        _client: &SpiClient,
+        _client: &SpiClient<'conn>,
         limit: Option<libc::c_long>,
         arguments: Self::Arguments,
     ) -> Self::Result {
@@ -377,11 +369,7 @@ impl<'conn> Query<'conn> for &str {
         Ok(SpiClient::prepare_tuple_table(status_code)?)
     }
 
-    fn open_cursor(
-        self,
-        _client: &'conn SpiClient<'conn>,
-        args: Self::Arguments,
-    ) -> SpiCursor<'conn> {
+    fn open_cursor(self, _client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {
         let src = CString::new(self).expect("query contained a null byte");
         let args = args.unwrap_or_default();
 
@@ -822,18 +810,14 @@ impl<'conn> Query<'conn> for &OwnedPreparedStatement {
 
     fn execute(
         self,
-        client: &SpiClient,
+        client: &SpiClient<'conn>,
         limit: Option<libc::c_long>,
         arguments: Self::Arguments,
     ) -> Self::Result {
         (&self.0).execute(client, limit, arguments)
     }
 
-    fn open_cursor(
-        self,
-        client: &'conn SpiClient<'conn>,
-        args: Self::Arguments,
-    ) -> SpiCursor<'conn> {
+    fn open_cursor(self, client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {
         (&self.0).open_cursor(client, args)
     }
 }
@@ -844,18 +828,14 @@ impl<'conn> Query<'conn> for OwnedPreparedStatement {
 
     fn execute(
         self,
-        client: &SpiClient,
+        client: &SpiClient<'conn>,
         limit: Option<libc::c_long>,
         arguments: Self::Arguments,
     ) -> Self::Result {
         (&self.0).execute(client, limit, arguments)
     }
 
-    fn open_cursor(
-        self,
-        client: &'conn SpiClient<'conn>,
-        args: Self::Arguments,
-    ) -> SpiCursor<'conn> {
+    fn open_cursor(self, client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {
         (&self.0).open_cursor(client, args)
     }
 }
@@ -881,7 +861,7 @@ impl<'conn: 'stmt, 'stmt> Query<'conn> for &'stmt PreparedStatement<'conn> {
 
     fn execute(
         self,
-        _client: &SpiClient,
+        _client: &SpiClient<'conn>,
         limit: Option<libc::c_long>,
         arguments: Self::Arguments,
     ) -> Self::Result {
@@ -914,11 +894,7 @@ impl<'conn: 'stmt, 'stmt> Query<'conn> for &'stmt PreparedStatement<'conn> {
         Ok(SpiClient::prepare_tuple_table(status_code)?)
     }
 
-    fn open_cursor(
-        self,
-        _client: &'conn SpiClient<'conn>,
-        args: Self::Arguments,
-    ) -> SpiCursor<'conn> {
+    fn open_cursor(self, _client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {
         let args = args.unwrap_or_default();
 
         let (mut datums, nulls): (Vec<_>, Vec<_>) = args.into_iter().map(prepare_datum).unzip();
@@ -944,18 +920,14 @@ impl<'conn> Query<'conn> for PreparedStatement<'conn> {
 
     fn execute(
         self,
-        client: &SpiClient,
+        client: &SpiClient<'conn>,
         limit: Option<libc::c_long>,
         arguments: Self::Arguments,
     ) -> Self::Result {
         (&self).execute(client, limit, arguments)
     }
 
-    fn open_cursor(
-        self,
-        client: &'conn SpiClient<'conn>,
-        args: Self::Arguments,
-    ) -> SpiCursor<'conn> {
+    fn open_cursor(self, client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {
         (&self).open_cursor(client, args)
     }
 }

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -1263,17 +1263,17 @@ impl<'conn> SpiHeapTupleData<'conn> {
     ///
     /// Returns a [`Error::DatumError`] if the desired Rust type is incompatible
     /// with the underlying Datum
-    pub fn get<T: IntoDatum + FromDatum + 'conn>(&self, ordinal: usize) -> Result<Option<T>> {
+    pub fn get<T: IntoDatum + FromDatum>(&self, ordinal: usize) -> Result<Option<T>> {
         self.get_datum_by_ordinal(ordinal).map(|entry| entry.value())?
     }
-
+T
     /// Get a typed value from this HeapTuple by its name in the resultset.
     ///
     /// # Errors
     ///
     /// Returns a [`Error::DatumError`] if the desired Rust type is incompatible
     /// with the underlying Datum
-    pub fn get_by_name<T: IntoDatum + FromDatum + 'conn, S: AsRef<str>>(
+    pub fn get_by_name<T: IntoDatum + FromDatum, S: AsRef<str>>(
         &self,
         name: S,
     ) -> Result<Option<T>> {
@@ -1385,7 +1385,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
 }
 
 impl<'conn> SpiHeapTupleDataEntry<'conn> {
-    pub fn value<T: IntoDatum + FromDatum + 'conn>(&self) -> Result<Option<T>> {
+    pub fn value<T: IntoDatum + FromDatum>(&self) -> Result<Option<T>> {
         match self.datum.as_ref() {
             Some(datum) => unsafe {
                 T::try_from_datum_in_memory_context(

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -1266,7 +1266,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     pub fn get<T: IntoDatum + FromDatum>(&self, ordinal: usize) -> Result<Option<T>> {
         self.get_datum_by_ordinal(ordinal).map(|entry| entry.value())?
     }
-T
+
     /// Get a typed value from this HeapTuple by its name in the resultset.
     ///
     /// # Errors


### PR DESCRIPTION
Cleanup lifetimes such that a `Spi::connect()` block can't return things that should be borrowed from the lifetime of that SPI connection, which includes cursors (`SpiCursor`).

This causes the test from #1209 to not compile, which is the desired result, with:

```
error[E0515]: cannot return value referencing temporary value
   --> pgrx-tests/src/tests/spi_tests.rs:516:13
    |
516 |               c.open_cursor("select 'hello' from generate_series(1, 10000)", None)
    |               ^-------------------------------------------------------------------
    |               |
    |  _____________temporary value created here
    | |
517 | |                 .fetch(10000)
518 | |                 .unwrap()
    | |_________________________^ returns a value referencing data owned by the current function
    |
    = help: use `.collect()` to allocate the iterator

error[E0515]: cannot return value referencing function parameter `c`
   --> pgrx-tests/src/tests/spi_tests.rs:516:13
    |
516 |               c.open_cursor("select 'hello' from generate_series(1, 10000)", None)
    |               ^-------------------------------------------------------------------
    |               |
    |  _____________`c` is borrowed here
    | |
517 | |                 .fetch(10000)
518 | |                 .unwrap()
    | |_________________________^ returns a value referencing data owned by the current function
    |
    = help: use `.collect()` to allocate the iterator

error[E0515]: cannot return value referencing temporary value
   --> pgrx-tests/src/tests/spi_tests.rs:523:30
    |
523 |             Spi::connect(|c| c.open_cursor("select 1", None).fetch(1).unwrap());
    |                              -------------------------------^^^^^^^^^^^^^^^^^^
    |                              |
    |                              returns a value referencing data owned by the current function
    |                              temporary value created here
    |
    = help: use `.collect()` to allocate the iterator

error[E0515]: cannot return value referencing function parameter `c`
   --> pgrx-tests/src/tests/spi_tests.rs:523:30
    |
523 |             Spi::connect(|c| c.open_cursor("select 1", None).fetch(1).unwrap());
    |                              -------------------------------^^^^^^^^^^^^^^^^^^
    |                              |
    |                              returns a value referencing data owned by the current function
    |                              `c` is borrowed here
    |
    = help: use `.collect()` to allocate the iterator
```

I am not sure how to write a test with pgrx' test suite to ensure something **doesn't** compile.  That'll be easy to do over in PL/Rust, but I feel like we should have some kind of regression test around this here.  Thoughts @thomcc or @workingjubilee?