### PR TITLE
Fix issue #1293

### DIFF
--- a/pgrx-tests/src/tests/composite_type_tests.rs
+++ b/pgrx-tests/src/tests/composite_type_tests.rs
@@ -1,0 +1,40 @@
+use pgrx::prelude::*;
+
+extension_sql!(
+    r#"
+    CREATE TYPE entity AS (id INT, lang TEXT);
+    CREATE TYPE result AS (score DOUBLE PRECISION, entities entity[]);
+    "#,
+    name = "issue1293"
+);
+
+#[pg_extern(requires = ["issue1293"])]
+fn create_result() -> pgrx::composite_type!("result") {
+    let mut record = PgHeapTuple::new_composite_type("result").unwrap();
+    record.set_by_name("score", 0.707).unwrap();
+    let mut entity_records: Vec<pgrx::composite_type!("entity")> = Vec::new();
+    for i in 0..10 {
+        let mut entity_record = PgHeapTuple::new_composite_type("entity").unwrap();
+        entity_record.set_by_name("id", i).unwrap();
+        entity_record.set_by_name("lang", "en".to_string()).unwrap();
+        entity_records.push(entity_record);
+    }
+    record.set_by_name("entities", entity_records).unwrap();
+    return record;
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[allow(unused_imports)]
+    use crate as pgrx_tests;
+
+    #[pg_test]
+    fn test_array_of_composite_type() {
+        Spi::get_one::<bool>("SELECT create_result() is not null")
+            .expect("SPI failed")
+            .expect("failed to create `result` composite type'");
+    }
+}

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod attributes_tests;
 mod bgworker_tests;
 mod bytea_tests;
 mod cfg_tests;
+mod composite_type_tests;
 mod datetime_tests;
 mod default_arg_value_tests;
 mod derive_pgtype_lifetimes;

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -741,6 +741,13 @@ impl<T: IntoDatum + FromDatum> IntoDatum for Array<'_, T> {
     fn type_oid() -> Oid {
         T::array_type_oid()
     }
+
+    fn composite_type_oid(&self) -> Option<Oid> {
+        // the composite type oid for a vec of composite types is the array type of the base composite type
+        self.get(0)
+            .map(|v| v.composite_type_oid().map(|oid| unsafe { pg_sys::get_array_type(oid) }))
+            .flatten()
+    }
 }
 
 impl<T: FromDatum> FromDatum for Vec<T> {
@@ -836,6 +843,13 @@ where
 
     fn type_oid() -> pg_sys::Oid {
         unsafe { pg_sys::get_array_type(T::type_oid()) }
+    }
+
+    fn composite_type_oid(&self) -> Option<Oid> {
+        // the composite type oid for a vec of composite types is the array type of the base composite type
+        self.get(0)
+            .map(|v| v.composite_type_oid().map(|oid| unsafe { pg_sys::get_array_type(oid) }))
+            .flatten()
     }
 
     #[inline]

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -352,17 +352,34 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
             match self.get_attribute_by_index(attno) {
                 None => return Err(TryFromDatumError::NoSuchAttributeNumber(attno)),
                 Some(att) => {
-                    let type_oid = T::type_oid();
-                    let composite_type_oid = value.composite_type_oid();
-                    let is_compatible_composite_types =
-                        type_oid == pg_sys::RECORDOID && composite_type_oid == Some(att.atttypid);
-                    if !is_compatible_composite_types && !T::is_compatible_with(att.atttypid) {
-                        return Err(TryFromDatumError::IncompatibleTypes {
-                            rust_type: std::any::type_name::<T>(),
-                            rust_oid: att.atttypid,
-                            datum_type: lookup_type_name(type_oid),
-                            datum_oid: type_oid,
-                        });
+                    // if the attribute's type is an array and our incoming value is a composite
+                    // then we need to ensure that the `att.atttypid` is the same as the array type
+                    // of `value`'s type
+                    if pg_sys::type_is_array(att.atttypid) && value.composite_type_oid().is_some() {
+                        let array_of_composite_type_oid = value.composite_type_oid().unwrap();
+
+                        if att.atttypid != array_of_composite_type_oid {
+                            return Err(TryFromDatumError::IncompatibleTypes {
+                                rust_type: std::any::type_name::<T>(),
+                                rust_oid: att.atttypid,
+                                datum_type: lookup_type_name(array_of_composite_type_oid),
+                                datum_oid: array_of_composite_type_oid,
+                            });
+                        }
+                    } else {
+                        // it's not an array type, so we'll do standard type compatability checks
+                        let type_oid = T::type_oid();
+                        let composite_type_oid = value.composite_type_oid();
+                        let is_compatible_composite_types = type_oid == pg_sys::RECORDOID
+                            && composite_type_oid == Some(att.atttypid);
+                        if !is_compatible_composite_types && !T::is_compatible_with(att.atttypid) {
+                            return Err(TryFromDatumError::IncompatibleTypes {
+                                rust_type: std::any::type_name::<T>(),
+                                rust_oid: att.atttypid,
+                                datum_type: lookup_type_name(type_oid),
+                                datum_oid: type_oid,
+                            });
+                        }
                     }
                 }
             }

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -367,7 +367,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
                             });
                         }
                     } else {
-                        // it's not an array type, so we'll do standard type compatability checks
+                        // it's not an array type, so we'll do standard type compatibility checks
                         let type_oid = T::type_oid();
                         let composite_type_oid = value.composite_type_oid();
                         let is_compatible_composite_types = type_oid == pg_sys::RECORDOID


### PR DESCRIPTION
This allows for `PgHeapTuple.set_by_index()` to work correctly with arrays of composite types.