### PR TITLE
Better error messages when `pg_config` isn't found.

### DIFF
--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -417,7 +417,18 @@ impl PgConfig {
                 Ok(output) => Ok(String::from_utf8(output.stdout).unwrap().trim().to_string()),
                 Err(e) => match e.kind() {
                     ErrorKind::NotFound => Err(e).wrap_err_with(|| {
-                        format!("Unable to find `{}` on the system $PATH", "pg_config".yellow())
+                        let pg_config_str = pg_config.display().to_string();
+
+                        if pg_config_str == "pg_config" {
+                            format!("Unable to find `{}` on the system $PATH", "pg_config".yellow())
+                        } else if pg_config_str.contains('~') {
+                            format!("The specified pg_config binary, `{}`, does not exist.  It contains a `~`, indicating your shell didn't properly expand your home directory", pg_config_str.yellow())
+                        } else {
+                            format!(
+                                "The specified pg_config binary, `{}`, does not exist",
+                                pg_config_str.yellow()
+                            )
+                        }
                     }),
                     _ => Err(e.into()),
                 },

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -421,8 +421,8 @@ impl PgConfig {
 
                         if pg_config_str == "pg_config" {
                             format!("Unable to find `{}` on the system $PATH", "pg_config".yellow())
-                        } else if pg_config_str.contains('~') {
-                            format!("The specified pg_config binary, `{}`, does not exist.  It contains a `~`, indicating your shell didn't properly expand your home directory", pg_config_str.yellow())
+                        } else if pg_config_str.starts_with('~') {
+                            format!("The specified pg_config binary, {}, does not exist. The shell didn't expand the `~`", pg_config_str.yellow())
                         } else {
                             format!(
                                 "The specified pg_config binary, `{}`, does not exist",


### PR DESCRIPTION
We do a little better job letting the user know why `pg_config` couldn't be found.
![Screenshot 2023-08-24 at 10 43 34 AM](https://github.com/pgcentralfoundation/pgrx/assets/5117238/57cbdeb7-9cc5-4da7-bcb8-7ebb696203a6)
