### PR TITLE
when constructing a new ListCell, the 'next' node begins life as NULL

### DIFF
--- a/pgrx/src/list/node_list.rs
+++ b/pgrx/src/list/node_list.rs
@@ -124,6 +124,7 @@ impl<T: Enlist> List<T> {
                     pg_sys::MemoryContextAlloc(context, mem::size_of::<pg_sys::List>()).cast();
                 let node: *mut pg_sys::ListCell =
                     pg_sys::MemoryContextAlloc(context, mem::size_of::<pg_sys::ListCell>()).cast();
+                (*node).next = ptr::null_mut();
                 *T::apoptosis(node) = value;
                 (*list).head = node;
                 (*list).tail = node;


### PR DESCRIPTION
This fixes a segfault when iterating a List.

CI helped to find this when testing #1279 on pg12.

There's still another bug but I haven't found it yet and therefore cannot explain what it is either!