### PR TITLE
Add `clippy -Awarnings` to CI and fix unsound fn

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -351,7 +351,7 @@ jobs:
       run: cargo pgrx init --pg$PG_VER download
 
     - name: Clippy -Awarnings
-      run: cargo clippy -- -Awarnings
+      run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
 
     - name: create new sample extension
       run: cd /tmp/ && cargo pgrx new sample

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
+        version: ["postgres-11", "postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
 
     steps:
     - uses: actions/checkout@v3
@@ -350,6 +350,9 @@ jobs:
 
     - name: Run 'cargo pgrx init' for ${{ matrix.version }}
       run: cargo pgrx init --pg$PG_VER download
+
+    - name: Clippy -Awarnings
+      run: cargo clippy -- -Awarnings
 
     - name: create new sample extension
       run: cd /tmp/ && cargo pgrx new sample

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,8 @@ jobs:
       SCCACHE_DIR: /home/runner/.cache/sccache
 
     strategy:
-      fail-fast: false
       matrix:
-        version: ["postgres-11", "postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
+        version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -299,10 +299,12 @@ impl PgAggregate {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
                 #pg_extern_attr
                 fn #fn_name(this: #type_state_without_self, #(#args_with_names),*, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> #type_state_without_self {
-                    <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                        fcinfo,
-                        move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::state(this, (#(#arg_names),*), fcinfo)
-                    )
+                    unsafe {
+                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                            fcinfo,
+                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::state(this, (#(#arg_names),*), fcinfo)
+                        )
+                    }
                 }
             });
             fn_name
@@ -322,10 +324,12 @@ impl PgAggregate {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
                 #pg_extern_attr
                 fn #fn_name(this: #type_state_without_self, v: #type_state_without_self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> #type_state_without_self {
-                    <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                        fcinfo,
-                        move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::combine(this, v, fcinfo)
-                    )
+                    unsafe {
+                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                            fcinfo,
+                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::combine(this, v, fcinfo)
+                        )
+                    }
                 }
             });
             Some(fn_name)
@@ -351,10 +355,12 @@ impl PgAggregate {
                     #[allow(non_snake_case, clippy::too_many_arguments)]
                     #pg_extern_attr
                     fn #fn_name(this: #type_state_without_self, #(#direct_args_with_names),*, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> #type_finalize {
-                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                            fcinfo,
-                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::finalize(this, (#(#direct_arg_names),*), fcinfo)
-                        )
+                        unsafe {
+                            <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                                fcinfo,
+                                move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::finalize(this, (#(#direct_arg_names),*), fcinfo)
+                            )
+                        }
                     }
                 });
             } else {
@@ -362,10 +368,12 @@ impl PgAggregate {
                     #[allow(non_snake_case, clippy::too_many_arguments)]
                     #pg_extern_attr
                     fn #fn_name(this: #type_state_without_self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> #type_finalize {
-                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                            fcinfo,
-                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::finalize(this, (), fcinfo)
-                        )
+                        unsafe {
+                            <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                                fcinfo,
+                                move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::finalize(this, (), fcinfo)
+                            )
+                        }
                     }
                 });
             };
@@ -388,10 +396,12 @@ impl PgAggregate {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
                 #pg_extern_attr
                 fn #fn_name(this: #type_state_without_self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> Vec<u8> {
-                    <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                        fcinfo,
-                        move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::serial(this, fcinfo)
-                    )
+                    unsafe {
+                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                            fcinfo,
+                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::serial(this, fcinfo)
+                        )
+                    }
                 }
             });
             Some(fn_name)
@@ -415,10 +425,12 @@ impl PgAggregate {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
                 #pg_extern_attr
                 fn #fn_name(this: #type_state_without_self, buf: Vec<u8>, internal: ::pgrx::pgbox::PgBox<#type_state_without_self>, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pgbox::PgBox<#type_state_without_self> {
-                    <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                        fcinfo,
-                        move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::deserial(this, buf, internal, fcinfo)
-                    )
+                    unsafe {
+                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                            fcinfo,
+                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::deserial(this, buf, internal, fcinfo)
+                        )
+                    }
                 }
             });
             Some(fn_name)
