### PR TITLE
Add Illumos target for sigsetjmp function.

### DIFF
--- a/pgrx-pg-sys/src/submodules/mod.rs
+++ b/pgrx-pg-sys/src/submodules/mod.rs
@@ -44,7 +44,7 @@ extern "C" {
     ) -> std::os::raw::c_int;
 }
 
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "illumos"))]
 extern "C" {
     pub(crate) fn sigsetjmp(
         env: *mut crate::sigjmp_buf,


### PR DESCRIPTION
Adding Illumos to be included in the target_os checks allows pgrx to be compiled on Illumos with no other changes.