### PR TITLE
Remove `SpiConnection`

### DIFF
--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -26,7 +26,7 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
     if arg > 0 {
         BackgroundWorker::transaction(|| {
             Spi::run("CREATE TABLE tests.bgworker_test (v INTEGER);")?;
-            Spi::connect(|mut client| {
+            Spi::connect(|client| {
                 client
                     .update(
                         "INSERT INTO tests.bgworker_test VALUES ($1);",
@@ -74,7 +74,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
     };
     while BackgroundWorker::wait_latch(Some(Duration::from_millis(100))) {}
     BackgroundWorker::transaction(|| {
-        Spi::connect(|mut c| {
+        Spi::connect(|c| {
             c.update(
                 "INSERT INTO tests.bgworker_test_return VALUES ($1)",
                 None,

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -180,7 +180,7 @@ mod tests {
 
     #[pg_test]
     fn test_inserting_null() -> Result<(), pgrx::spi::Error> {
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             client.update("CREATE TABLE tests.null_test (id uuid)", None, None).map(|_| ())
         })?;
         assert_eq!(
@@ -203,7 +203,7 @@ mod tests {
 
     #[pg_test]
     fn test_cursor() -> Result<(), spi::Error> {
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
@@ -223,7 +223,7 @@ mod tests {
 
     #[pg_test]
     fn test_cursor_prepared_statement() -> Result<(), pgrx::spi::Error> {
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
@@ -244,7 +244,7 @@ mod tests {
 
     #[pg_test]
     fn test_cursor_by_name() -> Result<(), pgrx::spi::Error> {
-        let cursor_name = Spi::connect(|mut client| {
+        let cursor_name = Spi::connect(|client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
@@ -298,7 +298,7 @@ mod tests {
             Ok::<_, spi::Error>(())
         })?;
 
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             let res = client.update("SET TIME ZONE 'PST8PDT'", None, None)?;
 
             assert_eq!(Err(spi::Error::NoTupleTable), res.columns());
@@ -315,7 +315,7 @@ mod tests {
     #[pg_test]
     fn test_spi_non_mut() -> Result<(), pgrx::spi::Error> {
         // Ensures update and cursor APIs do not need mutable reference to SpiClient
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             client.update("SELECT 1", None, None).expect("SPI failed");
             let cursor = client.open_cursor("SELECT 1", None).detach_into_name();
             client.find_cursor(&cursor).map(|_| ())
@@ -410,7 +410,7 @@ mod tests {
 
     #[pg_test]
     fn test_readwrite_in_select_readwrite() -> Result<(), spi::Error> {
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             // This is supposed to switch connection to read-write and run it there
             client.update("CREATE TABLE a (id INT)", None, None)?;
             // This is supposed to run in read-write
@@ -421,7 +421,7 @@ mod tests {
 
     #[pg_test]
     fn test_spi_select_sees_update() -> spi::Result<()> {
-        let with_select = Spi::connect(|mut client| {
+        let with_select = Spi::connect(|client| {
             client.update("CREATE TABLE asd(id int)", None, None)?;
             client.update("INSERT INTO asd(id) VALUES (1)", None, None)?;
             client.select("SELECT COUNT(*) FROM asd", None, None)?.first().get_one::<i64>()
@@ -447,7 +447,7 @@ mod tests {
 
     #[pg_test]
     fn test_spi_select_sees_update_in_other_session() -> spi::Result<()> {
-        Spi::connect::<spi::Result<()>, _>(|mut client| {
+        Spi::connect::<spi::Result<()>, _>(|client| {
             client.update("CREATE TABLE asd(id int)", None, None)?;
             client.update("INSERT INTO asd(id) VALUES (1)", None, None)?;
             Ok(())

--- a/pgrx-tests/src/tests/srf_tests.rs
+++ b/pgrx-tests/src/tests/srf_tests.rs
@@ -255,7 +255,7 @@ mod tests {
 
     #[pg_test]
     fn test_srf_setof_datum_detoasting_with_borrow() {
-        let cnt = Spi::connect(|mut client| {
+        let cnt = Spi::connect(|client| {
             // build up a table with one large column that Postgres will be forced to TOAST
             client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None)?;
 
@@ -273,7 +273,7 @@ mod tests {
 
     #[pg_test]
     fn test_srf_table_datum_detoasting_with_borrow() {
-        let cnt = Spi::connect(|mut client| {
+        let cnt = Spi::connect(|client| {
             // build up a table with one large column that Postgres will be forced to TOAST
             client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000000)) x;", None, None)?;
 

--- a/pgrx-tests/src/tests/struct_type_tests.rs
+++ b/pgrx-tests/src/tests/struct_type_tests.rs
@@ -143,7 +143,7 @@ mod tests {
 
     #[pg_test]
     fn test_complex_storage_and_retrieval() -> Result<(), pgrx::spi::Error> {
-        let complex = Spi::connect(|mut client| {
+        let complex = Spi::connect(|client| {
             client.update(
                 "CREATE TABLE complex_test AS SELECT s as id, (s || '.0, 2.0' || s)::complex as value FROM generate_series(1, 1000) s;\
                 SELECT value FROM complex_test ORDER BY id;", None, None)?.first().get_one::<PgBox<Complex>>()

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -240,13 +240,13 @@ impl Spi {
     }
 
     pub fn get_one<A: FromDatum + IntoDatum>(query: &str) -> Result<Option<A>> {
-        Spi::connect(|mut client| client.update(query, Some(1), None)?.first().get_one())
+        Spi::connect(|client| client.update(query, Some(1), None)?.first().get_one())
     }
 
     pub fn get_two<A: FromDatum + IntoDatum, B: FromDatum + IntoDatum>(
         query: &str,
     ) -> Result<(Option<A>, Option<B>)> {
-        Spi::connect(|mut client| client.update(query, Some(1), None)?.first().get_two::<A, B>())
+        Spi::connect(|client| client.update(query, Some(1), None)?.first().get_two::<A, B>())
     }
 
     pub fn get_three<
@@ -256,25 +256,21 @@ impl Spi {
     >(
         query: &str,
     ) -> Result<(Option<A>, Option<B>, Option<C>)> {
-        Spi::connect(|mut client| {
-            client.update(query, Some(1), None)?.first().get_three::<A, B, C>()
-        })
+        Spi::connect(|client| client.update(query, Some(1), None)?.first().get_three::<A, B, C>())
     }
 
     pub fn get_one_with_args<A: FromDatum + IntoDatum>(
         query: &str,
         args: Vec<(PgOid, Option<pg_sys::Datum>)>,
     ) -> Result<Option<A>> {
-        Spi::connect(|mut client| client.update(query, Some(1), Some(args))?.first().get_one())
+        Spi::connect(|client| client.update(query, Some(1), Some(args))?.first().get_one())
     }
 
     pub fn get_two_with_args<A: FromDatum + IntoDatum, B: FromDatum + IntoDatum>(
         query: &str,
         args: Vec<(PgOid, Option<pg_sys::Datum>)>,
     ) -> Result<(Option<A>, Option<B>)> {
-        Spi::connect(|mut client| {
-            client.update(query, Some(1), Some(args))?.first().get_two::<A, B>()
-        })
+        Spi::connect(|client| client.update(query, Some(1), Some(args))?.first().get_two::<A, B>())
     }
 
     pub fn get_three_with_args<
@@ -285,7 +281,7 @@ impl Spi {
         query: &str,
         args: Vec<(PgOid, Option<pg_sys::Datum>)>,
     ) -> Result<(Option<A>, Option<B>, Option<C>)> {
-        Spi::connect(|mut client| {
+        Spi::connect(|client| {
             client.update(query, Some(1), Some(args))?.first().get_three::<A, B, C>()
         })
     }
@@ -308,7 +304,7 @@ impl Spi {
         query: &str,
         args: Option<Vec<(PgOid, Option<pg_sys::Datum>)>>,
     ) -> std::result::Result<(), Error> {
-        Spi::connect(|mut client| client.update(query, None, args).map(|_| ()))
+        Spi::connect(|client| client.update(query, None, args).map(|_| ()))
     }
 
     /// explain a query, returning its result in json form
@@ -321,7 +317,7 @@ impl Spi {
         query: &str,
         args: Option<Vec<(PgOid, Option<pg_sys::Datum>)>>,
     ) -> Result<Json> {
-        Ok(Spi::connect(|mut client| {
+        Ok(Spi::connect(|client| {
             client
                 .update(&format!("EXPLAIN (format json) {}", query), None, args)?
                 .first()

--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -5,7 +5,12 @@ use std::ptr::NonNull;
 use crate::pg_sys::{self, PgOid};
 use crate::spi::{PreparedStatement, Query, Spi, SpiCursor, SpiError, SpiResult, SpiTupleTable};
 
-pub struct SpiClient;
+pub struct SpiClient {
+    // We need `SpiClient` to be publicly accessible but not constructable because we rely
+    // on it being properly constructed in order for its Drop impl, which calles `pg_sys::SPI_finish()`,
+    // to work as expected
+    _priv_constructor: (),
+}
 
 impl SpiClient {
     /// Connect to Postgres' SPI system
@@ -16,7 +21,7 @@ impl SpiClient {
         // assume it could.  The truth seems to be that it never actually does.  The one user
         // of SpiConnection::connect() returns `spi::Result` anyways, so it's no big deal
         Spi::check_status(unsafe { pg_sys::SPI_connect() })?;
-        Ok(SpiClient)
+        Ok(SpiClient { _priv_constructor: () })
     }
 
     /// Prepares a statement that is valid for the lifetime of the client

--- a/pgrx/src/spi/cursor.rs
+++ b/pgrx/src/spi/cursor.rs
@@ -1,5 +1,4 @@
 use std::ffi::CStr;
-use std::marker::PhantomData;
 use std::ptr::NonNull;
 
 use crate::pg_sys;
@@ -65,7 +64,7 @@ type CursorName = String;
 /// ```
 pub struct SpiCursor<'client> {
     pub(crate) ptr: NonNull<pg_sys::PortalData>,
-    pub(crate) __marker: PhantomData<&'client SpiClient<'client>>,
+    pub(crate) client: &'client SpiClient,
 }
 
 impl SpiCursor<'_> {
@@ -79,7 +78,7 @@ impl SpiCursor<'_> {
         }
         // SAFETY: SPI functions to create/find cursors fail via elog, so self.ptr is valid if we successfully set it
         unsafe { pg_sys::SPI_cursor_fetch(self.ptr.as_mut(), true, count) }
-        Ok(SpiClient::prepare_tuple_table(SpiOkCodes::Fetch as i32)?)
+        Ok(self.client.prepare_tuple_table(SpiOkCodes::Fetch as i32)?)
     }
 
     /// Consume the cursor, returning its name

--- a/pgrx/src/spi/cursor.rs
+++ b/pgrx/src/spi/cursor.rs
@@ -31,7 +31,7 @@ type CursorName = String;
 /// ```rust,no_run
 /// use pgrx::prelude::*;
 /// # fn foo() -> spi::Result<()> {
-/// Spi::connect(|mut client| {
+/// Spi::connect(|client| {
 ///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);
 ///     assert_eq!(Some(1u32), cursor.fetch(1)?.get_one::<u32>()?);
 ///     assert_eq!(Some(2u32), cursor.fetch(2)?.get_one::<u32>()?);
@@ -46,13 +46,13 @@ type CursorName = String;
 /// ```rust,no_run
 /// use pgrx::prelude::*;
 /// # fn foo() -> spi::Result<()> {
-/// let cursor_name = Spi::connect(|mut client| {
+/// let cursor_name = Spi::connect(|client| {
 ///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);
 ///     assert_eq!(Ok(Some(1u32)), cursor.fetch(1)?.get_one::<u32>());
 ///     Ok::<_, spi::Error>(cursor.detach_into_name()) // <-- cursor gets dropped here
 ///     // <--- first SpiTupleTable gets freed by Spi::connect at this point
 /// })?;
-/// Spi::connect(|mut client| {
+/// Spi::connect(|client| {
 ///     let mut cursor = client.find_cursor(&cursor_name)?;
 ///     assert_eq!(Ok(Some(2u32)), cursor.fetch(1)?.get_one::<u32>());
 ///     drop(cursor); // <-- cursor gets dropped here


### PR DESCRIPTION
This removes the `SpiConnection` struct and cleans up how `SpiClient` is used.

Also, the various `'conn` lifetimes have been renamed to `'client`.

I think there's more magic that can happen as a follow-up to this.