### PR TITLE
yeet IntoDatum for u32

### DIFF
--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -172,25 +172,6 @@ impl IntoDatum for i32 {
     }
 }
 
-/// for oid
-impl IntoDatum for u32 {
-    #[inline]
-    fn into_datum(self) -> Option<pg_sys::Datum> {
-        Some(pg_sys::Datum::from(self))
-    }
-
-    fn type_oid() -> pg_sys::Oid {
-        pg_sys::OIDOID
-    }
-
-    fn is_compatible_with(other: pg_sys::Oid) -> bool {
-        Self::type_oid() == other
-            || i8::type_oid() == other
-            || i16::type_oid() == other
-            || i32::type_oid() == other
-    }
-}
-
 /// for bigint
 impl IntoDatum for i64 {
     #[inline]

--- a/pgrx/src/spi/cursor.rs
+++ b/pgrx/src/spi/cursor.rs
@@ -34,9 +34,9 @@ type CursorName = String;
 /// # fn foo() -> spi::Result<()> {
 /// Spi::connect(|mut client| {
 ///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);
-///     assert_eq!(Some(1u32), cursor.fetch(1)?.get_one::<u32>()?);
-///     assert_eq!(Some(2u32), cursor.fetch(2)?.get_one::<u32>()?);
-///     assert_eq!(Some(3u32), cursor.fetch(3)?.get_one::<u32>()?);
+///     assert_eq!(Some(1), cursor.fetch(1)?.get_one::<i32>()?);
+///     assert_eq!(Some(2), cursor.fetch(2)?.get_one::<i32>()?);
+///     assert_eq!(Some(3), cursor.fetch(3)?.get_one::<i32>()?);
 ///     Ok::<_, pgrx::spi::Error>(())
 ///     // <--- all three SpiTupleTable get freed by Spi::connect at this point
 /// })
@@ -49,13 +49,13 @@ type CursorName = String;
 /// # fn foo() -> spi::Result<()> {
 /// let cursor_name = Spi::connect(|mut client| {
 ///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);
-///     assert_eq!(Ok(Some(1u32)), cursor.fetch(1)?.get_one::<u32>());
+///     assert_eq!(Ok(Some(1)), cursor.fetch(1)?.get_one::<i32>());
 ///     Ok::<_, spi::Error>(cursor.detach_into_name()) // <-- cursor gets dropped here
 ///     // <--- first SpiTupleTable gets freed by Spi::connect at this point
 /// })?;
 /// Spi::connect(|mut client| {
 ///     let mut cursor = client.find_cursor(&cursor_name)?;
-///     assert_eq!(Ok(Some(2u32)), cursor.fetch(1)?.get_one::<u32>());
+///     assert_eq!(Ok(Some(2)), cursor.fetch(1)?.get_one::<i32>());
 ///     drop(cursor); // <-- cursor gets dropped here
 ///     // ... more code ...
 ///     Ok(())


### PR DESCRIPTION
impl from when `pg_sys::Oid` was not a newtype but an alias.

now unnecessary.