### PR TITLE
Autoclippify cargo-pgrx and other build-support crates

### DIFF
--- a/cargo-pgrx/src/command/connect.rs
+++ b/cargo-pgrx/src/command/connect.rs
@@ -73,7 +73,7 @@ impl CommandExecute for Connect {
             Some(dbname) => dbname,
             None => {
                 // We should infer from package
-                get_property(&package_manifest_path, "extname")
+                get_property(package_manifest_path, "extname")
                     .wrap_err("could not determine extension name")?
                     .ok_or(eyre!("extname not found in control file"))?
             }
@@ -97,5 +97,5 @@ pub(crate) fn connect_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> e
     }
 
     // run psql
-    exec_psql(&pg_config, dbname, pgcli)
+    exec_psql(pg_config, dbname, pgcli)
 }

--- a/cargo-pgrx/src/command/get.rs
+++ b/cargo-pgrx/src/command/get.rs
@@ -40,7 +40,7 @@ impl CommandExecute for Get {
             crate::manifest::manifest_path(&metadata, self.package.as_ref())
                 .wrap_err("Couldn't get manifest path")?;
 
-        if let Some(value) = get_property(&package_manifest_path, &self.name)? {
+        if let Some(value) = get_property(package_manifest_path, &self.name)? {
             println!("{}", value);
         }
         Ok(())
@@ -72,7 +72,7 @@ pub fn get_property(manifest_path: impl AsRef<Path>, name: &str) -> eyre::Result
             continue;
         }
 
-        let (k, v) = (parts.get(0).unwrap().trim(), parts.get(1).unwrap().trim());
+        let (k, v) = (parts.first().unwrap().trim(), parts.get(1).unwrap().trim());
 
         if k == name {
             let v = v.trim_start_matches('\'');

--- a/cargo-pgrx/src/command/mod.rs
+++ b/cargo-pgrx/src/command/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod version;
 
 // Build a ureq::Agent by the given url. Requests from this agent are proxied if we have
 // set the HTTPS_PROXY/HTTP_PROXY environment variables.
-pub(self) fn build_agent_for_url(url: &str) -> eyre::Result<Agent> {
+fn build_agent_for_url(url: &str) -> eyre::Result<Agent> {
     if let Some(proxy_url) = for_url_str(url).to_string() {
         Ok(AgentBuilder::new().proxy(Proxy::new(proxy_url)?).build())
     } else {

--- a/cargo-pgrx/src/command/new.rs
+++ b/cargo-pgrx/src/command/new.rs
@@ -82,7 +82,7 @@ fn create_control_file(path: &PathBuf, name: &str) -> Result<(), std::io::Error>
     filename.push(format!("{}.control", name));
     let mut file = std::fs::File::create(filename)?;
 
-    file.write_all(&format!(include_str!("../templates/control"), name = name).as_bytes())?;
+    file.write_all(format!(include_str!("../templates/control"), name = name).as_bytes())?;
 
     Ok(())
 }
@@ -93,7 +93,7 @@ fn create_cargo_toml(path: &PathBuf, name: &str) -> Result<(), std::io::Error> {
     filename.push("Cargo.toml");
     let mut file = std::fs::File::create(filename)?;
 
-    file.write_all(&format!(include_str!("../templates/cargo_toml"), name = name).as_bytes())?;
+    file.write_all(format!(include_str!("../templates/cargo_toml"), name = name).as_bytes())?;
 
     Ok(())
 }
@@ -119,10 +119,10 @@ fn create_lib_rs(path: &PathBuf, name: &str, is_bgworker: bool) -> Result<(), st
 
     if is_bgworker {
         file.write_all(
-            &format!(include_str!("../templates/bgworker_lib_rs"), name = name).as_bytes(),
+            format!(include_str!("../templates/bgworker_lib_rs"), name = name).as_bytes(),
         )?;
     } else {
-        file.write_all(&format!(include_str!("../templates/lib_rs"), name = name).as_bytes())?;
+        file.write_all(format!(include_str!("../templates/lib_rs"), name = name).as_bytes())?;
     }
 
     Ok(())

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -60,7 +60,7 @@ impl Package {
 
         let pg_config = match self.pg_config {
             None => PgConfig::from_path(),
-            Some(config) => PgConfig::new_with_defaults(PathBuf::from(config)),
+            Some(config) => PgConfig::new_with_defaults(config),
         };
         let pg_version = format!("pg{}", pg_config.major_version()?);
 
@@ -74,7 +74,7 @@ impl Package {
         let profile = CargoProfile::from_flags(
             self.profile.as_deref(),
             // NB:  `cargo pgrx package` defaults to "--release" whereas all other commands default to "debug"
-            self.debug.then_some(CargoProfile::Dev).unwrap_or(CargoProfile::Release),
+            if self.debug { CargoProfile::Dev } else { CargoProfile::Release },
         )?;
         let out_dir = if let Some(out_dir) = self.out_dir {
             out_dir
@@ -127,7 +127,7 @@ pub(crate) fn package_extension(
         std::fs::create_dir_all(&out_dir)?;
     }
 
-    display_version_info(pg_config, &PgVersionSource::PgConfig(pg_config.label()?.into()));
+    display_version_info(pg_config, &PgVersionSource::PgConfig(pg_config.label()?));
     install_extension(
         user_manifest_path,
         user_package,

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -74,7 +74,7 @@ impl CommandExecute for Run {
         };
         let profile = CargoProfile::from_flags(
             self.profile.as_deref(),
-            self.release.then_some(CargoProfile::Release).unwrap_or(CargoProfile::Dev),
+            if self.release { CargoProfile::Release } else { CargoProfile::Dev },
         )?;
 
         run(

--- a/cargo-pgrx/src/command/start.rs
+++ b/cargo-pgrx/src/command/start.rs
@@ -44,7 +44,7 @@ impl CommandExecute for Start {
                 me.manifest_path,
             )?;
             let (pg_config, _) =
-                pg_config_and_version(&pgrx, &package_manifest, me.pg_version, None, false)?;
+                pg_config_and_version(pgrx, &package_manifest, me.pg_version, None, false)?;
 
             start_postgres(&pg_config)
         }

--- a/cargo-pgrx/src/command/stop.rs
+++ b/cargo-pgrx/src/command/stop.rs
@@ -43,7 +43,7 @@ impl CommandExecute for Stop {
                 me.manifest_path,
             )?;
             let (pg_config, _) =
-                pg_config_and_version(&pgrx, &package_manifest, me.pg_version, None, false)?;
+                pg_config_and_version(pgrx, &package_manifest, me.pg_version, None, false)?;
 
             stop_postgres(&pg_config)
         }
@@ -67,7 +67,7 @@ pub(crate) fn stop_postgres(pg_config: &PgConfig) -> eyre::Result<()> {
     let datadir = pg_config.data_dir()?;
     let bindir = pg_config.bin_dir()?;
 
-    if status_postgres(pg_config)? == false {
+    if !(status_postgres(pg_config)?) {
         // it's not running, no need to stop it
         tracing::debug!("Already stopped");
         return Ok(());

--- a/cargo-pgrx/src/command/sudo_install.rs
+++ b/cargo-pgrx/src/command/sudo_install.rs
@@ -29,7 +29,7 @@ impl From<Install> for SudoInstall {
             release: value.release,
             profile: value.profile,
             test: value.test,
-            pg_config: value.pg_config.map(|path| PathBuf::from(path)),
+            pg_config: value.pg_config.map(PathBuf::from),
             out_dir: None,
             features: value.features,
             verbose: value.verbose,

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -55,7 +55,7 @@ impl CommandExecute for Test {
             let (package_manifest, _package_manifest_path) =
                 get_package_manifest(&me.features, me.package.as_ref(), me.manifest_path.as_ref())?;
             let (pg_config, _pg_version) = pg_config_and_version(
-                &pgrx,
+                pgrx,
                 &package_manifest,
                 me.pg_version.clone(),
                 Some(&mut features),
@@ -64,7 +64,7 @@ impl CommandExecute for Test {
 
             let profile = CargoProfile::from_flags(
                 me.profile.as_deref(),
-                me.release.then_some(CargoProfile::Release).unwrap_or(CargoProfile::Dev),
+                if me.release { CargoProfile::Release } else { CargoProfile::Dev },
             )?;
 
             test_extension(
@@ -173,11 +173,9 @@ pub fn test_extension(
     tracing::debug!(command = ?command, "Running");
     let status = command.status().wrap_err("failed to run cargo test")?;
     tracing::trace!(status_code = %status, command = ?command, "Finished");
-    if !status.success() {
-        if !status.success() {
-            // We explicitly do not want to return a spantraced error here.
-            std::process::exit(1)
-        }
+    if !status.success() && !status.success() {
+        // We explicitly do not want to return a spantraced error here.
+        std::process::exit(1)
     }
 
     Ok(())

--- a/cargo-pgrx/src/main.rs
+++ b/cargo-pgrx/src/main.rs
@@ -87,18 +87,13 @@ fn main() -> color_eyre::Result<()> {
                 _ => "trace",
             };
             let filter_layer = EnvFilter::new("warn");
-            let filter_layer =
-                filter_layer.add_directive(format!("cargo_pgrx={}", log_level).parse()?);
-            let filter_layer = filter_layer.add_directive(format!("pgrx={}", log_level).parse()?);
-            let filter_layer =
-                filter_layer.add_directive(format!("pgrx_macros={}", log_level).parse()?);
-            let filter_layer =
-                filter_layer.add_directive(format!("pgrx_tests={}", log_level).parse()?);
-            let filter_layer =
-                filter_layer.add_directive(format!("pgrx_pg_sys={}", log_level).parse()?);
-            let filter_layer =
-                filter_layer.add_directive(format!("pgrx_utils={}", log_level).parse()?);
             filter_layer
+                .add_directive(format!("cargo_pgrx={}", log_level).parse()?)
+                .add_directive(format!("pgrx={}", log_level).parse()?)
+                .add_directive(format!("pgrx_macros={}", log_level).parse()?)
+                .add_directive(format!("pgrx_tests={}", log_level).parse()?)
+                .add_directive(format!("pgrx_pg_sys={}", log_level).parse()?)
+                .add_directive(format!("pgrx_utils={}", log_level).parse()?)
         }
     };
 

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -118,8 +118,8 @@ pub(crate) fn modify_features_for_version(
     }
 }
 
-pub(crate) fn pg_config_and_version<'a>(
-    pgrx: &'a Pgrx,
+pub(crate) fn pg_config_and_version(
+    pgrx: &Pgrx,
     manifest: &Manifest,
     specified_pg_version: Option<String>,
     user_features: Option<&mut Features>,
@@ -172,7 +172,7 @@ pub(crate) fn pg_config_and_version<'a>(
             // we have determined a Postgres version
 
             modify_features_for_version(pgrx, user_features, manifest, &pg_version, false);
-            let pg_config = pgrx.get(&pg_version.label())?;
+            let pg_config = pgrx.get(pg_version.label())?;
 
             if verbose {
                 display_version_info(&pg_config, &pg_version);
@@ -199,7 +199,7 @@ pub(crate) fn get_package_manifest(
     package_nane: Option<&String>,
     manifest_path: Option<impl AsRef<std::path::Path>>,
 ) -> eyre::Result<(Manifest, PathBuf)> {
-    let metadata = crate::metadata::metadata(&features, manifest_path.as_ref())
+    let metadata = crate::metadata::metadata(features, manifest_path.as_ref())
         .wrap_err("couldn't get cargo metadata")?;
     crate::metadata::validate(manifest_path.as_ref(), &metadata)?;
     let package_manifest_path = crate::manifest::manifest_path(&metadata, package_nane)

--- a/pgrx-examples/aggregate/src/lib.rs
+++ b/pgrx-examples/aggregate/src/lib.rs
@@ -18,6 +18,7 @@ pgrx::pg_module_magic!();
 
 #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]
+#[derive(Default)]
 pub struct IntegerAvgState {
     sum: i32,
     n: i32,
@@ -136,11 +137,7 @@ impl Aggregate for IntegerAvgState {
     // }
 }
 
-impl Default for IntegerAvgState {
-    fn default() -> Self {
-        Self { sum: 0, n: 0 }
-    }
-}
+
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]

--- a/pgrx-examples/aggregate/src/lib.rs
+++ b/pgrx-examples/aggregate/src/lib.rs
@@ -137,8 +137,6 @@ impl Aggregate for IntegerAvgState {
     // }
 }
 
-
-
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -37,7 +37,7 @@ fn default_array() -> Vec<i32> {
 
 #[pg_extern(requires = [ default_array, ])]
 fn sum_array(input: default!(Array<i32>, "default_array()")) -> i64 {
-    let mut sum = 0 as i64;
+    let mut sum = 0_i64;
 
     for i in input {
         sum += i.unwrap_or(-1) as i64;
@@ -48,7 +48,7 @@ fn sum_array(input: default!(Array<i32>, "default_array()")) -> i64 {
 
 #[pg_extern]
 fn sum_vec(mut input: Vec<Option<i32>>) -> i64 {
-    let mut sum = 0 as i64;
+    let mut sum = 0_i64;
 
     input.push(Some(6));
 
@@ -71,8 +71,7 @@ fn static_names_set() -> SetOfIterator<'static, Vec<Option<&'static str>>> {
             vec![Some("Brandy"), Some("Sally"), None, Some("Anchovy")],
             vec![Some("Eric"), Some("David")],
             vec![Some("ZomboDB"), Some("PostgreSQL"), Some("Elasticsearch")],
-        ]
-        .into_iter(),
+        ],
     )
 }
 
@@ -88,7 +87,7 @@ fn i32_array_with_nulls() -> Vec<Option<i32>> {
 
 #[pg_extern]
 fn strip_nulls(input: Vec<Option<i32>>) -> Vec<i32> {
-    input.into_iter().filter(|i| i.is_some()).map(|i| i.unwrap()).collect()
+    input.into_iter().flatten().collect()
 }
 
 #[derive(PostgresType, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -115,17 +114,17 @@ mod vectors {
 
     #[pg_extern]
     fn sum_vector_array(input: Array<f32>) -> f32 {
-        input.iter_deny_null().map(|v| v as f32).sum()
+        input.iter_deny_null().sum()
     }
 
     #[pg_extern]
     fn sum_vector_vec(input: Vec<f32>) -> f32 {
-        input.into_iter().map(|v| v as f32).sum()
+        input.into_iter().sum()
     }
 
     #[pg_extern]
     fn sum_vector_slice(input: Array<f32>) -> Result<f32, ArraySliceError> {
-        Ok(input.as_slice()?.iter().map(|v| *v as f32).sum())
+        Ok(input.as_slice()?.iter().copied().sum())
     }
 
     #[pg_extern]

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -66,13 +66,11 @@ fn static_names() -> Vec<Option<&'static str>> {
 
 #[pg_extern]
 fn static_names_set() -> SetOfIterator<'static, Vec<Option<&'static str>>> {
-    SetOfIterator::new(
-        vec![
-            vec![Some("Brandy"), Some("Sally"), None, Some("Anchovy")],
-            vec![Some("Eric"), Some("David")],
-            vec![Some("ZomboDB"), Some("PostgreSQL"), Some("Elasticsearch")],
-        ],
-    )
+    SetOfIterator::new(vec![
+        vec![Some("Brandy"), Some("Sally"), None, Some("Anchovy")],
+        vec![Some("Eric"), Some("David")],
+        vec![Some("ZomboDB"), Some("PostgreSQL"), Some("Elasticsearch")],
+    ])
 }
 
 #[pg_extern]

--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -115,10 +115,8 @@ pub unsafe extern "C" fn _PG_init() {
     extern "C" fn random_abort_callback(event: pg_sys::XactEvent, _arg: *mut std::os::raw::c_void) {
         // info!("in global xact callback: event={}", event);
 
-        if event == pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT {
-            if rand::random::<bool>() {
-                // panic!("aborting transaction");
-            }
+        if event == pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT && rand::random::<bool>() {
+            // panic!("aborting transaction");
         }
     }
 

--- a/pgrx-examples/custom_types/src/fixed_size.rs
+++ b/pgrx-examples/custom_types/src/fixed_size.rs
@@ -32,7 +32,7 @@ impl PgVarlenaInOutFuncs for FixedF32Array {
 
     fn output(&self, buffer: &mut StringInfo) {
         self.array.iter().for_each(|v| {
-            if buffer.len() > 0 {
+            if !buffer.is_empty() {
                 buffer.push(',');
             }
             buffer.push_str(&v.to_string());

--- a/pgrx-examples/custom_types/src/hstore_clone.rs
+++ b/pgrx-examples/custom_types/src/hstore_clone.rs
@@ -13,13 +13,10 @@ use serde::*;
 use std::collections::HashMap;
 
 #[derive(PostgresType, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Default)]
 pub struct RustStore(HashMap<String, String>);
 
-impl Default for RustStore {
-    fn default() -> Self {
-        RustStore(HashMap::default())
-    }
-}
+
 
 #[pg_extern]
 fn rstore(key: String, value: String) -> RustStore {
@@ -35,7 +32,7 @@ fn rstore_put(rstore: Option<RustStore>, key: String, value: String) -> RustStor
 
 #[pg_extern]
 fn rstore_get(rstore: Option<RustStore>, key: String) -> Option<String> {
-    rstore.map_or(None, |rstore| rstore.0.get(&key).cloned())
+    rstore.and_then(|rstore| rstore.0.get(&key).cloned())
 }
 
 #[pg_extern]
@@ -64,7 +61,7 @@ fn rstore_table(
     rstore: Option<RustStore>,
 ) -> TableIterator<'static, (name!(key, String), name!(value, String))> {
     match rstore {
-        Some(rstore) => TableIterator::new(rstore.0.into_iter()),
+        Some(rstore) => TableIterator::new(rstore.0),
         None => TableIterator::once((String::new(), String::new())),
     }
 }

--- a/pgrx-examples/custom_types/src/hstore_clone.rs
+++ b/pgrx-examples/custom_types/src/hstore_clone.rs
@@ -16,8 +16,6 @@ use std::collections::HashMap;
 #[derive(Default)]
 pub struct RustStore(HashMap<String, String>);
 
-
-
 #[pg_extern]
 fn rstore(key: String, value: String) -> RustStore {
     RustStore(hashmap!(key => value))

--- a/pgrx-examples/custom_types/src/ordered.rs
+++ b/pgrx-examples/custom_types/src/ordered.rs
@@ -40,12 +40,10 @@ impl Ord for OrderedThing {
             } else {
                 std::cmp::Ordering::Greater
             }
+        } else if starts_lower(other) {
+            std::cmp::Ordering::Less
         } else {
-            if starts_lower(other) {
-                std::cmp::Ordering::Less
-            } else {
-                self.item.cmp(&other.item).reverse()
-            }
+            self.item.cmp(&other.item).reverse()
         }
     }
 }

--- a/pgrx-examples/errors/src/lib.rs
+++ b/pgrx-examples/errors/src/lib.rs
@@ -14,7 +14,7 @@ pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn array_with_null_and_panic(input: Vec<Option<i32>>) -> i64 {
-    let mut sum = 0 as i64;
+    let mut sum = 0_i64;
 
     for i in input {
         sum += i.expect("NULL elements in input array are not supported") as i64;

--- a/pgrx-examples/numeric/src/lib.rs
+++ b/pgrx-examples/numeric/src/lib.rs
@@ -33,7 +33,7 @@ fn math() -> Numeric<10, 3> {
 
     n *= 5;
     n -= 2.234;
-    n /= 4 as i128;
+    n /= 4_i128;
     n %= 19;
     n += 99.42;
 
@@ -50,7 +50,7 @@ fn math() -> Numeric<10, 3> {
     n = n + 42.0f64;
     n = n - 42.0f64;
 
-    n = n / AnyNumeric::from(42);
+    n /= AnyNumeric::from(42);
     n = n / Numeric::<1000, 33>::try_from(42).unwrap();
 
     n.rescale().unwrap()

--- a/pgrx-examples/numeric/src/lib.rs
+++ b/pgrx-examples/numeric/src/lib.rs
@@ -50,7 +50,7 @@ fn math() -> Numeric<10, 3> {
     n = n + 42.0f64;
     n = n - 42.0f64;
 
-    n /= AnyNumeric::from(42);
+    n = n / AnyNumeric::from(42);
     n = n / Numeric::<1000, 33>::try_from(42).unwrap();
 
     n.rescale().unwrap()

--- a/pgrx-examples/operators/src/pgvarlena.rs
+++ b/pgrx-examples/operators/src/pgvarlena.rs
@@ -112,19 +112,19 @@ mod tests {
             "SELECT '1;2;3;[1,2,3,4,5]'::pgvarlenathing < '2;2;3;[1,2,3,4,5]'::pgvarlenathing",
         )?
         .unwrap();
-        assert_eq!(lt, true);
+        assert!(lt);
 
         let gt = Spi::get_one::<bool>(
             "SELECT '2;2;3;[1,2,3,4,5]'::pgvarlenathing > '1;2;3;[1,2,3,4,5]'::pgvarlenathing",
         )?
         .unwrap();
-        assert_eq!(gt, true);
+        assert!(gt);
 
         let eq = Spi::get_one::<bool>(
             "SELECT '1;2;3;[1,2,3,4,5]'::pgvarlenathing = '1;2;3;[1,2,3,4,5]'::pgvarlenathing",
         )?
         .unwrap();
-        assert_eq!(eq, true);
+        assert!(eq);
 
         Ok(())
     }

--- a/pgrx-examples/pgtrybuilder/src/lib.rs
+++ b/pgrx-examples/pgtrybuilder/src/lib.rs
@@ -26,7 +26,7 @@ fn is_valid_number(i: i32) -> i32 {
     .finally(|| finished = true)
     .execute();
 
-    assert_eq!(finished, true);
+    assert!(finished);
 
     result
 }

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -57,7 +57,7 @@ fn spi_return_query() -> Result<
             .map(|row| (row["oid"].value(), row[2].value()))
             .collect::<Vec<_>>())
     })
-    .map(|results| TableIterator::new(results))
+    .map(TableIterator::new)
 }
 
 #[pg_extern(immutable, parallel_safe)]

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -56,9 +56,9 @@ fn calculate_human_years() -> Result<
 
     Spi::connect(|client| {
         let mut results = Vec::new();
-        let mut tup_table = client.select(query, None, None)?;
+        let tup_table = client.select(query, None, None)?;
 
-        while let Some(row) = tup_table.next() {
+        for row in tup_table {
             let dog_name = row["dog_name"].value::<String>();
             let dog_age = row["dog_age"].value::<i32>()?.expect("dog_age was null");
             let dog_breed = row["dog_breed"].value::<String>();
@@ -66,7 +66,7 @@ fn calculate_human_years() -> Result<
             results.push((dog_name, dog_age, dog_breed, human_age));
         }
 
-        Ok(TableIterator::new(results.into_iter()))
+        Ok(TableIterator::new(results))
     })
 }
 
@@ -98,7 +98,7 @@ fn filter_by_breed(
         let filtered = tup_table
             .map(|row| (row["dog_name"].value(), row["dog_age"].value(), row["dog_breed"].value()))
             .collect::<Vec<_>>();
-        Ok(TableIterator::new(filtered.into_iter()))
+        Ok(TableIterator::new(filtered))
     })
 }
 

--- a/pgrx-examples/strings/src/lib.rs
+++ b/pgrx-examples/strings/src/lib.rs
@@ -35,12 +35,12 @@ fn append(mut input: String, extra: &str) -> String {
 
 #[pg_extern]
 fn split(input: &'static str, pattern: &str) -> Vec<&'static str> {
-    input.split_terminator(pattern).into_iter().collect()
+    input.split_terminator(pattern).collect()
 }
 
 #[pg_extern]
 fn split_set<'a>(input: &'a str, pattern: &'a str) -> SetOfIterator<'a, &'a str> {
-    SetOfIterator::new(input.split_terminator(pattern).into_iter())
+    SetOfIterator::new(input.split_terminator(pattern))
 }
 
 #[pg_extern]

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -268,7 +268,7 @@ impl PgConfig {
         } else {
             PgMinorVersion::Release(minor)
         };
-        return Ok((major, minor));
+        Ok((major, minor))
     }
 
     fn get_version(&self) -> eyre::Result<(u16, PgMinorVersion)> {
@@ -611,7 +611,7 @@ impl Pgrx {
     /// such as `pg14` or `pg15`
     pub fn is_feature_flag(&self, label: &str) -> bool {
         for pgver in SUPPORTED_VERSIONS() {
-            if label == &format!("pg{}", pgver.major) {
+            if label == format!("pg{}", pgver.major) {
                 return true;
             }
         }
@@ -738,7 +738,7 @@ fn does_db_exist(pg_config: &PgConfig, dbname: &str) -> eyre::Result<bool> {
         .arg("-c")
         .arg(&format!(
             "select count(*) from pg_database where datname = '{}';",
-            dbname.replace("'", "''")
+            dbname.replace('\'', "''")
         ))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -747,15 +747,15 @@ fn does_db_exist(pg_config: &PgConfig, dbname: &str) -> eyre::Result<bool> {
     let output = command.output()?;
 
     if !output.status.success() {
-        return Err(eyre!(
+        Err(eyre!(
             "problem checking if database '{}' exists: {}\n\n{}{}",
             dbname,
             command_str,
             String::from_utf8(output.stdout).unwrap(),
             String::from_utf8(output.stderr).unwrap()
-        ));
+        ))
     } else {
-        let count = i32::from_str(&String::from_utf8(output.stdout).unwrap().trim())
+        let count = i32::from_str(String::from_utf8(output.stdout).unwrap().trim())
             .wrap_err("result is not a number")?;
         Ok(count > 0)
     }


### PR DESCRIPTION
Last round of autoclippifying things for now...

...mostly because pgrx-sql-entity-graph induces such massive errors in `cargo clippy --fix` that it repeatedly aborts and emits the most fascinating errors, rather than try to complete the automatic fixes.