### PR TITLE
Add wrappers for postgres geometric types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,13 @@ cargo pgrx init
 | `timestamp with time zone` | `pgrx::TimestampWithTimeZone`                           |
 | `anyarray`                 | `pgrx::AnyArray`                                        |
 | `anyelement`               | `pgrx::AnyElement`                                      |
-| `box`                      | `pgrx::pg_sys::BOX`                                     |
-| `point`                    | `pgrx::pg_sys::Point`                                   |
+| `box`                      | `pgrx::geo::Box`                                        |
+| `circle`                   | `pgrx::geo::Circle`                                     |
+| `line`                     | `pgrx::geo::Line`                                       |
+| `lseg`                     | `pgrx::geo::LineSegment`                                |
+| `path`                     | `pgrx::geo::Path`                                       |
+| `point`                    | `pgrx::geo::Point`                                      |
+| `polygon`                  | `pgrx::geo::Polygon`                                    |
 | `tid`                      | `pgrx::pg_sys::ItemPointerData`                         |
 | `cstring`                  | `&core::ffi::CStr`                                      |
 | `inet`                     | `pgrx::Inet(String)` -- TODO: needs better support      |

--- a/README.md
+++ b/README.md
@@ -256,9 +256,13 @@ cargo pgrx init
 | `timestamp with time zone` | `pgrx::TimestampWithTimeZone`                           |
 | `anyarray`                 | `pgrx::AnyArray`                                        |
 | `anyelement`               | `pgrx::AnyElement`                                      |
-| `box`                      | `pgrx::pg_sys::BOX`                                     |
-| `circle`                   | `pgrx::pg_sys::CIRCLE`                                  |
-| `point`                    | `pgrx::pg_sys::Point`                                   |
+| `box`                      | `pgrx::geo::Box`                                        |
+| `circle`                   | `pgrx::geo::Circle`                                     |
+| `line`                     | `pgrx::geo::Line`                                       |
+| `lseg`                     | `pgrx::geo::LineSegment`                                |
+| `path`                     | `pgrx::geo::Path`                                       |
+| `point`                    | `pgrx::geo::Point`                                      |
+| `polygon`                  | `pgrx::geo::Polygon`                                    |
 | `tid`                      | `pgrx::pg_sys::ItemPointerData`                         |
 | `cstring`                  | `&core::ffi::CStr`                                      |
 | `inet`                     | `pgrx::Inet(String)` -- TODO: needs better support      |

--- a/pgrx-pg-sys/src/submodules/sql_translatable.rs
+++ b/pgrx-pg-sys/src/submodules/sql_translatable.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::{
     BOX, CIRCLE, Datum, FdwRoutine, FunctionCallInfoBaseData, IndexAmRoutine, ItemPointerData,
-    PlannerInfo, Point, TableAmRoutine,
+    LINE, LSEG, PlannerInfo, Point, TableAmRoutine,
 };
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
@@ -73,6 +73,22 @@ unsafe impl SqlTranslatable for CIRCLE {
     const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("circle"));
     const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
         Ok(ReturnsRef::One(SqlMappingRef::literal("circle")));
