### PR TITLE
Add trusted option in the control file

### DIFF
--- a/cargo-pgrx/src/templates/control
+++ b/cargo-pgrx/src/templates/control
@@ -3,3 +3,4 @@ default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/{name}'
 relocatable = false
 superuser = true
+trusted = false

--- a/pgrx-examples/custom_types/custom_types.control
+++ b/pgrx-examples/custom_types/custom_types.control
@@ -3,3 +3,4 @@ default_version = '@CARGO_VERSION@'
 module_pathname = '$libdir/custom_types'
 relocatable = false
 superuser = false
+trusted = false

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -38,6 +38,7 @@ pub struct ControlFile {
     pub relocatable: bool,
     pub superuser: bool,
     pub schema: Option<String>,
+    pub trusted: bool,
 }
 
 impl ControlFile {
@@ -86,6 +87,10 @@ impl ControlFile {
                 .ok_or(ControlFileError::MissingField { field: "superuser" })?
                 == &"true",
             schema: temp.get("schema").map(|v| v.to_string()),
+            trusted: temp
+                .get("trusted")
+                .ok_or(ControlFileError::MissingField { field: "trusted" })?
+                == &"false",
         })
     }
 }


### PR DESCRIPTION
`trusted` is supported in postgresql 13 and above. Extensions can add it to the control file and also want to support postgresql 12 and below. This PR removes the trusted option in the control file when installing the extension. The default value of `trusted` is false.

Related PR in postgresml https://github.com/postgresml/postgresml/pull/810

Options in the control file: https://www.postgresql.org/docs/13/extend-extensions.html#id-1.8.3.20.11
