### PR TITLE
Update version to 0.10.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -309,16 +309,16 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -347,7 +347,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_derive",
- "syn 2.0.23",
+ "syn 2.0.25",
  "tempfile",
  "tracing",
  "tracing-error",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
  "serde",
 ]
@@ -467,7 +467,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ checksum = "8560b409800a72d2d7860f8e5f4e0b0bd22bea6a352ea2a9ce30ccdef7f16d2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -900,7 +900,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.3",
+ "rustix 0.38.4",
  "windows-sys",
 ]
 
@@ -1427,7 +1427,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.3",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "atty",
  "convert_case",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1706,9 +1706,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plist"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd9647b268a3d3e14ff09c23201133a62589c658db02bb7388c7246aafe0590"
+checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
 dependencies = [
  "base64",
  "indexmap 1.9.3",
@@ -1774,23 +1774,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
 dependencies = [
  "memchr",
 ]
@@ -1907,8 +1907,8 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.2",
- "regex-syntax 0.7.3",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1922,13 +1922,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1939,9 +1939,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "ring"
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -2023,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.3"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -2183,9 +2183,9 @@ checksum = "63134939175b3131fe4d2c131b103fd42f25ccca89423d43b5e4f267920ccf03"
 
 [[package]]
 name = "serde"
-version = "1.0.167"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -2214,20 +2214,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.167"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "itoa",
  "ryu",
@@ -2431,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2525,7 +2525,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2540,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
  "serde",
@@ -2558,9 +2558,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -2657,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.12"
+version = "0.19.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+checksum = "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -2688,7 +2688,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2924,7 +2924,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -2946,7 +2946,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3075,9 +3075,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
 ]

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -33,10 +33,10 @@ semver = "1.0.17"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.16.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.0" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.1" }
 prettyplease = "0.2.10"
-proc-macro2 = { version = "1.0.63", features = [ "span-locations" ] }
+proc-macro2 = { version = "1.0.64", features = [ "span-locations" ] }
 quote = "1.0.29"
 rayon = "1.7.0"
 regex = "1.9.1"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -17,10 +17,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.0-beta.0"
+pgrx = "=0.10.0-beta.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.0-beta.0"
+pgrx-tests = "=0.10.0-beta.1"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -27,10 +27,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.0-beta.0"
+pgrx = "=0.10.0-beta.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.0-beta.0"
+pgrx-tests = "=0.10.0-beta.1"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -31,8 +31,8 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.0" }
-proc-macro2 = "1.0.63"
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.1" }
+proc-macro2 = "1.0.64"
 quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-sys"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -40,8 +40,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.10.0-beta.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.10.0-beta.0" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.10.0-beta.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.10.0-beta.1" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -49,8 +49,8 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.10.0-beta.0" }
-proc-macro2 = "1.0.63"
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.10.0-beta.1" }
+proc-macro2 = "1.0.64"
 quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"

--- a/pgrx-pg-sys/src/pg11.rs
+++ b/pgrx-pg-sys/src/pg11.rs
@@ -327,6 +327,7 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
@@ -732,9 +733,9 @@ pub const LC_IDENTIFICATION_MASK: u32 = 4096;
 pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const HAVE_PRAGMA_GCC_SYSTEM_HEADER: u32 = 1;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const USE_STDBOOL: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4] = b"%lu\0";
@@ -20553,6 +20554,7 @@ pub struct MemoryContextMethods {
             totals: *mut MemoryContextCounters,
         ),
     >,
+    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20657,6 +20659,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/pg12.rs
+++ b/pgrx-pg-sys/src/pg12.rs
@@ -335,6 +335,7 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_FLOAT4_BYVAL: u32 = 1;
 pub const USE_FLOAT8_BYVAL: u32 = 1;
@@ -740,9 +741,9 @@ pub const LC_IDENTIFICATION_MASK: u32 = 4096;
 pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const HAVE_PRAGMA_GCC_SYSTEM_HEADER: u32 = 1;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const USE_STDBOOL: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4] = b"%lu\0";
@@ -18989,6 +18990,7 @@ pub struct MemoryContextMethods {
             totals: *mut MemoryContextCounters,
         ),
     >,
+    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -19093,6 +19095,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/pg13.rs
+++ b/pgrx-pg-sys/src/pg13.rs
@@ -170,8 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS: &[u8; 73] =
-    b" '--prefix=/home/zombodb/.pgrx/13.11/pgrx-install' '--with-pgport=28813'\0";
+pub const CONFIGURE_ARGS : & [u8 ; 109] = b" '--prefix=/home/zombodb/.pgrx/13.11/pgrx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -331,6 +330,7 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_DEV_URANDOM: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
@@ -735,9 +735,9 @@ pub const LC_IDENTIFICATION_MASK: u32 = 4096;
 pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const HAVE_PRAGMA_GCC_SYSTEM_HEADER: u32 = 1;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4] = b"%lu\0";
 pub const HAVE_INT128: u32 = 1;
@@ -13381,6 +13381,10 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn AssertPendingSyncs_RelationCache();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn AtEOXact_RelationCache(isCommit: bool);
 }
 #[pgrx_macros::pg_guard]
@@ -19768,6 +19772,7 @@ pub struct MemoryContextMethods {
             totals: *mut MemoryContextCounters,
         ),
     >,