+}
+
+unsafe impl SqlTranslatable for LINE {
+    const TYPE_IDENT: &'static str = pgrx_sql_entity_graph::pgrx_resolved_type!(LINE);
+    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
+    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("line"));
+    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
+        Ok(ReturnsRef::One(SqlMappingRef::literal("line")));
+}
+
+unsafe impl SqlTranslatable for LSEG {
+    const TYPE_IDENT: &'static str = pgrx_sql_entity_graph::pgrx_resolved_type!(LSEG);
+    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
+    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("lseg"));
+    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
+        Ok(ReturnsRef::One(SqlMappingRef::literal("lseg")));
 }
 
 unsafe impl SqlTranslatable for Point {

--- a/pgrx-tests/src/tests/geo_tests.rs
+++ b/pgrx-tests/src/tests/geo_tests.rs
@@ -13,24 +13,97 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
+    use pgrx::datum::geo::*;
     use pgrx::prelude::*;
 
     #[pg_test]
-    fn test_point_into_datum() -> spi::Result<()> {
-        let p =
-            Spi::get_one::<pg_sys::Point>("SELECT '42, 99'::point")?.expect("SPI result was null");
-        assert_eq!(p.x, 42.0);
-        assert_eq!(p.y, 99.0);
+    fn test_point_datum() -> spi::Result<()> {
+        let p = Spi::get_one::<Point>("SELECT '42, 99'::point")?.expect("SPI result was null");
+        assert_eq!(p, Point { x: 42.0, y: 99.0 });
+        let p2 = Spi::get_one_with_args::<Point>(
+            "SELECT $1",
+            vec![(Point::type_oid().into(), p.into_datum())],
+        )?
+        .expect("SPI result was null");
+        assert_eq!(p, p2);
         Ok(())
     }
 
     #[pg_test]
-    fn test_box_into_datum() -> spi::Result<()> {
-        let b = Spi::get_one::<pg_sys::BOX>("SELECT '1,2,3,4'::box")?.expect("SPI result was null");
-        assert_eq!(b.high.x, 3.0);
-        assert_eq!(b.high.y, 4.0);
-        assert_eq!(b.low.x, 1.0);
-        assert_eq!(b.low.y, 2.0);
+    fn test_box_datum() -> spi::Result<()> {
+        let b = Spi::get_one::<Box>("SELECT '1,2,3,4'::box")?.expect("SPI result was null");
+        assert_eq!(b, Box { high: Point { x: 3.0, y: 4.0 }, low: Point { x: 1.0, y: 2.0 } });
+        let b2 = Spi::get_one_with_args::<Box>(
+            "SELECT $1",
+            vec![(Box::type_oid().into(), b.into_datum())],
+        )?
+        .expect("SPI result was null");
+        assert_eq!(b, b2);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_lseg_datum() -> spi::Result<()> {
+        let l = Spi::get_one::<LineSegment>("SELECT '(1,2),(3,4)'::lseg")?
+            .expect("SPI result was null");
+        assert_eq!(l.p, [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }]);
+        let l2 = Spi::get_one_with_args::<LineSegment>(
+            "SELECT $1",
+            vec![(LineSegment::type_oid().into(), l.into_datum())],
+        )?
+        .expect("SPI result was null");
+        assert_eq!(l.p, l2.p);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_path_datum() -> spi::Result<()> {
+        // Closed path
+        let p = Spi::get_one::<Path>("SELECT '((1,2),(3,4))'::path")?.expect("SPI result was null");
+        assert_eq!(p.points(), [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }]);
+        assert_eq!(p.closed(), true);
+        let p2 = Spi::get_one_with_args::<Path>(
+            "SELECT $1",
+            vec![(Path::type_oid().into(), p.clone().into_datum())],
+        )?
+        .expect("SPI result was null");
+        assert_eq!(p.points(), p2.points());
+        assert_eq!(p.closed(), p2.closed());
+
+        // Open path
+        let p = Spi::get_one::<Path>("SELECT '[(1,2),(3,4)]'::path")?.expect("SPI result was null");
+        assert_eq!(p.points(), [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }]);
+        assert_eq!(p.closed(), false);
+        let p2 = Spi::get_one_with_args::<Path>(
+            "SELECT $1",
+            vec![(Path::type_oid().into(), p.clone().into_datum())],
+        )?
+        .expect("SPI result was null");
+        assert_eq!(p.points(), p2.points());
+        assert_eq!(p.closed(), p2.closed());
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_polygon_datum() -> spi::Result<()> {
+        let p = Spi::get_one::<Polygon>("SELECT '((1,2),(3,4),(0,5))'::polygon")?
+            .expect("SPI result was null");
+        assert_eq!(
+            p.points(),
+            [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }, Point { x: 0.0, y: 5.0 }]
+        );
+        assert_eq!(
+            p.boundbox(),
+            Box { high: Point { x: 3.0, y: 5.0 }, low: Point { x: 0.0, y: 2.0 } }
+        );
+        let p2 = Spi::get_one_with_args::<Polygon>(
+            "SELECT $1",
+            vec![(Polygon::type_oid().into(), p.clone().into_datum())],
+        )?
+        .expect("SPI result was null");
+        assert_eq!(p.points(), p2.points());
+        assert_eq!(p.boundbox(), p2.boundbox());
         Ok(())
     }
 }

--- a/pgrx-unit-tests/src/tests/geo_tests.rs
+++ b/pgrx-unit-tests/src/tests/geo_tests.rs
@@ -13,34 +13,141 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_unit_tests;
 
+    use pgrx::fn_call::{Arg, fn_call};
+    use pgrx::geo::*;
     use pgrx::prelude::*;
 
+    #[pg_extern]
+    fn geo_path_identity(path: Path) -> Path {
+        path
+    }
+
+    #[pg_extern]
+    fn geo_polygon_identity(polygon: Polygon) -> Polygon {
+        polygon
+    }
+
     #[pg_test]
-    fn test_point_into_datum() -> spi::Result<()> {
-        let p =
-            Spi::get_one::<pg_sys::Point>("SELECT '42, 99'::point")?.expect("SPI result was null");
-        assert_eq!(p.x, 42.0);
-        assert_eq!(p.y, 99.0);
+    fn test_point_datum() -> spi::Result<()> {
+        let p = Spi::get_one::<Point>("SELECT '42, 99'::point")?.expect("SPI result was null");
+        assert_eq!(p, Point { x: 42.0, y: 99.0 });
+        let p2 = Spi::get_one_with_args::<Point>("SELECT $1", &[p.into()])?
+            .expect("SPI result was null");
+        assert_eq!(p, p2);
         Ok(())
     }
 
     #[pg_test]
-    fn test_box_into_datum() -> spi::Result<()> {
-        let b = Spi::get_one::<pg_sys::BOX>("SELECT '1,2,3,4'::box")?.expect("SPI result was null");
-        assert_eq!(b.high.x, 3.0);
-        assert_eq!(b.high.y, 4.0);
-        assert_eq!(b.low.x, 1.0);
-        assert_eq!(b.low.y, 2.0);
+    fn test_box_datum() -> spi::Result<()> {
+        let b = Spi::get_one::<Box>("SELECT '1,2,3,4'::box")?.expect("SPI result was null");
+        assert_eq!(b, Box { high: Point { x: 3.0, y: 4.0 }, low: Point { x: 1.0, y: 2.0 } });
+        let b2 =
+            Spi::get_one_with_args::<Box>("SELECT $1", &[b.into()])?.expect("SPI result was null");
+        assert_eq!(b, b2);
         Ok(())
     }
 
     #[pg_test]
-    fn test_circle_into_datum() -> spi::Result<()> {
-        let c =
-            Spi::get_one::<pg_sys::CIRCLE>("SELECT '1,2,3'::circle")?.expect("SPI result was null");
-        assert_eq!(c.center.x, 1.0);
-        assert_eq!(c.center.y, 2.0);
-        assert_eq!(c.radius, 3.0);
+    fn test_circle_datum() -> spi::Result<()> {
+        let c = Spi::get_one::<Circle>("SELECT '1,2,3'::circle")?.expect("SPI result was null");
+        assert_eq!(c, Circle { center: Point { x: 1.0, y: 2.0 }, radius: 3.0 });
+        let c2 = Spi::get_one_with_args::<Circle>("SELECT $1", &[c.into()])?
+            .expect("SPI result was null");
+        assert_eq!(c, c2);
         Ok(())
+    }
+
+    #[pg_test]
+    fn test_line_datum() -> spi::Result<()> {
+        let l = Spi::get_one::<Line>("SELECT '{1,2,3}'::line")?.expect("SPI result was null");
+        assert_eq!(l.A, 1.0);
+        assert_eq!(l.B, 2.0);
+        assert_eq!(l.C, 3.0);
+        let l2 =
+            Spi::get_one_with_args::<Line>("SELECT $1", &[l.into()])?.expect("SPI result was null");
+        assert_eq!(l.A, l2.A);
+        assert_eq!(l.B, l2.B);
+        assert_eq!(l.C, l2.C);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_lseg_datum() -> spi::Result<()> {
+        let l = Spi::get_one::<LineSegment>("SELECT '(1,2),(3,4)'::lseg")?
+            .expect("SPI result was null");
+        assert_eq!(l.p, [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }]);
+        let l2 = Spi::get_one_with_args::<LineSegment>("SELECT $1", &[l.into()])?
+            .expect("SPI result was null");
+        assert_eq!(l.p, l2.p);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_path_datum() -> spi::Result<()> {
+        // Closed path
+        let p = Spi::get_one::<Path>("SELECT '((1,2),(3,4))'::path")?.expect("SPI result was null");
+        assert_eq!(p.points(), [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }]);
+        assert_eq!(p.closed(), true);
+        let p2 = Spi::get_one_with_args::<Path>("SELECT $1", &[p.clone().into()])?
+            .expect("SPI result was null");
+        assert_eq!(p.points(), p2.points());
+        assert_eq!(p.closed(), p2.closed());
+
+        // Open path
+        let p = Spi::get_one::<Path>("SELECT '[(1,2),(3,4)]'::path")?.expect("SPI result was null");
+        assert_eq!(p.points(), [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }]);
+        assert_eq!(p.closed(), false);
+        let p2 = Spi::get_one_with_args::<Path>("SELECT $1", &[p.clone().into()])?
+            .expect("SPI result was null");
+        assert_eq!(p.points(), p2.points());
+        assert_eq!(p.closed(), p2.closed());
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_polygon_datum() -> spi::Result<()> {
+        let p = Spi::get_one::<Polygon>("SELECT '((1,2),(3,4),(0,5))'::polygon")?
+            .expect("SPI result was null");
+        assert_eq!(
+            p.points(),
+            [Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }, Point { x: 0.0, y: 5.0 }]
+        );
+        assert_eq!(
+            p.boundbox(),
+            Box { high: Point { x: 3.0, y: 5.0 }, low: Point { x: 0.0, y: 2.0 } }
+        );
+        let p2 = Spi::get_one_with_args::<Polygon>("SELECT $1", &[p.clone().into()])?
+            .expect("SPI result was null");
+        assert_eq!(p.points(), p2.points());
+        assert_eq!(p.boundbox(), p2.boundbox());
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_fn_call_path_datum() {
+        let path = Path::new(vec![Point { x: 1.0, y: 2.0 }, Point { x: 3.0, y: 4.0 }], true);
+        let result = fn_call::<Path>("tests.geo_path_identity", &[&Arg::Value(path.clone())])
+            .expect("fn_call failed")
+            .expect("fn_call result was null");
+
+        assert_eq!(path.points(), result.points());
+        assert_eq!(path.closed(), result.closed());
+    }
+
+    #[pg_test]
+    fn test_fn_call_polygon_datum() {
+        let polygon = Polygon::new(vec![
+            Point { x: 1.0, y: 2.0 },
+            Point { x: 3.0, y: 4.0 },
+            Point { x: 0.0, y: 5.0 },
+        ]);
+        let result =
+            fn_call::<Polygon>("tests.geo_polygon_identity", &[&Arg::Value(polygon.clone())])
+                .expect("fn_call failed")
+                .expect("fn_call result was null");
+
+        assert_eq!(polygon.points(), result.points());
+        assert_eq!(polygon.boundbox(), result.boundbox());
     }
 }

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -10,6 +10,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 //! Helper implementations for returning sets and tables from `#[pg_extern]`-style functions
 
+use crate::datum::geo::{Path, Polygon};
 use crate::datum::{
     AnyArray, AnyElement, AnyNumeric, Date, FromDatum, Inet, Internal, Interval, IntoDatum, Json,
     JsonB, Numeric, PgVarlena, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone,
@@ -268,7 +269,8 @@ argue_from_datum! { 'fcx; i8, i16, i32, i64, f32, f64, bool, char, String, Vec<u
 argue_from_datum! { 'fcx; Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone }
 argue_from_datum! { 'fcx; AnyArray, AnyElement, AnyNumeric }
 argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid, PgRelation }
-argue_from_datum! { 'fcx; pg_sys::BOX, pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point, pg_sys::TransactionId }
+argue_from_datum! { 'fcx; pg_sys::BOX, pg_sys::CIRCLE, pg_sys::LINE, pg_sys::LSEG, pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point, pg_sys::TransactionId }
+argue_from_datum! { 'fcx; Path, Polygon }
 // We could use the upcoming impl of ArgAbi for `&'fcx T where T: ?Sized + BorrowDatum`
 // to support these types by implementing BorrowDatum for them also, but we reject this.
 // It would greatly complicate other users of BorrowDatum like FlatArray, which want all impls
@@ -571,7 +573,9 @@ impl_repackage_into_datum! {
     String, CString, Vec<u8>, char,
     Json, JsonB, Inet, Uuid, AnyNumeric, AnyArray, AnyElement, Internal,
     Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone,
-    pg_sys::BOX, pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point, pg_sys::TransactionId
+    pg_sys::BOX, pg_sys::CIRCLE, pg_sys::LINE, pg_sys::LSEG,
+    pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point, pg_sys::TransactionId,
+    Path, Polygon
 }
 
 unsafe impl<const P: u32, const S: u32> BoxRet for Numeric<P, S> {

--- a/pgrx/src/datum/geo.rs
+++ b/pgrx/src/datum/geo.rs
@@ -7,9 +7,30 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
 
-impl FromDatum for pg_sys::BOX {
+//! This module contains implementations to make it easier to work with Postgres' geometric types
+//! in Rust.
+//!
+//! Simple types that support `Copy` are re-exported from the `pg_sys` crate and have `IntoDatum`
+//! and `FromDatum` trait implementations. Variable Length types have zero-copy and owned structs
+//! that have `IntoDatum` and `FromDatum` trait implementations.
+//!
+//! See the [Postgres docs](https://www.postgresql.org/docs/current/datatype-geometric.html) for
+//! more information on the geometric types.
+use std::{mem, ptr};
+
+use pgrx_pg_sys::pfree;
+use pgrx_sql_entity_graph::metadata::{
+    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+};
+
+use crate::{pg_sys, set_varsize_4b, FromDatum, IntoDatum, PgMemoryContexts};
+
+// Copy types
+
+pub type Box = pg_sys::BOX;
+
+impl FromDatum for Box {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
@@ -21,17 +42,17 @@ impl FromDatum for pg_sys::BOX {
         if is_null {
             None
         } else {
-            let the_box = datum.cast_mut_ptr::<pg_sys::BOX>();
+            let the_box = datum.cast_mut_ptr::<Self>();
             Some(the_box.read())
         }
     }
 }
 
-impl IntoDatum for pg_sys::BOX {
+impl IntoDatum for Box {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         unsafe {
             let ptr = PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::BOX>());
+                .copy_ptr_into(&mut self, std::mem::size_of::<Self>());
             Some(ptr.into())
         }
     }
@@ -41,7 +62,77 @@ impl IntoDatum for pg_sys::BOX {
     }
 }
 
-impl FromDatum for pg_sys::Point {
+pub type Line = pg_sys::LINE;
+
+impl FromDatum for Line {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let line = datum.cast_mut_ptr::<Self>();
+            Some(line.read())
+        }
+    }
+}
+
+impl IntoDatum for Line {
+    fn into_datum(mut self) -> Option<pg_sys::Datum> {
+        unsafe {
+            let ptr = PgMemoryContexts::CurrentMemoryContext
+                .copy_ptr_into(&mut self, std::mem::size_of::<Self>());
+            Some(ptr.into())
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::LINEOID
+    }
+}
+
+pub type LineSegment = pg_sys::LSEG;
+
+impl FromDatum for LineSegment {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let lseg = datum.cast_mut_ptr::<Self>();
+            Some(lseg.read())
+        }
+    }
+}
+
+impl IntoDatum for LineSegment {
+    fn into_datum(mut self) -> Option<pg_sys::Datum> {
+        unsafe {
+            let ptr = PgMemoryContexts::CurrentMemoryContext
+                .copy_ptr_into(&mut self, std::mem::size_of::<Self>());
+            Some(ptr.into())
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::LSEGOID
+    }
+}
+
+pub type Point = pg_sys::Point;
+
+impl FromDatum for Point {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
@@ -59,16 +150,227 @@ impl FromDatum for pg_sys::Point {
     }
 }
 
-impl IntoDatum for pg_sys::Point {
+impl IntoDatum for Point {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         unsafe {
             let copy = PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::Point>());
+                .copy_ptr_into(&mut self, std::mem::size_of::<Self>());
             Some(copy.into())
         }
     }
 
     fn type_oid() -> pg_sys::Oid {
         pg_sys::POINTOID
+    }
+}
+
+pub type Circle = pg_sys::CIRCLE;
+
+impl FromDatum for Circle {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let circle = datum.cast_mut_ptr::<Self>();
+            Some(circle.read())
+        }
+    }
+}
+
+impl IntoDatum for Circle {
+    fn into_datum(mut self) -> Option<pg_sys::Datum> {
+        unsafe {
+            let ptr = PgMemoryContexts::CurrentMemoryContext
+                .copy_ptr_into(&mut self, std::mem::size_of::<Self>());
+            Some(ptr.into())
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::CIRCLEOID
+    }
+}
+
+// Variable Length Types
+
+/// An owned Postgres `path` type.
+#[derive(Debug, Clone, Default)]
+pub struct Path {
+    points: Vec<Point>,
+    closed: bool,
+}
+
+impl Path {
+    pub fn new(points: Vec<pg_sys::Point>, closed: bool) -> Self {
+        Self { points, closed }
+    }
+
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    pub fn closed(&self) -> bool {
+        self.closed
+    }
+}
+
+impl IntoDatum for Path {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        let num_points = self.points.len();
+        let reserve_size = num_points * mem::size_of::<Point>();
+        // 16 bytes for the header (4 for varsize, 4 for npts, 4 for closed, 4 for padding)
+        let total_size = reserve_size + 16;
+
+        unsafe {
+            let path = PgMemoryContexts::CurrentMemoryContext
+                .palloc(total_size as usize)
+                .cast::<pg_sys::PATH>();
+            set_varsize_4b(path.cast(), total_size as i32);
+            (*path).npts = num_points as i32;
+            (*path).closed = self.closed as i32;
+            let points = (*path).p.as_mut_slice(num_points);
+            for (i, point) in self.points.iter().enumerate() {
+                points[i] = *point;
+            }
+            Some(pg_sys::Datum::from(path))
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::PATHOID
+    }
+}
+
+impl FromDatum for Path {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let data = pg_sys::pg_detoast_datum(datum.cast_mut_ptr()).cast::<pg_sys::PATH>();
+            let closed = (*data).closed != 0;
+            let points = ptr::addr_of!((*data).p);
+            let points = (*points).as_slice((*data).npts as usize).to_vec();
+            if data != datum.cast_mut_ptr() {
+                pfree(data.cast());
+            }
+            Some(Path { points, closed })
+        }
+    }
+}
+
+unsafe impl SqlTranslatable for Path {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("path"))
+    }
+
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("path")))
+    }
+}
+
+/// An owned Postgres `polygon` type.
+#[derive(Debug, Clone, Default)]
+pub struct Polygon {
+    points: Vec<Point>,
+    boundbox: Box,
+}
+
+unsafe impl SqlTranslatable for Polygon {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("polygon"))
+    }
+
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("polygon")))
+    }
+}
+
+impl Polygon {
+    pub fn new(points: Vec<pg_sys::Point>) -> Self {
+        // We determine our boundbox by finding the min/max x/y values of all the points
+        // Fold over the points, updating the min/max as we go
+        let Some(boundbox) = points.iter().fold(None, |acc, point| {
+            let boundbox = acc.unwrap_or_else(|| Box { high: *point, low: *point });
+            Some(Box {
+                high: Point { x: boundbox.high.x.max(point.x), y: boundbox.high.y.max(point.y) },
+                low: Point { x: boundbox.low.x.min(point.x), y: boundbox.low.y.min(point.y) },
+            })
+        }) else {
+            return Self::default();
+        };
+        Self { points, boundbox }
+    }
+
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    pub fn boundbox(&self) -> Box {
+        self.boundbox
+    }
+}
+
+impl IntoDatum for Polygon {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        let num_points = self.points.len();
+        let reserve_size = num_points * mem::size_of::<Point>();
+        // 40 bytes for the header (4 for varsize, 4 for npts, 32 for boundbox)
+        let total_size = reserve_size + 40;
+
+        unsafe {
+            let polygon = PgMemoryContexts::CurrentMemoryContext
+                .palloc(total_size as usize)
+                .cast::<pg_sys::POLYGON>();
+            set_varsize_4b(polygon.cast(), total_size as i32);
+            (*polygon).npts = num_points as i32;
+            let points = (*polygon).p.as_mut_slice(num_points);
+            for (i, point) in self.points.iter().enumerate() {
+                points[i] = *point;
+            }
+            (*polygon).boundbox = self.boundbox;
+            Some(pg_sys::Datum::from(polygon))
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::POLYGONOID
+    }
+}
+
+impl FromDatum for Polygon {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let data = pg_sys::pg_detoast_datum(datum.cast_mut_ptr()).cast::<pg_sys::POLYGON>();
+            let points = ptr::addr_of!((*data).p);
+            let points = (*points).as_slice((*data).npts as usize).to_vec();
+            let boundbox = (*data).boundbox;
+            if data != datum.cast_mut_ptr() {
+                pfree(data.cast());
+            }
+            Some(Polygon { points, boundbox })
+        }
     }
 }

