### PR TITLE
Pedantically use `pg_sys::Datum` (nfc)

### DIFF
--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -16,7 +16,7 @@ use bitvec::slice::BitSlice;
 use core::fmt::{Debug, Formatter};
 use core::ops::DerefMut;
 use core::ptr::NonNull;
-use pgrx_pg_sys::{Datum, Oid};
+use pgrx_pg_sys::Oid;
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
@@ -734,9 +734,9 @@ impl<'a, T: FromDatum> FromDatum for Array<'a, T> {
 
 impl<T: IntoDatum> IntoDatum for Array<'_, T> {
     #[inline]
-    fn into_datum(self) -> Option<Datum> {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
         let array_type = self.into_array_type();
-        let datum = Datum::from(array_type);
+        let datum = pg_sys::Datum::from(array_type);
         Some(datum)
     }
 

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::array::RawArray;
-use crate::datum::array::casper::ChaChaSlide;
 use crate::layout::*;
 use crate::toast::Toast;
 use crate::{pg_sys, FromDatum, IntoDatum, PgMemoryContexts};
@@ -67,7 +66,7 @@ impl<'a, T: FromDatum + Debug> Debug for Array<'a, T> {
     }
 }
 
-type ChaChaSlideImpl<T> = Box<dyn ChaChaSlide<T>>;
+type ChaChaSlideImpl<T> = Box<dyn casper::ChaChaSlide<T>>;
 
 enum NullKind<'a> {
     Bits(&'a BitSlice<u8>),

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -16,7 +16,6 @@ use bitvec::slice::BitSlice;
 use core::fmt::{Debug, Formatter};
 use core::ops::DerefMut;
 use core::ptr::NonNull;
-use pgrx_pg_sys::Oid;
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
@@ -741,11 +740,11 @@ impl<T: IntoDatum> IntoDatum for Array<'_, T> {
     }
 
     #[inline]
