### PR TITLE
Simplify logic in lifetimes.rs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,6 +4,9 @@
 # adding a rustfmt.toml
 1ded8553fbeff635fcca0cbc8f37034cc124d698
 
+# utils -> sql-entity-graph
+cf6fd6f1c4709491e86f5dc536d5a99adb1f18fc
+
 # the pgrx rename
 8726d4fb5482910ec389b014efa6b999c2208bae
 

--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -334,7 +334,7 @@ impl ToSql for PgAggregateEntity {
                     .find(|neighbor| match &context.graph[*neighbor] {
                         SqlGraphEntity::Type(ty) => ty.id_matches(&arg.used_ty.ty_id),
                         SqlGraphEntity::Enum(en) => en.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::BuiltinType(defined) => defined == &arg.used_ty.full_path,
+                        SqlGraphEntity::BuiltinType(defined) => defined == arg.used_ty.full_path,
                         _ => false,
                     })
                     .ok_or_else(|| {
@@ -406,7 +406,7 @@ impl ToSql for PgAggregateEntity {
                     .find(|neighbor| match &context.graph[*neighbor] {
                         SqlGraphEntity::Type(ty) => ty.id_matches(&arg.used_ty.ty_id),
                         SqlGraphEntity::Enum(en) => en.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::BuiltinType(defined) => defined == &arg.used_ty.full_path,
+                        SqlGraphEntity::BuiltinType(defined) => defined == arg.used_ty.full_path,
                         _ => false,
                     })
                     .ok_or_else(|| eyre!("Could not find arg type in graph. Got: {:?}", arg))?;

--- a/pgrx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/entity.rs
@@ -196,15 +196,15 @@ impl SqlDeclaredEntity {
             | (SqlDeclared::Enum(ident_name), &SqlDeclaredEntity::Enum(data))
             | (SqlDeclared::Function(ident_name), &SqlDeclaredEntity::Function(data)) => {
                 let matches = |identifier_name: &str| {
-                    identifier_name == &data.name
-                        || identifier_name == &data.option
-                        || identifier_name == &data.vec
-                        || identifier_name == &data.vec_option
-                        || identifier_name == &data.option_vec
-                        || identifier_name == &data.option_vec_option
-                        || identifier_name == &data.array
-                        || identifier_name == &data.option_array
-                        || identifier_name == &data.varlena
+                    identifier_name == data.name
+                        || identifier_name == data.option
+                        || identifier_name == data.vec
+                        || identifier_name == data.vec_option
+                        || identifier_name == data.option_vec
+                        || identifier_name == data.option_vec_option
+                        || identifier_name == data.array
+                        || identifier_name == data.option_array
+                        || identifier_name == data.varlena
                 };
                 if matches(ident_name) || data.pg_box.contains(ident_name) {
                     return true;

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -67,9 +67,7 @@ pub fn staticize_lifetimes(value: &mut syn::Type) {
         },
 
         syn::Type::Tuple(type_tuple) => {
-            for elem in &mut type_tuple.elems {
-                staticize_lifetimes(elem);
-            }
+            type_tuple.elems.iter_mut().for_each(|elem| staticize_lifetimes(elem))
         }
 
         syn::Type::Macro(syn::TypeMacro { mac }) => {

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -25,36 +25,33 @@ pub fn staticize_lifetimes_in_type_path(value: syn::TypePath) -> syn::TypePath {
 pub fn staticize_lifetimes(value: &mut syn::Type) {
     match value {
         syn::Type::Path(type_path) => {
-            for bracketed in
-                &mut type_path.path.segments.iter_mut().filter_map(|seg| match &mut seg.arguments {
+            for arg in &mut type_path
+                .path
+                .segments
+                .iter_mut()
+                .filter_map(|seg| match &mut seg.arguments {
                     syn::PathArguments::AngleBracketed(bracketed) => Some(bracketed),
                     _ => None,
                 })
+                .flat_map(|bracketed| &mut bracketed.args)
             {
-                for arg in &mut bracketed.args {
-                    match arg {
-                        // rename lifetimes to the static lifetime so the TypeIds match.
-                        syn::GenericArgument::Lifetime(lifetime) => {
-                            lifetime.ident = syn::Ident::new("static", lifetime.ident.span());
-                        }
-
-                        // recurse
-                        syn::GenericArgument::Type(ty) => staticize_lifetimes(ty),
-                        syn::GenericArgument::Binding(binding) => {
-                            staticize_lifetimes(&mut binding.ty)
-                        }
-                        syn::GenericArgument::Constraint(constraint) => {
-                            constraint.bounds.iter_mut().for_each(|bound| {
-                                if let syn::TypeParamBound::Lifetime(lifetime) = bound {
-                                    lifetime.ident =
-                                        syn::Ident::new("static", lifetime.ident.span())
-                                }
-                            })
-                        }
-
-                        // nothing to do otherwise
-                        _ => {}
+                match arg {
+                    // rename lifetimes to the static lifetime so the TypeIds match.
+                    syn::GenericArgument::Lifetime(lifetime) => {
+                        lifetime.ident = syn::Ident::new("static", lifetime.ident.span());
                     }
+                    // recurse
+                    syn::GenericArgument::Type(ty) => staticize_lifetimes(ty),
+                    syn::GenericArgument::Binding(binding) => staticize_lifetimes(&mut binding.ty),
+                    syn::GenericArgument::Constraint(constraint) => {
+                        constraint.bounds.iter_mut().for_each(|bound| {
+                            if let syn::TypeParamBound::Lifetime(lifetime) = bound {
+                                lifetime.ident = syn::Ident::new("static", lifetime.ident.span())
+                            }
+                        })
+                    }
+                    // nothing to do otherwise
+                    _ => {}
                 }
             }
         }

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -65,7 +65,7 @@ pub fn staticize_lifetimes(value: &mut syn::Type) {
         }
 
         syn::Type::Tuple(type_tuple) => {
-            type_tuple.elems.iter_mut().for_each(|elem| staticize_lifetimes(elem))
+            type_tuple.elems.iter_mut().for_each(staticize_lifetimes)
         }
 
         syn::Type::Macro(syn::TypeMacro { mac })

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -23,33 +23,31 @@ pub fn staticize_lifetimes_in_type_path(value: syn::TypePath) -> syn::TypePath {
 
 pub fn staticize_lifetimes(value: &mut syn::Type) {
     match value {
-        syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. }) => {
-            segments
-                .iter_mut()
-                .filter_map(|segment| match &mut segment.arguments {
-                    syn::PathArguments::AngleBracketed(bracketed) => Some(bracketed),
-                    _ => None,
-                })
-                .flat_map(|bracketed| &mut bracketed.args)
-                .for_each(|arg| match arg {
-                    // rename lifetimes to the static lifetime so the TypeIds match.
-                    syn::GenericArgument::Lifetime(lifetime) => {
-                        lifetime.ident = syn::Ident::new("static", lifetime.ident.span());
-                    }
-                    // recurse
-                    syn::GenericArgument::Type(ty) => staticize_lifetimes(ty),
-                    syn::GenericArgument::Binding(binding) => staticize_lifetimes(&mut binding.ty),
-                    syn::GenericArgument::Constraint(constraint) => {
-                        constraint.bounds.iter_mut().for_each(|bound| {
-                            if let syn::TypeParamBound::Lifetime(lifetime) = bound {
-                                lifetime.ident = syn::Ident::new("static", lifetime.ident.span())
-                            }
-                        })
-                    }
-                    // nothing to do otherwise
-                    _ => {}
-                })
-        }
+        syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. }) => segments
+            .iter_mut()
+            .filter_map(|segment| match &mut segment.arguments {
+                syn::PathArguments::AngleBracketed(bracketed) => Some(bracketed),
+                _ => None,
+            })
+            .flat_map(|bracketed| &mut bracketed.args)
+            .for_each(|arg| match arg {
+                // rename lifetimes to the static lifetime so the TypeIds match.
+                syn::GenericArgument::Lifetime(lifetime) => {
+                    lifetime.ident = syn::Ident::new("static", lifetime.ident.span());
+                }
+                // recurse
+                syn::GenericArgument::Type(ty) => staticize_lifetimes(ty),
+                syn::GenericArgument::Binding(binding) => staticize_lifetimes(&mut binding.ty),
+                syn::GenericArgument::Constraint(constraint) => {
+                    constraint.bounds.iter_mut().for_each(|bound| {
+                        if let syn::TypeParamBound::Lifetime(lifetime) = bound {
+                            lifetime.ident = syn::Ident::new("static", lifetime.ident.span())
+                        }
+                    })
+                }
+                // nothing to do otherwise
+                _ => {}
+            }),
 
         syn::Type::Reference(type_ref) => {
             if let Some(lifetime) = &mut type_ref.lifetime {
@@ -93,9 +91,7 @@ pub fn anonymize_lifetimes_in_type_path(value: syn::TypePath) -> syn::TypePath {
 
 pub fn anonymize_lifetimes(value: &mut syn::Type) {
     match value {
-        syn::Type::Path(type_path) => type_path
-            .path
-            .segments
+        syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. }) => segments
             .iter_mut()
             .filter_map(|segment| match &mut segment.arguments {
                 syn::PathArguments::AngleBracketed(bracketed) => Some(bracketed),

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::NameMacro;
 use proc_macro2::TokenStream;
-use syn::Lifetime;
+
 
 pub fn staticize_lifetimes_in_type_path(value: syn::TypePath) -> syn::TypePath {
     let mut ty = syn::Type::Path(value);

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -56,12 +56,13 @@ pub fn staticize_lifetimes(value: &mut syn::Type) {
             }
         }
 
-        syn::Type::Reference(type_ref) => match &mut type_ref.lifetime {
-            Some(ref mut lifetime) => {
+        syn::Type::Reference(type_ref) => {
+            if let Some(lifetime) = &mut type_ref.lifetime {
                 lifetime.ident = syn::Ident::new("static", lifetime.ident.span());
+            } else {
+                type_ref.lifetime = Some(syn::parse_quote!('static));
             }
-            this @ None => *this = Some(syn::parse_quote!('static)),
-        },
+        }
 
         syn::Type::Tuple(type_tuple) => {
             type_tuple.elems.iter_mut().for_each(|elem| staticize_lifetimes(elem))

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -93,53 +93,40 @@ pub fn anonymize_lifetimes_in_type_path(value: syn::TypePath) -> syn::TypePath {
 
 pub fn anonymize_lifetimes(value: &mut syn::Type) {
     match value {
-        syn::Type::Path(type_path) => {
-            for segment in &mut type_path.path.segments {
-                if let syn::PathArguments::AngleBracketed(bracketed) = &mut segment.arguments {
-                    for arg in &mut bracketed.args {
-                        match arg {
-                            // rename lifetimes to the anonymous lifetime
-                            syn::GenericArgument::Lifetime(lifetime) => {
-                                lifetime.ident = syn::Ident::new("_", lifetime.ident.span());
-                            }
-
-                            // recurse
-                            syn::GenericArgument::Type(ty) => anonymize_lifetimes(ty),
-                            syn::GenericArgument::Binding(binding) => {
-                                anonymize_lifetimes(&mut binding.ty)
-                            }
-                            syn::GenericArgument::Constraint(constraint) => {
-                                for bound in constraint.bounds.iter_mut() {
-                                    match bound {
-                                        syn::TypeParamBound::Lifetime(lifetime) => {
-                                            lifetime.ident =
-                                                syn::Ident::new("_", lifetime.ident.span())
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
-
-                            // nothing to do otherwise
-                            _ => {}
-                        }
-                    }
+        syn::Type::Path(type_path) => type_path
+            .path
+            .segments
+            .iter_mut()
+            .filter_map(|segment| match &mut segment.arguments {
+                syn::PathArguments::AngleBracketed(bracketed) => Some(bracketed),
+                _ => None,
+            })
+            .flat_map(|bracketed| &mut bracketed.args)
+            .for_each(|arg| match arg {
+                // rename lifetimes to the anonymous lifetime
+                syn::GenericArgument::Lifetime(lifetime) => {
+                    lifetime.ident = syn::Ident::new("_", lifetime.ident.span());
                 }
-            }
-        }
+                // recurse
+                syn::GenericArgument::Type(ty) => anonymize_lifetimes(ty),
+                syn::GenericArgument::Binding(binding) => anonymize_lifetimes(&mut binding.ty),
+                syn::GenericArgument::Constraint(constraint) => {
+                    constraint.bounds.iter_mut().for_each(|bound| {
+                        if let syn::TypeParamBound::Lifetime(lifetime) = bound {
+                            lifetime.ident = syn::Ident::new("_", lifetime.ident.span())
+                        }
+                    })
+                }
+                // nothing to do otherwise
+                _ => {}
+            }),
 
         syn::Type::Reference(type_ref) => {
             if let Some(lifetime) = type_ref.lifetime.as_mut() {
                 lifetime.ident = syn::Ident::new("_", lifetime.ident.span());
             }
         }
-
-        syn::Type::Tuple(type_tuple) => {
-            for elem in &mut type_tuple.elems {
-                anonymize_lifetimes(elem);
-            }
-        }
-
+        syn::Type::Tuple(type_tuple) => type_tuple.elems.iter_mut().for_each(anonymize_lifetimes),
         _ => {}
     }
 }

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -23,12 +23,10 @@ pub fn staticize_lifetimes_in_type_path(value: syn::TypePath) -> syn::TypePath {
 
 pub fn staticize_lifetimes(value: &mut syn::Type) {
     match value {
-        syn::Type::Path(type_path) => {
-            type_path
-                .path
-                .segments
+        syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. }) => {
+            segments
                 .iter_mut()
-                .filter_map(|seg| match &mut seg.arguments {
+                .filter_map(|segment| match &mut segment.arguments {
                     syn::PathArguments::AngleBracketed(bracketed) => Some(bracketed),
                     _ => None,
                 })

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -431,7 +431,7 @@ impl ToSql for PgExternEntity {
                 .find(|neighbor| match &context.graph[*neighbor] {
                     SqlGraphEntity::Type(ty) => ty.id_matches(&left_fn_arg.used_ty.ty_id),
                     SqlGraphEntity::Enum(en) => en.id_matches(&left_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::BuiltinType(defined) => defined == &left_arg.type_name,
+                    SqlGraphEntity::BuiltinType(defined) => defined == left_arg.type_name,
                     _ => false,
                 })
                 .ok_or_else(|| {
@@ -484,7 +484,7 @@ impl ToSql for PgExternEntity {
                 .find(|neighbor| match &context.graph[*neighbor] {
                     SqlGraphEntity::Type(ty) => ty.id_matches(&right_fn_arg.used_ty.ty_id),
                     SqlGraphEntity::Enum(en) => en.id_matches(&right_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::BuiltinType(defined) => defined == &right_arg.type_name,
+                    SqlGraphEntity::BuiltinType(defined) => defined == right_arg.type_name,
                     _ => false,
                 })
                 .ok_or_else(|| {

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -175,19 +175,19 @@ impl PgExtern {
             _ => None,
         }) {
             let Meta::NameValue(syn::MetaNameValue { lit, .. }) = meta else { continue };
-            if let syn::Lit::Str(ref inner) = lit {
-                span.get_or_insert(lit.span());
-                if !in_commented_sql_block && inner.value().trim() == "```pgrxsql" {
-                    in_commented_sql_block = true;
-                } else if in_commented_sql_block && inner.value().trim() == "```" {
-                    in_commented_sql_block = false;
-                } else if in_commented_sql_block {
-                    let line = inner.value().trim_start().replace(
-                        "@FUNCTION_NAME@",
-                        &(self.func.sig.ident.to_string() + "_wrapper"),
-                    ) + "\n";
-                    retval.get_or_insert_with(String::default).push_str(&line);
-                }
+            let syn::Lit::Str(ref inner) = lit else { continue };
+            span.get_or_insert(lit.span());
+            if !in_commented_sql_block && inner.value().trim() == "```pgrxsql" {
+                in_commented_sql_block = true;
+            } else if in_commented_sql_block && inner.value().trim() == "```" {
+                in_commented_sql_block = false;
+            } else if in_commented_sql_block {
+                let line = inner
+                    .value()
+                    .trim_start()
+                    .replace("@FUNCTION_NAME@", &(self.func.sig.ident.to_string() + "_wrapper"))
+                    + "\n";
+                retval.get_or_insert_with(String::default).push_str(&line);
             }
         }
         retval.map(|s| syn::LitStr::new(s.as_ref(), span.unwrap()))

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -89,12 +89,8 @@ impl PgExtern {
         let punctuated_attrs = parser.parse2(attr)?;
         for pair in punctuated_attrs.into_pairs() {
             match pair.into_value() {
-                Attribute::Sql(config) => {
-                    to_sql_config.get_or_insert(config);
-                }
-                attr => {
-                    attrs.push(attr);
-                }
+                Attribute::Sql(config) => to_sql_config = to_sql_config.or(Some(config)),
+                attr => attrs.push(attr),
             }
         }
 

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -461,13 +461,15 @@ impl PgExtern {
             }
             Returning::SetOf { ty: _retval_ty, optional, result } => {
                 let mut ret_expr = quote! { #func_name(#(#arg_pats),*) };
-                if *result { // If it's a result, we need to report it.
+                if *result {
+                    // If it's a result, we need to report it.
                     ret_expr = quote! { #ret_expr.report() };
                 }
-                if !*optional { // If it's not already an option, we need to wrap it.
+                if !*optional {
+                    // If it's not already an option, we need to wrap it.
                     ret_expr = quote! { Some(#ret_expr) };
                 }
-                let import = result.then(|| quote ! { use ::pgrx::pg_sys::panic::ErrorReportable; });
+                let import = result.then(|| quote! { use ::pgrx::pg_sys::panic::ErrorReportable; });
                 let result_handler = quote_spanned! {
                     self.func.sig.span() =>
                         #import

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -599,13 +599,9 @@ impl ToRustCodeTokens for PgExtern {
 
 impl Parse for CodeEnrichment<PgExtern> {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let mut attrs = Vec::new();
-
         let parser = Punctuated::<Attribute, Token![,]>::parse_terminated;
         let punctuated_attrs = input.call(parser).ok().unwrap_or_default();
-        for pair in punctuated_attrs.into_pairs() {
-            attrs.push(pair.into_value())
-        }
+        let attrs = punctuated_attrs.into_pairs().map(|pair| pair.into_value());
         PgExtern::new(quote! {#(#attrs)*}, input.parse()?)
     }
 }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -284,11 +284,7 @@ impl PgExtern {
         let operator = self.operator.clone().into_iter();
         let to_sql_config = match self.overridden() {
             None => self.to_sql_config.clone(),
-            Some(content) => {
-                let mut config = self.to_sql_config.clone();
-                config.content = Some(content);
-                config
-            }
+            Some(content) => ToSqlConfig { content: Some(content), ..self.to_sql_config.clone() },
         };
 
         let sql_graph_entity_fn_name =

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -94,8 +94,7 @@ impl UsedType {
             // composite_type!(..)
             syn::Type::Macro(macro_pat) => {
                 let mac = &macro_pat.mac;
-                let archetype = mac.path.segments.last().expect("No last segment");
-                match archetype.ident.to_string().as_str() {
+                match &*mac.path.segments.last().expect("No last segment").ident.to_string() {
                     "default" => {
                         // If we land here, after already expanding the `default!()` above, the user has written it twice.
                         // This is definitely an issue and we should tell them.

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -287,9 +287,9 @@ impl UsedType {
         let mut resolved_ty_inner: Option<syn::Type> = None;
         if result {
             if let syn::Type::Path(tp) = &resolved_ty {
-                if let Some(first_segment) = tp.path.segments.first().map(Some).unwrap_or(None) {
+                if let Some(first_segment) = tp.path.segments.first() {
                     if let syn::PathArguments::AngleBracketed(ab) = &first_segment.arguments {
-                        if let Some(first_arg) = ab.args.first().map(Some).unwrap_or(None) {
+                        if let Some(first_arg) = ab.args.first() {
                             if let syn::GenericArgument::Type(ty) = first_arg {
                                 resolved_ty_inner = Some(ty.clone());
                             }

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -289,10 +289,8 @@ impl UsedType {
             if let syn::Type::Path(tp) = &resolved_ty {
                 if let Some(first_segment) = tp.path.segments.first() {
                     if let syn::PathArguments::AngleBracketed(ab) = &first_segment.arguments {
-                        if let Some(first_arg) = ab.args.first() {
-                            if let syn::GenericArgument::Type(ty) = first_arg {
-                                resolved_ty_inner = Some(ty.clone());
-                            }
+                        if let Some(syn::GenericArgument::Type(ty)) = ab.args.first() {
+                            resolved_ty_inner = Some(ty.clone());
                         }
                     }
                 }


### PR DESCRIPTION
This cleans up pgrx-sql-entity-graph AGAIN, this time focusing mostly on the lifetimes.rs file and where the related functions are used, now that the entire thing isn't quite such a horrorshow any more. Unfortunately it still needs quite a bit of work just to be able to see what the hell is going on.