### PR TITLE
Demand Ord for PostgresOrd

### DIFF
--- a/pgrx-macros/src/operators.rs
+++ b/pgrx-macros/src/operators.rs
@@ -208,7 +208,7 @@ pub fn derive_pg_cmp(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macr
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
         fn #pg_name(left: #path, right: #path) -> i32 {
-            left.cmp(&right) as i32
+            ::core::cmp::Ord::cmp(&left, &right) as i32
         }
     }
 }

--- a/pgrx-tests/tests/ui/total_eq_for_postgres_eq.rs
+++ b/pgrx-tests/tests/ui/total_eq_for_postgres_eq.rs
@@ -1,7 +1,8 @@
 use pgrx::prelude::*;
+use serde::{Serialize, Deserialize};
 
-#[derive(PartialEq, PostgresEq)]
-struct BrokenType {
+#[derive(Serialize, Deserialize, PartialEq, PostgresType, PostgresEq)]
+pub struct BrokenType {
     int: i32,
 }
 

--- a/pgrx-tests/tests/ui/total_eq_for_postgres_eq.stderr
+++ b/pgrx-tests/tests/ui/total_eq_for_postgres_eq.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `BrokenType: std::cmp::Eq` is not satisfied
- --> tests/ui/total_eq_for_postgres_eq.rs:4:8
+ --> tests/ui/total_eq_for_postgres_eq.rs:5:12
   |
-4 | struct BrokenType {
-  |        ^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `BrokenType`
+5 | pub struct BrokenType {
+  |            ^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `BrokenType`
   |
 note: required by a bound in `PostgresEqRequiresTotalEq`
  --> $WORKSPACE/pgrx/src/deriving.rs
@@ -11,6 +11,6 @@ note: required by a bound in `PostgresEqRequiresTotalEq`
   |                                      ^^ required by this bound in `PostgresEqRequiresTotalEq`
 help: consider annotating `BrokenType` with `#[derive(Eq)]`
   |
-4 + #[derive(Eq)]
-5 | struct BrokenType {
+5 + #[derive(Eq)]
+6 | pub struct BrokenType {
   |

--- a/pgrx-tests/tests/ui/total_ord_for_postgres_ord.rs
+++ b/pgrx-tests/tests/ui/total_ord_for_postgres_ord.rs
@@ -1,0 +1,45 @@
+use core::cmp::Ordering;
+use pgrx::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, PartialOrd, PostgresType, PostgresOrd)]
+pub struct BrokenType {
+    int: i32,
+}
+
+impl Iterator for BrokenType {
+    type Item = i32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+
+    // Previously, this fn could win over Ord::cmp in trait resolution
+    fn cmp<I>(self, _rhs: I) -> Ordering
+    where
+        I: IntoIterator<Item = Self::Item>,
+    {
+        todo!()
+    }
+}
+
+impl IntoIterator for &BrokenType {
+    type Item = i32;
+    type IntoIter = BrokenIter;
+
+    fn into_iter(self) -> BrokenIter {
+        todo!()
+    }
+}
+
+pub struct BrokenIter {}
+
+impl Iterator for BrokenIter {
+    type Item = i32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/pgrx-tests/tests/ui/total_ord_for_postgres_ord.rs
+++ b/pgrx-tests/tests/ui/total_ord_for_postgres_ord.rs
@@ -1,45 +1,20 @@
-use core::cmp::Ordering;
 use pgrx::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, Deserialize};
 
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, PartialOrd, PostgresType, PostgresOrd)]
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, PostgresType, PostgresOrd)]
 pub struct BrokenType {
     int: i32,
 }
 
-impl Iterator for BrokenType {
-    type Item = i32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        todo!()
-    }
-
-    // Previously, this fn could win over Ord::cmp in trait resolution
-    fn cmp<I>(self, _rhs: I) -> Ordering
-    where
-        I: IntoIterator<Item = Self::Item>,
-    {
-        todo!()
+impl BrokenType {
+    fn cmp(&mut self, _other: &Self) -> Anything {
+        Anything::Whatever
     }
 }
 
-impl IntoIterator for &BrokenType {
-    type Item = i32;
-    type IntoIter = BrokenIter;
-
-    fn into_iter(self) -> BrokenIter {
-        todo!()
-    }
-}
-
-pub struct BrokenIter {}
-
-impl Iterator for BrokenIter {
-    type Item = i32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        todo!()
-    }
+#[repr(u8)]
+enum Anything {
+    Whatever = 0,
 }
 
 fn main() {}

--- a/pgrx-tests/tests/ui/total_ord_for_postgres_ord.stderr
+++ b/pgrx-tests/tests/ui/total_ord_for_postgres_ord.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `BrokenType: std::cmp::Ord` is not satisfied
+ --> tests/ui/total_ord_for_postgres_ord.rs:5:84
+  |
+5 | #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, PartialOrd, PostgresType, PostgresOrd)]
+  |                                                                                    ^^^^^^^^^^^ the trait `std::cmp::Ord` is not implemented for `BrokenType`
+  |
+  = note: this error originates in the derive macro `PostgresOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `BrokenType` with `#[derive(Ord)]`
+  |
+6 + #[derive(Ord)]
+7 | pub struct BrokenType {
+  |

--- a/pgrx-tests/tests/ui/total_ord_for_postgres_ord.stderr
+++ b/pgrx-tests/tests/ui/total_ord_for_postgres_ord.stderr
@@ -1,12 +1,12 @@
 error[E0277]: the trait bound `BrokenType: std::cmp::Ord` is not satisfied
- --> tests/ui/total_ord_for_postgres_ord.rs:5:84
+ --> tests/ui/total_ord_for_postgres_ord.rs:4:71
   |
-5 | #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, PartialOrd, PostgresType, PostgresOrd)]
-  |                                                                                    ^^^^^^^^^^^ the trait `std::cmp::Ord` is not implemented for `BrokenType`
+4 | #[derive(Serialize, Deserialize, PartialEq, PartialOrd, PostgresType, PostgresOrd)]
+  |                                                                       ^^^^^^^^^^^ the trait `std::cmp::Ord` is not implemented for `BrokenType`
   |
   = note: this error originates in the derive macro `PostgresOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Ord)]`
   |
-6 + #[derive(Ord)]
-7 | pub struct BrokenType {
+5 + #[derive(Ord)]
+6 | pub struct BrokenType {
   |


### PR DESCRIPTION
Previously, the cmp invocation could be misinterpreted as Iterator.
Code exploiting this bug is unlikely, but it could hit other errors,
so this way the error is much nicer.

Also makes the previous trybuild test for PostgresEq more realistic.