### PR TITLE
Remove `IntoDatum::array_type_oid()`

### DIFF
--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -732,7 +732,7 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
     }
 }
 
-impl<T: IntoDatum + FromDatum> IntoDatum for Array<'_, T> {
+impl<T: IntoDatum> IntoDatum for Array<'_, T> {
     #[inline]
     fn into_datum(self) -> Option<Datum> {
         let array_type = self.into_array_type();
@@ -742,7 +742,7 @@ impl<T: IntoDatum + FromDatum> IntoDatum for Array<'_, T> {
 
     #[inline]
     fn type_oid() -> Oid {
-        T::array_type_oid()
+        unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
 
     fn composite_type_oid(&self) -> Option<Oid> {

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -34,9 +34,6 @@ pub trait IntoDatum {
     fn composite_type_oid(&self) -> Option<Oid> {
         None
     }
-    fn array_type_oid() -> pg_sys::Oid {
-        unsafe { pg_sys::get_array_type(Self::type_oid()) }
-    }
 
     /// Is a Datum of this type compatible with another Postgres type?
     ///


### PR DESCRIPTION
This existed purely to serve `<Array as IntoDatum>::type_oid()`, and is not necessary. Array can furnish its own impl here.