--- a/pgrx/src/datum/geo.rs
+++ b/pgrx/src/datum/geo.rs
@@ -7,9 +7,28 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use crate::{FromDatum, IntoDatum, PgMemoryContexts, pg_sys};
+//! This module contains implementations to make it easier to work with Postgres' geometric types
+//! in Rust.
+//!
+//! Simple types that support `Copy` are re-exported from the `pg_sys` crate and have `IntoDatum`
+//! and `FromDatum` trait implementations. Variable length types have owned structs that have
+//! `IntoDatum`, `FromDatum`, and `SqlTranslatable` trait implementations.
+//!
+//! See the [Postgres docs](https://www.postgresql.org/docs/current/datatype-geometric.html) for
+//! more information on the geometric types.
+use std::{mem, ptr};
 
-impl FromDatum for pg_sys::BOX {
+use pgrx_sql_entity_graph::metadata::{
+    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
+};
+
+use crate::{FromDatum, IntoDatum, PgMemoryContexts, pg_sys, set_varsize_4b};
+
+// Copy types
+
+pub type Box = pg_sys::BOX;
+
+impl FromDatum for Box {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
@@ -21,17 +40,17 @@ impl FromDatum for pg_sys::BOX {
         if is_null {
             None
         } else {
-            let the_box = datum.cast_mut_ptr::<pg_sys::BOX>();
+            let the_box = datum.cast_mut_ptr::<Self>();
             Some(the_box.read())
         }
     }
 }
 
-impl IntoDatum for pg_sys::BOX {
+impl IntoDatum for Box {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         unsafe {
             let ptr = PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::BOX>());
+                .copy_ptr_into(&mut self, mem::size_of::<Self>());
             Some(ptr.into())
         }
     }
@@ -41,7 +60,77 @@ impl IntoDatum for pg_sys::BOX {
     }
 }
 
