### PR TITLE
Isolate non-dlopen Unix code in cargo-pgrx

### DIFF
--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -585,9 +585,17 @@ fn get_pg_installdir(pgdir: &PathBuf) -> PathBuf {
     dir
 }
 
+#[cfg(unix)]
 fn is_root_user() -> bool {
     use nix::unistd::Uid;
     Uid::effective().is_root()
+}
+
+/// Incorrectly answers false, reverting pgrx to pre-root-aware behavior,
+/// which is likely incorrect even if the system lacks "root" semantics.
+#[cfg(not(unix))]
+fn is_root_user() -> bool {
+    false
 }
 
 pub(crate) fn initdb(bindir: &PathBuf, datadir: &PathBuf) -> eyre::Result<()> {

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -17,7 +17,6 @@ use crate::CommandExecute;
 use eyre::eyre;
 use owo_colors::OwoColorize;
 use pgrx_pg_config::{createdb, PgConfig, Pgrx};
-use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
 
@@ -133,7 +132,9 @@ pub(crate) fn run(
     exec_psql(pg_config, dbname, pgcli)
 }
 
+#[cfg(unix)]
 pub(crate) fn exec_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> eyre::Result<()> {
+    use std::os::unix::process::CommandExt;
     let mut command = Command::new(match pgcli {
         false => pg_config.psql_path()?.into_os_string(),
         true => "pgcli".to_string().into(),
@@ -151,4 +152,9 @@ pub(crate) fn exec_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> eyre
 
     // we'll never return from here as we've now become psql
     panic!("{}", command.exec());
+}
+
+#[cfg(not(unix))]
+pub(crate) fn exec_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> eyre::Result<()> {
+    panic!("Tried to exec on a platform that doesn't support exec!")
 }


### PR DESCRIPTION
This isolates Unix-related code that isn't "requires dlopen because we are sinners" in cargo-pgrx. It doesn't fully solve what you might call "OS neutrality", but with the recent removal of our dependency on `fork`, it's a quick, incremental step to improving portability.

cc @passcod @robe2