### PR TITLE
Generate bindings for WAL recovery functions

### DIFF
--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -30,6 +30,7 @@
 #include "access/sysattr.h"
 #include "access/table.h"
 #include "access/xact.h"
+#include "access/xlogrecovery.h"
 #include "catalog/dependency.h"
 #include "catalog/index.h"
 #include "catalog/indexing.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -30,6 +30,7 @@
 #include "access/sysattr.h"
 #include "access/table.h"
 #include "access/xact.h"
+#include "access/xlogrecovery.h"
 #include "catalog/dependency.h"
 #include "catalog/index.h"
 #include "catalog/indexing.h"


### PR DESCRIPTION
While building a feature, I found out `GetXLogReplayRecPtr` was no longer available in PostgreSQL 15 and 16. Older versions did contain it just fine. In commit 70e81861 of the PostgreSQL repository, xlog.c was split: recovery related functions were moved into xlogrecovery.c

This commit ensures we also generate the bindings for this file

1: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=70e81861fadd9112fa2d425c762e163910a4ee52