### PR TITLE
Fix GetMemoryChunkContext port

### DIFF
--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -73,7 +73,7 @@ pub const unsafe fn MAXALIGN(len: usize) -> usize {
 /// This function will panic if `pointer` is null, if it's not properly aligned, or if the memory
 /// it points do doesn't have the a header that looks like a memory context pointer
 #[allow(non_snake_case)]
-pub unsafe fn GetMemoryContextChunk(pointer: *mut std::os::raw::c_void) -> pg_sys::MemoryContext {
+pub unsafe fn GetMemoryChunkContext(pointer: *mut std::os::raw::c_void) -> pg_sys::MemoryContext {
     // Postgres versions <16 don't export the "GetMemoryChunkContext" function.  It's a "static inline"
     // function in `memutils.h`, so we port it to Rust right here
     #[cfg(any(

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -71,9 +71,9 @@ pub const unsafe fn MAXALIGN(len: usize) -> usize {
 /// # Panics
 ///
 /// This function will panic if `pointer` is null, if it's not properly aligned, or if the memory
-/// it points do doesn't have the a header that looks like a memory context pointer
+/// it points to doesn't have a prefix that looks like a memory context pointer
 #[allow(non_snake_case)]
-pub unsafe fn GetMemoryChunkContext(pointer: *mut std::os::raw::c_void) -> pg_sys::MemoryContext {
+pub unsafe fn GetMemoryContextChunk(pointer: *mut std::os::raw::c_void) -> pg_sys::MemoryContext {
     // Postgres versions <16 don't export the "GetMemoryChunkContext" function.  It's a "static inline"
     // function in `memutils.h`, so we port it to Rust right here
     #[cfg(any(

--- a/pgrx/src/memcxt.rs
+++ b/pgrx/src/memcxt.rs
@@ -233,10 +233,10 @@ impl PgMemoryContexts {
     pub unsafe fn of(ptr: void_mut_ptr) -> Option<PgMemoryContexts> {
         let parent = unsafe {
             // (un)SAFETY: the caller assumes responsibility for ensuring the provided pointer is
-            // going to be accepted by Postgres `GetMemoryContextChunk`.  Postgres will ERROR
+            // going to be accepted by Postgres `GetMemoryChunkContext`.  Postgres will ERROR
             // if its invariants aren't met, but who really knows when the ptr could have come
             // come from anywhere
-            pg_sys::GetMemoryContextChunk(ptr)
+            pg_sys::GetMemoryChunkContext(ptr)
         };
         let memcxt = NonNull::new(parent)?;
         Some(PgMemoryContexts::Of(OwnerMemoryContext { memcxt }))


### PR DESCRIPTION
- The name was needlessly backwards-ish.
- `MemoryContextIsValid` performed a potentially-UB read.