### PR TITLE
Ignores UI tests for MUSL environments

### DIFF
--- a/.github/docker/Dockerfile.alpine:3.18
+++ b/.github/docker/Dockerfile.alpine:3.18
@@ -1,5 +1,5 @@
 # Example of how to build this container (ran from pgrx checkout directory):
-#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.16 -t pgrx-alpine .
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.18 -t pgrx-alpine .
 #
 # Example of how to run this container with tests after building the image:
 #   docker run pgrx-alpine cargo test --no-default-features --features pg14 --locked
@@ -9,25 +9,26 @@
 
 ARG PG_MAJOR_VER
 # Use Postgres' official alpine version, it's just easier that way
-FROM postgres:${PG_MAJOR_VER}-alpine3.16
+FROM postgres:${PG_MAJOR_VER}-alpine3.18
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
 # Required for compiling Rust
 ENV RUSTFLAGS="-C target-feature=-crt-static"
 
 RUN apk add --no-cache \
-  git \
-  curl \
   bash \
-  musl-dev \
-  make \
-  gcc \
+  clang \
+  clang-dev \
+  clang-libs \
   coreutils \
-  util-linux-dev \
+  curl \
+  gcc \
+  git \
+  make \
   musl-dev \
   openssl-dev \
-  clang-libs \
-  tar
+  tar \
+  util-linux-dev
 
 # Set up permissions so that the rust user below can create extensions
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -1,19 +1,9 @@
 name: Will It Blend™
 
-# on:
-#   schedule:
-#     - cron: '0 7 * * *'
-#   workflow_dispatch:
-
 on:
-  push:
-    branches:
-      - master
-      - develop
-  pull_request:
-    branches:
-      - master
-      - develop
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -1,9 +1,19 @@
 name: Will It Blend™
 
+# on:
+#   schedule:
+#     - cron: '0 7 * * *'
+#   workflow_dispatch:
+
 on:
-  schedule:
-    - cron: '0 7 * * *'
-  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 env:
   # NB: Don't modify `RUSTFLAGS` here, since it would override the ones
@@ -20,7 +30,7 @@ jobs:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:
         pg_version: ["pg11", "pg12", "pg13", "pg14", "pg15"]
-        container: ["fedora:36", "debian:bullseye", "alpine:3.16", "amazon:2"]
+        container: ["fedora:36", "debian:bullseye", "alpine:3.18", "amazon:2"]
     steps:
       # If this workflow is being called from a schedule/cron job, then let's
       # force the "develop" branch. Otherwise, use whatever is passed in via

--- a/pgrx-tests/tests/ui.rs
+++ b/pgrx-tests/tests/ui.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_env = "musl"))]
+
 use trybuild::TestCases;
 
 #[test]


### PR DESCRIPTION
The new UI tests introduced in `develop` seem to be incompatible with musl environments such as Alpine. The current working theory is that there could be a bug in `TryBuild` that ignores/replaces certain rustc flags. In particular, it seems to be disregarding the `"-Ctarget-feature=-crt-static"` flags that are necessary for pgrx to build and be used in Alpine.

Also includes a couple minor updates, such as bumping the postgresql-alpine Docker version.