### PR TITLE
Update version to 0.10.0-beta.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arrays"
@@ -125,7 +125,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -166,9 +166,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -238,7 +238,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -356,7 +356,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_derive",
- "syn 2.0.28",
+ "syn 2.0.29",
  "tempfile",
  "tracing",
  "tracing-error",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.21"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
 dependencies = [
  "anstream",
  "anstyle",
@@ -479,7 +479,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "digest"
@@ -750,7 +750,7 @@ checksum = "ccb14d927583dd5c2eac0f2cf264fc4762aefe1ae14c47a8a20fc1939d3a5fc0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -838,9 +838,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -915,7 +915,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "glob"
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "flate2",
  "memchr",
@@ -1449,7 +1449,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1557,17 +1557,17 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
 ]
 
 [[package]]
 name = "pgrx"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.0",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "atty",
  "convert_case",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1744,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.5"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bed5017bc2ff49649c0075d0d7a9d676933c1292480c1d137776fb205b5cd18"
+checksum = "2843af30d9b6dccec9f8779eb50d56cfbec54b38c7b1bbaf50b37d6c8a4f8959"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1758,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
  "base64",
  "byteorder",
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f028f05971fe20f512bcc679e2c10227e57809a3af86a7606304435bc8896cd6"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1798,7 +1798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2088,15 +2088,15 @@ checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.3",
+ "rustls-webpki 0.101.4",
  "sct",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
 dependencies = [
  "ring",
  "untrusted",
@@ -2104,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -2126,12 +2126,12 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
 dependencies = [
  "byteorder",
- "thiserror",
+ "thiserror-core",
  "twox-hash",
 ]
 
@@ -2254,9 +2254,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
@@ -2285,20 +2285,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -2358,9 +2358,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
@@ -2492,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2545,9 +2545,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2577,22 +2577,42 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
-name = "thiserror-impl"
-version = "1.0.44"
+name = "thiserror-core"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "0d97345f6437bb2004cd58819d8a9ef8e36cdd7661c2abc4bbde0a7c40d9f497"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2607,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
 dependencies = [
  "deranged",
  "itoa",
@@ -2626,9 +2646,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
+checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
 dependencies = [
  "time-core",
 ]
@@ -2650,9 +2670,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2665,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e89f6234aa8fd43779746012fcf53603cdb91fdd8399aa0de868c2d56b6dde1"
+checksum = "000387915083ea6406ee44b50ca74813aba799fe682a7689e382bf9e13b74ce9"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2682,9 +2702,11 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
+ "rand",
  "socket2",
  "tokio",
  "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -2755,7 +2777,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2818,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84e0202ea606ba5ebee8507ab2bfbe89b98551ed9b8f0be198109275cff284b"
+checksum = "6df60d81823ed9c520ee897489573da4b1d79ffbe006b8134f46de1a1aa03555"
 dependencies = [
  "basic-toml",
  "glob",
@@ -2910,7 +2932,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "rustls",
- "rustls-webpki 0.100.1",
+ "rustls-webpki 0.100.2",
  "url",
  "webpki-roots",
 ]
@@ -3021,7 +3043,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -3043,7 +3065,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3070,7 +3092,17 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki 0.100.1",
+ "rustls-webpki 0.100.2",
+]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3115,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -3130,51 +3162,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.10"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5504cc7644f4b593cbc05c4a55bf9bd4e94b867c3c0bd440934174d50482427d"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -27,17 +27,17 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.17.0"
 cargo_toml = "0.15.3"
-clap = { version = "4.3.21", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.3.23", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.11.0", features = [ "cargo_metadata" ] }
 semver = "1.0.18"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.16.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.3" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.3" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.4" }
 prettyplease = "0.2.12"
 proc-macro2 = { version = "1.0.66", features = [ "span-locations" ] }
-quote = "1.0.32"
+quote = "1.0.33"
 rayon = "1.7.0"
 regex = "1.9.3"
 ureq = "2.7.1"
@@ -49,15 +49,15 @@ syn = { version = "2.0.18", features = [ "extra-traits", "full", "fold", "parsin
 unescape = "0.1.0"
 fork = "0.1.22"
 libloading = "0.8.0"
-object = "0.31.1"
+object = "0.32.0"
 once_cell = "1.18.0"
 eyre = "0.6.8"
 color-eyre = "0.6.2"
 tracing = "0.1"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
-flate2 = { version = "1.0.26", default-features = false, features = ["rust_backend"] }
-tempfile = "3.7.1"
+flate2 = { version = "1.0.27", default-features = false, features = ["rust_backend"] }
+tempfile = "3.8.0"
 nix = { version = "0.26", default-features = false, features = ["user"] }
 
 [features]

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -17,10 +17,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.0-beta.3"
+pgrx = "=0.10.0-beta.4"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.0-beta.3"
+pgrx-tests = "=0.10.0-beta.4"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -27,10 +27,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.0-beta.3"
+pgrx = "=0.10.0-beta.4"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.0-beta.3"
+pgrx-tests = "=0.10.0-beta.4"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -31,9 +31,9 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.3" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.4" }
 proc-macro2 = "1.0.66"
-quote = "1.0.32"
+quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 
 [dev-dependencies]

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-sys"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -40,8 +40,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.10.0-beta.3" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.10.0-beta.3" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.10.0-beta.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.10.0-beta.4" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -49,9 +49,9 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.10.0-beta.3" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.10.0-beta.4" }
 proc-macro2 = "1.0.66"
-quote = "1.0.32"
+quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
 shlex = "1.1.0" # shell lexing, also used by many of our deps

--- a/pgrx-pg-sys/src/include/pg11.rs
+++ b/pgrx-pg-sys/src/include/pg11.rs
@@ -311,15 +311,16 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 26] = b"pgsql-bugs@postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 11.21\0";
+pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 11.20\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6] = b"11.21\0";
+pub const PACKAGE_VERSION: &[u8; 6] = b"11.20\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"11\0";
-pub const PG_VERSION: &[u8; 6] = b"11.21\0";
-pub const PG_VERSION_NUM: u32 = 110021;
-pub const PG_VERSION_STR : & [u8 ; 103] = b"PostgreSQL 11.21 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6] = b"11.20\0";
+pub const PG_VERSION_NUM: u32 = 110020;
+pub const PG_VERSION_STR: &[u8; 87] =
+    b"PostgreSQL 11.20 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -381,6 +382,7 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -389,7 +391,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 35;
+pub const __GLIBC_MINOR__: u32 = 38;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -420,6 +422,7 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -429,9 +432,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -890,6 +893,9 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -978,6 +984,9 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1043,6 +1052,7 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1171,7 +1181,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 11.21\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 11.20\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
@@ -1497,11 +1507,6 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1547,6 +1552,11 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2527,8 +2537,6 @@ pub const Anum_pg_database_dattablespace: u32 = 12;
 pub const Anum_pg_database_datacl: u32 = 13;
 pub const Natts_pg_database: u32 = 13;
 pub const TemplateDbOid: Oid = Oid(1);
-pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
-pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_enumtypid: u32 = 1;
 pub const Anum_pg_enum_enumsortorder: u32 = 2;
@@ -3516,6 +3524,39 @@ impl Default for _IO_FILE {
         }
     }
 }
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -3940,6 +3981,18 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -3986,6 +4039,22 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4384,13 +4453,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4417,6 +4479,7 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4522,6 +4585,13 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5833,22 +5903,6 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -31697,14 +31751,6 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -39343,11 +39389,6 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -57355,10 +57396,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_index_isreplident(index_oid: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn get_index_isvalid(index_oid: Oid) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg12.rs
+++ b/pgrx-pg-sys/src/include/pg12.rs
@@ -319,15 +319,16 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 12.16\0";
+pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 12.15\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6] = b"12.16\0";
+pub const PACKAGE_VERSION: &[u8; 6] = b"12.15\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"12\0";
-pub const PG_VERSION: &[u8; 6] = b"12.16\0";
-pub const PG_VERSION_NUM: u32 = 120016;
-pub const PG_VERSION_STR : & [u8 ; 103] = b"PostgreSQL 12.16 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6] = b"12.15\0";
+pub const PG_VERSION_NUM: u32 = 120015;
+pub const PG_VERSION_STR: &[u8; 87] =
+    b"PostgreSQL 12.15 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -389,6 +390,7 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -397,7 +399,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 35;
+pub const __GLIBC_MINOR__: u32 = 38;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -428,6 +430,7 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -437,9 +440,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -898,6 +901,9 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -986,6 +992,9 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1051,6 +1060,7 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1179,7 +1189,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 12.16\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 12.15\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1369,11 +1379,6 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1419,6 +1424,11 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2586,8 +2596,6 @@ pub const Anum_pg_database_dattablespace: u32 = 13;
 pub const Anum_pg_database_datacl: u32 = 14;
 pub const Natts_pg_database: u32 = 14;
 pub const TemplateDbOid: Oid = Oid(1);
-pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
-pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_oid: u32 = 1;
 pub const Anum_pg_enum_enumtypid: u32 = 2;
@@ -3587,6 +3595,39 @@ impl Default for _IO_FILE {
         }
     }
 }
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4011,6 +4052,18 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4057,6 +4110,22 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4455,13 +4524,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4488,6 +4550,7 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4593,6 +4656,13 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5954,22 +6024,6 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -31707,14 +31761,6 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -41241,11 +41287,6 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 206] = b" '--prefix=/home/zombodb/.pgrx/13.12/pgrx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 223] = b" '--prefix=/home/atelier/.pgrx/13.11/pgrx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -311,18 +311,19 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 13.12\0";
+pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 13.11\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 6] = b"13.12\0";
+pub const PACKAGE_VERSION: &[u8; 6] = b"13.11\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"13\0";
 pub const PG_MAJORVERSION_NUM: u32 = 13;
-pub const PG_MINORVERSION_NUM: u32 = 12;
+pub const PG_MINORVERSION_NUM: u32 = 11;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 6] = b"13.12\0";
-pub const PG_VERSION_NUM: u32 = 130012;
-pub const PG_VERSION_STR : & [u8 ; 103] = b"PostgreSQL 13.12 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 6] = b"13.11\0";
+pub const PG_VERSION_NUM: u32 = 130011;
+pub const PG_VERSION_STR: &[u8; 87] =
+    b"PostgreSQL 13.11 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -383,6 +384,7 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -391,7 +393,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 35;
+pub const __GLIBC_MINOR__: u32 = 38;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -422,6 +424,7 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -431,9 +434,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -892,6 +895,9 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -980,6 +986,9 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1045,6 +1054,7 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1173,7 +1183,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 13.12\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 13.11\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1348,11 +1358,6 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1398,6 +1403,11 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2784,8 +2794,6 @@ pub const Anum_pg_database_dattablespace: u32 = 13;
 pub const Anum_pg_database_datacl: u32 = 14;
 pub const Natts_pg_database: u32 = 14;
 pub const TemplateDbOid: Oid = Oid(1);
-pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
-pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_oid: u32 = 1;
 pub const Anum_pg_enum_enumtypid: u32 = 2;
@@ -3630,6 +3638,39 @@ impl Default for _IO_FILE {
         }
     }
 }
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4054,6 +4095,18 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4100,6 +4153,22 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4498,13 +4567,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4531,6 +4593,7 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4636,6 +4699,13 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -6005,22 +6075,6 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -32391,14 +32445,6 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -42691,11 +42737,6 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 205] = b" '--prefix=/home/zombodb/.pgrx/14.9/pgrx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 222] = b" '--prefix=/home/atelier/.pgrx/14.8/pgrx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28814;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28814\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -319,18 +319,19 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 14.9\0";
+pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 14.8\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5] = b"14.9\0";
+pub const PACKAGE_VERSION: &[u8; 5] = b"14.8\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"14\0";
 pub const PG_MAJORVERSION_NUM: u32 = 14;
