### PR TITLE
Touch up Display for PgNode

### DIFF
--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -532,7 +532,7 @@ fn impl_pg_node(
         pgnode_impls.extend(quote! {
             impl ::core::fmt::Display for #struct_name {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.write_str(&self.display_node())
+                    self.display_node().fmt(f)
                 }
             }
         });

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -530,9 +530,9 @@ fn impl_pg_node(
 
         // impl Rust's Display trait for all nodes
         pgnode_impls.extend(quote! {
-            impl std::fmt::Display for #struct_name {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    write!(f, "{}", self.display_node() )
+            impl ::core::fmt::Display for #struct_name {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    f.write_str(&self.display_node())
                 }
             }
         });


### PR DESCRIPTION
This wasn't using the unambiguous root path addressing.

Avoiding `write!` is often faster for fmt impls, simply because the macro tends to generate subpar code. This now dispatches to the String fmt impl, which respects alignment and padding requests, so it's hard to say if it will be faster, but in any case it's more correct.