### PR TITLE
fix issue #1301

### DIFF
--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -573,11 +573,17 @@ impl ToSql for PgExternEntity {
                 Err(err) => return Err(err.into()),
             };
 
+            let schema = self
+                .schema
+                .map(|schema| format!("{}.", schema))
+                .unwrap_or_else(|| context.schema_prefix_for(&self_index));
+
+            eprintln!("schema={schema}");
             let operator_sql = format!("\n\n\
                                                     -- {file}:{line}\n\
                                                     -- {module_path}::{name}\n\
-                                                    CREATE OPERATOR {opname} (\n\
-                                                        \tPROCEDURE=\"{name}\",\n\
+                                                    CREATE OPERATOR {schema}{opname} (\n\
+                                                        \tPROCEDURE={schema}\"{name}\",\n\
                                                         \tLEFTARG={schema_prefix_left}{left_arg}, /* {left_name} */\n\
                                                         \tRIGHTARG={schema_prefix_right}{right_arg}{maybe_comma} /* {right_name} */\n\
                                                         {optionals}\

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod name_tests;
 mod numeric_tests;
 mod pg_extern_tests;
 mod pg_guard_tests;
+mod pg_operator_tests;
 mod pg_try_tests;
 mod pgbox_tests;
 mod pgrx_module_qualification;

--- a/pgrx-tests/src/tests/pg_operator_tests.rs
+++ b/pgrx-tests/src/tests/pg_operator_tests.rs
@@ -1,0 +1,35 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::prelude::*;
+
+#[pg_schema]
+mod pg_catalog {
+    use pgrx::{opname, pg_operator};
+
+    #[pg_operator]
+    #[opname(==>)]
+    fn concat_strings(left: String, right: String) -> String {
+        left + &right
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgrx_tests;
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_correct_schema() {
+        let result = Spi::get_one::<String>("SELECT 'hello, ' OPERATOR(pg_catalog.==>) 'world';");
+        assert_eq!(result, Ok(Some(String::from("hello, world"))));
+    }
+}


### PR DESCRIPTION
This fixes issue #1301 such that the schema generator now schema-qualifies the operator name when generating a `CREATE OPERATOR` statement.  It also qualifies the associated function.

This allows us to pick up the fact that a `#[pg_operator]` annotation was applied to function in a module with `#[pg_schema]`.