### PR TITLE
Stop overriding the host clang during build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,14 +52,14 @@ jobs:
         echo ""
 
         echo "----- Remove old postgres -----"
-        sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
+        sudo apt remove -y '^postgres.*' '^libpq.*'
         echo ""
 
         echo "----- Install system dependencies -----"
         sudo apt-get install -y \
           build-essential \
-          llvm-14-dev libclang-14-dev clang-14 \
-          gcc \
+          clang \
+          libclang-dev \
           libssl-dev \
           libz-dev \
           make \


### PR DESCRIPTION
This should also fix the same thing that #1325 does, but I believe both should be accepted... if it works.