### PR TITLE
`clippy --fix` pgrx libraries

### DIFF
--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -102,8 +102,7 @@ pub fn pg_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             let sql_funcname = func.sig.ident.to_string();
-            let test_func_name =
-                Ident::new(&format!("pg_{}", func.sig.ident.to_string()), func.span());
+            let test_func_name = Ident::new(&format!("pg_{}", func.sig.ident), func.span());
 
             let attributes = func.attrs;
             let mut att_stream = proc_macro2::TokenStream::new();
@@ -1053,7 +1052,7 @@ Functions inside the `impl` may use the [`#[pgrx]`](macro@pgrx) attribute.
 pub fn pg_aggregate(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // We don't care about `_attr` as we can find it in the `ItemMod`.
     fn wrapped(item_impl: ItemImpl) -> Result<TokenStream, syn::Error> {
-        let sql_graph_entity_item = PgAggregate::new(item_impl.into())?;
+        let sql_graph_entity_item = PgAggregate::new(item_impl)?;
 
         Ok(sql_graph_entity_item.to_token_stream().into())
     }

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -68,8 +68,7 @@ impl PgGuardRewriter {
         // nor do we need a visibility beyond "private"
         func.vis = Visibility::Inherited;
 
-        func.sig.ident =
-            Ident::new(&format!("{}_inner", func.sig.ident.to_string()), func.sig.ident.span());
+        func.sig.ident = Ident::new(&format!("{}_inner", func.sig.ident), func.sig.ident.span());
 
         let arg_list = PgGuardRewriter::build_arg_list(&sig, false)?;
         let func_name = PgGuardRewriter::build_func_name(&func.sig);

--- a/pgrx-pg-sys/src/include.rs
+++ b/pgrx-pg-sys/src/include.rs
@@ -4,6 +4,7 @@
 
 #[cfg(all(feature = "pg12", not(docsrs)))]
 pub(crate) mod pg12 {
+    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/pg12.rs"));
 }
 #[cfg(all(feature = "pg12", docsrs))]
@@ -11,6 +12,7 @@ pub(crate) mod pg12;
 
 #[cfg(all(feature = "pg13", not(docsrs)))]
 pub(crate) mod pg13 {
+    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/pg13.rs"));
 }
 #[cfg(all(feature = "pg13", docsrs))]
@@ -18,6 +20,7 @@ pub(crate) mod pg13;
 
 #[cfg(all(feature = "pg14", not(docsrs)))]
 pub(crate) mod pg14 {
+    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/pg14.rs"));
 }
 #[cfg(all(feature = "pg14", docsrs))]
@@ -25,6 +28,7 @@ pub(crate) mod pg14;
 
 #[cfg(all(feature = "pg15", not(docsrs)))]
 pub(crate) mod pg15 {
+    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/pg15.rs"));
 }
 #[cfg(all(feature = "pg15", docsrs))]
@@ -32,6 +36,7 @@ pub(crate) mod pg15;
 
 #[cfg(all(feature = "pg16", not(docsrs)))]
 pub(crate) mod pg16 {
+    #[allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/pg16.rs"));
 }
 #[cfg(all(feature = "pg16", docsrs))]

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -197,8 +197,7 @@ pub unsafe fn BufferGetBlock(buffer: crate::Buffer) -> crate::Block {
     if BufferIsLocal(buffer) {
         *crate::LocalBufferBlockPointers.offset(((-buffer) - 1) as isize)
     } else {
-        crate::BufferBlocks
-            .offset((((buffer as crate::Size) - 1) * crate::BLCKSZ as usize) as isize)
+        crate::BufferBlocks.add(((buffer as crate::Size) - 1) * crate::BLCKSZ as usize)
             as crate::Block
     }
 }

--- a/pgrx-pg-sys/src/submodules/datum.rs
+++ b/pgrx-pg-sys/src/submodules/datum.rs
@@ -214,7 +214,7 @@ impl TryFrom<NullableDatum> for Datum {
 impl From<NullableDatum> for Option<Datum> {
     #[inline]
     fn from(nd: NullableDatum) -> Option<Datum> {
-        Some(Datum::try_from(nd).ok()?)
+        Datum::try_from(nd).ok()
     }
 }
 
@@ -259,6 +259,6 @@ mod test {
 
         let val: usize = 123456;
         let datum = Datum::from(val);
-        assert_eq!(datum.value() as usize, val);
+        assert_eq!({ datum.value() }, val);
     }
 }

--- a/pgrx-pg-sys/src/submodules/errcodes.rs
+++ b/pgrx-pg-sys/src/submodules/errcodes.rs
@@ -1280,15 +1280,15 @@ impl From<isize> for PgSqlErrorCode {
 #[allow(non_snake_case)]
 #[inline]
 const fn PGSIXBIT(ch: i32) -> i32 {
-    (((ch) - '0' as i32) & 0x3F) as i32
+    ((ch) - '0' as i32) & 0x3F
 }
 
 #[allow(non_snake_case)]
 #[inline]
 const fn MAKE_SQLSTATE(ch1: char, ch2: char, ch3: char, ch4: char, ch5: char) -> i32 {
-    (PGSIXBIT(ch1 as i32)
+    PGSIXBIT(ch1 as i32)
         + (PGSIXBIT(ch2 as i32) << 6)
         + (PGSIXBIT(ch3 as i32) << 12)
         + (PGSIXBIT(ch4 as i32) << 18)
-        + (PGSIXBIT(ch5 as i32) << 24)) as i32
+        + (PGSIXBIT(ch5 as i32) << 24)
 }

--- a/pgrx-pg-sys/src/submodules/ffi.rs
+++ b/pgrx-pg-sys/src/submodules/ffi.rs
@@ -123,7 +123,7 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
             pg_sys::PG_exception_stack = prev_exception_stack;
             pg_sys::error_context_stack = prev_error_context_stack;
 
-            return result;
+            result
         } else {
             // we're back here b/c of a longjmp originating in Postgres
 
@@ -148,13 +148,13 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
                 .is_null()
                 .then(|| String::from("<null error message>"))
                 .unwrap_or_else(|| CStr::from_ptr(errdata.message).to_string_lossy().to_string());
-            let detail = errdata.detail.is_null().then(|| None).unwrap_or_else(|| {
+            let detail = errdata.detail.is_null().then_some(None).unwrap_or_else(|| {
                 Some(CStr::from_ptr(errdata.detail).to_string_lossy().to_string())
             });
-            let hint = errdata.hint.is_null().then(|| None).unwrap_or_else(|| {
+            let hint = errdata.hint.is_null().then_some(None).unwrap_or_else(|| {
                 Some(CStr::from_ptr(errdata.hint).to_string_lossy().to_string())
             });
-            let funcname = errdata.funcname.is_null().then(|| None).unwrap_or_else(|| {
+            let funcname = errdata.funcname.is_null().then_some(None).unwrap_or_else(|| {
                 Some(CStr::from_ptr(errdata.funcname).to_string_lossy().to_string())
             });
             let file =

--- a/pgrx-pg-sys/src/submodules/htup.rs
+++ b/pgrx-pg-sys/src/submodules/htup.rs
@@ -393,13 +393,11 @@ unsafe fn fastgetattr(
             } else {
                 nocachegetattr(tup, attnum, tupleDesc)
             }
+        } else if att_isnull(attnum - 1, (*(*tup).t_data).t_bits.as_ptr()) {
+            *isnull = true;
+            Datum::from(0) // a NULL pointer
         } else {
-            if att_isnull(attnum - 1, (*(*tup).t_data).t_bits.as_ptr()) {
-                *isnull = true;
-                Datum::from(0) // a NULL pointer
-            } else {
-                nocachegetattr(tup, attnum, tupleDesc)
-            }
+            nocachegetattr(tup, attnum, tupleDesc)
         }
     }
 }

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -224,7 +224,7 @@ impl ErrorReportWithLevel {
 
     /// Returns the name of the function that generated this error report, if we were able to figure it out
     pub fn function_name(&self) -> Option<&str> {
-        self.inner.location.funcname.as_ref().map(|s| s.as_str())
+        self.inner.location.funcname.as_deref()
     }
 
     /// Returns the context message of this error report, if any
@@ -282,12 +282,12 @@ impl ErrorReport {
 
     /// Returns the detail message of this error report
     pub fn detail(&self) -> Option<&str> {
-        self.detail.as_ref().map(|s| s.as_str())
+        self.detail.as_deref()
     }
 
     /// Returns the hint message of this error report
     pub fn hint(&self) -> Option<&str> {
-        self.hint.as_ref().map(|s| s.as_str())
+        self.hint.as_deref()
     }
 
     /// Report this [PgErrorReport], which will ultimately be reported by Postgres at the specified [PgLogLevel]

--- a/pgrx/src/fn_call.rs
+++ b/pgrx/src/fn_call.rs
@@ -51,7 +51,7 @@ unsafe impl<T: IntoDatum + Clone + seal::Sealed> FnCallArg for Arg<T> {
         match self {
             Arg::Null => Ok(None),
             Arg::Value(v) => Ok(Clone::clone(v).into_datum()),
-            Arg::Default => create_default_value(&pg_proc, argnum),
+            Arg::Default => create_default_value(pg_proc, argnum),
         }
     }
 
@@ -342,7 +342,7 @@ fn lookup_fn(fname: &str, args: &[&dyn FnCallArg]) -> Result<pg_sys::Oid> {
         let nargs: i16 = arg_types.len().try_into().map_err(|_| FnCallError::TooManyArguments)?;
 
         // parse the function name into its possibly-qualified name parts
-        let ident_parts = parse_sql_ident(&fname)?;
+        let ident_parts = parse_sql_ident(fname)?;
         ident_parts
             .iter_deny_null()
             .map(|part| {

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -381,8 +381,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
                 }
             }
 
-            let mut datums =
-                (0..self.tupdesc.len()).map(pg_sys::Datum::from).collect::<Vec<_>>();
+            let mut datums = (0..self.tupdesc.len()).map(pg_sys::Datum::from).collect::<Vec<_>>();
             let mut nulls = (0..self.tupdesc.len()).map(|_| false).collect::<Vec<_>>();
             let mut do_replace = (0..self.tupdesc.len()).map(|_| false).collect::<Vec<_>>();
 

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -159,7 +159,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByPostgres> {
         // from incorrect assignment from the `trigger_data.tg_trigtuple/tg_newtuple` fields above.
         //
         // IOW, we are double-checking that we're using those fields correctly
-        assert_eq!(tuple.is_null(), false, "encountered unexpected NULL trigger tuple");
+        assert!(!tuple.is_null(), "encountered unexpected NULL trigger tuple");
 
         unsafe {
             // SAFETY:  The caller has asserted that `trigger_data` is valid, and that means its
@@ -222,7 +222,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
     ) -> Result<PgHeapTuple<'a, AllocatedByRust>, PgHeapTupleError> {
         PgTryBuilder::new(|| {
             let tuple_desc = PgTupleDesc::for_composite_type_by_oid(typoid)
-                .ok_or_else(|| PgHeapTupleError::NotACompositeType(typoid))?;
+                .ok_or(PgHeapTupleError::NotACompositeType(typoid))?;
             let natts = tuple_desc.len();
 
             unsafe {
@@ -382,7 +382,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
             }
 
             let mut datums =
-                (0..self.tupdesc.len()).map(|i| pg_sys::Datum::from(i)).collect::<Vec<_>>();
+                (0..self.tupdesc.len()).map(pg_sys::Datum::from).collect::<Vec<_>>();
             let mut nulls = (0..self.tupdesc.len()).map(|_| false).collect::<Vec<_>>();
             let mut do_replace = (0..self.tupdesc.len()).map(|_| false).collect::<Vec<_>>();
 

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -104,7 +104,6 @@ impl Align {
 
     #[inline]
     pub(crate) fn pad(self, size: usize) -> usize {
-        let size = size;
         let align = self.as_usize();
         (size + (align - 1)) & !(align - 1)
     }

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -104,7 +104,7 @@ impl Align {
 
     #[inline]
     pub(crate) fn pad(self, size: usize) -> usize {
-        let size = size as usize;
+        let size = size;
         let align = self.as_usize();
         (size + (align - 1)) & !(align - 1)
     }

--- a/pgrx/src/list/old_list.rs
+++ b/pgrx/src/list/old_list.rs
@@ -162,17 +162,17 @@ impl<T> PgList<T> {
 
     #[inline]
     pub fn iter_ptr(&self) -> impl Iterator<Item = *mut T> + '_ {
-        PgListIteratorPtr { list: &self, pos: 0 }
+        PgListIteratorPtr { list: self, pos: 0 }
     }
 
     #[inline]
     pub fn iter_oid(&self) -> impl Iterator<Item = pg_sys::Oid> + '_ {
-        PgListIteratorOid { list: &self, pos: 0 }
+        PgListIteratorOid { list: self, pos: 0 }
     }
 
     #[inline]
     pub fn iter_int(&self) -> impl Iterator<Item = i32> + '_ {
-        PgListIteratorInt { list: &self, pos: 0 }
+        PgListIteratorInt { list: self, pos: 0 }
     }
 
     /// Add a pointer value to the end of this list

--- a/pgrx/src/pg_catalog/pg_proc.rs
+++ b/pgrx/src/pg_catalog/pg_proc.rs
@@ -230,7 +230,7 @@ impl PgProc {
         self.get_attr::<Vec<i8>>(pg_sys::Anum_pg_proc_proargmodes)
             .unwrap_or_else(|| vec!['i' as i8; self.proargnames().len()])
             .into_iter()
-            .map(|mode| ProArgMode::from(mode))
+            .map(ProArgMode::from)
             .collect::<Vec<_>>()
     }
 

--- a/pgrx/src/rel.rs
+++ b/pgrx/src/rel.rs
@@ -339,9 +339,7 @@ impl Drop for PgRelation {
         if !self.boxed.is_null() && self.need_close {
             match self.lockmode {
                 None => unsafe { pg_sys::RelationClose(self.boxed.as_ptr()) },
-                Some(lockmode) => unsafe {
-                    pg_sys::relation_close(self.boxed.as_ptr(), lockmode)
-                },
+                Some(lockmode) => unsafe { pg_sys::relation_close(self.boxed.as_ptr(), lockmode) },
             }
         }
     }

--- a/pgrx/src/rel.rs
+++ b/pgrx/src/rel.rs
@@ -217,7 +217,7 @@ impl PgRelation {
     /// assert_eq!(tupdesc.len(), 12);
     /// ```
     pub fn tuple_desc(&self) -> PgTupleDesc {
-        PgTupleDesc::from_relation(&self)
+        PgTupleDesc::from_relation(self)
     }
 
     /// Number of tuples in this relation (not always up-to-date)
@@ -336,14 +336,12 @@ impl Deref for PgRelation {
 
 impl Drop for PgRelation {
     fn drop(&mut self) {
-        if !self.boxed.is_null() {
-            if self.need_close {
-                match self.lockmode {
-                    None => unsafe { pg_sys::RelationClose(self.boxed.as_ptr()) },
-                    Some(lockmode) => unsafe {
-                        pg_sys::relation_close(self.boxed.as_ptr(), lockmode)
-                    },
-                }
+        if !self.boxed.is_null() && self.need_close {
+            match self.lockmode {
+                None => unsafe { pg_sys::RelationClose(self.boxed.as_ptr()) },
+                Some(lockmode) => unsafe {
+                    pg_sys::relation_close(self.boxed.as_ptr(), lockmode)
+                },
             }
         }
     }

--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -95,7 +95,7 @@ impl<'conn> SpiClient<'conn> {
     ///
     /// See [`SpiCursor`] docs for usage details.
     pub fn open_cursor<Q: Query<'conn>>(&self, query: Q, args: Q::Arguments) -> SpiCursor<'conn> {
-        query.open_cursor(&self, args)
+        query.open_cursor(self, args)
     }
 
     /// Set up a cursor that will execute the specified update (mutating) query

--- a/pgrx/src/spi/cursor.rs
+++ b/pgrx/src/spi/cursor.rs
@@ -79,7 +79,7 @@ impl SpiCursor<'_> {
         }
         // SAFETY: SPI functions to create/find cursors fail via elog, so self.ptr is valid if we successfully set it
         unsafe { pg_sys::SPI_cursor_fetch(self.ptr.as_mut(), true, count) }
-        Ok(SpiClient::prepare_tuple_table(SpiOkCodes::Fetch as i32)?)
+        SpiClient::prepare_tuple_table(SpiOkCodes::Fetch as i32)
     }
 
     /// Consume the cursor, returning its name

--- a/pgrx/src/spi/query.rs
+++ b/pgrx/src/spi/query.rs
@@ -117,7 +117,7 @@ impl<'conn> Query<'conn> for &str {
             },
         };
 
-        Ok(SpiClient::prepare_tuple_table(status_code)?)
+        SpiClient::prepare_tuple_table(status_code)
     }
 
     fn open_cursor(self, _client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {
@@ -254,7 +254,7 @@ impl<'conn: 'stmt, 'stmt> Query<'conn> for &'stmt PreparedStatement<'conn> {
             )
         };
 
-        Ok(SpiClient::prepare_tuple_table(status_code)?)
+        SpiClient::prepare_tuple_table(status_code)
     }
 
     fn open_cursor(self, _client: &SpiClient<'conn>, args: Self::Arguments) -> SpiCursor<'conn> {

--- a/pgrx/src/spi/tuple.rs
+++ b/pgrx/src/spi/tuple.rs
@@ -380,7 +380,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     pub fn get_datum_by_ordinal(&self, ordinal: usize) -> SpiResult<&SpiHeapTupleDataEntry<'conn>> {
         // Wrapping because `self.entries.get(...)` will bounds check.
         let index = ordinal.wrapping_sub(1);
-        self.entries.get(index).ok_or_else(|| SpiError::SpiError(SpiErrorCodes::NoAttribute))
+        self.entries.get(index).ok_or(SpiError::SpiError(SpiErrorCodes::NoAttribute))
     }
 
     /// Get a raw Datum from this HeapTuple by its field name.
@@ -475,7 +475,7 @@ impl<'conn> SpiHeapTupleDataEntry<'conn> {
                     false,
                     self.type_oid,
                 )
-                .map_err(|e| SpiError::DatumError(e))
+                .map_err(SpiError::DatumError)
             },
             None => Ok(None),
         }

--- a/pgrx/src/stringinfo.rs
+++ b/pgrx/src/stringinfo.rs
@@ -29,7 +29,7 @@ impl<AllocatedBy: WhoAllocated> From<StringInfo<AllocatedBy>> for &'static core:
         unsafe {
             core::ffi::CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
                 ptr as *const u8,
-                (len + 1) as usize, // +1 to get the trailing null byte
+                len + 1, // +1 to get the trailing null byte
             ))
         }
     }

--- a/pgrx/src/toast.rs
+++ b/pgrx/src/toast.rs
@@ -48,8 +48,8 @@ impl<T: Toasty> Deref for Toast<T> {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            Toast::Stale(t) => &t,
-            Toast::Fresh(t) => &t,
+            Toast::Stale(t) => t,
+            Toast::Fresh(t) => t,
         }
     }
 }

--- a/pgrx/src/tupdesc.rs
+++ b/pgrx/src/tupdesc.rs
@@ -261,7 +261,7 @@ impl<'a> Clone for PgTupleDesc<'a> {
             unsafe { PgBox::from_pg(pg_sys::CreateTupleDescCopyConstr(tupdesc.as_ptr())) };
         Self {
             tupdesc: Some(tupdesc),
-            parent: self.parent.clone(),
+            parent: self.parent,
             need_release: false,
             need_pfree: true,
         }

--- a/pgrx/src/tupdesc.rs
+++ b/pgrx/src/tupdesc.rs
@@ -259,12 +259,7 @@ impl<'a> Clone for PgTupleDesc<'a> {
         // This will force the pfree() approach upon drop
         let tupdesc =
             unsafe { PgBox::from_pg(pg_sys::CreateTupleDescCopyConstr(tupdesc.as_ptr())) };
-        Self {
-            tupdesc: Some(tupdesc),
-            parent: self.parent,
-            need_release: false,
-            need_pfree: true,
-        }
+        Self { tupdesc: Some(tupdesc), parent: self.parent, need_release: false, need_pfree: true }
     }
 }
 


### PR DESCRIPTION
I backed out changes from inside sensitive files where they might make semantics less clear, but the rest are fairly simple. Modulo those holdbacks, this brings up to conformance with `clippy --fix`:
- pgrx
- pgrx-macros
- pgrx-pg-sys