### PR TITLE
Remove unused cshim headers

### DIFF
--- a/pgrx-pg-sys/cshim/pgrx-cshim.c
+++ b/pgrx-pg-sys/cshim/pgrx-cshim.c
@@ -18,8 +18,6 @@
 #include "nodes/pathnodes.h"
 #include "nodes/pg_list.h"
 #include "parser/parsetree.h"
-#include "utils/memutils.h"
-#include "utils/builtins.h"
 #include "storage/spin.h"
 
 PGDLLEXPORT RangeTblEntry *pgrx_planner_rt_fetch(Index index, PlannerInfo *plannerInfo);

--- a/pgrx-pg-sys/cshim/pgrx-cshim.c
+++ b/pgrx-pg-sys/cshim/pgrx-cshim.c
@@ -22,7 +22,6 @@
 #include "parser/parsetree.h"
 #include "utils/memutils.h"
 #include "utils/builtins.h"
-#include "utils/array.h"
 #include "storage/spin.h"
 
 PGDLLEXPORT RangeTblEntry *pgrx_planner_rt_fetch(Index index, PlannerInfo *plannerInfo);

--- a/pgrx-pg-sys/cshim/pgrx-cshim.c
+++ b/pgrx-pg-sys/cshim/pgrx-cshim.c
@@ -14,8 +14,6 @@
 #define IS_PG_12 (PG_VERSION_NUM >= 120000 && PG_VERSION_NUM < 130000)
 #define IS_PG_13 (PG_VERSION_NUM >= 130000 && PG_VERSION_NUM < 140000)
 
-#include "access/htup.h"
-#include "access/htup_details.h"
 #include "catalog/pg_type.h"
 #include "nodes/pathnodes.h"
 #include "nodes/pg_list.h"

--- a/pgrx-pg-sys/cshim/pgrx-cshim.c
+++ b/pgrx-pg-sys/cshim/pgrx-cshim.c
@@ -14,7 +14,6 @@
 #define IS_PG_12 (PG_VERSION_NUM >= 120000 && PG_VERSION_NUM < 130000)
 #define IS_PG_13 (PG_VERSION_NUM >= 130000 && PG_VERSION_NUM < 140000)
 
-#include "catalog/pg_type.h"
 #include "nodes/pathnodes.h"
 #include "nodes/pg_list.h"
 #include "parser/parsetree.h"


### PR DESCRIPTION
These are unused by either the C code in the shim, or the Rust code in pgrx-pg-sys.