### PR TITLE
Update version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,33 +45,32 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -93,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -125,7 +124,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -191,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "basic-toml"
@@ -238,7 +237,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -327,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -356,7 +355,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_derive",
- "syn 2.0.29",
+ "syn 2.0.31",
  "tempfile",
  "tracing",
  "tracing-error",
@@ -436,13 +435,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
@@ -458,35 +456,34 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "once_cell",
  "strsim",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "color-eyre"
@@ -750,7 +747,7 @@ checksum = "ccb14d927583dd5c2eac0f2cf264fc4762aefe1ae14c47a8a20fc1939d3a5fc0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -771,9 +768,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -829,6 +826,12 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "fixedbitset"
@@ -915,7 +918,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1105,17 +1108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi 0.3.2",
- "rustix 0.38.8",
- "windows-sys",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -1332,14 +1324,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -1411,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "flate2",
  "memchr",
@@ -1428,11 +1419,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.56"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1449,7 +1440,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1460,9 +1451,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.91"
+version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
@@ -1547,10 +1538,11 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
+checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
@@ -1567,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.0",
@@ -1590,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1601,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1617,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1637,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 dependencies = [
  "atty",
  "convert_case",
@@ -1653,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1712,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1744,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2843af30d9b6dccec9f8779eb50d56cfbec54b38c7b1bbaf50b37d6c8a4f8959"
+checksum = "7915b33ed60abc46040cbcaa25ffa1c7ec240668e0477c4f3070786f5916d451"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1793,12 +1785,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+checksum = "8832c0f9be7e3cae60727e6256cfd2cd3c3e2b6cd5dad4190ecb2fd658c9030b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1960,14 +1952,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.8",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1981,13 +1973,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1998,9 +1990,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "ring"
@@ -2069,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2082,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -2254,9 +2246,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -2285,13 +2277,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -2336,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "shmem"
@@ -2352,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -2441,10 +2433,11 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3737bde7edce97102e0e2b15365bf7a20bfdb5f60f4f9e8d7004258a51a8da"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
 dependencies = [
+ "finl_unicode",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -2492,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2514,7 +2507,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "plist",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
  "serde",
  "serde_json",
  "thiserror",
@@ -2524,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.8"
+version = "0.29.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10ed79c22663a35a255d289a7fdcb43559fc77ff15df5ce6c341809e7867528"
+checksum = "a8d0e9cc2273cc8d31377bdd638d72e3ac3e5607b18621062b169d02787f1bab"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2552,7 +2545,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.38.8",
+ "rustix 0.38.11",
  "windows-sys",
 ]
 
@@ -2577,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
@@ -2606,13 +2599,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -2627,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
@@ -2646,9 +2639,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
  "time-core",
 ]
@@ -2685,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000387915083ea6406ee44b50ca74813aba799fe682a7689e382bf9e13b74ce9"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2777,7 +2770,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -2939,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3008,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3043,7 +3036,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
  "wasm-bindgen-shared",
 ]
 
@@ -3065,7 +3058,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3204,9 +3197,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]
@@ -3222,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
+checksum = "1eee6bf5926be7cf998d7381a9a23d833fd493f6a8034658a9505a4dc4b20444"
 
 [[package]]
 name = "yaml-rust"

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -27,21 +27,21 @@ edition = "2021"
 atty = "0.2.14"
 cargo_metadata = "0.17.0"
 cargo_toml = "0.15.3"
