### PR TITLE
(cargo-pgrx init) Use toml serializer to write config.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "serde_derive",
  "syn 2.0.38",
  "tempfile",
+ "toml",
  "tracing",
  "tracing-error",
  "tracing-subscriber",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { version = "0.3.17", features = [ "env-filter" ] }
 flate2 = { version = "1.0.27", default-features = false, features = ["rust_backend"] }
 tempfile = "3.8.0"
 nix = { version = "0.27", default-features = false, features = ["user"] }
+toml = "0.8.2"
 
 [features]
 default = ["ureq/native-tls"]

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -13,7 +13,7 @@ use crate::CommandExecute;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use pgrx_pg_config::{
-    get_c_locale_flags, prefix_path, PgConfig, PgConfigSelector, Pgrx, PgrxHomeError,
+    get_c_locale_flags, prefix_path, ConfigToml, PgConfig, PgConfigSelector, Pgrx, PgrxHomeError,
 };
 use rayon::prelude::*;
 
@@ -540,26 +540,27 @@ fn validate_pg_config(pg_config: &PgConfig) -> eyre::Result<()> {
 
 fn write_config(pg_configs: &Vec<PgConfig>, init: &Init) -> eyre::Result<()> {
     let config_path = Pgrx::config_toml()?;
-    let mut file = File::create(&config_path)?;
+    let mut config = match std::fs::read_to_string(&config_path) {
+        Ok(file) => toml::from_str::<ConfigToml>(&file)?,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                ConfigToml::default()
+            } else {
+                Err(e)?
+            }
+        }
+    };
 
-    if let Some(port) = init.base_port {
-        file.write_all(format!("base_port = {}\n", port).as_bytes())?;
-    }
-    if let Some(port) = init.base_testing_port {
-        file.write_all(format!("base_testing_port = {}\n", port).as_bytes())?;
-    }
-
-    file.write_all(b"[configs]\n")?;
+    config.base_port = init.base_port;
+    config.base_testing_port = init.base_testing_port;
     for pg_config in pg_configs {
-        file.write_all(
-            format!(
-                "{}=\"{}\"\n",
-                pg_config.label()?,
-                pg_config.path().ok_or(eyre!("no path for pg_config"))?.display()
-            )
-            .as_bytes(),
-        )?;
+        config
+            .configs
+            .insert(pg_config.label()?, pg_config.path().ok_or(eyre!("no path for pg_config"))?);
     }
+
+    let mut file = File::create(&config_path)?;
+    file.write_all(toml::to_string(&config)?.as_bytes())?;
 
     Ok(())
 }

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -454,13 +454,13 @@ impl Default for Pgrx {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct ConfigToml {
-    configs: HashMap<String, PathBuf>,
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ConfigToml {
+    pub configs: HashMap<String, PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    base_port: Option<u16>,
+    pub base_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    base_testing_port: Option<u16>,
+    pub base_testing_port: Option<u16>,
 }
 
 pub enum PgConfigSelector<'a> {


### PR DESCRIPTION
Writing the toml by formatting strings meant that on Windows, backslashes in paths weren't escaped, outputting invalid toml. This uses the `toml` crate and the existing `ConfigToml` struct to read/write the file intead.

---

Also in the readme it says

> If a new minor Postgres version is released in the future you can simply run `cargo pgrx init [args]` again, and your local version will be updated, preserving all existing databases and configuration.

That was a bit confusing to me, as e.g. running:

```console
$ cargo pgrx init --pg12 download --pg13 download
```

Followed by

```console
$ cargo pgrx init --pg13 download --pg14 download
```

Would "erase" the pg12 checkout from the config.toml file, even though the files remained there.

I took that as accidental and fixed it (ie, we read the config and modify it) in this PR, but of course can revert that bit if it was intentional.