### PR TITLE
Include bindings for controlfile

### DIFF
--- a/pgrx-pg-sys/include/pg11.h
+++ b/pgrx-pg-sys/include/pg11.h
@@ -66,6 +66,7 @@
 #include "commands/user.h"
 #include "commands/vacuum.h"
 #include "common/config_info.h"
+#include "common/controldata_utils.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "executor/tuptable.h"

--- a/pgrx-pg-sys/include/pg12.h
+++ b/pgrx-pg-sys/include/pg12.h
@@ -68,6 +68,7 @@
 #include "commands/user.h"
 #include "commands/vacuum.h"
 #include "common/config_info.h"
+#include "common/controldata_utils.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "executor/tuptable.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -68,6 +68,7 @@
 #include "commands/user.h"
 #include "commands/vacuum.h"
 #include "common/config_info.h"
+#include "common/controldata_utils.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "executor/tuptable.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -68,6 +68,7 @@
 #include "commands/user.h"
 #include "commands/vacuum.h"
 #include "common/config_info.h"
+#include "common/controldata_utils.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "executor/tuptable.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -69,6 +69,7 @@
 #include "commands/user.h"
 #include "commands/vacuum.h"
 #include "common/config_info.h"
+#include "common/controldata_utils.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "executor/tuptable.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -69,6 +69,7 @@
 #include "commands/user.h"
 #include "commands/vacuum.h"
 #include "common/config_info.h"
+#include "common/controldata_utils.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "executor/tuptable.h"


### PR DESCRIPTION
> NOTE: I didn't include the updated generated bindings, as I'm still unsure as to what the proper invocation is, these still need to be generated.

The function get_controlfile is very useful for some monitoring experiments and solutions.

I'm working on a bgworker that starts even when in crash recovery. Part of the goal of this worker is to provide more insight into the progress of crash recovery:

- distance to consistency (in WAL bytes)
- distance since last checkpoint (in WAL bytes)

For that to work nicely, it would be great to have access to the `get_controlfile` function, which exposes this information in an easy digestable fashion.