-clap = { version = "4.3.23", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
+clap = { version = "4.4.2", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.11.0", features = [ "cargo_metadata" ] }
 semver = "1.0.18"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.16.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.4" }
-prettyplease = "0.2.12"
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0" }
+prettyplease = "0.2.14"
 proc-macro2 = { version = "1.0.66", features = [ "span-locations" ] }
 quote = "1.0.33"
 rayon = "1.7.0"
-regex = "1.9.3"
+regex = "1.9.5"
 ureq = "2.7.1"
-url = "2.4.0"
+url = "2.4.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde-xml-rs = "0.6.0"
@@ -49,7 +49,7 @@ syn = { version = "2.0.18", features = [ "extra-traits", "full", "fold", "parsin
 unescape = "0.1.0"
 fork = "0.1.22"
 libloading = "0.8.0"
-object = "0.32.0"
+object = "0.32.1"
 once_cell = "1.18.0"
 eyre = "0.6.8"
 color-eyre = "0.6.2"
@@ -58,7 +58,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
 flate2 = { version = "1.0.27", default-features = false, features = ["rust_backend"] }
 tempfile = "3.8.0"
-nix = { version = "0.26", default-features = false, features = ["user"] }
+nix = { version = "0.27", default-features = false, features = ["user"] }
 
 [features]
 default = ["ureq/native-tls"]

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -17,10 +17,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.0-beta.4"
+pgrx = "=0.10.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.0-beta.4"
+pgrx-tests = "=0.10.0"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -27,10 +27,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.0-beta.4"
+pgrx = "=0.10.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.0-beta.4"
+pgrx-tests = "=0.10.0"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -31,7 +31,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.4" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0" }
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"
@@ -31,5 +31,5 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.7.6"
-url = "2.4.0"
+url = "2.4.1"
 cargo_toml = "0.15.3"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-sys"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -40,8 +40,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.10.0-beta.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.10.0-beta.4" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.10.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.10.0" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -49,10 +49,10 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.10.0-beta.4" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.10.0" }
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 eyre = "0.6.8"
-shlex = "1.1.0" # shell lexing, also used by many of our deps
+shlex = "1.2.0" # shell lexing, also used by many of our deps
 once_cell = "1.18.0"

--- a/pgrx-pg-sys/src/include/pg11.rs
+++ b/pgrx-pg-sys/src/include/pg11.rs
@@ -311,16 +311,15 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 26] = b"pgsql-bugs@postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 11.20\0";
+pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 11.21\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6] = b"11.20\0";
+pub const PACKAGE_VERSION: &[u8; 6] = b"11.21\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"11\0";
-pub const PG_VERSION: &[u8; 6] = b"11.20\0";
-pub const PG_VERSION_NUM: u32 = 110020;
-pub const PG_VERSION_STR: &[u8; 87] =
-    b"PostgreSQL 11.20 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
+pub const PG_VERSION: &[u8; 6] = b"11.21\0";
+pub const PG_VERSION_NUM: u32 = 110021;
+pub const PG_VERSION_STR : & [u8 ; 103] = b"PostgreSQL 11.21 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -382,7 +381,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -391,7 +389,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 38;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -422,7 +420,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -432,9 +429,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -893,9 +890,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -984,9 +978,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1052,7 +1043,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1181,7 +1171,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 11.20\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 11.21\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const PG_IOLBF: u32 = 1;
@@ -1507,6 +1497,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1552,11 +1547,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2537,6 +2527,8 @@ pub const Anum_pg_database_dattablespace: u32 = 12;
 pub const Anum_pg_database_datacl: u32 = 13;
 pub const Natts_pg_database: u32 = 13;
 pub const TemplateDbOid: Oid = Oid(1);
+pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
+pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_enumtypid: u32 = 1;
 pub const Anum_pg_enum_enumsortorder: u32 = 2;
@@ -3524,39 +3516,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *const ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __pos: *mut __off64_t,
-        __w: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int,
->;
-pub type cookie_close_function_t = ::std::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -3981,18 +3940,6 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn arc4random() -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4039,22 +3986,6 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4453,6 +4384,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4479,7 +4417,6 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
-pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4585,13 +4522,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5903,6 +5833,22 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -31751,6 +31697,14 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -39389,6 +39343,11 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
+        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -57396,6 +57355,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn get_index_isreplident(index_oid: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn get_index_isvalid(index_oid: Oid) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg12.rs
+++ b/pgrx-pg-sys/src/include/pg12.rs
@@ -319,16 +319,15 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 12.15\0";
+pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 12.16\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 1] = b"\0";
-pub const PACKAGE_VERSION: &[u8; 6] = b"12.15\0";
+pub const PACKAGE_VERSION: &[u8; 6] = b"12.16\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"12\0";
-pub const PG_VERSION: &[u8; 6] = b"12.15\0";
-pub const PG_VERSION_NUM: u32 = 120015;
-pub const PG_VERSION_STR: &[u8; 87] =
-    b"PostgreSQL 12.15 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
+pub const PG_VERSION: &[u8; 6] = b"12.16\0";
+pub const PG_VERSION_NUM: u32 = 120016;
+pub const PG_VERSION_STR : & [u8 ; 103] = b"PostgreSQL 12.16 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -390,7 +389,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -399,7 +397,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 38;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -430,7 +428,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -440,9 +437,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -901,9 +898,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -992,9 +986,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1060,7 +1051,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1189,7 +1179,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 12.15\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 12.16\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1379,6 +1369,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1424,11 +1419,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2596,6 +2586,8 @@ pub const Anum_pg_database_dattablespace: u32 = 13;
 pub const Anum_pg_database_datacl: u32 = 14;
 pub const Natts_pg_database: u32 = 14;
 pub const TemplateDbOid: Oid = Oid(1);
+pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
+pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_oid: u32 = 1;
 pub const Anum_pg_enum_enumtypid: u32 = 2;
@@ -3595,39 +3587,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *const ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __pos: *mut __off64_t,
-        __w: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int,
->;
-pub type cookie_close_function_t = ::std::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4052,18 +4011,6 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn arc4random() -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4110,22 +4057,6 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4524,6 +4455,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4550,7 +4488,6 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
-pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4656,13 +4593,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -6024,6 +5954,22 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -31761,6 +31707,14 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -41287,6 +41241,11 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
+        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 223] = b" '--prefix=/home/atelier/.pgrx/13.11/pgrx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 206] = b" '--prefix=/home/zombodb/.pgrx/13.12/pgrx-install' '--with-pgport=28813' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28813;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28813\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -311,19 +311,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 13.11\0";
+pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 13.12\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 6] = b"13.11\0";
+pub const PACKAGE_VERSION: &[u8; 6] = b"13.12\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"13\0";
 pub const PG_MAJORVERSION_NUM: u32 = 13;