-impl FromDatum for pg_sys::Point {
+pub type Line = pg_sys::LINE;
+
+impl FromDatum for Line {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let line = datum.cast_mut_ptr::<Self>();
+            Some(line.read())
+        }
+    }
+}
+
+impl IntoDatum for Line {
+    fn into_datum(mut self) -> Option<pg_sys::Datum> {
+        unsafe {
+            let ptr = PgMemoryContexts::CurrentMemoryContext
+                .copy_ptr_into(&mut self, mem::size_of::<Self>());
+            Some(ptr.into())
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::LINEOID
+    }
+}
+
+pub type LineSegment = pg_sys::LSEG;
+
+impl FromDatum for LineSegment {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let lseg = datum.cast_mut_ptr::<Self>();
+            Some(lseg.read())
+        }
+    }
+}
+
+impl IntoDatum for LineSegment {
+    fn into_datum(mut self) -> Option<pg_sys::Datum> {
+        unsafe {
+            let ptr = PgMemoryContexts::CurrentMemoryContext
+                .copy_ptr_into(&mut self, mem::size_of::<Self>());
+            Some(ptr.into())
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::LSEGOID
+    }
+}
+
+pub type Point = pg_sys::Point;
+
+impl FromDatum for Point {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
@@ -59,11 +148,11 @@ impl FromDatum for pg_sys::Point {
     }
 }
 
-impl IntoDatum for pg_sys::Point {
+impl IntoDatum for Point {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         unsafe {
             let copy = PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::Point>());
+                .copy_ptr_into(&mut self, mem::size_of::<Self>());
             Some(copy.into())
         }
     }
@@ -73,7 +162,9 @@ impl IntoDatum for pg_sys::Point {
     }
 }
 
