### PR TITLE
Record ignorable commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,14 @@
+# to make `git blame` ignore the following commits, run:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# adding a rustfmt.toml
+1ded8553fbeff635fcca0cbc8f37034cc124d698
+
+# the pgrx rename
+8726d4fb5482910ec389b014efa6b999c2208bae
+
+# modularizing pgrx::spi
+d333053dc6f6afc6433e40f343c885a9c261562d
+
+# modularizing pgrx-pg-sys
+c83c203aa0ca3021bf8bafdd2109f74f940812e5

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ d333053dc6f6afc6433e40f343c885a9c261562d
 
 # modularizing pgrx-pg-sys
 c83c203aa0ca3021bf8bafdd2109f74f940812e5
+
+# removing the PgGuardRewriter struct and impl
+ccf82259a01ccef132cbdc6f56ea60845d387b23


### PR DESCRIPTION
In general it is bad form to remove commits from the commit history, however some commits shed more heat than light when examining blame. Assist with ignoring them by writing down the commits that qualify.

This name in particular is conventionally used by code forges, so it will be used for their webview as well.