-pub const PG_MINORVERSION_NUM: u32 = 11;
+pub const PG_MINORVERSION_NUM: u32 = 12;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 6] = b"13.11\0";
-pub const PG_VERSION_NUM: u32 = 130011;
-pub const PG_VERSION_STR: &[u8; 87] =
-    b"PostgreSQL 13.11 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
+pub const PG_VERSION: &[u8; 6] = b"13.12\0";
+pub const PG_VERSION_NUM: u32 = 130012;
+pub const PG_VERSION_STR : & [u8 ; 103] = b"PostgreSQL 13.12 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -384,7 +383,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -393,7 +391,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 38;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -424,7 +422,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -434,9 +431,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -895,9 +892,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -986,9 +980,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1054,7 +1045,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1183,7 +1173,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 13.11\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 13.12\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1358,6 +1348,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1403,11 +1398,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2794,6 +2784,8 @@ pub const Anum_pg_database_dattablespace: u32 = 13;
 pub const Anum_pg_database_datacl: u32 = 14;
 pub const Natts_pg_database: u32 = 14;
 pub const TemplateDbOid: Oid = Oid(1);
+pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
+pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_oid: u32 = 1;
 pub const Anum_pg_enum_enumtypid: u32 = 2;
@@ -3638,39 +3630,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *const ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __pos: *mut __off64_t,
-        __w: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int,
->;
-pub type cookie_close_function_t = ::std::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4095,18 +4054,6 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn arc4random() -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4153,22 +4100,6 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4567,6 +4498,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4593,7 +4531,6 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
-pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4699,13 +4636,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -6075,6 +6005,22 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -32445,6 +32391,14 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -42737,6 +42691,11 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
+        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 222] = b" '--prefix=/home/atelier/.pgrx/14.8/pgrx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 205] = b" '--prefix=/home/zombodb/.pgrx/14.9/pgrx-install' '--with-pgport=28814' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28814;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28814\0";
 pub const ENABLE_THREAD_SAFETY: u32 = 1;
@@ -319,19 +319,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 14.8\0";
+pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 14.9\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5] = b"14.8\0";
+pub const PACKAGE_VERSION: &[u8; 5] = b"14.9\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"14\0";
 pub const PG_MAJORVERSION_NUM: u32 = 14;
-pub const PG_MINORVERSION_NUM: u32 = 8;
+pub const PG_MINORVERSION_NUM: u32 = 9;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5] = b"14.8\0";
-pub const PG_VERSION_NUM: u32 = 140008;
-pub const PG_VERSION_STR: &[u8; 86] =
-    b"PostgreSQL 14.8 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
+pub const PG_VERSION: &[u8; 5] = b"14.9\0";
+pub const PG_VERSION_NUM: u32 = 140009;
+pub const PG_VERSION_STR : & [u8 ; 102] = b"PostgreSQL 14.9 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -391,7 +390,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -400,7 +398,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 38;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -431,7 +429,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -441,9 +438,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -900,9 +897,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -991,9 +985,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1059,7 +1050,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1188,7 +1178,7 @@ pub const NI_DGRAM: u32 = 16;
 pub const _PWD_H: u32 = 1;
 pub const NSS_BUFLEN_PASSWD: u32 = 1024;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 14.8\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 14.9\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1371,6 +1361,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1416,11 +1411,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2605,6 +2595,8 @@ pub const PgDatabaseToastTable: u32 = 4177;
 pub const PgDatabaseToastIndex: u32 = 4178;
 pub const DatabaseNameIndexId: u32 = 2671;
 pub const DatabaseOidIndexId: u32 = 2672;
+pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
+pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const Anum_pg_enum_oid: u32 = 1;
 pub const Anum_pg_enum_enumtypid: u32 = 2;
