### PR TITLE
Fix pg16 CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,22 +53,21 @@ jobs:
         echo ""
 
         echo "----- Remove old postgres -----"
-        sudo apt remove -y '^postgres.*' '^libpq.*'
+        sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
         echo ""
 
         echo "----- Install system dependencies -----"
-        sudo apt-get update && sudo apt-get install -y \
-          clang-11 \
-          llvm-11 \
-          clang \
-          gcc \
-          make \
+        sudo apt-get install -y \
           build-essential \
-          libz-dev \
-          zlib1g-dev \
-          strace \
+          llvm-14-dev libclang-14-dev clang-14 \
+          gcc \
           libssl-dev \
-          pkg-config
+          libz-dev \
+          make \
+          pkg-config \
+          strace \
+          zlib1g-dev
+        echo ""
 
         echo "----- Set up cross compilation -----"
         sudo apt-get install -y --fix-missing crossbuild-essential-arm64
@@ -296,23 +295,21 @@ jobs:
         cat $GITHUB_ENV
         echo ""
 
-        echo "----- Remove existing installations of postgres -----"
-        sudo apt remove -y '^postgres.*' '^libpq.*'
+        echo "----- Remove old postgres -----"
+        sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
         echo ""
 
         echo "----- Install system dependencies -----"
         sudo apt-get install -y \
-          clang-11 \
-          llvm-11 \
-          clang \
-          gcc \
-          make \
           build-essential \
-          libz-dev \
-          zlib1g-dev \
-          strace \
+          llvm-14-dev libclang-14-dev clang-14 \
+          gcc \
           libssl-dev \
-          pkg-config
+          libz-dev \
+          make \
+          pkg-config \
+          strace \
+          zlib1g-dev
         echo ""
 
         echo "----- Output Cargo version -----"


### PR DESCRIPTION
Taking what we learned from PL/Rust and pg16 and CI, this does essentially the same two things:

- removes all the old postgres/clang/llvm-related packages that github might have installed
- sets up clang14 only

The "problem" seems to be having multiple versions of clang installed at once.  There may be some way to say, "dear bindgen, only use this particular clang", but I think this is more expedient.  Also, it's probably best CI doesn't have a bunch of clutter we don't need.