-    fn type_oid() -> Oid {
+    fn type_oid() -> pg_sys::Oid {
         unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
 
-    fn composite_type_oid(&self) -> Option<Oid> {
+    fn composite_type_oid(&self) -> Option<pg_sys::Oid> {
         Some(unsafe { pg_sys::get_array_type(self.raw.oid()) })
     }
 }
@@ -845,7 +844,7 @@ where
         unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
 
-    fn composite_type_oid(&self) -> Option<Oid> {
+    fn composite_type_oid(&self) -> Option<pg_sys::Oid> {
         // the composite type oid for a vec of composite types is the array type of the base composite type
         self.get(0)
             .and_then(|v| v.composite_type_oid().map(|oid| unsafe { pg_sys::get_array_type(oid) }))

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -13,7 +13,7 @@ use crate::{
     pg_sys, varlena, varlena_to_byte_slice, AllocatedByPostgres, IntoDatum, PgBox, PgMemoryContexts,
 };
 use core::ffi::CStr;
-use pgrx_pg_sys::{Datum, Oid};
+use pgrx_pg_sys::Oid;
 use std::num::NonZeroUsize;
 
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
@@ -450,7 +450,7 @@ impl<'a> FromDatum for &'a core::ffi::CStr {
 
     unsafe fn from_datum_in_memory_context(
         mut memory_context: PgMemoryContexts,
-        datum: Datum,
+        datum: pg_sys::Datum,
         is_null: bool,
         _typoid: Oid,
     ) -> Option<Self>

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -13,7 +13,6 @@ use crate::{
     pg_sys, varlena, varlena_to_byte_slice, AllocatedByPostgres, IntoDatum, PgBox, PgMemoryContexts,
 };
 use core::ffi::CStr;
-use pgrx_pg_sys::Oid;
 use std::num::NonZeroUsize;
 
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
@@ -452,7 +451,7 @@ impl<'a> FromDatum for &'a core::ffi::CStr {
         mut memory_context: PgMemoryContexts,
         datum: pg_sys::Datum,
         is_null: bool,
-        _typoid: Oid,
+        _typoid: pg_sys::Oid,
     ) -> Option<Self>
     where
         Self: Sized,

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -15,7 +15,7 @@
 use crate::{pg_sys, rust_regtypein, PgBox, PgOid, WhoAllocated};
 use core::fmt::Display;
 use pgrx_pg_sys::panic::ErrorReportable;
-use pgrx_pg_sys::{Datum, Oid};
+use pgrx_pg_sys::Oid;
 use std::any::Any;
 
 /// Convert a Rust type into a `pg_sys::Datum`.
@@ -104,7 +104,7 @@ where
     /// directly raise that as the error.  This enables users to set a specific "sql error code"
     /// for a returned error, along with providing the HINT and DETAIL lines of the error.
     #[inline]
-    fn into_datum(self) -> Option<Datum> {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
         self.report().into_datum()
     }
 
@@ -387,7 +387,7 @@ impl<'a> IntoDatum for &'a [u8] {
                 self.len(),
             );
 
-            Some(Datum::from(varlena))
+            Some(pg_sys::Datum::from(varlena))
         }
     }
 
@@ -414,7 +414,7 @@ impl IntoDatum for () {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         // VOID isn't very useful, but Postgres represents it as a non-null Datum with a zero value
-        Some(Datum::from(0))
+        Some(pg_sys::Datum::from(0))
     }
 
     fn type_oid() -> pg_sys::Oid {

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -15,7 +15,6 @@
 use crate::{pg_sys, rust_regtypein, PgBox, PgOid, WhoAllocated};
 use core::fmt::Display;
 use pgrx_pg_sys::panic::ErrorReportable;
-use pgrx_pg_sys::Oid;
 use std::any::Any;
 
 /// Convert a Rust type into a `pg_sys::Datum`.
@@ -31,7 +30,7 @@ pub trait IntoDatum {
     fn into_datum(self) -> Option<pg_sys::Datum>;
     fn type_oid() -> pg_sys::Oid;
 
-    fn composite_type_oid(&self) -> Option<Oid> {
+    fn composite_type_oid(&self) -> Option<pg_sys::Oid> {
         None
     }
 
@@ -255,7 +254,7 @@ impl<'a> IntoDatum for &'a str {
     }
 
     #[inline]
-    fn is_compatible_with(other: Oid) -> bool {
+    fn is_compatible_with(other: pg_sys::Oid) -> bool {
         Self::type_oid() == other || other == pg_sys::VARCHAROID
     }
 }
@@ -271,7 +270,7 @@ impl IntoDatum for String {
     }
 
     #[inline]
-    fn is_compatible_with(other: Oid) -> bool {
+    fn is_compatible_with(other: pg_sys::Oid) -> bool {
         Self::type_oid() == other || other == pg_sys::VARCHAROID
     }
 }
@@ -287,7 +286,7 @@ impl IntoDatum for &String {
     }
 
     #[inline]
-    fn is_compatible_with(other: Oid) -> bool {
+    fn is_compatible_with(other: pg_sys::Oid) -> bool {
         Self::type_oid() == other || other == pg_sys::VARCHAROID
     }
 }
@@ -303,7 +302,7 @@ impl IntoDatum for char {
     }
 
     #[inline]
-    fn is_compatible_with(other: Oid) -> bool {
+    fn is_compatible_with(other: pg_sys::Oid) -> bool {
         Self::type_oid() == other || other == pg_sys::VARCHAROID
     }
 }

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -14,7 +14,6 @@ use crate::{
     varsize_any_exhdr, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts, PostgresType,
     StringInfo,
 };
-use pgrx_pg_sys::varlena;
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
@@ -466,7 +465,7 @@ where
 }
 
 #[allow(dead_code)]
-fn json_encode<T>(input: T) -> *const varlena
+fn json_encode<T>(input: T) -> *const pg_sys::varlena
 where
     T: Serialize,
 {

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -11,7 +11,7 @@
 //!
 //! [`PgHeapTuple`]s also describe composite types as defined by [`pgrx::composite_type!()`][crate::composite_type].
 use crate::datum::lookup_type_name;
-use crate::pg_sys::{Datum, Oid};
+use crate::pg_sys::Oid;
 use crate::{
     heap_getattr_raw, pg_sys, trigger_fired_by_delete, trigger_fired_by_insert,
     trigger_fired_by_update, trigger_fired_for_statement, AllocatedByPostgres, AllocatedByRust,
@@ -73,7 +73,7 @@ impl<'a> FromDatum for PgHeapTuple<'a, AllocatedByRust> {
 
     unsafe fn from_datum_in_memory_context(
         mut memory_context: PgMemoryContexts,
-        composite: Datum,
+        composite: pg_sys::Datum,
         is_null: bool,
         _oid: pg_sys::Oid,
     ) -> Option<Self> {

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -11,7 +11,6 @@
 //!
 //! [`PgHeapTuple`]s also describe composite types as defined by [`pgrx::composite_type!()`][crate::composite_type].
 use crate::datum::lookup_type_name;
-use crate::pg_sys::Oid;
 use crate::{
     heap_getattr_raw, pg_sys, trigger_fired_by_delete, trigger_fired_by_insert,
     trigger_fired_by_update, trigger_fired_for_statement, AllocatedByPostgres, AllocatedByRust,
@@ -419,7 +418,7 @@ impl<'a, AllocatedBy: WhoAllocated> IntoDatum for PgHeapTuple<'a, AllocatedBy> {
         crate::pg_sys::RECORDOID
     }
 
-    fn composite_type_oid(&self) -> Option<Oid> {
+    fn composite_type_oid(&self) -> Option<pg_sys::Oid> {
         Some(self.tupdesc.oid())
     }
 

--- a/pgrx/src/spi/query.rs
+++ b/pgrx/src/spi/query.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use std::ptr::NonNull;
 
 use libc::c_char;
-use pg_sys::{Datum, Oid};
+use pg_sys::Oid;
 
 use super::{Spi, SpiClient, SpiCursor, SpiError, SpiResult, SpiTupleTable};
 use crate::pg_sys::{self, PgOid};
@@ -55,7 +55,7 @@ fn prepare_datum(datum: Option<pg_sys::Datum>) -> (pg_sys::Datum, std::os::raw::
 
 fn args_to_datums(
     args: Vec<(PgOid, Option<pg_sys::Datum>)>,
-) -> (Vec<Oid>, Vec<Datum>, Vec<c_char>) {
+) -> (Vec<Oid>, Vec<pg_sys::Datum>, Vec<c_char>) {
     let mut argtypes = Vec::with_capacity(args.len());
     let mut datums = Vec::with_capacity(args.len());
     let mut nulls = Vec::with_capacity(args.len());

--- a/pgrx/src/spi/query.rs
+++ b/pgrx/src/spi/query.rs
@@ -4,7 +4,6 @@ use std::ops::Deref;
 use std::ptr::NonNull;
 
 use libc::c_char;
-use pg_sys::Oid;
 
 use super::{Spi, SpiClient, SpiCursor, SpiError, SpiResult, SpiTupleTable};
 use crate::pg_sys::{self, PgOid};
@@ -55,7 +54,7 @@ fn prepare_datum(datum: Option<pg_sys::Datum>) -> (pg_sys::Datum, std::os::raw::
 
 fn args_to_datums(
     args: Vec<(PgOid, Option<pg_sys::Datum>)>,
-) -> (Vec<Oid>, Vec<pg_sys::Datum>, Vec<c_char>) {
+) -> (Vec<pg_sys::Oid>, Vec<pg_sys::Datum>, Vec<c_char>) {
     let mut argtypes = Vec::with_capacity(args.len());
     let mut datums = Vec::with_capacity(args.len());
     let mut nulls = Vec::with_capacity(args.len());


### PR DESCRIPTION
Use `pg_sys::Datum` consistently throughout pgrx. This brings the crate better in conformance with its own style, and also is an important refactor for reasons that will become obvious in a later PR. No functional changes.

In a few places I also touched up some other imports, but that isn't done as consistently, so I have no idea if this misses a spot on that.