-pub const PG_MINORVERSION_NUM: u32 = 9;
+pub const PG_MINORVERSION_NUM: u32 = 8;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5] = b"14.9\0";
-pub const PG_VERSION_NUM: u32 = 140009;
-pub const PG_VERSION_STR : & [u8 ; 102] = b"PostgreSQL 14.9 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 5] = b"14.8\0";
+pub const PG_VERSION_NUM: u32 = 140008;
+pub const PG_VERSION_STR: &[u8; 86] =
+    b"PostgreSQL 14.8 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -390,6 +391,7 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -398,7 +400,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 35;
+pub const __GLIBC_MINOR__: u32 = 38;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -429,6 +431,7 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -438,9 +441,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -897,6 +900,9 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -985,6 +991,9 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1050,6 +1059,7 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1178,7 +1188,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 14.9\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 14.8\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1361,11 +1371,6 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1411,6 +1416,11 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2595,8 +2605,6 @@ pub const PgDatabaseToastTable: u32 = 4177;
 pub const PgDatabaseToastIndex: u32 = 4178;
 pub const DatabaseNameIndexId: u32 = 2671;
 pub const DatabaseOidIndexId: u32 = 2672;
-pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
-pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_oid: u32 = 1;
 pub const Anum_pg_enum_enumtypid: u32 = 2;
@@ -3658,6 +3666,39 @@ impl Default for _IO_FILE {
         }
     }
 }
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4082,6 +4123,18 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4128,6 +4181,22 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4522,13 +4591,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4555,6 +4617,7 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
+pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4660,6 +4723,13 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -6024,22 +6094,6 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -15018,7 +15072,7 @@ impl Default for PlanState {
 pub struct EPQState {
     pub parentestate: *mut EState,
     pub epqParam: ::std::os::raw::c_int,
-    pub epqExtra: *mut EPQStateExtra,
+    pub tuple_table: *mut List,
     pub relsubs_slot: *mut *mut TupleTableSlot,
     pub plan: *mut Plan,
     pub arowMarks: *mut List,
@@ -15029,22 +15083,6 @@ pub struct EPQState {
     pub recheckplanstate: *mut PlanState,
 }
 impl Default for EPQState {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct EPQStateExtra {
-    pub resultRelations: *mut List,
-    pub tuple_table: *mut List,
-    pub relsubs_blocked: *mut bool,
-}
-impl Default for EPQStateExtra {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -20924,17 +20962,6 @@ extern "C" {
         subplan: *mut Plan,
         auxrowmarks: *mut List,
         epqParam: ::std::os::raw::c_int,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn EvalPlanQualInitExt(
-        epqstate: *mut EPQState,
-        parentestate: *mut EState,
-        subplan: *mut Plan,
-        auxrowmarks: *mut List,
-        epqParam: ::std::os::raw::c_int,
-        resultRelations: *mut List,
     );
 }
 #[pgrx_macros::pg_guard]
@@ -32588,14 +32615,6 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -43757,11 +43776,6 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 205] = b" '--prefix=/home/zombodb/.pgrx/15.4/pgrx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 222] = b" '--prefix=/home/atelier/.pgrx/15.3/pgrx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28815;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28815\0";
 pub const DLSUFFIX: &[u8; 4] = b".so\0";
@@ -322,18 +322,19 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 15.4\0";
+pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 15.3\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5] = b"15.4\0";
+pub const PACKAGE_VERSION: &[u8; 5] = b"15.3\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"15\0";
 pub const PG_MAJORVERSION_NUM: u32 = 15;
-pub const PG_MINORVERSION_NUM: u32 = 4;
+pub const PG_MINORVERSION_NUM: u32 = 3;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5] = b"15.4\0";
-pub const PG_VERSION_NUM: u32 = 150004;
-pub const PG_VERSION_STR : & [u8 ; 102] = b"PostgreSQL 15.4 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
+pub const PG_VERSION: &[u8; 5] = b"15.3\0";
+pub const PG_VERSION_NUM: u32 = 150003;
+pub const PG_VERSION_STR: &[u8; 86] =
+    b"PostgreSQL 15.3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -394,6 +395,7 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -402,7 +404,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 35;
+pub const __GLIBC_MINOR__: u32 = 38;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -433,6 +435,7 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -442,9 +445,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -774,7 +777,7 @@ pub const PG_BINARY_R: &[u8; 2] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2] = b"w\0";
 pub const _CTYPE_H: u32 = 1;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 15.4\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 15.3\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -958,11 +961,6 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1008,6 +1006,11 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -1894,6 +1897,9 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -1982,6 +1988,9 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -2049,6 +2058,7 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -2628,8 +2638,6 @@ pub const Anum_pg_database_datcollversion: u32 = 15;
 pub const Anum_pg_database_datacl: u32 = 16;
 pub const Natts_pg_database: u32 = 16;
 pub const Template1DbOid: u32 = 1;
-pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
-pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const EnumOidIndexId: u32 = 3502;
 pub const EnumTypIdLabelIndexId: u32 = 3503;
@@ -3702,6 +3710,39 @@ impl Default for _IO_FILE {
         }
     }
 }
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4126,6 +4167,18 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4172,6 +4225,22 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5518,22 +5587,6 @@ pub const FP_ZERO: _bindgen_ty_2 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_2 = 3;
 pub const FP_NORMAL: _bindgen_ty_2 = 4;
 pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_get_user_name(
@@ -18543,7 +18596,7 @@ impl Default for PlanState {
 pub struct EPQState {
     pub parentestate: *mut EState,
     pub epqParam: ::std::os::raw::c_int,
-    pub epqExtra: *mut EPQStateExtra,
+    pub tuple_table: *mut List,
     pub relsubs_slot: *mut *mut TupleTableSlot,
     pub plan: *mut Plan,
     pub arowMarks: *mut List,
@@ -18554,22 +18607,6 @@ pub struct EPQState {
     pub recheckplanstate: *mut PlanState,
 }
 impl Default for EPQState {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct EPQStateExtra {
-    pub resultRelations: *mut List,
-    pub tuple_table: *mut List,
-    pub relsubs_blocked: *mut bool,
-}
-impl Default for EPQStateExtra {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -20831,17 +20868,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn EvalPlanQualInitExt(
-        epqstate: *mut EPQState,
-        parentestate: *mut EState,
-        subplan: *mut Plan,
-        auxrowmarks: *mut List,
-        epqParam: ::std::os::raw::c_int,
-        resultRelations: *mut List,
-    );
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn EvalPlanQualSetPlan(epqstate: *mut EPQState, subplan: *mut Plan, auxrowmarks: *mut List);
 }
 #[pgrx_macros::pg_guard]
@@ -23075,13 +23101,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -23108,6 +23127,7 @@ pub const IPPROTO_BEETPH: _bindgen_ty_16 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_16 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_16 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_16 = 108;
+pub const IPPROTO_L2TP: _bindgen_ty_16 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_16 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_16 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_16 = 137;
@@ -23213,6 +23233,13 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -24149,13 +24176,6 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pgstat_have_entry(kind: PgStat_Kind, dboid: Oid, objoid: Oid) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn assign_stats_fetch_consistency(
-        newval: ::std::os::raw::c_int,
-        extra: *mut ::std::os::raw::c_void,
-    );
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -32782,14 +32802,6 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -44171,11 +44183,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
 }
 #[pgrx_macros::pg_guard]
@@ -48142,7 +48149,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *const ::std::os::raw::c_char;
+    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *mut ::std::os::raw::c_char;
 }
 pub const CRSSnapshotAction_CRS_EXPORT_SNAPSHOT: CRSSnapshotAction = 0;
 pub const CRSSnapshotAction_CRS_NOEXPORT_SNAPSHOT: CRSSnapshotAction = 1;

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 208] = b" '--prefix=/home/zombodb/.pgrx/16beta3/pgrx-install' '--with-pgport=28816' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 225] = b" '--prefix=/home/atelier/.pgrx/16beta2/pgrx-install' '--with-pgport=28816' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28816;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28816\0";
 pub const DLSUFFIX: &[u8; 4] = b".so\0";
@@ -277,18 +277,19 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 19] = b"PostgreSQL 16beta3\0";
+pub const PACKAGE_STRING: &[u8; 19] = b"PostgreSQL 16beta2\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 8] = b"16beta3\0";
+pub const PACKAGE_VERSION: &[u8; 8] = b"16beta2\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"16\0";
 pub const PG_MAJORVERSION_NUM: u32 = 16;
 pub const PG_MINORVERSION_NUM: u32 = 0;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 8] = b"16beta3\0";
