### PR TITLE
Allow most low-info clippy warnings

### DIFF
--- a/pgrx-examples/numeric/src/lib.rs
+++ b/pgrx-examples/numeric/src/lib.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+#![allow(clippy::assign_op_pattern)]
 use pgrx::prelude::*;
 
 pg_module_magic!();

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -52,6 +52,7 @@ impl ControlFile {
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(input: &str) -> Result<Self, ControlFileError> {
         let mut temp = HashMap::new();
         for line in input.lines() {

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -15,6 +15,7 @@ Rust to SQL mapping support.
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */
+#![allow(clippy::too_many_arguments)]
 pub use aggregate::entity::{AggregateTypeEntity, PgAggregateEntity};
 pub use aggregate::{
     AggregateType, AggregateTypeList, FinalizeModify, ParallelOption, PgAggregate,

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -460,6 +460,7 @@ fn build_base_edges(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn initialize_extension_sqls(
     graph: &mut StableGraph<SqlGraphEntity, SqlGraphRelationship>,
     root: NodeIndex,

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+#![allow(clippy::precedence, clippy::unnecessary_cast)]
 use crate::datum::Array;
 use crate::pg_sys;
 use crate::toast::{Toast, Toasty};

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -7,7 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-#![allow(clippy::precedence, clippy::unnecessary_cast)]
+#![allow(clippy::precedence)]
 use crate::datum::Array;
 use crate::pg_sys;
 use crate::toast::{Toast, Toasty};

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -10,6 +10,7 @@
 //! Safely create Postgres Background Workers, including with full SPI support
 //!
 //! See: [https://www.postgresql.org/docs/current/bgworker.html](https://www.postgresql.org/docs/current/bgworker.html)
+#![allow(clippy::useless_transmute)]
 use crate::pg_sys;
 use pgrx_pg_sys::PgTryBuilder;
 use std::convert::TryInto;

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+#![allow(clippy::question_mark)]
 use crate::array::RawArray;
 use crate::layout::*;
 use crate::toast::Toast;

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -8,7 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! for converting a pg_sys::Datum and a corresponding "is_null" bool into a typed Option
-
+#![allow(clippy::manual_map, clippy::map_clone, clippy::into_iter_on_ref)]
 use crate::{
     pg_sys, varlena, varlena_to_byte_slice, AllocatedByPostgres, IntoDatum, PgBox, PgMemoryContexts,
 };

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -9,6 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Handing for easily converting Postgres Datum types into their corresponding Rust types
 //! and converting Rust types into their corresponding Postgres types
+#![allow(clippy::unused_unit)]
 mod anyarray;
 mod anyelement;
 mod array;

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
-#![allow(clippy::unnecessary_cast)]
 use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{
     pg_sys, rust_regtypein, set_varsize, set_varsize_short, vardata_any, varsize_any,

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -8,6 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
+#![allow(clippy::unnecessary_cast)]
 use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{
     pg_sys, rust_regtypein, set_varsize, set_varsize_short, vardata_any, varsize_any,

--- a/pgrx/src/hooks.rs
+++ b/pgrx/src/hooks.rs
@@ -8,6 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! A trait and registration system for hooking Postgres internal operations such as its planner and executor
+#![allow(clippy::unit_arg)]
 use crate as pgrx; // for #[pg_guard] support from within ourself
 use crate::prelude::*;
 use crate::{void_mut_ptr, PgBox, PgList};

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+#![allow(clippy::vec_init_then_push)]
 use std::iter::once;
 
 use crate::IntoHeapTuple;

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -21,8 +21,14 @@
 //! }
 //!
 //! ```
-#![allow(clippy::missing_safety_doc)]
-#![allow(clippy::cast_ptr_alignment)]
+#![allow(
+    clippy::cast_ptr_alignment,
+    clippy::len_without_is_empty,
+    clippy::missing_safety_doc,
+    clippy::too_many_arguments,
+    clippy::type_complexity,
+    clippy::unnecessary_cast
+)]
 
 #[macro_use]
 extern crate bitflags;

--- a/pgrx/src/lwlock.rs
+++ b/pgrx/src/lwlock.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+#![allow(clippy::needless_borrow)]
 use crate::pg_sys;
 use core::ops::{Deref, DerefMut};
 use once_cell::sync::OnceCell;


### PR DESCRIPTION
Many clippy warnings are not very informative or are unlikely to be usefully fixed any time soon. Allow them so that the remainder which constitute a problem actually stand out and can be fixed.