### PR TITLE
use `get_array_type` in Array IntoDatum

### DIFF
--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -743,10 +743,7 @@ impl<T: IntoDatum + FromDatum> IntoDatum for Array<'_, T> {
     }
 
     fn composite_type_oid(&self) -> Option<Oid> {
-        // the composite type oid for a vec of composite types is the array type of the base composite type
-        self.get(0)
-            .map(|v| v.composite_type_oid().map(|oid| unsafe { pg_sys::get_array_type(oid) }))
-            .flatten()
+        Some(unsafe { pg_sys::get_array_type(self.raw.oid()) })
     }
 }
 


### PR DESCRIPTION
I recommended using `get_array_type` earlier, but it was not adopted due to keeping it similar to the Vec impls. However, this allows making a bunch of things easier in refactored impls of Array, by making it easier to impl IntoDatum with different bounds on Array's T.