+pub const PG_VERSION: &[u8; 8] = b"16beta2\0";
 pub const PG_VERSION_NUM: u32 = 160000;
-pub const PG_VERSION_STR : & [u8 ; 105] = b"PostgreSQL 16beta3 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
+pub const PG_VERSION_STR: &[u8; 89] =
+    b"PostgreSQL 16beta2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -349,6 +350,7 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -357,7 +359,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 35;
+pub const __GLIBC_MINOR__: u32 = 38;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -388,6 +390,7 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -397,9 +400,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -728,7 +731,7 @@ pub const PG_BINARY_R: &[u8; 2] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2] = b"w\0";
 pub const _CTYPE_H: u32 = 1;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 31] = b"postgres (PostgreSQL) 16beta3\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 31] = b"postgres (PostgreSQL) 16beta2\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -916,11 +919,6 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -966,6 +964,11 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -1365,7 +1368,7 @@ pub const RTPrefixStrategyNumber: u32 = 28;
 pub const RTOldBelowStrategyNumber: u32 = 29;
 pub const RTOldAboveStrategyNumber: u32 = 30;
 pub const RTMaxStrategyNumber: u32 = 30;
-pub const CATALOG_VERSION_NO: u32 = 202307071;
+pub const CATALOG_VERSION_NO: u32 = 202306141;
 pub const OIDCHARS: u32 = 10;
 pub const FORKNAMECHARS: u32 = 4;
 pub const INNER_VAR: i32 = -1;
@@ -1388,7 +1391,8 @@ pub const ACL_CREATE_TEMP: u32 = 1024;
 pub const ACL_CONNECT: u32 = 2048;
 pub const ACL_SET: u32 = 4096;
 pub const ACL_ALTER_SYSTEM: u32 = 8192;
-pub const N_ACL_RIGHTS: u32 = 14;
+pub const ACL_MAINTAIN: u32 = 16384;
+pub const N_ACL_RIGHTS: u32 = 15;
 pub const ACL_NO_RIGHTS: u32 = 0;
 pub const ACL_SELECT_FOR_UPDATE: u32 = 4;
 pub const FRAMEOPTION_NONDEFAULT: u32 = 1;
@@ -1857,6 +1861,9 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
+pub const SOL_MPTCP: u32 = 284;
+pub const SOL_MCTP: u32 = 285;
+pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -1945,6 +1952,9 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
+pub const SO_RESERVE_MEM: u32 = 73;
+pub const SO_TXREHASH: u32 = 74;
+pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -2013,6 +2023,7 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
+pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -2535,6 +2546,7 @@ pub const ROLE_PG_WRITE_SERVER_FILES: u32 = 4570;
 pub const ROLE_PG_EXECUTE_SERVER_PROGRAM: u32 = 4571;
 pub const ROLE_PG_SIGNAL_BACKEND: u32 = 4200;
 pub const ROLE_PG_CHECKPOINT: u32 = 4544;
