### PR TITLE
Avoid colons in filenames

### DIFF
--- a/.github/docker/Dockerfile.alpine_3.18
+++ b/.github/docker/Dockerfile.alpine_3.18
@@ -1,38 +1,34 @@
 # Example of how to build this container (ran from pgrx checkout directory):
-#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.debian\:bullseye -t pgrx-debian .
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine_3.18 -t pgrx-alpine .
 #
 # Example of how to run this container with tests after building the image:
-#   docker run pgrx-debian cargo test --no-default-features --features pg14 --locked
+#   docker run pgrx-alpine cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
 
-FROM debian:bullseye
-
 ARG PG_MAJOR_VER
+# Use Postgres' official alpine version, it's just easier that way
+FROM postgres:${PG_MAJOR_VER}-alpine3.18
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
-ARG DEBIAN_FRONTEND=noninteractive
+# Required for compiling Rust
+ENV RUSTFLAGS="-C target-feature=-crt-static"
 
-RUN apt-get update
-RUN apt-get install -y wget gnupg
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update -y --fix-missing
-RUN apt-get install -y \
-  build-essential \
-  curl \
+RUN apk add --no-cache \
+  bash \
   clang \
-  git \
+  clang-dev \
+  clang-libs \
+  coreutils \
+  curl \
   gcc \
-  libssl-dev \
-  libz-dev \
+  git \
   make \
