### PR TITLE
Correct docs for datetime `From` impls

### DIFF
--- a/pgrx/src/datum/date.rs
+++ b/pgrx/src/datum/date.rs
@@ -28,10 +28,16 @@ pub const UNIX_EPOCH_JDATE: i32 = pg_sys::UNIX_EPOCH_JDATE as i32;
 #[repr(transparent)]
 pub struct Date(pg_sys::DateADT);
 
-/// Blindly create a [`Date]` from a Postgres [`pg_sys::DateADT`] value.
+/// Create a [`Date`] from a [`pg_sys::DateADT`]
 ///
-/// Note that [`pg_sys::DateADT`] is just an `i32`, so using a random i32 could construct a date value
-/// that ultimately Postgres doesn't understand
+/// Note that [`pg_sys::DateADT`] is an `i32` as a day offset from the "Postgres epoch".
+/// This impl currently allows producing a `Date` that cannot be made via SQL,
+/// such as a date before "Julian day zero".
+///
+/// The details of the encoding may also prove surprising, for instance:
+/// - It is not a Gregorian calendar date, but rather a Julian day
+/// - There is no "year zero", so Postgres defines the offset of -2000 years as 1 BC instead
+/// - Some values such as `i32::MIN` and `i32::MAX` have special meanings as infinities
 impl From<pg_sys::DateADT> for Date {
     #[inline]
     fn from(value: pg_sys::DateADT) -> Self {

--- a/pgrx/src/datum/date.rs
+++ b/pgrx/src/datum/date.rs
@@ -227,7 +227,7 @@ impl Date {
     }
 
     pub fn is_finite(&self) -> bool {
-        unsafe { direct_function_call(pg_sys::date_finite, &[self.into_datum()]).unwrap() }
+        !matches!(self.0, pg_sys::DateADT::MIN | pg_sys::DateADT::MAX)
     }
 
     /// Return the backing [`pg_sy::DateADT`] value.

--- a/pgrx/src/datum/interval.rs
+++ b/pgrx/src/datum/interval.rs
@@ -172,8 +172,11 @@ impl Interval {
         self.0.month < 0 || self.0.day < 0 || self.0.time < 0
     }
 
+    /// Postgres defines intervals as bounded
+    #[deprecated(since = "0.10.0", note = "consider using `true`")]
     pub fn is_finite(&self) -> bool {
-        unsafe { direct_function_call(pg_sys::interval_finite, &[self.into_datum()]).unwrap() }
+        // Yes, really.
+        true
     }
 
     /// Truncate [`Interval`] to specified units

--- a/pgrx/src/datum/time.rs
+++ b/pgrx/src/datum/time.rs
@@ -24,10 +24,11 @@ use std::num::TryFromIntError;
 #[repr(transparent)]
 pub struct Time(pg_sys::TimeADT);
 
-/// Blindly create a [`Time]` from a Postgres [`pg_sys::TimeADT`] value.
+/// Create a [`Time`] from a [`pg_sys::TimeADT`]
 ///
-/// Note that [`pg_sys::TimeADT`] is just an `i64`, so using a random i64 could construct a time value
-/// that ultimately Postgres doesn't understand
+/// Note that [`pg_sys::TimeADT`] is just an `i64` as a number of microseconds.
+/// This impl currently allows creating a `Time` that cannot be constructed by SQL,
+/// such as at the time 37:42, which may yield logic bugs if used.
 impl From<pg_sys::TimeADT> for Time {
     #[inline]
     fn from(value: pg_sys::TimeADT) -> Self {

--- a/pgrx/src/datum/time.rs
+++ b/pgrx/src/datum/time.rs
@@ -20,9 +20,6 @@ use pgrx_sql_entity_graph::metadata::{
 use std::num::TryFromIntError;
 
 /// A safe wrapper around Postgres `TIME` type, backed by a [`pg_sys::TimeADT`] integer value.
-///
-/// That value is `pub` so that users can directly use it to provide interfaces into other date/time
-/// crates.
 #[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
 pub struct Time(pg_sys::TimeADT);

--- a/pgrx/src/datum/time_stamp.rs
+++ b/pgrx/src/datum/time_stamp.rs
@@ -258,7 +258,7 @@ impl Timestamp {
     }
 
     pub fn is_finite(&self) -> bool {
-        unsafe { direct_function_call(pg_sys::timestamp_finite, &[self.into_datum()]).unwrap() }
+        !matches!(self.0, pg_sys::Timestamp::MIN | pg_sys::Timestamp::MAX)
     }
 
     /// Truncate [`Timestamp`] to specified units

--- a/pgrx/src/datum/time_stamp.rs
+++ b/pgrx/src/datum/time_stamp.rs
@@ -19,9 +19,6 @@ use pgrx_sql_entity_graph::metadata::{
 use std::num::TryFromIntError;
 
 /// A safe wrapper around Postgres `TIMESTAMP WITHOUT TIME ZONE` type, backed by a [`pg_sys::Timestamp`] integer value.
-///
-/// That value is `pub` so that users can directly use it to provide interfaces into other date/time
-/// crates.
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 pub struct Timestamp(pg_sys::Timestamp);

--- a/pgrx/src/datum/time_stamp.rs
+++ b/pgrx/src/datum/time_stamp.rs
@@ -59,10 +59,19 @@ impl From<Timestamp> for pg_sys::Timestamp {
     }
 }
 
-/// Blindly create a [`Timestamp]` from a Postgres [`pg_sys::Timestamp`] value.
+/// Create a [`Timestamp`] from a [`pg_sys::Timestamp`]
 ///
-/// Note that [`pg_sys::Timestamp`] is just an `i64`, so using a random i64 could construct a time value
-/// that ultimately Postgres doesn't understand
+/// Note that `pg_sys::Timestamp` is an `i64` as a microsecond offset from the "Postgres epoch".
+/// This impl currently allows producing a `Timestamp` that cannot be constructed by SQL,
+/// such as a timestamp before "Julian day zero".
+///
+/// The details of the encoding may also prove surprising, for instance:
+/// - Postgres uses Julian days to reason about time instead of the Gregorian calendar
+/// - There is no "year zero", so Postgres defines the offset of -2000 years as 1 BC instead
+/// - Some values such as `i64::MIN` and `i64::MAX` have special meanings as infinities
+/// - The way `Timestamp` translates to/from `TimestampWithTimeZone`, or rather doesn't, is "fun"
+/// - In the past `pg_sys::Timestamp`'s type has changed, so in the future this may change with it
+/// - This is likely to coincide with a change in Timestamp's precision
 impl From<pg_sys::Timestamp> for Timestamp {
     fn from(value: pgrx_pg_sys::Timestamp) -> Self {
         Timestamp(value)

--- a/pgrx/src/datum/time_stamp_with_timezone.rs
+++ b/pgrx/src/datum/time_stamp_with_timezone.rs
@@ -24,9 +24,6 @@ const MIN_TIMESTAMP_USEC: i64 = -211_813_488_000_000_000;
 const END_TIMESTAMP_USEC: i64 = 9_223_371_331_200_000_000 - 1; // dec by 1 to accommodate exclusive range match pattern
 
 /// A safe wrapper around Postgres `TIMESTAMP WITH TIME ZONE` type, backed by a [`pg_sys::Timestamp`] integer value.
-///
-/// That value is `pub` so that users can directly use it to provide interfaces into other date/time
-/// crates.
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 pub struct TimestampWithTimeZone(pg_sys::TimestampTz);

--- a/pgrx/src/datum/time_stamp_with_timezone.rs
+++ b/pgrx/src/datum/time_stamp_with_timezone.rs
@@ -353,8 +353,7 @@ impl TimestampWithTimeZone {
     }
 
     pub fn is_finite(&self) -> bool {
-        // yes, this is the correct function, despite the seemingly mismatched type name
-        unsafe { direct_function_call(pg_sys::timestamp_finite, &[self.into_datum()]).unwrap() }
+        !matches!(self.0, pg_sys::TimestampTz::MIN | pg_sys::TimestampTz::MAX)
     }
 
     /// Truncate [`TimestampWithTimeZone`] to specified units

--- a/pgrx/src/datum/time_with_timezone.rs
+++ b/pgrx/src/datum/time_with_timezone.rs
@@ -25,10 +25,10 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 #[repr(transparent)]
 pub struct TimeWithTimeZone(pg_sys::TimeTzADT);
 
-/// Blindly create a [`TimeWithTimeZone]` from a Postgres [`pg_sys::TimeTzADT`] value.
+/// Create a [`TimeWithTimeZone`] from a [`pg_sys::TimeTzADT`]
 ///
-/// Note that the [`pg_sys::TimeTzADT`] is not validated here, so using a random i64 could construct a time value
-/// that ultimately Postgres doesn't understand
+/// This impl currently allows creating a `TimeWithTimeZone` that cannot be constructed by SQL,
+/// such as at the time 37:42 in the timezone UTC+25:00, which may yield logic bugs if used.
 impl From<pg_sys::TimeTzADT> for TimeWithTimeZone {
     #[inline]
     fn from(value: pg_sys::TimeTzADT) -> Self {

--- a/pgrx/src/datum/time_with_timezone.rs
+++ b/pgrx/src/datum/time_with_timezone.rs
@@ -21,9 +21,6 @@ use pgrx_sql_entity_graph::metadata::{
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 /// A safe wrapper around Postgres `TIME WITH TIME ZONE` type, backed by a [`pg_sys::TimeTzADT`] integer value.
-///
-/// That value is `pub` so that users can directly use it to provide interfaces into other date/time
-/// crates.
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]
 pub struct TimeWithTimeZone(pg_sys::TimeTzADT);


### PR DESCRIPTION
These impls needed much closer attention in many cases. Rather than being nebulously ominous, we can just tell people what the problems are.

We can also stop calling Postgres just to obtain a `true` value.