-impl FromDatum for pg_sys::CIRCLE {
+pub type Circle = pg_sys::CIRCLE;
+
+impl FromDatum for Circle {
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,
@@ -85,17 +176,17 @@ impl FromDatum for pg_sys::CIRCLE {
         if is_null {
             None
         } else {
-            let the_box = datum.cast_mut_ptr::<pg_sys::CIRCLE>();
-            Some(the_box.read())
+            let circle = datum.cast_mut_ptr::<Self>();
+            Some(circle.read())
         }
     }
 }
 
-impl IntoDatum for pg_sys::CIRCLE {
+impl IntoDatum for Circle {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         unsafe {
             let ptr = PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::CIRCLE>());
+                .copy_ptr_into(&mut self, mem::size_of::<Self>());
             Some(ptr.into())
         }
     }
@@ -103,4 +194,189 @@ impl IntoDatum for pg_sys::CIRCLE {
     fn type_oid() -> pg_sys::Oid {
         pg_sys::CIRCLEOID
     }
+}
+
+// Variable Length Types
+
+/// An owned Postgres `path` type.
+#[derive(Debug, Clone, Default)]
+pub struct Path {
+    points: Vec<Point>,
+    closed: bool,
+}
+
+impl Path {
+    pub fn new(points: Vec<pg_sys::Point>, closed: bool) -> Self {
+        Self { points, closed }
+    }
+
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    pub fn closed(&self) -> bool {
+        self.closed
+    }
+}
+
+impl IntoDatum for Path {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        let num_points = self.points.len();
+        let (total_size, varlena_size) =
+            geo_varlena_size(num_points, mem::size_of::<pg_sys::PATH>());
+
+        unsafe {
+            let path =
+                PgMemoryContexts::CurrentMemoryContext.palloc(total_size).cast::<pg_sys::PATH>();
+            set_varsize_4b(path.cast(), varlena_size);
+            (*path).npts = num_points as i32;
+            (*path).closed = self.closed as i32;
+            (*path).dummy = 0;
+            let points = (*path).p.as_mut_slice(num_points);
+            for (i, point) in self.points.iter().enumerate() {
+                points[i] = *point;
+            }
+            Some(pg_sys::Datum::from(path))
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::PATHOID
+    }
+}
+
+impl FromDatum for Path {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let data = pg_sys::pg_detoast_datum(datum.cast_mut_ptr()).cast::<pg_sys::PATH>();
+            let closed = (*data).closed != 0;
+            let points = ptr::addr_of!((*data).p);
+            let points = (*points).as_slice((*data).npts as usize).to_vec();
+            if data != datum.cast_mut_ptr() {
+                pg_sys::pfree(data.cast());
+            }
+            Some(Path { points, closed })
+        }
+    }
+}
+
+unsafe impl SqlTranslatable for Path {
+    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Path);
+    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
+    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("path"));
+    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
+        Ok(ReturnsRef::One(SqlMappingRef::literal("path")));
+}
+
+/// An owned Postgres `polygon` type.
+#[derive(Debug, Clone, Default)]
+pub struct Polygon {
+    points: Vec<Point>,
+    boundbox: Box,
+}
+
+unsafe impl SqlTranslatable for Polygon {
+    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Polygon);
+    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
+    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
+        Ok(SqlMappingRef::literal("polygon"));
+    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
+        Ok(ReturnsRef::One(SqlMappingRef::literal("polygon")));
+}
+
+impl Polygon {
+    pub fn new(points: Vec<pg_sys::Point>) -> Self {
+        // We determine our boundbox by finding the min/max x/y values of all the points
+        // Fold over the points, updating the min/max as we go
+        let Some(boundbox) = points.iter().fold(None, |acc, point| {
+            let boundbox = acc.unwrap_or_else(|| Box { high: *point, low: *point });
+            Some(Box {
+                high: Point { x: boundbox.high.x.max(point.x), y: boundbox.high.y.max(point.y) },
+                low: Point { x: boundbox.low.x.min(point.x), y: boundbox.low.y.min(point.y) },
+            })
+        }) else {
+            return Self::default();
+        };
+        Self { points, boundbox }
+    }
+
+    pub fn points(&self) -> &[Point] {
+        &self.points
+    }
+
+    pub fn boundbox(&self) -> Box {
+        self.boundbox
+    }
+}
+
+impl IntoDatum for Polygon {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        let num_points = self.points.len();
+        let (total_size, varlena_size) =
+            geo_varlena_size(num_points, mem::size_of::<pg_sys::POLYGON>());
+
+        unsafe {
+            let polygon =
+                PgMemoryContexts::CurrentMemoryContext.palloc(total_size).cast::<pg_sys::POLYGON>();
+            set_varsize_4b(polygon.cast(), varlena_size);
+            (*polygon).npts = num_points as i32;
+            let points = (*polygon).p.as_mut_slice(num_points);
+            for (i, point) in self.points.iter().enumerate() {
+                points[i] = *point;
+            }
+            (*polygon).boundbox = self.boundbox;
+            Some(pg_sys::Datum::from(polygon))
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::POLYGONOID
+    }
+}
+
+impl FromDatum for Polygon {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let data = pg_sys::pg_detoast_datum(datum.cast_mut_ptr()).cast::<pg_sys::POLYGON>();
+            let points = ptr::addr_of!((*data).p);
+            let points = (*points).as_slice((*data).npts as usize).to_vec();
+            let boundbox = (*data).boundbox;
+            if data != datum.cast_mut_ptr() {
+                pg_sys::pfree(data.cast());
+            }
+            Some(Polygon { points, boundbox })
+        }
+    }
+}
+
+fn geo_varlena_size(num_points: usize, header_size: usize) -> (usize, i32) {
+    const VARLENA_4B_MAX_SIZE: usize = 0x3fff_ffff;
+
+    let points_size =
+        num_points.checked_mul(mem::size_of::<Point>()).expect("geometric datum is too large");
+    let total_size = header_size.checked_add(points_size).expect("geometric datum is too large");
+    if total_size > VARLENA_4B_MAX_SIZE {
+        panic!("geometric datum is too large");
+    }
+    let varlena_size = total_size as i32;
+
+    (total_size, varlena_size)
 }

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -15,7 +15,7 @@ mod array;
 mod date;
 pub mod datetime_support;
 mod from;
-mod geo;
+pub mod geo;
 mod inet;
 mod internal;
 mod interval;

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -19,7 +19,7 @@ mod array;
 mod borrow;
 mod bytea_type;
 mod from;
-mod geo;
+pub mod geo;
 mod inet;
 mod internal;
 mod into;

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -91,7 +91,7 @@ pub use atomics::*;
 pub use callbacks::*;
 pub use datum::{
     AnyArray, AnyElement, AnyNumeric, Array, FromDatum, Inet, Internal, IntoDatum, Json, JsonB,
-    Numeric, Range, Uuid, VariadicArray, numeric,
+    Numeric, Range, Uuid, VariadicArray, geo, numeric,
 };
 pub use enum_helper::*;
 pub use fcinfo::*;


### PR DESCRIPTION
For simple `Copy` types, just newtype them and add impls for FromDatum and ToDatum.

For more complex variable length types, create zero-copy and owned structs with impls for FromDatum and ToDatum as well as SqlTranslatable.