### PR TITLE
Fix rustdoc lints

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -25,7 +25,7 @@ use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 
 /// Type used for memoizing expensive to calculate values.
-/// Arc<Mutex> is needed to get around compiler safety checks.
+/// `Arc<Mutex>` is needed to get around compiler safety checks.
 type MemoizeKeyValue = Arc<Mutex<HashMap<PathBuf, String>>>;
 
 /// Install the extension from the current crate to the Postgres specified by whatever `pg_config` is currently on your $PATH

--- a/pgrx-pg-config/src/cargo.rs
+++ b/pgrx-pg-config/src/cargo.rs
@@ -24,7 +24,7 @@ pub trait PgrxManifestExt {
 
     /// Resolved string for target library name, either its lib.name,
     /// or package name with hyphens replaced with underscore.
-    /// https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-name-field
+    /// <https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-name-field>
     fn lib_name(&self) -> eyre::Result<String>;
 
     /// Resolved string for target artifact name, used for matching on

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -24,7 +24,7 @@ pub const MaxTransactionId: super::TransactionId = 0xFFFF_FFFF as super::Transac
 ///
 /// # Safety
 ///
-/// This function cannot determine if the `tuple` argument is really a non-null pointer to a [`HeapTuple`].
+/// This function cannot determine if the `tuple` argument is really a non-null pointer to a [`pg_sys::HeapTuple`].
 #[inline(always)]
 pub unsafe fn GETSTRUCT(tuple: crate::HeapTuple) -> *mut std::os::raw::c_char {
     // #define GETSTRUCT(TUP) ((char *) ((TUP)->t_data) + (TUP)->t_data->t_hoff)
@@ -108,7 +108,7 @@ pub unsafe fn GetMemoryChunkContext(pointer: *mut std::os::raw::c_void) -> pg_sy
 /// # Safety
 ///
 /// The caller must only attempt this on a pointer to a Node.
-/// This may clarify if the pointee is correctly-initialized [`MemoryContextData`].
+/// This may clarify if the pointee is correctly-initialized [`pg_sys::MemoryContextData`].
 ///
 /// # Implementation Note
 ///
@@ -208,17 +208,17 @@ pub unsafe fn BufferIsLocal(buffer: crate::Buffer) -> bool {
     buffer < 0
 }
 
-/// Retrieve the "user data" of the specified [`HeapTuple`] as a specific type. Typically this
+/// Retrieve the "user data" of the specified [`pg_sys::HeapTuple`] as a specific type. Typically this
 /// will be a struct that represents a Postgres system catalog, such as [`FormData_pg_class`].
 ///
 /// # Returns
 ///
-/// A pointer to the [`HeapTuple`]'s "user data", cast as a mutable pointer to `T`.  If the
+/// A pointer to the [`pg_sys::HeapTuple`]'s "user data", cast as a mutable pointer to `T`.  If the
 /// specified `htup` pointer is null, the null pointer is returned.
 ///
 /// # Safety
 ///
-/// This function cannot verify that the specified `htup` points to a valid [`HeapTuple`] nor
+/// This function cannot verify that the specified `htup` points to a valid [`pg_sys::HeapTuple`] nor
 /// that if it does, that its bytes are bitwise compatible with `T`.
 #[inline]
 pub unsafe fn heap_tuple_get_struct<T>(htup: super::HeapTuple) -> *mut T {

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -72,6 +72,8 @@ pub const unsafe fn MAXALIGN(len: usize) -> usize {
 ///
 /// This function will panic if `pointer` is null, if it's not properly aligned, or if the memory
 /// it points to doesn't have a prefix that looks like a memory context pointer
+///
+/// [`palloc`]: crate::palloc
 #[allow(non_snake_case)]
 #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
 pub unsafe fn GetMemoryChunkContext(pointer: *mut std::os::raw::c_void) -> pg_sys::MemoryContext {
@@ -220,6 +222,8 @@ pub unsafe fn BufferIsLocal(buffer: crate::Buffer) -> bool {
 ///
 /// This function cannot verify that the specified `htup` points to a valid [`pg_sys::HeapTuple`] nor
 /// that if it does, that its bytes are bitwise compatible with `T`.
+///
+/// [`FormData_pg_class`]: crate::FormData_pg_class
 #[inline]
 pub unsafe fn heap_tuple_get_struct<T>(htup: super::HeapTuple) -> *mut T {
     if htup.is_null() {

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -98,7 +98,7 @@ impl From<i32> for PgLogLevel {
 
 /// Log to Postgres' `debug5` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG5` level, depending on how the
@@ -115,7 +115,7 @@ macro_rules! debug5 {
 
 /// Log to Postgres' `debug4` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG4` level, depending on how the
@@ -132,7 +132,7 @@ macro_rules! debug4 {
 
 /// Log to Postgres' `debug3` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG3` level, depending on how the
@@ -149,7 +149,7 @@ macro_rules! debug3 {
 
 /// Log to Postgres' `debug2` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG2` level, depending on how the
@@ -166,7 +166,7 @@ macro_rules! debug2 {
 
 /// Log to Postgres' `debug1` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG1` level, depending on how the
@@ -183,7 +183,7 @@ macro_rules! debug1 {
 
 /// Log to Postgres' `log` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `LOG` level, depending on how the
@@ -200,7 +200,7 @@ macro_rules! log {
 
 /// Log to Postgres' `info` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! info {
@@ -214,7 +214,7 @@ macro_rules! info {
 
 /// Log to Postgres' `notice` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! notice {
@@ -228,7 +228,7 @@ macro_rules! notice {
 
 /// Log to Postgres' `warning` log level.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! warning {
@@ -242,7 +242,7 @@ macro_rules! warning {
 
 /// Log to Postgres' `error` log level.  This will abort the current Postgres transaction.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! error {
@@ -257,7 +257,7 @@ macro_rules! error {
 
 /// Log to Postgres' `fatal` log level.  This will abort the current Postgres backend connection process.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[allow(non_snake_case)]
 #[macro_export]
@@ -273,7 +273,7 @@ macro_rules! FATAL {
 
 /// Log to Postgres' `panic` log level.  This will cause the entire Postgres cluster to crash.
 ///
-/// This macro accepts arguments like the [`println`](std::println) and [`format`](std::format) macros.
+/// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[allow(non_snake_case)]
 #[macro_export]

--- a/pgrx-pg-sys/src/submodules/htup.rs
+++ b/pgrx-pg-sys/src/submodules/htup.rs
@@ -152,7 +152,7 @@ pub unsafe fn HeapTupleHeaderGetXmin(tup: *const HeapTupleHeaderData) -> Transac
     }
 }
 
-/// How many attributes does the specified [`HeapTupleHeader`] have?
+/// How many attributes does the specified [`HeapTupleHeader`][crate::HeapTupleHeader] have?
 ///
 /// # Safety
 ///
@@ -167,7 +167,7 @@ pub unsafe fn HeapTupleHeaderGetNatts(tup: *const HeapTupleHeaderData) -> u16 {
     }
 }
 
-/// Does the specified [`HeapTuple`] (`tup`) contain nulls?
+/// Does the specified [`HeapTuple`][crate::HeapTuple] contain nulls?
 ///
 /// # Safety
 ///

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -235,8 +235,8 @@ impl ErrorReportWithLevel {
 }
 
 impl ErrorReport {
-    /// Create a [PgErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
-    /// a specific Postgres "ereport()` level via [PgErrorReport::report(self, PgLogLevel)]
+    /// Create an [ErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
+    /// a specific Postgres "ereport()` level via [ErrorReport::report(self, PgLogLevel)]
     ///
     /// Embedded "file:line:col" location information is taken from the caller's location
     #[track_caller]
@@ -251,8 +251,8 @@ impl ErrorReport {
         Self { sqlerrcode, message: message.into(), hint: None, detail: None, location }
     }
 
-    /// Create a [PgErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
-    /// a specific Postgres "ereport()` level via [PgErrorReport::report(self, PgLogLevel)].
+    /// Create an [ErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
+    /// a specific Postgres "ereport()` level via [ErrorReport::report(self, PgLogLevel)].
     ///
     /// For internal use only
     fn with_location<S: Into<String>>(
@@ -290,7 +290,7 @@ impl ErrorReport {
         self.hint.as_deref()
     }
 
-    /// Report this [PgErrorReport], which will ultimately be reported by Postgres at the specified [PgLogLevel]
+    /// Report this [ErrorReport], which will ultimately be reported by Postgres at the specified [PgLogLevel]
     ///
     /// If the provided `level` is >= [`PgLogLevel::ERROR`] this function will not return.
     pub fn report(self, level: PgLogLevel) {

--- a/pgrx-sql-entity-graph/src/aggregate/aggregate_type.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/aggregate_type.rs
@@ -11,7 +11,7 @@
 
 `#[pg_aggregate]` related type metadata for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -11,7 +11,7 @@
 
 `#[pg_aggregate]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 

--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -48,67 +48,67 @@ pub struct PgAggregateEntity {
 
     /// The `arg_data_type` list.
     ///
-    /// Corresponds to `Args` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `Args` in `pgrx::aggregate::Aggregate`.
     pub args: Vec<AggregateTypeEntity>,
 
     /// The direct argument list, appearing before `ORDER BY` in ordered set aggregates.
     ///
-    /// Corresponds to `OrderBy` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `OrderBy` in `pgrx::aggregate::Aggregate`.
     pub direct_args: Option<Vec<AggregateTypeEntity>>,
 
     /// The `STYPE` and `name` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// The implementor of an [`pgrx::aggregate::Aggregate`].
+    /// The implementor of an `pgrx::aggregate::Aggregate`.
     pub stype: AggregateTypeEntity,
 
     /// The `SFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `state` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `state` in `pgrx::aggregate::Aggregate`.
     pub sfunc: &'static str,
 
     /// The `FINALFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `finalize` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `finalize` in `pgrx::aggregate::Aggregate`.
     pub finalfunc: Option<&'static str>,
 
     /// The `FINALFUNC_MODIFY` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `FINALIZE_MODIFY` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `FINALIZE_MODIFY` in `pgrx::aggregate::Aggregate`.
     pub finalfunc_modify: Option<FinalizeModify>,
 
     /// The `COMBINEFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `combine` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `combine` in `pgrx::aggregate::Aggregate`.
     pub combinefunc: Option<&'static str>,
 
     /// The `SERIALFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `serial` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `serial` in `pgrx::aggregate::Aggregate`.
     pub serialfunc: Option<&'static str>,
 
     /// The `DESERIALFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `deserial` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `deserial` in `pgrx::aggregate::Aggregate`.
     pub deserialfunc: Option<&'static str>,
 
     /// The `INITCOND` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `INITIAL_CONDITION` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `INITIAL_CONDITION` in `pgrx::aggregate::Aggregate`.
     pub initcond: Option<&'static str>,
 
     /// The `MSFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `moving_state` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `moving_state` in `pgrx::aggregate::Aggregate`.
     pub msfunc: Option<&'static str>,
 
     /// The `MINVFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `moving_state_inverse` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `moving_state_inverse` in `pgrx::aggregate::Aggregate`.
     pub minvfunc: Option<&'static str>,
 
     /// The `MSTYPE` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `MovingState` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `MovingState` in `pgrx::aggregate::Aggregate`.
     pub mstype: Option<UsedTypeEntity>,
 
     // The `MSSPACE` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
@@ -117,32 +117,32 @@ pub struct PgAggregateEntity {
     // pub msspace: &'static str,
     /// The `MFINALFUNC` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `moving_state_finalize` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `moving_state_finalize` in `pgrx::aggregate::Aggregate`.
     pub mfinalfunc: Option<&'static str>,
 
     /// The `MFINALFUNC_MODIFY` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `MOVING_FINALIZE_MODIFY` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `MOVING_FINALIZE_MODIFY` in `pgrx::aggregate::Aggregate`.
     pub mfinalfunc_modify: Option<FinalizeModify>,
 
     /// The `MINITCOND` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `MOVING_INITIAL_CONDITION` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `MOVING_INITIAL_CONDITION` in `pgrx::aggregate::Aggregate`.
     pub minitcond: Option<&'static str>,
 
     /// The `SORTOP` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `SORT_OPERATOR` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `SORT_OPERATOR` in `pgrx::aggregate::Aggregate`.
     pub sortop: Option<&'static str>,
 
     /// The `PARALLEL` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `PARALLEL` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `PARALLEL` in `pgrx::aggregate::Aggregate`.
     pub parallel: Option<ParallelOption>,
 
     /// The `HYPOTHETICAL` parameter for [`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html)
     ///
-    /// Corresponds to `hypothetical` in [`pgrx::aggregate::Aggregate`].
+    /// Corresponds to `hypothetical` in `pgrx::aggregate::Aggregate`.
     pub hypothetical: bool,
     pub to_sql_config: ToSqlConfigEntity,
 }

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -11,7 +11,7 @@
 
 `#[pg_aggregate]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 

--- a/pgrx-sql-entity-graph/src/aggregate/options.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/options.rs
@@ -11,7 +11,7 @@
 
 `#[pg_aggregate]` related options for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -11,7 +11,7 @@
 
 `pgrx_module_magic!()` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/entity.rs
@@ -11,7 +11,7 @@
 
 `pgrx::extension_sql!()` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 

--- a/pgrx-sql-entity-graph/src/extension_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/mod.rs
@@ -11,7 +11,7 @@
 
 `pgrx::extension_sql!()` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -11,7 +11,7 @@
 
 Rust to SQL mapping support.
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/mapping.rs
+++ b/pgrx-sql-entity-graph/src/mapping.rs
@@ -11,7 +11,7 @@
 
 Rust to SQL mapping support for dependency graph generation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/metadata/entity.rs
+++ b/pgrx-sql-entity-graph/src/metadata/entity.rs
@@ -11,7 +11,7 @@
 
 Function and type level metadata entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 

--- a/pgrx-sql-entity-graph/src/metadata/function_metadata.rs
+++ b/pgrx-sql-entity-graph/src/metadata/function_metadata.rs
@@ -11,7 +11,7 @@
 
 Function level metadata for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 

--- a/pgrx-sql-entity-graph/src/metadata/mod.rs
+++ b/pgrx-sql-entity-graph/src/metadata/mod.rs
@@ -11,7 +11,7 @@
 
 Function and type level metadata for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 

--- a/pgrx-sql-entity-graph/src/metadata/phantomdata_ext.rs
+++ b/pgrx-sql-entity-graph/src/metadata/phantomdata_ext.rs
@@ -11,7 +11,7 @@
 
 Zero sized type marker metadata for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/metadata/phantomdata_ext.rs
+++ b/pgrx-sql-entity-graph/src/metadata/phantomdata_ext.rs
@@ -21,9 +21,9 @@ use super::return_variant::ReturnsError;
 use super::{ArgumentError, FunctionMetadataTypeEntity, Returns, SqlMapping, SqlTranslatable};
 
 /**
-An extension trait for [`PhantomData`][core::marker::PhantomData] offering SQL generation related info
+An extension trait for [`PhantomData`] offering SQL generation related info
 
-Since we don't actually want to construct values during SQL generation, we use a [`PhantomData`][core::marker::PhantomData].
+Since we don't actually want to construct values during SQL generation, we use a [`PhantomData`].
  */
 pub trait PhantomDataExt {
     fn type_name(&self) -> &'static str;

--- a/pgrx-sql-entity-graph/src/metadata/return_variant.rs
+++ b/pgrx-sql-entity-graph/src/metadata/return_variant.rs
@@ -21,7 +21,7 @@ use super::sql_translatable::SqlMapping;
 
 /// Describes the RETURNS of CREATE FUNCTION ... RETURNS ...
 /// See the PostgreSQL documentation for [CREATE FUNCTION]
-/// [CREATE FUNCTION]: https://www.postgresql.org/docs/current/sql-createfunction.html
+/// [CREATE FUNCTION]: <https://www.postgresql.org/docs/current/sql-createfunction.html>
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Returns {
     One(SqlMapping),

--- a/pgrx-sql-entity-graph/src/metadata/return_variant.rs
+++ b/pgrx-sql-entity-graph/src/metadata/return_variant.rs
@@ -11,7 +11,7 @@
 
 Return value specific metadata for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -11,7 +11,7 @@
 
 A trait denoting a type can possibly be mapped to an SQL type
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/argument.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/argument.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` related argument macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` related attributes for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/argument.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/argument.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` related argument entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/operator.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/operator.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` related operator entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/returning.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` related return value entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/operator.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/operator.rs
@@ -11,7 +11,7 @@
 
 `#[pg_operator]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/returning.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` return value related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
@@ -11,7 +11,7 @@
 
 `#[pg_extern]` search path related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
@@ -11,7 +11,7 @@
 
 `#[pg_trigger]` attribute related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_trigger/entity.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/entity.rs
@@ -11,7 +11,7 @@
 
 `#[pg_trigger]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -11,7 +11,7 @@
 
 `#[pg_trigger]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pgrx_attribute.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_attribute.rs
@@ -11,7 +11,7 @@
 
 `#[pgrx]` attribute for Rust to SQL mapping support.
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -11,7 +11,7 @@
 
 Rust to SQL mapping support.
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/positioning_ref.rs
+++ b/pgrx-sql-entity-graph/src/positioning_ref.rs
@@ -11,7 +11,7 @@
 
 Positioning references for Rust to SQL mapping support.
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_enum/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_enum/entity.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresEnum)]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresEnum)]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_hash/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_hash/entity.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresHash)]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_hash/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_hash/mod.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresHash)]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_ord/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_ord/entity.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresOrd)]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_ord/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_ord/mod.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresOrd)]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresType)]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -11,7 +11,7 @@
 
 `#[derive(PostgresType)]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/schema/entity.rs
+++ b/pgrx-sql-entity-graph/src/schema/entity.rs
@@ -11,7 +11,7 @@
 
 `#[pg_schema]` related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/schema/mod.rs
+++ b/pgrx-sql-entity-graph/src/schema/mod.rs
@@ -11,7 +11,7 @@
 
 `#[pg_schema]` related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/to_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/entity.rs
@@ -11,7 +11,7 @@
 
 `sql = ...` fragment related entities for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/to_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/mod.rs
@@ -11,7 +11,7 @@
 
 `sql = ...` fragment related macro expansion for Rust to SQL translation
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -11,7 +11,7 @@
 
 Type level metadata for Rust to SQL generation.
 
-> Like all of the [`sql_entity_graph`][crate::pgrx_sql_entity_graph] APIs, this is considered **internal**
+> Like all of the [`sql_entity_graph`][crate] APIs, this is considered **internal**
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */

--- a/pgrx-version-updater/src/main.rs
+++ b/pgrx-version-updater/src/main.rs
@@ -58,7 +58,7 @@ struct UpdateFilesArgs {
     #[arg(short, long)]
     include_for_dep_updates: Vec<String>,
 
-    /// Exclude Cargo.toml files from [package] version updates
+    /// Exclude Cargo.toml files from `[package]` version updates
     ///
     /// Add multiple values using --exclude /path/foo/Cargo.toml --exclude /path/bar/Cargo.toml
     #[arg(short, long)]

--- a/pgrx/src/aggregate.rs
+++ b/pgrx/src/aggregate.rs
@@ -80,7 +80,7 @@ aggregate=# SELECT DemoSum(value) FROM demo_table;
 ## Multiple Arguments
 
 Sometimes aggregates need to handle multiple arguments. The
-[`Aggregate::Args`](Aggregate::Args) associated type can be a tuple:
+[`Aggregate::Args`] associated type can be a tuple:
 
 ```rust
 # use pgrx::prelude::*;

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -515,7 +515,7 @@ impl<'a, T: FromDatum> VariadicArray<'a, T> {
         self.0.into_array_type()
     }
 
-    /// Return an Iterator of Option<T> over the contained Datums.
+    /// Return an Iterator of `Option<T>` over the contained Datums.
     #[inline]
     pub fn iter(&self) -> ArrayIterator<'_, T> {
         self.0.iter()

--- a/pgrx/src/datum/datetime_support/mod.rs
+++ b/pgrx/src/datum/datetime_support/mod.rs
@@ -128,7 +128,7 @@ pub enum DateTimeParts {
 }
 
 impl From<DateTimeParts> for &'static str {
-    /// Convert to Postgres' string representation of a [`DateTimePart`]
+    /// Convert to Postgres' string representation of [`DateTimeParts`]
     #[inline]
     fn from(value: DateTimeParts) -> Self {
         match value {

--- a/pgrx/src/datum/interval.rs
+++ b/pgrx/src/datum/interval.rs
@@ -16,7 +16,7 @@ use pgrx_sql_entity_graph::metadata::{
 pub const USECS_PER_SEC: i64 = 1_000_000;
 pub const USECS_PER_DAY: i64 = pg_sys::SECS_PER_DAY as i64 * USECS_PER_SEC;
 
-/// From the PG docs  https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
+/// From the PG docs <https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT>
 /// Internally interval values are stored as months, days, and microseconds. This is done because the number of days in a month varies,
 /// and a day can have 23 or 25hours if a daylight savings time adjustment is involved. The months and days fields are integers while
 /// the microseconds field can store fractional seconds. Because intervals are usually created from constant strings or timestamp

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -70,7 +70,7 @@ pub trait IntoDatum {
     }
 }
 
-/// for supporting NULL as the None value of an Option<T>
+/// for supporting NULL as the None value of an `Option<T>`
 impl<T> IntoDatum for Option<T>
 where
     T: IntoDatum,

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -336,7 +336,7 @@ impl<'a> IntoDatum for &'a core::ffi::CStr {
 }
 
 impl IntoDatum for alloc::ffi::CString {
-    /// The [`core::ffi::CString`] is copied to `palloc`'d memory.  That memory will either be freed by
+    /// The [`alloc::ffi::CString`] is copied to `palloc`'d memory.  That memory will either be freed by
     /// Postgres when [`pg_sys::CurrentMemoryContext`] is reset, or when the function you passed the
     /// returned Datum to decides to free it.
     #[inline]

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -97,11 +97,14 @@ where
     /// ## Panics
     ///
     /// If this Result represents an error, then that error is raised as a Postgres ERROR, using
-    /// the [`PgSqlErrorCode::ERRCODE_DATA_EXCEPTION`] error code.
+    /// the [`ERRCODE_DATA_EXCEPTION`] error code.
     ///
-    /// If we detect that the `Err()` variant contains `[pg_sys::panic::ErrorReport]`, then we
+    /// If we detect that the `Err()` variant contains [ErrorReport], then we
     /// directly raise that as the error.  This enables users to set a specific "sql error code"
     /// for a returned error, along with providing the HINT and DETAIL lines of the error.
+    ///
+    /// [ErrorReport]: pg_sys::panic::ErrorReport
+    /// [`ERRCODE_DATA_EXCEPTION`]: pg_sys::errcodes::PgSqlErrorCode::ERRCODE_DATA_EXCEPTION
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         self.report().into_datum()

--- a/pgrx/src/datum/json.rs
+++ b/pgrx/src/datum/json.rs
@@ -25,7 +25,7 @@ pub struct Json(pub Value);
 #[derive(Debug)]
 pub struct JsonB(pub Value);
 
-/// A wholly Rust-[`String`][std::string::String] owned copy of a `json` type from PostgreSQL
+/// A wholly Rust-[`String`] owned copy of a `json` type from PostgreSQL
 #[derive(Debug)]
 pub struct JsonString(pub String);
 

--- a/pgrx/src/datum/numeric.rs
+++ b/pgrx/src/datum/numeric.rs
@@ -28,7 +28,7 @@ use crate::{direct_function_call, pg_sys};
 ///
 /// All the various Rust arithmetic traits are implemented for [`AnyNumeric`], but using them, even
 /// if the (P, S) is the same on both sides of the operator converts the result to an [`AnyNumeric`].
-/// It is [`AnyNumeric`] that also supports the various "Assign" (ie, [`AddAssign`]) traits.
+/// It is [`AnyNumeric`] that also supports the various "Assign" (ie, [`AddAssign`][core::ops::AddAssign]) traits.
 ///
 /// [`Numeric`] is well-suited for a `#[pg_extern]` return type, more so than a function argument.
 /// Use [`AnyNumeric`] for those.

--- a/pgrx/src/datum/range.rs
+++ b/pgrx/src/datum/range.rs
@@ -122,7 +122,7 @@ where
     /// Conversion of an [`Option`] to a [`RangeBound`].  
     ///
     /// `Some` maps to the [`RangeBound::Inclusive`] variant and `None` maps to the
-    /// [`RangeBound::infinite`] value.
+    /// [`RangeBound::Infinite`] value.
     #[inline]
     fn from(value: Option<T>) -> Self {
         match value {

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -107,9 +107,6 @@ impl<'a> PgHeapTuple<'a, AllocatedByPostgres> {
     /// [PgHeapTuple] will be considered by have been allocated by Postgres and is not mutable until
     /// [PgHeapTuple::into_owned] is called.
     ///
-    /// pgrx also invents the concept of a "current" ([`TriggerTuple::Current`]) tuple, which is either
-    /// the new row being inserted or the row being updated (not the new version) or deleted.
-    ///
     /// Asking for a [`TriggerTuple`] that isn't compatible with how the trigger was fired causes
     /// this function to return `None`.  Specifically this means `None` is always returned for
     /// statement-level triggers.

--- a/pgrx/src/htup.rs
+++ b/pgrx/src/htup.rs
@@ -7,7 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-//! Utility functions for working with [`pg_sys::HeapTuple`][crate::pg_sys::HeapTuple] and [`pg_sys::HeapTupleHeader`][crate::pg_sys::HeapTupleHeader] structs
+//! Utility functions for working with [`pg_sys::HeapTuple`] and [`pg_sys::HeapTupleHeader`] structs
 use crate::*;
 use seq_macro::seq;
 use std::num::NonZeroUsize;

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -88,7 +88,7 @@ where
 /// [`TableIterator`] is typically used as the return type of a `#[pg_extern]`-style function,
 /// indicating that the function returns a table of named columns.  [`TableIterator`] is
 /// generic over `T`, but that `T` must be a Rust tuple containing one or more elements.  They
-/// must also be "named" using pgrx' [`name!`] macro.  See the examples below.
+/// must also be "named" using pgrx's [`name!`][crate::name] macro.  See the examples below.
 ///
 /// It is a lightweight wrapper around an iterator, which you provide during construction.  The
 /// iterator *can* borrow from its environment, following Rust's normal borrowing rules.  If no

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -25,7 +25,7 @@ use crate::pg_sys::{self, TYPALIGN_CHAR, TYPALIGN_DOUBLE, TYPALIGN_INT, TYPALIGN
 use core::mem;
 
 /// Postgres type information, corresponds to part of a row in pg_type
-/// This layout describes T, not &T, even if passbyval: false, which would mean the datum array is effectively &[&T]
+/// This layout describes T, not &T, even if passbyval: false, which would mean the datum array is effectively `&[&T]`
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Layout {
     // We could add more fields to this if we are curious enough, as the function we call pulls an entire row

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -347,7 +347,7 @@ pub(crate) enum Utf8Compat {
 
 /// Initialize the extension with Postgres
 ///
-/// Sets up panic handling with [`register_pg_guard_panic_hook()`] to ensure that a crash within
+/// Sets up panic handling with [`pg_sys::panic::register_pg_guard_panic_hook`] to ensure that a crash within
 /// the extension does not adversely affect the entire server process.
 ///
 /// ## Note

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -9,8 +9,8 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! A safe wrapper around Postgres' internal [`List`][crate::pg_sys::List] structure.
 //!
-//! It functions similarly to a Rust [`Vec`][std::vec::Vec], including iterator support, but provides separate
-//! understandings of [`List`][crate::pg_sys::List]s of [`Oid`][crate::pg_sys::Oid]s, Integers, and Pointers.
+//! It functions similarly to a Rust [`Vec`], including iterator support, but provides separate
+//! understandings of [`List`][crate::pg_sys::List]s of [`pg_sys::Oid`]s, Integers, and Pointers.
 
 use crate::pg_sys;
 use crate::seal::Sealed;

--- a/pgrx/src/pg_catalog/pg_proc.rs
+++ b/pgrx/src/pg_catalog/pg_proc.rs
@@ -143,14 +143,14 @@ impl PgProc {
         self.get_attr(pg_sys::Anum_pg_proc_proowner).unwrap()
     }
 
-    /// Estimated execution cost (in units of cpu_operator_cost); if [`proretset()`], this is cost per row
-    /// returned
+    /// Estimated execution cost (in units of cpu_operator_cost); if [`proretset()`][PgProc::proretset],
+    /// this is cost per row returned
     pub fn procost(&self) -> f32 {
         // won't panic because `procost` has a NOT NULL constraint
         self.get_attr(pg_sys::Anum_pg_proc_procost).unwrap()
     }
 
-    /// Estimated number of result rows (zero if not [`proretset()`],)
+    /// Estimated number of result rows (zero if not [`proretset()`][PgProc::proretset],)
     pub fn prorows(&self) -> f32 {
         // won't panic because `prorows` has a NOT NULL constraint, so `.unwrap()` wont panic
         self.get_attr(pg_sys::Anum_pg_proc_prorows).unwrap()

--- a/pgrx/src/spi/tuple.rs
+++ b/pgrx/src/spi/tuple.rs
@@ -109,8 +109,8 @@ impl<'conn> SpiTupleTable<'conn> {
     ///
     /// # Errors
     ///
-    /// If the specified ordinal is out of bounds a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
+    /// If the specified ordinal is out of bounds an [`SpiError::SpiError(SpiError::NoAttribute)`] is returned
+    /// If we have no backing tuple table an [`SpiError::NoTupleTable`] is returned
     ///
     /// # Panics
     ///
@@ -142,8 +142,8 @@ impl<'conn> SpiTupleTable<'conn> {
     ///
     /// # Errors
     ///
-    /// If the specified name is invalid a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
+    /// If the specified name is invalid an [`SpiError::SpiError(SpiError::NoAttribute)`] is returned
+    /// If we have no backing tuple table an [`SpiError::NoTupleTable`] is returned
     pub fn get_by_name<T: IntoDatum + FromDatum, S: AsRef<str>>(
         &self,
         name: S,
@@ -157,8 +157,8 @@ impl<'conn> SpiTupleTable<'conn> {
     ///
     /// # Errors
     ///
-    /// If the specified ordinal is out of bounds a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
+    /// If the specified ordinal is out of bounds an [`SpiError::SpiError(SpiError::NoAttribute)`] is returned
+    /// If we have no backing tuple table an [`SpiError::NoTupleTable`] is returned
     pub fn get_datum_by_ordinal(&self, ordinal: usize) -> SpiResult<Option<pg_sys::Datum>> {
         self.check_ordinal_bounds(ordinal)?;
 
@@ -184,8 +184,8 @@ impl<'conn> SpiTupleTable<'conn> {
     ///
     /// # Errors
     ///
-    /// If the specified name is invalid a [`Error::SpiError(SpiError::NoAttribute)`] is returned
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
+    /// If the specified name is invalid an [`SpiError::SpiError(SpiError::NoAttribute)`] is returned
+    /// If we have no backing tuple table an [`SpiError::NoTupleTable`] is returned
     pub fn get_datum_by_name<S: AsRef<str>>(&self, name: S) -> SpiResult<Option<pg_sys::Datum>> {
         self.get_datum_by_ordinal(self.column_ordinal(name)?)
     }
@@ -226,7 +226,7 @@ impl<'conn> SpiTupleTable<'conn> {
     /// # Errors
     ///
     /// Returns [`Error::SpiError(SpiError::NoAttribute)`] if the specified ordinal value is out of bounds
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
+    /// If we have no backing tuple table an [`SpiError::NoTupleTable`] is returned
     ///
     /// # Panics
     ///
@@ -255,7 +255,7 @@ impl<'conn> SpiTupleTable<'conn> {
     /// # Errors
     ///
     /// Returns [`Error::SpiError(SpiError::NoAttribute)`] if the specified column name isn't found
-    /// If we have no backing tuple table a [`Error::NoTupleTable`] is returned
+    /// If we have no backing tuple table an [`SpiError::NoTupleTable`] is returned
     ///
     /// # Panics
     ///
@@ -351,7 +351,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     ///
     /// # Errors
     ///
-    /// Returns a [`Error::DatumError`] if the desired Rust type is incompatible
+    /// Returns an [`SpiError::DatumError`] if the desired Rust type is incompatible
     /// with the underlying Datum
     pub fn get<T: IntoDatum + FromDatum>(&self, ordinal: usize) -> SpiResult<Option<T>> {
         self.get_datum_by_ordinal(ordinal).map(|entry| entry.value())?
@@ -361,7 +361,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     ///
     /// # Errors
     ///
-    /// Returns a [`Error::DatumError`] if the desired Rust type is incompatible
+    /// Returns an [`SpiError::DatumError`] if the desired Rust type is incompatible
     /// with the underlying Datum
     pub fn get_by_name<T: IntoDatum + FromDatum, S: AsRef<str>>(
         &self,
@@ -376,7 +376,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     ///
     /// # Errors
     ///
-    /// If the specified ordinal is out of bounds a [`Error::SpiError(SpiError::NoAttribute)`] is returned
+    /// If the specified ordinal is out of bounds an [`SpiError::SpiError(SpiError::NoAttribute)`] is returned
     pub fn get_datum_by_ordinal(&self, ordinal: usize) -> SpiResult<&SpiHeapTupleDataEntry<'conn>> {
         // Wrapping because `self.entries.get(...)` will bounds check.
         let index = ordinal.wrapping_sub(1);
@@ -387,7 +387,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     ///
     /// # Errors
     ///
-    /// If the specified name isn't valid a [`Error::SpiError(SpiError::NoAttribute)`] is returned
+    /// If the specified name isn't valid an [`SpiError::SpiError(SpiError::NoAttribute)`] is returned
     ///
     /// # Panics
     ///
@@ -427,7 +427,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     ///
     /// # Errors
     ///
-    /// If the specified name isn't valid a [`Error::SpiError(SpiError::NoAttribute)`] is returned
+    /// If the specified name isn't valid an [`SpiError::SpiError(SpiError::NoAttribute)`] is returned
     ///
     /// # Panics
     ///

--- a/pgrx/src/stringinfo.rs
+++ b/pgrx/src/stringinfo.rs
@@ -188,7 +188,7 @@ impl<AllocatedBy: WhoAllocated> StringInfo<AllocatedBy> {
     ///
     /// # Errors
     ///
-    /// If the contained bytes aren't valid UTF8, a [UTF8Error] is returned.  Postgres StringInfo
+    /// If the contained bytes aren't valid UTF8, a [Utf8Error] is returned.  Postgres StringInfo
     /// is allowed to contain non-UTF8 byte sequences, so this is a real possibility.
     #[inline]
     pub fn as_str(&self) -> Result<&str, Utf8Error> {

--- a/pgrx/src/trigger_support/mod.rs
+++ b/pgrx/src/trigger_support/mod.rs
@@ -24,8 +24,8 @@ fn trigger_example<'a>(trigger: &'a PgTrigger<'a>) -> Result<
 }
 ```
 
-Trigger functions only accept one argument, a [`PgTrigger`], and they return a [`Result`][std::result::Result] containing
-either a [`PgHeapTuple`][crate::PgHeapTuple] or any error that implements [`impl std::error::Error`][std::error::Error].
+Trigger functions only accept one argument, a [`PgTrigger`], and they return a [`Result`] containing
+either a [`PgHeapTuple`][crate::PgHeapTuple] or any error that implements [`std::error::Error`].
 
 # Use from SQL
 

--- a/pgrx/src/trigger_support/mod.rs
+++ b/pgrx/src/trigger_support/mod.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 /*! Support for writing Rust trigger functions
 
-A "no-op" trigger that gets the current [`PgHeapTuple`][crate::PgHeapTuple],
+A "no-op" trigger that gets the current [`PgHeapTuple`],
 panicking (into a PostgreSQL error) if it doesn't exist:
 
 ```rust,no_run
@@ -25,7 +25,7 @@ fn trigger_example<'a>(trigger: &'a PgTrigger<'a>) -> Result<
 ```
 
 Trigger functions only accept one argument, a [`PgTrigger`], and they return a [`Result`] containing
-either a [`PgHeapTuple`][crate::PgHeapTuple] or any error that implements [`std::error::Error`].
+either a [`PgHeapTuple`] or any error that implements [`impl std::error::Error`][std::error::Error].
 
 # Use from SQL
 
@@ -91,7 +91,7 @@ INSERT INTO test (title, description, payload) VALUES ('Fox', 'a description', '
 
 # Working with [`WhoAllocated`][crate::WhoAllocated]
 
-Trigger functions can return [`PgHeapTuple`][crate::PgHeapTuple]s which are [`AllocatedByRust`][crate::AllocatedByRust]
+Trigger functions can return [`PgHeapTuple`]s which are [`AllocatedByRust`][crate::AllocatedByRust]
 or [`AllocatedByPostgres`][crate::AllocatedByPostgres]. In most cases, it can be inferred by the compiler using
 [`impl WhoAllocated<pg_sys::HeapTupleData>>`][crate::WhoAllocated].
 
@@ -176,8 +176,8 @@ fn example_lifetimes<'a, 'b>(trigger: &'a PgTrigger<'a>) -> Result<
 Unsafe [`pgrx::pg_sys::FunctionCallInfo`][crate::pg_sys::FunctionCallInfo] and
 [`pgrx::pg_sys::TriggerData`][crate::pg_sys::TriggerData] (include its contained
 [`pgrx::pg_sys::Trigger`][crate::pg_sys::Trigger]) accessors are available..
-```
 
+[`PgHeapTuple`]: crate::heap_tuple::PgHeapTuple
  */
 
 mod pg_trigger;

--- a/pgrx/src/trigger_support/trigger_tuple.rs
+++ b/pgrx/src/trigger_support/trigger_tuple.rs
@@ -7,7 +7,9 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-/// Indicates which trigger tuple to convert into a [crate::PgHeapTuple].
+/// Indicates which trigger tuple to convert into a [`PgHeapTuple`].
+///
+/// [`PgHeapTuple`]: crate::heap_tuple::PgHeapTuple
 #[derive(Debug, Copy, Clone)]
 pub enum TriggerTuple {
     /// Represents the new database row for INSERT/UPDATE operations in row-level triggers.


### PR DESCRIPTION
At some point we got like a zillion errors in doc-link generation and I finally had it enough that I wanted them all fixed. This does not necessarily mean all the docs are good or correctly linked, just that the lints are silent.