@@ -447,10 +459,12 @@ impl PgAggregate {
                     #(#args_with_names),*,
                     fcinfo: ::pgrx::pg_sys::FunctionCallInfo,
                 ) -> #type_moving_state {
-                    <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                        fcinfo,
-                        move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::moving_state(mstate, (#(#arg_names),*), fcinfo)
-                    )
+                    unsafe {
+                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                            fcinfo,
+                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::moving_state(mstate, (#(#arg_names),*), fcinfo)
+                        )
+                    }
                 }
             });
             Some(fn_name)
@@ -483,10 +497,12 @@ impl PgAggregate {
                     #(#args_with_names),*,
                     fcinfo: ::pgrx::pg_sys::FunctionCallInfo,
                 ) -> #type_moving_state {
-                    <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                        fcinfo,
-                        move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::moving_state_inverse(mstate, (#(#arg_names),*), fcinfo)
-                    )
+                    unsafe {
+                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                            fcinfo,
+                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::moving_state_inverse(mstate, (#(#arg_names),*), fcinfo)
+                        )
+                    }
                 }
             });
             Some(fn_name)
@@ -517,10 +533,12 @@ impl PgAggregate {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
                 #pg_extern_attr
                 fn #fn_name(mstate: #type_moving_state, #(#direct_args_with_names),* #maybe_comma fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> #type_finalize {
-                    <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
-                        fcinfo,
-                        move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::moving_finalize(mstate, (#(#direct_arg_names),*), fcinfo)
-                    )
+                    unsafe {
+                        <#target_path as ::pgrx::aggregate::Aggregate>::in_memory_context(
+                            fcinfo,
+                            move |_context| <#target_path as ::pgrx::aggregate::Aggregate>::moving_finalize(mstate, (#(#direct_arg_names),*), fcinfo)
+                        )
+                    }
                 }
             });
             Some(fn_name)

--- a/pgrx/src/aggregate.rs
+++ b/pgrx/src/aggregate.rs
@@ -433,7 +433,7 @@ where
     }
 
     #[inline(always)]
-    fn in_memory_context<
+    unsafe fn in_memory_context<
         R,
         F: FnOnce(&mut PgMemoryContexts) -> R + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
     >(

--- a/pgrx/src/datum/numeric_support/cmp.rs
+++ b/pgrx/src/datum/numeric_support/cmp.rs
@@ -102,7 +102,7 @@ impl<const P: u32, const S: u32> Eq for Numeric<P, S> {}
 impl<const P: u32, const S: u32> PartialOrd for Numeric<P, S> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.as_anynumeric().partial_cmp(other.as_anynumeric())
+        Some(self.cmp(other))
     }
 
     #[inline]

--- a/pgrx/src/htup.rs
+++ b/pgrx/src/htup.rs
@@ -46,7 +46,7 @@ pub fn heap_tuple_header_get_datum_length(htup_header: pg_sys::HeapTupleHeader) 
 
 /// convert a HeapTupleHeader to a Datum.
 #[inline]
-pub fn heap_tuple_get_datum(heap_tuple: pg_sys::HeapTuple) -> pg_sys::Datum {
+pub unsafe fn heap_tuple_get_datum(heap_tuple: pg_sys::HeapTuple) -> pg_sys::Datum {
     unsafe { pg_sys::HeapTupleHeaderGetDatum((*heap_tuple).t_data) }
 }
 


### PR DESCRIPTION
I have resolved to grumble less about clippy: it detected **serious soundness issues related to the implementation of `pg_aggregate`** after I ran it over the repo (ignoring all the warnings, of course). These functions are publicly reachable but `unsafe` to use, as they may accept and dereference e.g. null pointers.

Add clippy to CI, but allow all warnings, so it only monitors correctness lints. Mark the relevant unsound `pub fn` as `unsafe`, catching:
- `aggregate::Aggregate::in_memory_context`
- `htup::heap_tuple_get_datum`