### PR TITLE
Untar directly in rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +350,7 @@ name = "cargo-pgrx"
 version = "0.11.0"
 dependencies = [
  "atty",
+ "bzip2",
  "cargo_metadata",
  "cargo_toml",
  "clap",
@@ -356,6 +378,7 @@ dependencies = [
  "serde-xml-rs",
  "serde_derive",
  "syn 2.0.38",
+ "tar",
  "tempfile",
  "toml",
  "tracing",
@@ -806,6 +829,18 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys",
+]
 
 [[package]]
 name = "finl_unicode"
@@ -2481,6 +2516,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,6 +3198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@
 - `libclang` 5.0 or greater (required by bindgen)
    - Ubuntu: `apt install libclang-dev` or `apt install clang`
    - RHEL: `yum install clang`
-- `tar`
-- `bzip2`
 - GCC 7 or newer
 - [PostgreSQL's build dependencies](https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code) ‡
 

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -60,6 +60,8 @@ flate2 = { version = "1.0.27", default-features = false, features = ["rust_backe
 tempfile = "3.8.0"
 nix = { version = "0.27", default-features = false, features = ["user"] }
 toml = "0.8.2"
+bzip2 = "0.4.4"
+tar = "0.4.40"
 
 [features]
 default = ["ureq/native-tls"]


### PR DESCRIPTION
Good: doesn't require tar and bzip2 cli tools
Bad: more rust dependencies I guess

This PR also changes the untar process to be a little more resistant to unexpected crashes (or power failures), downloading and unpacking to a staging directory before moving the new sources in place. Happy to split that into its own PR if you want.