+pub const ROLE_PG_MAINTAIN: u32 = 4549;
 pub const ROLE_PG_USE_RESERVED_CONNECTIONS: u32 = 4550;
 pub const ROLE_PG_CREATE_SUBSCRIPTION: u32 = 6304;
 pub const DatabaseRelationId: Oid = Oid(1262);
@@ -2564,8 +2576,6 @@ pub const Anum_pg_database_datcollversion: u32 = 16;
 pub const Anum_pg_database_datacl: u32 = 17;
 pub const Natts_pg_database: u32 = 17;
 pub const Template1DbOid: u32 = 1;
-pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
-pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const EnumOidIndexId: u32 = 3502;
 pub const EnumTypIdLabelIndexId: u32 = 3503;
@@ -2847,9 +2857,10 @@ pub const ACL_CREATE_TEMP_CHR: u8 = 84u8;
 pub const ACL_CONNECT_CHR: u8 = 99u8;
 pub const ACL_SET_CHR: u8 = 115u8;
 pub const ACL_ALTER_SYSTEM_CHR: u8 = 65u8;
-pub const ACL_ALL_RIGHTS_STR: &[u8; 15] = b"arwdDxtXUCTcsA\0";
+pub const ACL_MAINTAIN_CHR: u8 = 109u8;
+pub const ACL_ALL_RIGHTS_STR: &[u8; 16] = b"arwdDxtXUCTcsAm\0";
 pub const ACL_ALL_RIGHTS_COLUMN: u32 = 39;
-pub const ACL_ALL_RIGHTS_RELATION: u32 = 127;
+pub const ACL_ALL_RIGHTS_RELATION: u32 = 16511;
 pub const ACL_ALL_RIGHTS_SEQUENCE: u32 = 262;
 pub const ACL_ALL_RIGHTS_DATABASE: u32 = 3584;
 pub const ACL_ALL_RIGHTS_FDW: u32 = 256;
@@ -3076,6 +3087,7 @@ pub const VACOPT_PROCESS_TOAST: u32 = 128;
 pub const VACOPT_DISABLE_PAGE_SKIPPING: u32 = 256;
 pub const VACOPT_SKIP_DATABASE_STATS: u32 = 512;
 pub const VACOPT_ONLY_DATABASE_STATS: u32 = 1024;
+pub const VACOPT_SKIP_PRIVS: u32 = 2048;
 pub const CACHEDPLANSOURCE_MAGIC: u32 = 195726186;
 pub const CACHEDPLAN_MAGIC: u32 = 953717834;
 pub const CACHEDEXPR_MAGIC: u32 = 838275847;
@@ -3712,6 +3724,39 @@ impl Default for _IO_FILE {
         }
     }
 }
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4136,6 +4181,18 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4182,6 +4239,22 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5541,22 +5614,6 @@ pub const FP_ZERO: _bindgen_ty_2 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_2 = 3;
 pub const FP_NORMAL: _bindgen_ty_2 = 4;
 pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        dst: *mut ::std::os::raw::c_char,
