### PR TITLE
Use one 🦭 per crate

### DIFF
--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -131,6 +131,11 @@ pub use pg_sys::{
 #[doc(hidden)]
 pub use pgrx_sql_entity_graph;
 
+mod seal {
+    /// A trait you can reference but can't impl externally
+    pub trait Sealed {}
+}
+
 // Postgres v15+ has the concept of an ABI "name".  The default is `b"PostgreSQL\0"` and this is the
 // ABI that pgrx extensions expect to be running under.  We will refuse to compile if it is detected
 // that we're trying to be built against some other kind of "postgres" that has its own ABI name.

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -13,6 +13,7 @@
 //! understandings of [`List`][crate::pg_sys::List]s of [`Oid`][crate::pg_sys::Oid]s, Integers, and Pointers.
 
 use crate::pg_sys;
+use crate::seal::Sealed;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr::{self, NonNull};
@@ -62,10 +63,6 @@ const _: () = {
     assert!(mem::size_of::<ListCell<u128>>() == mem::size_of::<pg_sys::ListCell>());
 };
 
-mod seal {
-    pub trait Sealed {}
-}
-
 /// The bound to describe a type which may be used in a Postgres List
 /// It must know what an appropriate type tag is, and how to pointer-cast to itself
 ///
@@ -75,7 +72,7 @@ mod seal {
 ///
 /// Only realistically valid to implement for union variants of pg_sys::ListCell.
 /// It's not even correct to impl for `*mut T`, as `*mut T` may be a fat pointer!
-pub unsafe trait Enlist: seal::Sealed + Sized {
+pub unsafe trait Enlist: Sealed + Sized {
     /// The appropriate list tag for this type.
     const LIST_TAG: pg_sys::NodeTag;
 

--- a/pgrx/src/list/flat_list.rs
+++ b/pgrx/src/list/flat_list.rs
@@ -1,5 +1,6 @@
-use super::{seal, Enlist, List, ListCell, ListHead};
+use super::{Enlist, List, ListCell, ListHead};
 use crate::pg_sys;
+use crate::seal::Sealed;
 use core::cmp;
 use core::ffi;
 use core::marker::PhantomData;
@@ -28,7 +29,7 @@ impl<T: Enlist> DerefMut for ListCell<T> {
     }
 }
 
-impl seal::Sealed for *mut ffi::c_void {}
+impl Sealed for *mut ffi::c_void {}
 unsafe impl Enlist for *mut ffi::c_void {
     const LIST_TAG: pg_sys::NodeTag = pg_sys::NodeTag::T_List;
 
@@ -41,7 +42,7 @@ unsafe impl Enlist for *mut ffi::c_void {
     }
 }
 
-impl seal::Sealed for ffi::c_int {}
+impl Sealed for ffi::c_int {}
 unsafe impl Enlist for ffi::c_int {
     const LIST_TAG: pg_sys::NodeTag = pg_sys::NodeTag::T_IntList;
 
@@ -54,7 +55,7 @@ unsafe impl Enlist for ffi::c_int {
     }
 }
 
-impl seal::Sealed for pg_sys::Oid {}
+impl Sealed for pg_sys::Oid {}
 unsafe impl Enlist for pg_sys::Oid {
     const LIST_TAG: pg_sys::NodeTag = pg_sys::NodeTag::T_OidList;
 
@@ -68,7 +69,7 @@ unsafe impl Enlist for pg_sys::Oid {
 }
 
 #[cfg(feature = "pg16")]
-impl seal::Sealed for pg_sys::TransactionId {}
+impl Sealed for pg_sys::TransactionId {}
 #[cfg(feature = "pg16")]
 unsafe impl Enlist for pg_sys::TransactionId {
     const LIST_TAG: pg_sys::NodeTag = pg_sys::NodeTag::T_XidList;

--- a/pgrx/src/list/linked_list.rs
+++ b/pgrx/src/list/linked_list.rs
@@ -1,5 +1,6 @@
-use super::{seal, Enlist, List, ListCell, ListHead};
+use super::{Enlist, List, ListCell, ListHead};
 use crate::pg_sys;
+use crate::seal::Sealed;
 use core::cmp;
 use core::ffi;
 use core::marker::PhantomData;

--- a/pgrx/src/list/linked_list.rs
+++ b/pgrx/src/list/linked_list.rs
@@ -27,7 +27,7 @@ impl<T: Enlist> DerefMut for ListCell<T> {
     }
 }
 
-impl seal::Sealed for *mut ffi::c_void {}
+impl Sealed for *mut ffi::c_void {}
 unsafe impl Enlist for *mut ffi::c_void {
     const LIST_TAG: pg_sys::NodeTag = pg_sys::NodeTag::T_List;
 
@@ -50,7 +50,7 @@ unsafe impl Enlist for *mut ffi::c_void {
     }
 }
 
-impl seal::Sealed for ffi::c_int {}
+impl Sealed for ffi::c_int {}
 unsafe impl Enlist for ffi::c_int {
     const LIST_TAG: pg_sys::NodeTag = pg_sys::NodeTag::T_IntList;
 
@@ -73,7 +73,7 @@ unsafe impl Enlist for ffi::c_int {
     }
 }
 
-impl seal::Sealed for pg_sys::Oid {}
+impl Sealed for pg_sys::Oid {}
 unsafe impl Enlist for pg_sys::Oid {
     const LIST_TAG: pg_sys::NodeTag = pg_sys::NodeTag::T_OidList;
 


### PR DESCRIPTION
I discovered we had two Sealed traits inside pgrx while doing some rework, so I decided to unify them, as we don't actually need two. I also believe that the use of the pgrx::fn_call::seal::Sealed trait was incorrect: it was binding the type T, but with a blanket impl. This means downstream crates could impl FnCallArg for types other than Arg, as long as they had first implemented Clone (which they obviously can) and IntoDatum (which remains a public trait).

This didn't occur to me the first time I saw FnCallArg because I hadn't arrived at my current interpretation of what "This is only implemented for the Arg enum" was supposed to mean: This _must_ only be implemented for the Arg enum!

I have corrected the bounds according to what I believe was intended.