### PR TITLE
Make `#[derive(PostgresType)]` impl its own FromDatum

### DIFF
--- a/pgrx-examples/custom_types/Cargo.toml
+++ b/pgrx-examples/custom_types/Cargo.toml
@@ -29,7 +29,7 @@ no-schema-generation = [ "pgrx/no-schema-generation", "pgrx-tests/no-schema-gene
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
 maplit = "1.0.2"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/custom_types/Cargo.toml
+++ b/pgrx-examples/custom_types/Cargo.toml
@@ -29,7 +29,7 @@ no-schema-generation = [ "pgrx/no-schema-generation", "pgrx-tests/no-schema-gene
 [dependencies]
 pgrx = { path = "../../pgrx", default-features = false }
 maplit = "1.0.2"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/custom_types/src/fixed_size.rs
+++ b/pgrx-examples/custom_types/src/fixed_size.rs
@@ -13,6 +13,7 @@ use pgrx::{opname, pg_operator, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use std::str::FromStr;
 
 #[derive(Copy, Clone, PostgresType)]
+#[bikeshed_postgres_type_manually_impl_from_into_datum]
 #[pgvarlena_inoutfuncs]
 pub struct FixedF32Array {
     array: [f32; 91],

--- a/pgrx-examples/custom_types/src/fixed_size.rs
+++ b/pgrx-examples/custom_types/src/fixed_size.rs
@@ -11,11 +11,12 @@ use core::ffi::CStr;
 use pgrx::prelude::*;
 use pgrx::{opname, pg_operator, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use std::str::FromStr;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, PostgresType)]
+#[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]
 pub struct FixedF32Array {
-    array: [f32; 91],
+    array: [f32; 32],
 }
 
 impl PgVarlenaInOutFuncs for FixedF32Array {

--- a/pgrx-examples/custom_types/src/fixed_size.rs
+++ b/pgrx-examples/custom_types/src/fixed_size.rs
@@ -10,8 +10,8 @@
 use core::ffi::CStr;
 use pgrx::prelude::*;
 use pgrx::{opname, pg_operator, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
-use std::str::FromStr;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]

--- a/pgrx-examples/custom_types/src/fixed_size.rs
+++ b/pgrx-examples/custom_types/src/fixed_size.rs
@@ -10,13 +10,12 @@
 use core::ffi::CStr;
 use pgrx::prelude::*;
 use pgrx::{opname, pg_operator, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
+#[derive(Copy, Clone, PostgresType)]
 #[pgvarlena_inoutfuncs]
 pub struct FixedF32Array {
-    array: [f32; 32],
+    array: [f32; 91],
 }
 
 impl PgVarlenaInOutFuncs for FixedF32Array {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -18,9 +18,10 @@ use syn::spanned::Spanned;
 use syn::{parse_macro_input, Attribute, Data, DeriveInput, Item, ItemImpl};
 
 use operators::{deriving_postgres_eq, deriving_postgres_hash, deriving_postgres_ord};
-use pgrx_sql_entity_graph::{
+use pgrx_sql_entity_graph as sql_gen;
+use sql_gen::{
     parse_extern_attributes, CodeEnrichment, ExtensionSql, ExtensionSqlFile, ExternArgs,
-    PgAggregate, PgExtern, PostgresEnum, PostgresType, Schema,
+    PgAggregate, PgExtern, PostgresEnum, Schema,
 };
 
 use crate::rewriter::PgGuardRewriter;
@@ -878,7 +879,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         });
     }
 
-    let sql_graph_entity_item = PostgresType::from_derive_input(ast)?;
+    let sql_graph_entity_item = sql_gen::PostgresTypeDerive::from_derive_input(ast)?;
     sql_graph_entity_item.to_tokens(&mut stream);
 
     Ok(stream)

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -42,7 +42,7 @@ pub use postgres_hash::PostgresHash;
 pub use postgres_ord::entity::PostgresOrdEntity;
 pub use postgres_ord::PostgresOrd;
 pub use postgres_type::entity::PostgresTypeEntity;
-pub use postgres_type::PostgresType;
+pub use postgres_type::PostgresTypeDerive;
 pub use schema::entity::SchemaEntity;
 pub use schema::Schema;
 pub use to_sql::entity::ToSqlConfigEntity;

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -49,7 +49,7 @@ use crate::{CodeEnrichment, ToSqlConfig};
 /// # }
 /// ```
 #[derive(Debug, Clone)]
-pub struct PostgresType {
+pub struct PostgresTypeDerive {
     name: Ident,
     generics: Generics,
     in_fn: Ident,
@@ -57,7 +57,7 @@ pub struct PostgresType {
     to_sql_config: ToSqlConfig,
 }
 
-impl PostgresType {
+impl PostgresTypeDerive {
     pub fn new(
         name: Ident,
         generics: Generics,
@@ -100,7 +100,7 @@ impl PostgresType {
     }
 }
 
-impl ToEntityGraphTokens for PostgresType {
+impl ToEntityGraphTokens for PostgresTypeDerive {
     fn to_entity_graph_tokens(&self) -> TokenStream2 {
         let name = &self.name;
         let mut static_generics = self.generics.clone();
@@ -211,17 +211,14 @@ impl ToEntityGraphTokens for PostgresType {
     }
 }
 
-impl ToRustCodeTokens for PostgresType {}
+impl ToRustCodeTokens for PostgresTypeDerive {}
 
-impl Parse for CodeEnrichment<PostgresType> {
+impl Parse for CodeEnrichment<PostgresTypeDerive> {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let parsed: ItemStruct = input.parse()?;
-        let to_sql_config =
-            ToSqlConfig::from_attributes(parsed.attrs.as_slice())?.unwrap_or_default();
-        let funcname_in =
-            Ident::new(&format!("{}_in", parsed.ident).to_lowercase(), parsed.ident.span());
-        let funcname_out =
-            Ident::new(&format!("{}_out", parsed.ident).to_lowercase(), parsed.ident.span());
-        PostgresType::new(parsed.ident, parsed.generics, funcname_in, funcname_out, to_sql_config)
+        let ItemStruct { attrs, ident, generics, .. } = input.parse()?;
+        let to_sql_config = ToSqlConfig::from_attributes(attrs.as_slice())?.unwrap_or_default();
+        let in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
+        let out_fn = Ident::new(&format!("{}_out", ident).to_lowercase(), ident.span());
+        PostgresTypeDerive::new(ident, generics, in_fn, out_fn, to_sql_config)
     }
 }

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -34,11 +34,11 @@ use crate::{CodeEnrichment, ToSqlConfig};
 /// ```rust
 /// use syn::{Macro, parse::Parse, parse_quote, parse};
 /// use quote::{quote, ToTokens};
-/// use pgrx_sql_entity_graph::PostgresType;
+/// use pgrx_sql_entity_graph::PostgresTypeDerive;
 ///
 /// # fn main() -> eyre::Result<()> {
 /// use pgrx_sql_entity_graph::CodeEnrichment;
-/// let parsed: CodeEnrichment<PostgresType> = parse_quote! {
+/// let parsed: CodeEnrichment<PostgresTypeDerive> = parse_quote! {
 ///     #[derive(PostgresType)]
 ///     struct Example<'a> {
 ///         demo: &'a str,

--- a/pgrx-tests/src/tests/postgres_type_tests.rs
+++ b/pgrx-tests/src/tests/postgres_type_tests.rs
@@ -13,7 +13,7 @@ use pgrx::{InOutFuncs, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Copy, Clone, PostgresType)]
+#[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]
 pub struct VarlenaType {
     a: f32,
@@ -38,7 +38,7 @@ impl PgVarlenaInOutFuncs for VarlenaType {
     }
 }
 
-#[derive(Copy, Clone, PostgresType)]
+#[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]
 pub enum VarlenaEnumType {
     A,

--- a/pgrx-tests/src/tests/postgres_type_tests.rs
+++ b/pgrx-tests/src/tests/postgres_type_tests.rs
@@ -13,7 +13,7 @@ use pgrx::{InOutFuncs, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
+#[derive(Copy, Clone, PostgresType)]
 #[pgvarlena_inoutfuncs]
 pub struct VarlenaType {
     a: f32,
@@ -38,7 +38,7 @@ impl PgVarlenaInOutFuncs for VarlenaType {
     }
 }
 
-#[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
+#[derive(Copy, Clone, PostgresType)]
 #[pgvarlena_inoutfuncs]
 pub enum VarlenaEnumType {
     A,

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -421,7 +421,8 @@ where
     }
 }
 
-fn cbor_encode<T>(input: T) -> *const pg_sys::varlena
+#[doc(hidden)]
+pub unsafe fn cbor_encode<T>(input: T) -> *const pg_sys::varlena
 where
     T: Serialize,
 {
@@ -439,6 +440,7 @@ where
     varlena as *const pg_sys::varlena
 }
 
+#[doc(hidden)]
 pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
@@ -450,6 +452,7 @@ where
     serde_cbor::from_slice(slice).expect("failed to decode CBOR")
 }
 
+#[doc(hidden)]
 pub unsafe fn cbor_decode_into_context<'de, T>(
     mut memory_context: PgMemoryContexts,
     input: *mut pg_sys::varlena,

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -11,8 +11,7 @@
 use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{
     pg_sys, rust_regtypein, set_varsize, set_varsize_short, vardata_any, varsize_any,
-    varsize_any_exhdr, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts, PostgresType,
-    StringInfo,
+    varsize_any_exhdr, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts, StringInfo,
 };
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,


### PR DESCRIPTION
Mainly, this removes a source of persistent and confounding type errors because of the generic blanket impl of FromDatum for all T that fulfill so-and-so bounds. These may mislead one, if one is writing code generic over FromDatum, to imagine that one needs a Serialize and Deserialize impl or bound for a given case, even when those are _not_ required. By moving these requirements onto the type that derives, this moves any confusion to the specific cases it actually applies to.

This has a regrettable effect that now PostgresType _requires_ a Serialize and Deserialize impl in order to work, _unless_ one uses the hacky `#[bikeshed_postgres_type_manually_impl_from_into_datum]` attribute, which I intend to rename or otherwise fix up before pgrx reaches its 0.12.0 release. 