@@ -3666,39 +3658,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *const ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __pos: *mut __off64_t,
-        __w: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int,
->;
-pub type cookie_close_function_t = ::std::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4123,18 +4082,6 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn arc4random() -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4181,22 +4128,6 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -4591,6 +4522,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -4617,7 +4555,6 @@ pub const IPPROTO_BEETPH: _bindgen_ty_5 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_5 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_5 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_5 = 108;
-pub const IPPROTO_L2TP: _bindgen_ty_5 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_5 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_5 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_5 = 137;
@@ -4723,13 +4660,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -6094,6 +6024,22 @@ pub const FP_ZERO: _bindgen_ty_8 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_8 = 3;
 pub const FP_NORMAL: _bindgen_ty_8 = 4;
 pub type _bindgen_ty_8 = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_qsort(
@@ -15072,7 +15018,7 @@ impl Default for PlanState {
 pub struct EPQState {
     pub parentestate: *mut EState,
     pub epqParam: ::std::os::raw::c_int,
-    pub tuple_table: *mut List,
+    pub epqExtra: *mut EPQStateExtra,
     pub relsubs_slot: *mut *mut TupleTableSlot,
     pub plan: *mut Plan,
     pub arowMarks: *mut List,
@@ -15083,6 +15029,22 @@ pub struct EPQState {
     pub recheckplanstate: *mut PlanState,
 }
 impl Default for EPQState {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct EPQStateExtra {
+    pub resultRelations: *mut List,
+    pub tuple_table: *mut List,
+    pub relsubs_blocked: *mut bool,
+}
+impl Default for EPQStateExtra {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -20962,6 +20924,17 @@ extern "C" {
         subplan: *mut Plan,
         auxrowmarks: *mut List,
         epqParam: ::std::os::raw::c_int,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn EvalPlanQualInitExt(
+        epqstate: *mut EPQState,
+        parentestate: *mut EState,
+        subplan: *mut Plan,
+        auxrowmarks: *mut List,
+        epqParam: ::std::os::raw::c_int,
+        resultRelations: *mut List,
     );
 }
 #[pgrx_macros::pg_guard]
@@ -32615,6 +32588,14 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -43776,6 +43757,11 @@ extern "C" {
         joinquals: *mut *mut List,
         otherquals: *mut *mut List,
     );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
+        -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 222] = b" '--prefix=/home/atelier/.pgrx/15.3/pgrx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 205] = b" '--prefix=/home/zombodb/.pgrx/15.4/pgrx-install' '--with-pgport=28815' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28815;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28815\0";
 pub const DLSUFFIX: &[u8; 4] = b".so\0";
@@ -322,19 +322,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 15.3\0";
+pub const PACKAGE_STRING: &[u8; 16] = b"PostgreSQL 15.4\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 5] = b"15.3\0";
+pub const PACKAGE_VERSION: &[u8; 5] = b"15.4\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"15\0";
 pub const PG_MAJORVERSION_NUM: u32 = 15;
-pub const PG_MINORVERSION_NUM: u32 = 3;
+pub const PG_MINORVERSION_NUM: u32 = 4;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 5] = b"15.3\0";
-pub const PG_VERSION_NUM: u32 = 150003;
-pub const PG_VERSION_STR: &[u8; 86] =
-    b"PostgreSQL 15.3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
+pub const PG_VERSION: &[u8; 5] = b"15.4\0";
+pub const PG_VERSION_NUM: u32 = 150004;
+pub const PG_VERSION_STR : & [u8 ; 102] = b"PostgreSQL 15.4 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -395,7 +394,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -404,7 +402,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 38;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -435,7 +433,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -445,9 +442,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -777,7 +774,7 @@ pub const PG_BINARY_R: &[u8; 2] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2] = b"w\0";
 pub const _CTYPE_H: u32 = 1;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 15.3\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 28] = b"postgres (PostgreSQL) 15.4\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -961,6 +958,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -1006,11 +1008,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -1897,9 +1894,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -1988,9 +1982,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -2058,7 +2049,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -2638,6 +2628,8 @@ pub const Anum_pg_database_datcollversion: u32 = 15;
 pub const Anum_pg_database_datacl: u32 = 16;
 pub const Natts_pg_database: u32 = 16;
 pub const Template1DbOid: u32 = 1;
+pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
+pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const EnumOidIndexId: u32 = 3502;
 pub const EnumTypIdLabelIndexId: u32 = 3503;
@@ -3710,39 +3702,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *const ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __pos: *mut __off64_t,
-        __w: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int,
->;
-pub type cookie_close_function_t = ::std::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4167,18 +4126,6 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn arc4random() -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4225,22 +4172,6 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5587,6 +5518,22 @@ pub const FP_ZERO: _bindgen_ty_2 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_2 = 3;
 pub const FP_NORMAL: _bindgen_ty_2 = 4;
 pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_get_user_name(
@@ -18596,7 +18543,7 @@ impl Default for PlanState {
 pub struct EPQState {
     pub parentestate: *mut EState,
     pub epqParam: ::std::os::raw::c_int,
-    pub tuple_table: *mut List,
+    pub epqExtra: *mut EPQStateExtra,
     pub relsubs_slot: *mut *mut TupleTableSlot,
     pub plan: *mut Plan,
     pub arowMarks: *mut List,
@@ -18607,6 +18554,22 @@ pub struct EPQState {
     pub recheckplanstate: *mut PlanState,
 }
 impl Default for EPQState {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct EPQStateExtra {
+    pub resultRelations: *mut List,
+    pub tuple_table: *mut List,
+    pub relsubs_blocked: *mut bool,
+}
+impl Default for EPQStateExtra {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -20868,6 +20831,17 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn EvalPlanQualInitExt(
+        epqstate: *mut EPQState,
+        parentestate: *mut EState,
+        subplan: *mut Plan,
+        auxrowmarks: *mut List,
+        epqParam: ::std::os::raw::c_int,
+        resultRelations: *mut List,
+    );
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn EvalPlanQualSetPlan(epqstate: *mut EPQState, subplan: *mut Plan, auxrowmarks: *mut List);
 }
 #[pgrx_macros::pg_guard]
@@ -23101,6 +23075,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -23127,7 +23108,6 @@ pub const IPPROTO_BEETPH: _bindgen_ty_16 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_16 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_16 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_16 = 108;
-pub const IPPROTO_L2TP: _bindgen_ty_16 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_16 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_16 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_16 = 137;
@@ -23233,13 +23213,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -24176,6 +24149,13 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pgstat_have_entry(kind: PgStat_Kind, dboid: Oid, objoid: Oid) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn assign_stats_fetch_consistency(
+        newval: ::std::os::raw::c_int,
+        extra: *mut ::std::os::raw::c_void,
+    );
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -32802,6 +32782,14 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -44183,6 +44171,11 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
+        -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
 }
 #[pgrx_macros::pg_guard]
@@ -48149,7 +48142,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *mut ::std::os::raw::c_char;
+    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *const ::std::os::raw::c_char;
 }
 pub const CRSSnapshotAction_CRS_EXPORT_SNAPSHOT: CRSSnapshotAction = 0;
 pub const CRSSnapshotAction_CRS_NOEXPORT_SNAPSHOT: CRSSnapshotAction = 1;

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -170,7 +170,7 @@ pub const ALIGNOF_LONG: u32 = 8;
 pub const ALIGNOF_PG_INT128_TYPE: u32 = 16;
 pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
-pub const CONFIGURE_ARGS : & [u8 ; 225] = b" '--prefix=/home/atelier/.pgrx/16beta2/pgrx-install' '--with-pgport=28816' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 -DUSE_VALGRIND=1 '\0" ;
+pub const CONFIGURE_ARGS : & [u8 ; 206] = b" '--prefix=/home/zombodb/.pgrx/16rc1/pgrx-install' '--with-pgport=28816' '--enable-debug' '--enable-cassert' 'CPPFLAGS= -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 '\0" ;
 pub const DEF_PGPORT: u32 = 28816;
 pub const DEF_PGPORT_STR: &[u8; 6] = b"28816\0";
 pub const DLSUFFIX: &[u8; 4] = b".so\0";
@@ -277,19 +277,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &[u8; 32] = b"pgsql-bugs@lists.postgresql.org\0";
 pub const PACKAGE_NAME: &[u8; 11] = b"PostgreSQL\0";
-pub const PACKAGE_STRING: &[u8; 19] = b"PostgreSQL 16beta2\0";
+pub const PACKAGE_STRING: &[u8; 17] = b"PostgreSQL 16rc1\0";
 pub const PACKAGE_TARNAME: &[u8; 11] = b"postgresql\0";
 pub const PACKAGE_URL: &[u8; 28] = b"https://www.postgresql.org/\0";
-pub const PACKAGE_VERSION: &[u8; 8] = b"16beta2\0";
+pub const PACKAGE_VERSION: &[u8; 6] = b"16rc1\0";
 pub const PG_KRB_SRVNAM: &[u8; 9] = b"postgres\0";
 pub const PG_MAJORVERSION: &[u8; 3] = b"16\0";
 pub const PG_MAJORVERSION_NUM: u32 = 16;
 pub const PG_MINORVERSION_NUM: u32 = 0;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &[u8; 8] = b"16beta2\0";
+pub const PG_VERSION: &[u8; 6] = b"16rc1\0";
 pub const PG_VERSION_NUM: u32 = 160000;
-pub const PG_VERSION_STR: &[u8; 89] =
-    b"PostgreSQL 16beta2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.1.1 20230714, 64-bit\0";
+pub const PG_VERSION_STR : & [u8 ; 103] = b"PostgreSQL 16rc1 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -350,7 +349,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -359,7 +357,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 38;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -390,7 +388,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -400,9 +397,9 @@ pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
 pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const L_tmpnam: u32 = 20;
 pub const TMP_MAX: u32 = 238328;
-pub const _BITS_STDIO_LIM_H: u32 = 1;
 pub const FILENAME_MAX: u32 = 4096;
 pub const L_ctermid: u32 = 9;
 pub const FOPEN_MAX: u32 = 16;
@@ -731,7 +728,7 @@ pub const PG_BINARY_R: &[u8; 2] = b"r\0";
 pub const PG_BINARY_W: &[u8; 2] = b"w\0";
 pub const _CTYPE_H: u32 = 1;
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &[u8; 31] = b"postgres (PostgreSQL) 16beta2\n\0";
+pub const PG_BACKEND_VERSIONSTR: &[u8; 29] = b"postgres (PostgreSQL) 16rc1\n\0";
 pub const EXE: &[u8; 1] = b"\0";
 pub const DEVNULL: &[u8; 10] = b"/dev/null\0";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -919,6 +916,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const _BITS_STAT_H: u32 = 1;
 pub const _BITS_STRUCT_STAT_H: u32 = 1;
 pub const __S_IFMT: u32 = 61440;
@@ -964,11 +966,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -1368,7 +1365,7 @@ pub const RTPrefixStrategyNumber: u32 = 28;
 pub const RTOldBelowStrategyNumber: u32 = 29;
 pub const RTOldAboveStrategyNumber: u32 = 30;
 pub const RTMaxStrategyNumber: u32 = 30;
-pub const CATALOG_VERSION_NO: u32 = 202306141;
+pub const CATALOG_VERSION_NO: u32 = 202307071;
 pub const OIDCHARS: u32 = 10;
 pub const FORKNAMECHARS: u32 = 4;
 pub const INNER_VAR: i32 = -1;
@@ -1391,8 +1388,7 @@ pub const ACL_CREATE_TEMP: u32 = 1024;
 pub const ACL_CONNECT: u32 = 2048;
 pub const ACL_SET: u32 = 4096;
 pub const ACL_ALTER_SYSTEM: u32 = 8192;
-pub const ACL_MAINTAIN: u32 = 16384;
-pub const N_ACL_RIGHTS: u32 = 15;
+pub const N_ACL_RIGHTS: u32 = 14;
 pub const ACL_NO_RIGHTS: u32 = 0;
 pub const ACL_SELECT_FOR_UPDATE: u32 = 4;
 pub const FRAMEOPTION_NONDEFAULT: u32 = 1;
@@ -1861,9 +1857,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _BITS_SOCKADDR_H: u32 = 1;
 pub const _SS_SIZE: u32 = 128;
@@ -1952,9 +1945,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -2023,7 +2013,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -2546,7 +2535,6 @@ pub const ROLE_PG_WRITE_SERVER_FILES: u32 = 4570;
 pub const ROLE_PG_EXECUTE_SERVER_PROGRAM: u32 = 4571;
 pub const ROLE_PG_SIGNAL_BACKEND: u32 = 4200;
 pub const ROLE_PG_CHECKPOINT: u32 = 4544;
-pub const ROLE_PG_MAINTAIN: u32 = 4549;
 pub const ROLE_PG_USE_RESERVED_CONNECTIONS: u32 = 4550;
 pub const ROLE_PG_CREATE_SUBSCRIPTION: u32 = 6304;
 pub const DatabaseRelationId: Oid = Oid(1262);
@@ -2576,6 +2564,8 @@ pub const Anum_pg_database_datcollversion: u32 = 16;
 pub const Anum_pg_database_datacl: u32 = 17;
 pub const Natts_pg_database: u32 = 17;
 pub const Template1DbOid: u32 = 1;
+pub const DATCONNLIMIT_UNLIMITED: i32 = -1;
+pub const DATCONNLIMIT_INVALID_DB: i32 = -2;
 pub const EnumRelationId: Oid = Oid(3501);
 pub const EnumOidIndexId: u32 = 3502;
 pub const EnumTypIdLabelIndexId: u32 = 3503;
@@ -2857,10 +2847,9 @@ pub const ACL_CREATE_TEMP_CHR: u8 = 84u8;
 pub const ACL_CONNECT_CHR: u8 = 99u8;
 pub const ACL_SET_CHR: u8 = 115u8;
 pub const ACL_ALTER_SYSTEM_CHR: u8 = 65u8;
-pub const ACL_MAINTAIN_CHR: u8 = 109u8;
-pub const ACL_ALL_RIGHTS_STR: &[u8; 16] = b"arwdDxtXUCTcsAm\0";
+pub const ACL_ALL_RIGHTS_STR: &[u8; 15] = b"arwdDxtXUCTcsA\0";
 pub const ACL_ALL_RIGHTS_COLUMN: u32 = 39;
-pub const ACL_ALL_RIGHTS_RELATION: u32 = 16511;
+pub const ACL_ALL_RIGHTS_RELATION: u32 = 127;
 pub const ACL_ALL_RIGHTS_SEQUENCE: u32 = 262;
 pub const ACL_ALL_RIGHTS_DATABASE: u32 = 3584;
 pub const ACL_ALL_RIGHTS_FDW: u32 = 256;
@@ -3087,7 +3076,6 @@ pub const VACOPT_PROCESS_TOAST: u32 = 128;
 pub const VACOPT_DISABLE_PAGE_SKIPPING: u32 = 256;
 pub const VACOPT_SKIP_DATABASE_STATS: u32 = 512;
 pub const VACOPT_ONLY_DATABASE_STATS: u32 = 1024;
-pub const VACOPT_SKIP_PRIVS: u32 = 2048;
 pub const CACHEDPLANSOURCE_MAGIC: u32 = 195726186;
 pub const CACHEDPLAN_MAGIC: u32 = 953717834;
 pub const CACHEDEXPR_MAGIC: u32 = 838275847;
@@ -3724,39 +3712,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *mut ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __buf: *const ::std::os::raw::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::std::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::std::os::raw::c_void,
-        __pos: *mut __off64_t,
-        __w: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int,
->;
-pub type cookie_close_function_t = ::std::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -4181,18 +4136,6 @@ pub struct drand48_data {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn arc4random() -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 #[pgrx_macros::pg_guard]
@@ -4239,22 +4182,6 @@ impl Default for __locale_struct {
 }
 pub type __locale_t = *mut __locale_struct;
 pub type locale_t = __locale_t;
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcpy(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-#[pgrx_macros::pg_guard]
-extern "C" {
-    pub fn strlcat(
-        __dest: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5614,6 +5541,22 @@ pub const FP_ZERO: _bindgen_ty_2 = 2;
 pub const FP_SUBNORMAL: _bindgen_ty_2 = 3;
 pub const FP_NORMAL: _bindgen_ty_2 = 4;
 pub type _bindgen_ty_2 = ::std::os::raw::c_uint;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcat(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn strlcpy(
+        dst: *mut ::std::os::raw::c_char,
+        src: *const ::std::os::raw::c_char,
+        siz: usize,
+    ) -> usize;
+}
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn pg_get_user_name(
@@ -16702,7 +16645,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn ConditionVariableCancelSleep();
+    pub fn ConditionVariableCancelSleep() -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -23823,6 +23766,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::std::os::raw::c_int,
     pub ipi_spec_dst: in_addr,
@@ -23849,7 +23799,6 @@ pub const IPPROTO_BEETPH: _bindgen_ty_16 = 94;
 pub const IPPROTO_ENCAP: _bindgen_ty_16 = 98;
 pub const IPPROTO_PIM: _bindgen_ty_16 = 103;
 pub const IPPROTO_COMP: _bindgen_ty_16 = 108;
-pub const IPPROTO_L2TP: _bindgen_ty_16 = 115;
 pub const IPPROTO_SCTP: _bindgen_ty_16 = 132;
 pub const IPPROTO_UDPLITE: _bindgen_ty_16 = 136;
 pub const IPPROTO_MPLS: _bindgen_ty_16 = 137;
@@ -23955,13 +23904,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::std::os::raw::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -32380,6 +32322,14 @@ impl Default for FormData_pg_database {
     }
 }
 pub type Form_pg_database = *mut FormData_pg_database;
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_form(datform: Form_pg_database) -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn database_is_invalid_oid(dboid: Oid) -> bool;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FormData_pg_enum {
@@ -35423,7 +35373,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn RangeVarCallbackMaintainsTable(
+    pub fn RangeVarCallbackOwnsTable(
         relation: *const RangeVar,
         relId: Oid,
         oldRelId: Oid,
@@ -37645,11 +37595,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn vacuum_is_permitted_for_relation(
-        relid: Oid,
-        reltuple: Form_pg_class,
-        options: bits32,
-    ) -> bool;
+    pub fn vacuum_is_relation_owner(relid: Oid, reltuple: Form_pg_class, options: bits32) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -41848,7 +41794,11 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn makeJsonValueExpr(expr: *mut Expr, format: *mut JsonFormat) -> *mut JsonValueExpr;
+    pub fn makeJsonValueExpr(
+        raw_expr: *mut Expr,
+        formatted_expr: *mut Expr,
+        format: *mut JsonFormat,
+    ) -> *mut JsonValueExpr;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -45027,6 +44977,11 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
+    pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
+        -> bool;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
 }
 #[pgrx_macros::pg_guard]
@@ -45170,10 +45125,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn JumbleQuery(
-        query: *mut Query,
-        querytext: *const ::std::os::raw::c_char,
-    ) -> *mut JumbleState;
+    pub fn JumbleQuery(query: *mut Query) -> *mut JumbleState;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -45250,6 +45202,10 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn transformStmt(pstate: *mut ParseState, parseTree: *mut Node) -> *mut Query;
+}
+#[pgrx_macros::pg_guard]
+extern "C" {
+    pub fn stmt_requires_parse_analysis(parseTree: *mut RawStmt) -> bool;
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
@@ -49042,7 +48998,7 @@ extern "C" {
 }
 #[pgrx_macros::pg_guard]
 extern "C" {
-    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *mut ::std::os::raw::c_char;
+    pub fn logicalrep_message_type(action: LogicalRepMsgType) -> *const ::std::os::raw::c_char;
 }
 pub const CRSSnapshotAction_CRS_EXPORT_SNAPSHOT: CRSSnapshotAction = 0;
 pub const CRSSnapshotAction_CRS_NOEXPORT_SNAPSHOT: CRSSnapshotAction = 1;
@@ -50135,12 +50091,12 @@ pub const ExtendBufferedFlags_EB_LOCK_TARGET: ExtendBufferedFlags = 32;
 pub type ExtendBufferedFlags = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct ExtendBufferedWhat {
+pub struct BufferManagerRelation {
     pub rel: Relation,
     pub smgr: *mut SMgrRelationData,
     pub relpersistence: ::std::os::raw::c_char,
 }
-impl Default for ExtendBufferedWhat {
+impl Default for BufferManagerRelation {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -50274,7 +50230,7 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn ExtendBufferedRel(
-        eb: ExtendBufferedWhat,
+        bmr: BufferManagerRelation,
         forkNum: ForkNumber,
         strategy: BufferAccessStrategy,
         flags: uint32,
@@ -50283,7 +50239,7 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn ExtendBufferedRelBy(
-        eb: ExtendBufferedWhat,
+        bmr: BufferManagerRelation,
         fork: ForkNumber,
         strategy: BufferAccessStrategy,
         flags: uint32,
@@ -50295,7 +50251,7 @@ extern "C" {
 #[pgrx_macros::pg_guard]
 extern "C" {
     pub fn ExtendBufferedRelTo(
-        eb: ExtendBufferedWhat,
+        bmr: BufferManagerRelation,
         fork: ForkNumber,
         strategy: BufferAccessStrategy,
         flags: uint32,

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-tests"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -49,14 +49,14 @@ clap-cargo = "0.11.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.147"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.4" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0-beta.4" }
-postgres = "0.19.6"
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.10.0" }
+postgres = "0.19.7"
 proptest = { version = "1", optional = true }
-regex = "1.9.3"
+regex = "1.9.5"
 serde = "1.0"
 serde_json = "1.0"
-sysinfo = "0.29.8"
+sysinfo = "0.29.9"
 eyre = "0.6.8"
 thiserror = "1.0"
 rand = "0.8.5"
@@ -68,4 +68,4 @@ trybuild = "1"
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.10.0-beta.4"
+version = "=0.10.0"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 description = "Standalone tool to update PGRX Cargo.toml versions and dependencies in preparation for a release."
 
 [dependencies]
-clap = { version = "4.3.23", features = [ "env", "derive" ] }
+clap = { version = "4.4.2", features = [ "env", "derive" ] }
 owo-colors = "3.5.0"
 toml_edit = { version = "0.19.14" }
 walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx"
-version = "0.10.0-beta.4"
+version = "0.10.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -44,9 +44,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0-beta.4" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.10.0-beta.4" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0-beta.4" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.10.0" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.10.0" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.10.0" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
This is the final release of v0.10.0.  Thanks everyone for the beta testing, pull requests, issues, and patience.

As always, install `cargo-pgrx` with `cargo install cargo-pgrx --locked` and update your extension Cargo.toml files to use the `0.10.0` pgrx dependencies.

This release includes support for Postgres 16RC1.  Support for the previous betas has been removed.  As such, a fresh `cargo pgrx init` is required.

## What's Changed Since v0.10.0-beta.4

* Fix `GetMemoryChunkContext` port by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1273
* Better error messages when `pg_config` isn't found. by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1271
* Make `PostgresHash` also need `Eq` by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1264
* Memoize git hash and extension metadata by @levkk in https://github.com/pgcentralfoundation/pgrx/pull/1274
* move to pg16rc1 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1276
* Fix bgworker template up to 0.10.0-beta.4 by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1270

## New Contributors
* @levkk made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1274

**Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.10.0-beta.4...v0.10.0

---

v0.10.0's full set of changes throughout the entire beta period are:

* Postgres 16beta1 Support by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1169
* Support building against macOS universal binaries by @clowder in https://github.com/pgcentralfoundation/pgrx/pull/1166
* list specific versions in feature gates by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1175
* Fix bug with converting a `pg_sys::Datum` into a `pgrx::Date` by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1177
* Fix Arrays with leading nulls by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1180
* Disable hello_versioned_so test by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1192
* doc: fix link broken by @yihong0618 in https://github.com/pgcentralfoundation/pgrx/pull/1181
* fcinfo: fix incorrect length set in unsafe code by @Sasasu in https://github.com/pgcentralfoundation/pgrx/pull/1190
* update to pg16beta2 support by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1188
* Array-walking is aligned by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1191
* Implement PGRXSharedMemory for Deque by @feikesteenbergen in https://github.com/pgcentralfoundation/pgrx/pull/1170
* Include security labels header by @daamien in https://github.com/pgcentralfoundation/pgrx/pull/1189
* Fixes macos-11 tests by @BradyBonnette in https://github.com/pgcentralfoundation/pgrx/pull/1197
* Pgcentralfoundation updates again by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1200
* Update version to 0.10.0-beta.0 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1201
* Testing help by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1203
* Type testability cleanup by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1204
* Try to smartly propagate fs errors by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1186
* Fix issue #1209 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1210
* Type roundtrip tests by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1185
* Update version to 0.10.0-beta.1 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1213
* Add a workaround for the pg16/homebrew/icu4c situation  by @thomcc in https://github.com/pgcentralfoundation/pgrx/pull/1206
* Add security policy by @johnrballard in https://github.com/pgcentralfoundation/pgrx/pull/1207
* `AnyNumeric` is no longer backed by Postgres-allocated memory by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1216
* Modularize pgrx::spi by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1219
* Stop SpiClient soundness from regressing by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1214
* Add foreign table headers by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1226
* Modularize the interior of pgrx-pg-sys by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1227
* Initial valgrind support by @thomcc in https://github.com/pgcentralfoundation/pgrx/pull/1218
* Add support for handling SIGINT and SIGCHLD from bgworker by @JelteF in https://github.com/pgcentralfoundation/pgrx/pull/1229
* Ignores UI tests for MUSL environments by @BradyBonnette in https://github.com/pgcentralfoundation/pgrx/pull/1235
* Add a env flag that can be set to skip `#[pg_test]`-generated tests. by @thomcc in https://github.com/pgcentralfoundation/pgrx/pull/1239
* Fix issue #1076: Properly handle dependency graph of `Result<T, _>` by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1241
* Cleanup the error when cargo-pgrx version doesn't match Cargo.toml by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1240
* Add operator and cache related api by @VoVAllen in https://github.com/pgcentralfoundation/pgrx/pull/1242
* Addresses cargo-pgrx error reporting by @BradyBonnette in https://github.com/pgcentralfoundation/pgrx/pull/1238
* Update version to 0.10.0-beta.2 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1244
* Bump cargo-metadata and clap-cargo by @thomcc in https://github.com/pgcentralfoundation/pgrx/pull/1246
* Derive Clone for Inet by @JelteF in https://github.com/pgcentralfoundation/pgrx/pull/1251
* Correct docs for datetime `From` impls by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1253
* Only enable line tables for profile.dev by @thomcc in https://github.com/pgcentralfoundation/pgrx/pull/1249
* Remove references to master branch by @thomcc in https://github.com/pgcentralfoundation/pgrx/pull/1243
* Ensure bindgen gets all the `cppflags` it needs (on macOS, anyway) by @thomcc in https://github.com/pgcentralfoundation/pgrx/pull/1247
* update for pg16beta3 support by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1254
* Update version to 0.10.0-beta.3 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1255
* Add proptest support by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1258
* Misc reformatting and typo fixes by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1260
* spi: simplify (optimize?) Datum preparation by @vrmiguel in https://github.com/pgcentralfoundation/pgrx/pull/1256
* Assume commutation when deriving PostgresEq by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1261
* Demand Ord for PostgresOrd by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1262
* Fix pgrx install causing postgresql coredump by @Sasasu in https://github.com/pgcentralfoundation/pgrx/pull/1263
* Update version to 0.10.0-beta.4 by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1267

## New Contributors
* @clowder made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1166
* @yihong0618 made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1181
* @Sasasu made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1190
* @daamien made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1189
* @johnrballard made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1207
* @VoVAllen made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1242
* @vrmiguel made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1256


**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.9.8...v0.10.0