### PR TITLE
Only enable line tables for profile.dev

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -431,8 +431,11 @@ jobs:
         # ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
         echo ""
 
-        echo "----- Output Cargo version -----"
-        cargo --version
+        echo "----- Stable Rust ----"
+        rustup update stable
+        rustup default stable
+        rustc -vV
+        cargo -vV
         echo ""
 
         echo "----- Outputting env -----"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,17 @@ members = [
     "pgrx-examples/spi_srf",
 ]
 
+[profile.dev]
+# Only include line tables in debuginfo. This reduces the size of target/ (after
+# running tests) by almost half, while keeping the part of debuginfo which
+# people care about the most (the part used to produce backtraces). This seems
+# like something we would generally want (when actually running in a debugger
+# you can just comment out the line).
+#
+# That said, if it turns out to hurt development more than expected, we could
+# move this to only toggle this in CI
+debug = 'line-tables-only'
+
 [profile.dev.build-override]
 opt-level = 3
 


### PR DESCRIPTION
This reduces the size of target after running tests from ~8GB to ~5GB, and makes them complete a good amount faster (generating debug info is slow). It only really makes a difference if you're going to use a debugger, in which case perhaps you should just turn that flag off.

The size and speed saving make me think it should be done generally, rather than only for CI.