-  pkg-config \
-  postgresql-$PG_MAJOR_VER \
-  postgresql-server-dev-$PG_MAJOR_VER \
-  zlib1g-dev \
-  && rm -rf /var/lib/apt/lists/*
+  musl-dev \
+  openssl-dev \
+  tar \
+  util-linux-dev
 
 # Set up permissions so that the rust user below can create extensions
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
@@ -40,18 +36,17 @@ RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
   /var/run/postgresql/
 
 # Running pgrx and tests require a non-root user
-RUN useradd --create-home --shell /bin/bash rust
+RUN adduser -s /bin/bash -D rust
 WORKDIR /checkout
 RUN chown -R rust:rust /checkout
 COPY --chown=rust:rust . /checkout
 
 USER rust
-
 # This environment variable is required for postgres while running the tests
 ENV USER=rust
 
 # Install cargo and Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 # By default, we always want to use '--locked'. However, there are some circumstances
@@ -63,7 +58,9 @@ ENV CARGO_LOCKED_OPTION=${CARGO_LOCKED_OPTION}
 # Install cargo-pgrx from source copied into this container
 RUN echo "Running cargo install --path cargo-pgrx/ $CARGO_LOCKED_OPTION" && cargo install --path cargo-pgrx/ $CARGO_LOCKED_OPTION
 
-# Initialize cargo pgrx so that we can run the tests
-RUN cargo pgrx init --pg$PG_MAJOR_VER=$(which pg_config)
+# This seems strange, but by this point $PG_MAJOR_VER is blank and
+# $PG_MAJOR is always set to the correct version. I think it's something built
+# into the postgres:XX-alpine3.16 images, so it was easier to go with the grain
+RUN cargo pgrx init --pg$PG_MAJOR=$(which pg_config)
 
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER} cshim", "${CARGO_LOCKED_OPTION}"]

--- a/.github/docker/Dockerfile.amazon_2
+++ b/.github/docker/Dockerfile.amazon_2
@@ -1,5 +1,5 @@
 # Example of how to build this container (ran from pgrx checkout directory):
-#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.amazon\:2 -t pgrx-amazonlinux2 .
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.amazon_2 -t pgrx-amazonlinux2 .
 #
 # Example of how to run this container with tests after building the image:
 #   docker run pgrx-amazonlinux2 cargo test --no-default-features --features pg14 --locked

--- a/.github/docker/Dockerfile.debian_bullseye
+++ b/.github/docker/Dockerfile.debian_bullseye
@@ -1,34 +1,38 @@
 # Example of how to build this container (ran from pgrx checkout directory):
-#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine\:3.18 -t pgrx-alpine .
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.debian_bullseye -t pgrx-debian .
 #
 # Example of how to run this container with tests after building the image:
-#   docker run pgrx-alpine cargo test --no-default-features --features pg14 --locked
+#   docker run pgrx-debian cargo test --no-default-features --features pg14 --locked
 #
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
 
+FROM debian:bullseye
+
 ARG PG_MAJOR_VER
-# Use Postgres' official alpine version, it's just easier that way
-FROM postgres:${PG_MAJOR_VER}-alpine3.18
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
-# Required for compiling Rust
-ENV RUSTFLAGS="-C target-feature=-crt-static"
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apk add --no-cache \
-  bash \
-  clang \
-  clang-dev \
-  clang-libs \
-  coreutils \
+RUN apt-get update
+RUN apt-get install -y wget gnupg
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get update -y --fix-missing
+RUN apt-get install -y \
+  build-essential \
   curl \
-  gcc \
+  clang \
   git \
+  gcc \
+  libssl-dev \
+  libz-dev \
   make \
-  musl-dev \
-  openssl-dev \
-  tar \
-  util-linux-dev
+  pkg-config \
+  postgresql-$PG_MAJOR_VER \
+  postgresql-server-dev-$PG_MAJOR_VER \
+  zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 # Set up permissions so that the rust user below can create extensions
 RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
@@ -36,17 +40,18 @@ RUN chmod a+rwx `$(which pg_config) --pkglibdir` \
   /var/run/postgresql/
 
 # Running pgrx and tests require a non-root user
-RUN adduser -s /bin/bash -D rust
+RUN useradd --create-home --shell /bin/bash rust
 WORKDIR /checkout
 RUN chown -R rust:rust /checkout
 COPY --chown=rust:rust . /checkout
 
 USER rust
+
 # This environment variable is required for postgres while running the tests
 ENV USER=rust
 
 # Install cargo and Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/home/rust/.cargo/bin:${PATH}"
 
 # By default, we always want to use '--locked'. However, there are some circumstances
@@ -58,9 +63,7 @@ ENV CARGO_LOCKED_OPTION=${CARGO_LOCKED_OPTION}
 # Install cargo-pgrx from source copied into this container
 RUN echo "Running cargo install --path cargo-pgrx/ $CARGO_LOCKED_OPTION" && cargo install --path cargo-pgrx/ $CARGO_LOCKED_OPTION
 
-# This seems strange, but by this point $PG_MAJOR_VER is blank and
-# $PG_MAJOR is always set to the correct version. I think it's something built
-# into the postgres:XX-alpine3.16 images, so it was easier to go with the grain
-RUN cargo pgrx init --pg$PG_MAJOR=$(which pg_config)
+# Initialize cargo pgrx so that we can run the tests
+RUN cargo pgrx init --pg$PG_MAJOR_VER=$(which pg_config)
 
 CMD ["cargo", "test", "--no-default-features", "--features", "pg${PG_MAJOR_VER} cshim", "${CARGO_LOCKED_OPTION}"]

--- a/.github/docker/run-docker.sh
+++ b/.github/docker/run-docker.sh
@@ -8,7 +8,7 @@
 #                        blank '' to use "cargo" without "--locked"
 
 # Examples of running this script in CI (currently Github Actions):
-#   ./.github/docker/run-docker.sh 14 debian:bullseye
+#   ./.github/docker/run-docker.sh 14 debian_bullseye
 #   ./.github/docker/run-docker.sh 12 fedora
 
 set -x

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:
         pg_version: ["pg11", "pg12", "pg13", "pg14", "pg15"]
-        container: ["fedora", "debian:bullseye", "alpine:3.18", "amazon:2"]
+        container: ["fedora", "debian_bullseye", "alpine_3.18", "amazon_2"]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Colons (`:`) are invalid in filenames on Windows, which makes it impossible (or at least unpleasant) to checkout the repo.

This PR uses underscores instead, but happy to switch to any other [allowed character](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names).