### PR TITLE
Replace cshimmed fn

### DIFF
--- a/pgrx-pg-sys/src/cshim.rs
+++ b/pgrx-pg-sys/src/cshim.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "cshim")]
+#![allow(deprecated)]
 
 use crate as pg_sys;
 use core::ffi;
@@ -11,6 +12,7 @@ extern "C" {
     pub fn pgrx_list_nth_cell(list: *mut pg_sys::List, nth: i32) -> *mut pg_sys::ListCell;
 
     #[link_name = "pgrx_planner_rt_fetch"]
+    #[deprecated(since = "0.11", note = "use pgrx::pg_sys::planner_rt_fetch")]
     pub fn planner_rt_fetch(
         index: pg_sys::Index,
         root: *mut pg_sys::PlannerInfo,
@@ -31,6 +33,7 @@ extern "C" {
 ///     ((RangeTblEntry *) list_nth(rangetable, (rangetable_index)-1))
 /// ```
 #[inline]
+#[deprecated(since = "0.11", note = "use pgrx::pg_sys::rt_fetch")]
 pub unsafe fn rt_fetch(
     index: super::Index,
     range_table: *mut super::List,

--- a/pgrx-pg-sys/src/cshim.rs
+++ b/pgrx-pg-sys/src/cshim.rs
@@ -25,3 +25,15 @@ extern "C" {
     #[link_name = "pgrx_SpinLockFree"]
     pub fn SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
 }
+
+/// ```c
+/// #define rt_fetch(rangetable_index, rangetable) \
+///     ((RangeTblEntry *) list_nth(rangetable, (rangetable_index)-1))
+/// ```
+#[inline]
+pub unsafe fn rt_fetch(
+    index: super::Index,
+    range_table: *mut super::List,
+) -> *mut super::RangeTblEntry {
+    pgrx_list_nth(range_table, index as i32 - 1).cast()
+}

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -115,7 +115,7 @@ pub use varlena::*;
 pub use wrappers::*;
 pub use xid::*;
 
-pub use pgrx_pg_sys as pg_sys; // the module only, not its contents
+pub mod pg_sys;
 
 // and re-export these
 pub use pg_sys::elog::PgLogLevel;

--- a/pgrx/src/pg_sys.rs
+++ b/pgrx/src/pg_sys.rs
@@ -1,0 +1,44 @@
+//! dirty hacks
+
+// Flatten out the contents into here.
+pub use pgrx_pg_sys::*;
+
+// Interposing here can allow extensions like ZomboDB to skip the cshim,
+// i.e. we are deliberately shadowing the upcoming names.
+
+/**
+```c
+ #define rt_fetch(rangetable_index, rangetable) \
+     ((RangeTblEntry *) list_nth(rangetable, (rangetable_index)-1))
+```
+*/
+pub unsafe fn rt_fetch(index: Index, range_table: *mut List) -> *mut RangeTblEntry {
+    crate::list::List::<*mut core::ffi::c_void>::downcast_ptr(range_table)
+        .unwrap()
+        .get((index - 1) as _)
+        .unwrap()
+        .cast()
+}
+
+/**
+```c
+ /*
+  * In places where it's known that simple_rte_array[] must have been prepared
+  * already, we just index into it to fetch RTEs.  In code that might be
+  * executed before or after entering query_planner(), use this macro.
+  */
+#define planner_rt_fetch(rti, root) \
+    ((root)->simple_rte_array ? (root)->simple_rte_array[rti] : \
+    rt_fetch(rti, (root)->parse->rtable))
+```
+*/
+#[inline]
+pub unsafe fn planner_rt_fetch(index: Index, root: *mut PlannerInfo) -> *mut RangeTblEntry {
+    unsafe {
+        if (*root).simple_rte_array != core::ptr::null_mut() {
+            *(*root).simple_rte_array.add(index as _)
+        } else {
+            rt_fetch(index, (*(*root).parse).rtable).cast()
+        }
+    }
+}

--- a/pgrx/src/pg_sys.rs
+++ b/pgrx/src/pg_sys.rs
@@ -12,11 +12,12 @@ pub use pgrx_pg_sys::*;
      ((RangeTblEntry *) list_nth(rangetable, (rangetable_index)-1))
 ```
 */
+#[inline]
 pub unsafe fn rt_fetch(index: Index, range_table: *mut List) -> *mut RangeTblEntry {
     crate::list::List::<*mut core::ffi::c_void>::downcast_ptr(range_table)
-        .unwrap()
+        .expect("rt_fetch used on non-ptr List")
         .get((index - 1) as _)
-        .unwrap()
+        .expect("rt_fetch used out-of-bounds")
         .cast()
 }
 


### PR DESCRIPTION
This returns to their rightful place some cshimmed fn that were accidentally dropped on the floor while I was trying to clean up pgrx-pg-sys to... make it harder to lose track of things... yeah! The best-laid plans of mice and men etc.

It then does something more devilish: by shadowing certain names, it allows us to outmode them entirely in the future.