### PR TITLE
:fix: avoid segfault on background worker pool exhaustion

### DIFF
--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -86,6 +86,16 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
     .expect("bgworker transaction failed");
 }
 
+
+#[pg_guard]
+#[no_mangle]
+/// Simple background worker that waits to be terminated; used to test behaviour in case of worker slots exhaustion
+pub extern "C" fn bgworker_sleep() {
+    use pgrx::bgworkers::*;
+    BackgroundWorker::attach_signal_handlers(SignalWakeFlags::SIGHUP | SignalWakeFlags::SIGTERM);
+    while BackgroundWorker::wait_latch(None) {}
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
@@ -95,16 +105,18 @@ mod tests {
     use pgrx::bgworkers::*;
     use pgrx::prelude::*;
     use pgrx::{pg_sys, IntoDatum};
-
     #[pg_test]
     fn test_dynamic_bgworker() {
+        // Required to avoid bgworker pool exhaustion errors, see `test_dynamic_worker_allocation_failure`
+        Spi::run("SELECT pg_advisory_xact_lock_shared(42)").unwrap();
         let worker = BackgroundWorkerBuilder::new("dynamic_bgworker")
             .set_library("pgrx_tests")
             .set_function("bgworker")
             .set_argument(123i32.into_datum())
             .enable_spi_access()
             .set_notify_pid(unsafe { pg_sys::MyProcPid })
-            .load_dynamic();
+            .load_dynamic()
+            .expect("Failed to start worker");
         let pid = worker.wait_for_startup().expect("no PID from the worker");
         assert!(pid > 0);
         let handle = worker.terminate();
@@ -115,12 +127,15 @@ mod tests {
 
     #[pg_test]
     fn test_dynamic_bgworker_untracked() {
+        // Required to avoid bgworker pool exhaustion errors, see `test_dynamic_worker_allocation_failure`
+        Spi::run("SELECT pg_advisory_xact_lock_shared(42)").unwrap();
         let worker = BackgroundWorkerBuilder::new("dynamic_bgworker")
             .set_library("pgrx_tests")
             .set_function("bgworker")
             .set_argument(0i32.into_datum())
             .enable_spi_access()
-            .load_dynamic();
+            .load_dynamic()
+            .expect("Failed to start worker");
         assert!(matches!(worker.wait_for_startup(), Err(BackgroundWorkerStatus::Untracked { .. })));
         assert!(matches!(
             worker.wait_for_shutdown(),
@@ -130,12 +145,15 @@ mod tests {
 
     #[pg_test]
     fn test_dynamic_bgworker_untracked_termination_handle() {
+        // Required to avoid bgworker pool exhaustion errors, see `test_dynamic_worker_allocation_failure`
+        Spi::run("SELECT pg_advisory_xact_lock_shared(42)").unwrap();
         let worker = BackgroundWorkerBuilder::new("dynamic_bgworker")
             .set_library("pgrx_tests")
             .set_function("bgworker")
             .set_argument(0i32.into_datum())
             .enable_spi_access()
-            .load_dynamic();
+            .load_dynamic()
+            .expect("Failed to start worker");
         let handle = worker.terminate();
         assert!(matches!(
             handle.wait_for_shutdown(),
@@ -145,18 +163,48 @@ mod tests {
 
     #[pg_test]
     fn test_background_worker_transaction_return() {
+        // Required to avoid bgworker pool exhaustion errors, see `test_dynamic_worker_allocation_failure`
+        Spi::run("SELECT pg_advisory_xact_lock_shared(42)").unwrap();
         let worker = BackgroundWorkerBuilder::new("dynamic_bgworker")
             .set_library("pgrx_tests")
             .set_function("bgworker_return_value")
             .set_argument(123i32.into_datum())
             .enable_spi_access()
             .set_notify_pid(unsafe { pg_sys::MyProcPid })
-            .load_dynamic();
+            .load_dynamic()
+            .expect("Failed to start worker");
         let pid = worker.wait_for_startup().expect("no PID from the worker");
         assert!(pid > 0);
         let handle = worker.terminate();
         handle.wait_for_shutdown().expect("aborted shutdown");
 
         assert_eq!(Ok(Some(123)), Spi::get_one::<i32>("SELECT v FROM tests.bgworker_test_return;"));
+    }
+
+    #[pg_test]
+    fn test_dynamic_worker_allocation_failure() {
+        // This test temporarily exhausts the max_worker_processes slots, so needs to be run in isolation
+        // from other tests that require starting background workers to avoid spurious failures
+        // We use an advisory RW lock for this
+        Spi::run("SELECT pg_advisory_xact_lock(42)").unwrap();
+        let max_proc = Spi::get_one::<i32>("SELECT current_setting('max_worker_processes')::int")
+            .expect("failed to get max_worker_processes")
+            .expect("got null for max_worker_processes");
+        let available_proc = max_proc - 1; // One worker process for logical replication launcher
+
+        let results = (0..available_proc+1).map(|_| {
+            BackgroundWorkerBuilder::new("dynamic_bgworker")
+                .set_library("pgrx_tests")
+                .set_function("bgworker_sleep")
+                .enable_shmem_access(None)
+                .set_notify_pid(unsafe { pg_sys::MyProcPid })
+                .load_dynamic()
+        }).collect::<Vec<_>>();
+        let has_failures = results.iter().any(|w| w.is_err());
+        for worker in results.into_iter().filter_map(|r| r.ok()) {
+            let handle = worker.terminate();
+            handle.wait_for_shutdown().expect("aborted shutdown");
+        }
+        assert!(has_failures);
     }
 }

--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -86,7 +86,6 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
     .expect("bgworker transaction failed");
 }
 
-
 #[pg_guard]
 #[no_mangle]
 /// Simple background worker that waits to be terminated; used to test behaviour in case of worker slots exhaustion
@@ -192,14 +191,16 @@ mod tests {
             .expect("got null for max_worker_processes");
         let available_proc = max_proc - 1; // One worker process for logical replication launcher
 
-        let results = (0..available_proc+1).map(|_| {
-            BackgroundWorkerBuilder::new("dynamic_bgworker")
-                .set_library("pgrx_tests")
-                .set_function("bgworker_sleep")
-                .enable_shmem_access(None)
-                .set_notify_pid(unsafe { pg_sys::MyProcPid })
-                .load_dynamic()
-        }).collect::<Vec<_>>();
+        let results = (0..available_proc + 1)
+            .map(|_| {
+                BackgroundWorkerBuilder::new("dynamic_bgworker")
+                    .set_library("pgrx_tests")
+                    .set_function("bgworker_sleep")
+                    .enable_shmem_access(None)
+                    .set_notify_pid(unsafe { pg_sys::MyProcPid })
+                    .load_dynamic()
+            })
+            .collect::<Vec<_>>();
         let has_failures = results.iter().any(|w| w.is_err());
         for worker in results.into_iter().filter_map(|r| r.ok()) {
             let handle = worker.terminate();

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -602,9 +602,8 @@ impl BackgroundWorkerBuilder {
         let mut bgw: pg_sys::BackgroundWorker = (&self).into();
         let mut handle: *mut pg_sys::BackgroundWorkerHandle = null_mut();
 
-        let success = unsafe {
-            pg_sys::RegisterDynamicBackgroundWorker(&mut bgw, &mut handle)
-        };
+        // SAFETY: bgw and handle are set just above, and postgres guarantees to set handle to a valid pointer in case of success
+        let success = unsafe { pg_sys::RegisterDynamicBackgroundWorker(&mut bgw, &mut handle) };
 
         if !success {
             Err(())


### PR DESCRIPTION
`BackgroundWorkerBuilder::load_dynamic()` does not check the return value from `pg_sys::RegisterDynamicBackgroundWorker`; in case of failure (e.g. because of `max_worker_processes` being exceeded) the passed `handle` is left set to null.
Later trying to call `DynamicBackgroundWorker::wait_for_shutdown()` causes a segfault due to null pointer dereference.

We make load_dynamic() fallible, returning an `Err` in this case, preventing the null pointer dereference.

For testing, we spawn multiple workers until we exhaust the pool; this needs to be done in isolation, as concurrently-run tests, that spawn bgworkers might fail spuriously otherwise; we do this using an RW advisory lock.

Fixes https://github.com/pgcentralfoundation/pgrx/issues/1417
