### PR TITLE
install --sudo destination path must exist to be canonicalized

### DIFF
--- a/cargo-pgrx/src/command/sudo_install.rs
+++ b/cargo-pgrx/src/command/sudo_install.rs
@@ -69,7 +69,11 @@ impl CommandExecute for SudoInstall {
         eprintln!("Using sudo to copy extension files from {}", outdir.display().cyan());
         for src in output_files {
             let src = src.canonicalize()?;
-            let dest = make_absolute(src.strip_prefix(&outdir)?).canonicalize()?;
+            let dest_abs = make_absolute(src.strip_prefix(&outdir)?);
+            let dest = match dest_abs.canonicalize() {
+                Ok(path) => path,
+                Err(_) => dest_abs,
+            };
 
             // we're about to run `sudo` to copy some files, one at a time
             let mut command = Command::new("sudo"); // NB:  If we ever support Windows...


### PR DESCRIPTION
`fs::canonicalize` calls `realpath` which requires the dest path to exist. It doesn't when installing the extension for the first time (and a new version of the extension for subsequent times). So...best we can [1] do is trust that @eeeebbbbrrrr 's canonicalization works . :rocket: 

[1]: https://stackoverflow.com/questions/68231306/stdfscanonicalize-for-files-that-dont-exist