-        src: *const ::std::os::raw::c_char,
-        siz: usize,
-    ) -> usize;
-}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_get_user_name(
@@ -23766,13 +23823,6 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -23799,6 +23849,7 @@ pub const IPPROTO_BEETPH: _bindgen_ty_16 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_16 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_16 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_16 = 108;
+pub const IPPROTO_L2TP: _bindgen_ty_16 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_16 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_16 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_16 = 137;
@@ -23904,6 +23955,13 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -32322,14 +32380,6 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -35373,7 +35423,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn RangeVarCallbackOwnsTable(
+    pub fn RangeVarCallbackMaintainsTable(
         relation: *const RangeVar,
         relId: Oid,
         oldRelId: Oid,
@@ -37595,7 +37645,11 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn vacuum_is_relation_owner(relid: Oid, reltuple: Form_pg_class, options: bits32) -> bool;
+    pub fn vacuum_is_permitted_for_relation(
+        relid: Oid,
+        reltuple: Form_pg_class,
+        options: bits32,
+    ) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -41794,11 +41848,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn makeJsonValueExpr(
-        raw_expr: *mut Expr,
-        formatted_expr: *mut Expr,
-        format: *mut JsonFormat,
-    ) -> *mut JsonValueExpr;
+    pub fn makeJsonValueExpr(expr: *mut Expr, format: *mut JsonFormat) -> *mut JsonValueExpr;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -44977,11 +45027,6 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
 }
 #[pgrx_macros::pg_guard]
@@ -45125,7 +45170,10 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn JumbleQuery(query: *mut Query) -> *mut JumbleState;
+    pub fn JumbleQuery(
+        query: *mut Query,
+        querytext: *const ::std::os::raw::c_char,
+    ) -> *mut JumbleState;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -48994,7 +49042,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *const ::std::os::raw::c_char;
+    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *mut ::std::os::raw::c_char;
 }
 pub const CRSSnapshotAction_CRS_EXPORT_SNAPSHOT: CRSSnapshotAction = 0;
 pub const CRSSnapshotAction_CRS_NOEXPORT_SNAPSHOT: CRSSnapshotAction = 1;

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"
@@ -27,9 +27,9 @@ no-schema-generation = []
 [dependencies]
 convert_case = "0.6.0"
 eyre = "0.6.8"
-petgraph = "0.6.3"
+petgraph = "0.6.4"
 proc-macro2 = { version = "1.0.66", features = [ "span-locations" ] }
-quote = "1.0.32"
+quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0"
 

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-tests"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -49,14 +49,14 @@ clap-cargo = "0.11.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.147"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.3" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.3" }
-postgres = "0.19.5"
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.4" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.4" }
+postgres = "0.19.6"
 proptest = { version = "1", optional = true }
 regex = "1.9.3"
 serde = "1.0"
 serde_json = "1.0"
-sysinfo = "0.29.7"
+sysinfo = "0.29.8"
 eyre = "0.6.8"
 thiserror = "1.0"
 rand = "0.8.5"
@@ -68,4 +68,4 @@ trybuild = "1"
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.10.0-beta.3"
+version = "=0.10.0-beta.4"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 description = "Standalone tool to update PGRX Cargo.toml versions and dependencies in preparation for a release."
 
 [dependencies]
-clap = { version = "4.3.21", features = [ "env", "derive" ] }
+clap = { version = "4.3.23", features = [ "env", "derive" ] }
 owo-colors = "3.5.0"
 toml_edit = { version = "0.19.14" }
 walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -44,9 +44,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.3" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.10.0-beta.3" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.3" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.4" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.10.0-beta.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.4" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
@@ -59,7 +59,7 @@ thiserror = "1.0"
 
 # exposed in public API
 atomic-traits = "0.3.0" # PgAtomic and shmem init
-bitflags = "2.3.3" # BackgroundWorker
+bitflags = "2.4.0" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
 heapless = "0.7.16" # shmem and PgLwLock
 libc = "0.2.147" # FFI type compat


### PR DESCRIPTION
The fifth beta release of 0.10.0!

* `#[pg_test]`-compatible proptest support in https://github.com/pgcentralfoundation/pgrx/pull/1258 courtesy of moi
* PostgresEq (https://github.com/pgcentralfoundation/pgrx/pull/1261) and PostgresOrd (https://github.com/pgcentralfoundation/pgrx/pull/1262) now explicitly require their "base" Rust traits, which may hypothetically break some impls, but in exchange your equality implementations are now presumed to be commutative.
* Work on improving/simplifying/optimizing our SPI continues, with @vrmiguel contributing some polish to Datum preparation in https://github.com/pgcentralfoundation/pgrx/pull/1256
* We have been finding some extra-spicy edge cases in how PGRX interacts with a continuously-operational Postgres installation which might feature extensions being installed and reinstalled lately! @Sasasu fixed at least one core-dump-causing case from `cargo pgrx install` in https://github.com/pgcentralfoundation/pgrx/pull/1263

## New Contributors
* @vrmiguel made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1256

**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.10.0-beta.3...v0.10.0-beta.4