+    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -19877,6 +19882,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -23575,6 +23584,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn LockHeldByMe(locktag: *const LOCKTAG, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockMethodLocalHash() -> *mut HTAB;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/pg14.rs
+++ b/pgrx-pg-sys/src/pg14.rs
@@ -170,8 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS: &[u8; 72] =
-    b" '--prefix=/home/zombodb/.pgrx/14.8/pgrx-install' '--with-pgport=28814'\0";
+pub const CONFIGURE_ARGS : & [u8 ; 108] = b" '--prefix=/home/zombodb/.pgrx/14.8/pgrx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28814;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28814\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -339,6 +338,7 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
 pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
@@ -742,9 +742,9 @@ pub const LC_IDENTIFICATION_MASK: u32 = 4096;
 pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const HAVE_PRAGMA_GCC_SYSTEM_HEADER: u32 = 1;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4] = b"%lu\0";
 pub const HAVE_INT128: u32 = 1;
@@ -8069,6 +8069,10 @@ extern "C" {
 extern "C" {
     pub fn GetNewObjectId() -> Oid;
 }
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AssertTransactionIdInAllowableRange(xid: TransactionId);
+}
 pub type Item = Pointer;
 pub type Page = Pointer;
 pub type LocationIndex = uint16;
@@ -13702,6 +13706,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn RelationCloseSmgrByOid(relationId: Oid);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AssertPendingSyncs_RelationCache();
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -20321,6 +20329,7 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
+    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20434,6 +20443,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -30763,6 +30776,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn LockHeldByMe(locktag: *const LOCKTAG, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockMethodLocalHash() -> *mut HTAB;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/pg15.rs
+++ b/pgrx-pg-sys/src/pg15.rs
@@ -170,8 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS: &[u8; 72] =
-    b" '--prefix=/home/zombodb/.pgrx/15.3/pgrx-install' '--with-pgport=28815'\0";
+pub const CONFIGURE_ARGS : & [u8 ; 108] = b" '--prefix=/home/zombodb/.pgrx/15.3/pgrx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert'\0" ;
 pub const DEF_PGPORT: u32 = 28815;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28815\0";
 pub const DLSUFFIX: &[u8; 4] = b".so\0";
@@ -342,6 +341,7 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
+pub const USE_ASSERT_CHECKING: u32 = 1;
 pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
 pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
@@ -746,9 +746,9 @@ pub const LC_IDENTIFICATION_MASK: u32 = 4096;
 pub const LC_ALL_MASK: u32 = 8127;
 pub const HAVE_PG_ATTRIBUTE_NORETURN: u32 = 1;
 pub const HAVE_PRAGMA_GCC_SYSTEM_HEADER: u32 = 1;
+pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
 pub const false_: u32 = 0;
-pub const __bool_true_false_are_defined: u32 = 1;
 pub const INT64_FORMAT: &[u8; 4] = b"%ld\0";
 pub const UINT64_FORMAT: &[u8; 4] = b"%lu\0";
 pub const HAVE_INT128: u32 = 1;
@@ -7630,6 +7630,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn StopGeneratingPinnedObjectIds();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn AssertTransactionIdInAllowableRange(xid: TransactionId);
 }
 pub type Item = Pointer;
 pub type Page = Pointer;
@@ -17180,6 +17184,10 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn AssertPendingSyncs_RelationCache();
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn AtEOXact_RelationCache(isCommit: bool);
 }
 #[pgrx_macros::pg_guard]
@@ -20211,6 +20219,7 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
+    pub check: ::std::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20324,6 +20333,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn MemoryContextCheck(context: MemoryContext);
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -30897,6 +30910,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn LockHeldByMe(locktag: *const LOCKTAG, lockmode: LOCKMODE) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn GetLockMethodLocalHash() -> *mut HTAB;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"
@@ -28,7 +28,7 @@ no-schema-generation = []
 convert_case = "0.6.0"
 eyre = "0.6.8"
 petgraph = "0.6.3"
-proc-macro2 = { version = "1.0.63", features = [ "span-locations" ] }
+proc-macro2 = { version = "1.0.64", features = [ "span-locations" ] }
 quote = "1.0.29"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-tests"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -48,8 +48,8 @@ clap-cargo = "0.10.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.147"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.0" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.0" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.1" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.1" }
 postgres = "0.19.5"
 regex = "1.9.1"
 serde = "1.0"
@@ -65,4 +65,4 @@ eyre = "0.6.8"  # testing functions that return `eyre::Result`
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.10.0-beta.0"
+version = "=0.10.0-beta.1"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -19,5 +19,5 @@ description = "Standalone tool to update PGRX Cargo.toml versions and dependenci
 [dependencies]
 clap = { version = "4.3.11", features = [ "env", "derive" ] }
 owo-colors = "3.5.0"
-toml_edit = { version = "0.19.12" }
+toml_edit = { version = "0.19.13" }
 walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx"
-version = "0.10.0-beta.0"
+version = "0.10.0-beta.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -44,9 +44,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.0" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.10.0-beta.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.0" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.1" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.10.0-beta.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.1" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
Welcome to pgrx v0.10.0-beta.1.  The second in our series to add Postgres 16 support.

This release contains a few bugfixes around arrays of certain types and compile-time Spi API soundness.  It also improves the output of `cargo pgrx test` test failures.

To evaluate this release please run `cargo install cargo-pgrx --version 0.10.0-beta.1 --locked && cargo pgrx init`.  And make sure to update your extension crate dependencies as well, adding a corresponding `pg16` line to the `[features]` block.

## What's Changed

* Testing help by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1203
* Type testability cleanup by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1204
* Try to smartly propagate fs errors by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1186
* Type roundtrip tests by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1185
* Spi API Lifetime Correctness by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1210


**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.10.0-beta.0...v0.10.0-beta.1