### PR TITLE
Fix issue #1076: Properly handle dependency graph of `Result<T, _>`

### DIFF
--- a/pgrx-tests/src/tests/result_tests.rs
+++ b/pgrx-tests/src/tests/result_tests.rs
@@ -7,6 +7,25 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+use pgrx::prelude::*;
+use serde::*;
+
+//
+// the ResultTestsA type and the corresponding function test issue #1076.  Should that regress
+// it's likely that `CREATE EXTENSION` will fail with:
+//
+//   ERROR SQLSTATE[42710]: type "resulttestsa" already exists
+//
+
+#[derive(Debug, Serialize, Deserialize, PostgresType)]
+pub struct ResultTestsA;
+
+#[pg_extern]
+fn result_tests_a_func() -> Result<ResultTestsA, spi::Error> {
+    Ok(ResultTestsA)
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {


### PR DESCRIPTION
When a `#[pg_extern]` function returns `Result<T, E>`, the entity graph was using the "type_id" of that whole type instead of just `T`, which is what would be in the graph.

This detects that type from the first argument of the return type and uses it in the code generation.

This closes issue #1076.