### PR TITLE
Satisfy clippy errors on 7 of 8 crates

### DIFF
--- a/pgrx-examples/custom_types/src/ordered.rs
+++ b/pgrx-examples/custom_types/src/ordered.rs
@@ -19,7 +19,6 @@ use std::cmp::Ordering;
     Clone,
     Eq,
     PartialEq,
-    PartialOrd,
     PostgresType,
     PostgresEq,
     PostgresOrd
@@ -48,6 +47,12 @@ impl Ord for OrderedThing {
                 self.item.cmp(&other.item).reverse()
             }
         }
+    }
+}
+
+impl PartialOrd for OrderedThing {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -57,6 +57,20 @@ impl PgrxOverrides {
                 "FP_SUBNORMAL".into(),
                 "FP_ZERO".into(),
                 "IPPORT_RESERVED".into(),
+                // These are just annoying due to clippy
+                "M_E".into(),
+                "M_LOG2E".into(),
+                "M_LOG10E".into(),
+                "M_LN2".into(),
+                "M_LN10".into(),
+                "M_PI".into(),
+                "M_PI_2".into(),
+                "M_PI_4".into(),
+                "M_1_PI".into(),
+                "M_2_PI".into(),
+                "M_SQRT2".into(),
+                "M_SQRT1_2".into(),
+                "M_2_SQRTPI".into(),
             ]
             .into_iter()
             .collect(),
@@ -383,15 +397,9 @@ fn extract_oids(code: &syn::File) -> BTreeMap<syn::Ident, Box<syn::Expr>> {
 }
 
 fn is_builtin_oid(name: &str) -> bool {
-    if name.ends_with("OID") && name != "HEAP_HASOID" {
-        true
-    } else if name.ends_with("RelationId") {
-        true
-    } else if name == "TemplateDbOid" {
-        true
-    } else {
-        false
-    }
+    name.ends_with("OID") && name != "HEAP_HASOID"
+        || name.ends_with("RelationId")
+        || name == "TemplateDbOid"
 }
 
 fn rewrite_oid_consts(

--- a/pgrx-pg-sys/src/cshim.rs
+++ b/pgrx-pg-sys/src/cshim.rs
@@ -12,7 +12,7 @@ extern "C" {
     pub fn pgrx_list_nth_cell(list: *mut pg_sys::List, nth: i32) -> *mut pg_sys::ListCell;
 
     #[link_name = "pgrx_planner_rt_fetch"]
-    #[deprecated(since = "0.11", note = "use pgrx::pg_sys::planner_rt_fetch")]
+    #[deprecated(since = "0.11.0", note = "use pgrx::pg_sys::planner_rt_fetch")]
     pub fn planner_rt_fetch(
         index: pg_sys::Index,
         root: *mut pg_sys::PlannerInfo,
@@ -33,7 +33,7 @@ extern "C" {
 ///     ((RangeTblEntry *) list_nth(rangetable, (rangetable_index)-1))
 /// ```
 #[inline]
-#[deprecated(since = "0.11", note = "use pgrx::pg_sys::rt_fetch")]
+#[deprecated(since = "0.11.0", note = "use pgrx::pg_sys::rt_fetch")]
 pub unsafe fn rt_fetch(
     index: super::Index,
     range_table: *mut super::List,

--- a/pgrx-tests/src/tests/zero_datum_edge_cases.rs
+++ b/pgrx-tests/src/tests/zero_datum_edge_cases.rs
@@ -14,7 +14,7 @@ mod tests {
     use crate as pgrx_tests;
     use pgrx::prelude::*;
 
-    fn from_helper<T: FromDatum + IntoDatum>(d: pg_sys::Datum) -> Option<T> {
+    fn from_helper<T: FromDatum>(d: pg_sys::Datum) -> Option<T> {
         unsafe { T::from_polymorphic_datum(d, false, pg_sys::InvalidOid) }
     }
 

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -7,7 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use crate::datum::{Array, FromDatum};
+use crate::datum::Array;
 use crate::pg_sys;
 use crate::toast::{Toast, Toasty};
 use bitvec::prelude::*;
@@ -273,7 +273,7 @@ impl RawArray {
     /// # Safety
     /// Array must have been made from an ArrayType pointer,
     /// or a null value, as-if [RawArray::from_ptr].
-    pub unsafe fn from_array<T: FromDatum>(arr: Array<T>) -> Option<RawArray> {
+    pub unsafe fn from_array<T>(arr: Array<T>) -> Option<RawArray> {
         let array_type = arr.into_array_type() as *mut _;
         // SAFETY: Validity asserted by the caller.
         let len = unsafe { ARR_NELEMS(array_type) } as usize;

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -549,7 +549,7 @@ impl<'a, T: FromDatum> VariadicArray<'a, T> {
     }
 }
 
-pub struct ArrayTypedIterator<'a, T: 'a + FromDatum> {
+pub struct ArrayTypedIterator<'a, T: 'a> {
     array: &'a Array<'a, T>,
     curr: usize,
     ptr: *const u8,
@@ -592,7 +592,7 @@ impl<'a, T: FromDatum + serde::Serialize> serde::Serialize for ArrayTypedIterato
     }
 }
 
-pub struct ArrayIterator<'a, T: 'a + FromDatum> {
+pub struct ArrayIterator<'a, T: 'a> {
     array: &'a Array<'a, T>,
     curr: usize,
     ptr: *const u8,
@@ -627,7 +627,7 @@ impl<'a, T: FromDatum> Iterator for ArrayIterator<'a, T> {
 impl<'a, T: FromDatum> ExactSizeIterator for ArrayIterator<'a, T> {}
 impl<'a, T: FromDatum> core::iter::FusedIterator for ArrayIterator<'a, T> {}
 
-pub struct ArrayIntoIterator<'a, T: FromDatum> {
+pub struct ArrayIntoIterator<'a, T> {
     array: Array<'a, T>,
     curr: usize,
     ptr: *const u8,

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -76,10 +76,7 @@ impl<'a> FromDatum for PgHeapTuple<'a, AllocatedByRust> {
         composite: Datum,
         is_null: bool,
         _oid: pg_sys::Oid,
-    ) -> Option<Self>
-    where
-        Self: Sized,
-    {
+    ) -> Option<Self> {
         if is_null {
             None
         } else {


### PR DESCRIPTION
This does more cleanup in the vein of weakening needless bounds.
- https://github.com/pgcentralfoundation/pgrx/pull/1355

However, the "main point" is some no-op "make clippy happy" refactoring. This permits running `cargo clippy` without getting *errors* (it still issues literally hundreds of warnings) on most of the repository's crates. It does not solve this for `pgrx` itself, as clippy detected a more serious issue there, and that issue is instead its own PR:
- https://github.com/pgcentralfoundation/pgrx/pull/1357