### PR TITLE
Simplify void return handling

### DIFF
--- a/pgrx-sql-entity-graph/src/extension_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/mod.rs
@@ -226,15 +226,10 @@ impl Parse for CodeEnrichment<ExtensionSql> {
         let sql = input.parse()?;
         let _after_sql_comma: Option<Token![,]> = input.parse()?;
         let attrs = input.parse_terminated(ExtensionSqlAttribute::parse)?;
-        // it's rfind_map
-        let name = attrs
-            .iter()
-            .filter_map(|attr| match attr {
-                ExtensionSqlAttribute::Name(found_name) => Some(found_name),
-                _ => None,
-            })
-            .cloned()
-            .next_back();
+        let name = attrs.iter().rev().find_map(|attr| match attr {
+            ExtensionSqlAttribute::Name(found_name) => Some(found_name.clone()),
+            _ => None,
+        });
         let name =
             name.ok_or_else(|| syn::Error::new(input.span(), "expected `name` to be set"))?;
         Ok(CodeEnrichment(ExtensionSql { sql, attrs, name }))

--- a/pgrx-sql-entity-graph/src/metadata/entity.rs
+++ b/pgrx-sql-entity-graph/src/metadata/entity.rs
@@ -21,7 +21,7 @@ use super::{ArgumentError, Returns, ReturnsError, SqlMapping};
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FunctionMetadataEntity {
     pub arguments: Vec<FunctionMetadataTypeEntity>,
-    pub retval: Option<FunctionMetadataTypeEntity>,
+    pub retval: FunctionMetadataTypeEntity,
     pub path: &'static str,
 }
 

--- a/pgrx-sql-entity-graph/src/metadata/function_metadata.rs
+++ b/pgrx-sql-entity-graph/src/metadata/function_metadata.rs
@@ -51,7 +51,7 @@ where
             arguments: vec![],
             retval: {
                 let marker: PhantomData<R> = PhantomData;
-                Some(marker.entity())
+                marker.entity()
             },
             path: self.path(),
         }
@@ -67,22 +67,10 @@ where
             arguments: vec![],
             retval: {
                 let marker: PhantomData<R> = PhantomData;
-                Some(marker.entity())
+                marker.entity()
             },
             path: self.path(),
         }
-    }
-}
-
-impl FunctionMetadata<()> for fn() {
-    fn entity(&self) -> FunctionMetadataEntity {
-        FunctionMetadataEntity { arguments: vec![], retval: None, path: self.path() }
-    }
-}
-
-impl FunctionMetadata<()> for unsafe fn() {
-    fn entity(&self) -> FunctionMetadataEntity {
-        FunctionMetadataEntity { arguments: vec![], retval: None, path: self.path() }
     }
 }
 
@@ -92,7 +80,7 @@ macro_rules! impl_fn {
             fn entity(&self) -> FunctionMetadataEntity {
                 FunctionMetadataEntity {
                     arguments: vec![$(PhantomData::<$T>.entity()),+],
-                    retval: Some(PhantomData::<R>.entity()),
+                    retval: PhantomData::<R>.entity(),
                     path: self.path(),
                 }
             }
@@ -101,25 +89,7 @@ macro_rules! impl_fn {
             fn entity(&self) -> FunctionMetadataEntity {
                 FunctionMetadataEntity {
                     arguments: vec![$(PhantomData::<$T>.entity()),+],
-                    retval: Some(PhantomData::<R>.entity()),
-                    path: self.path(),
-                }
-            }
-        }
-        impl<$($T: SqlTranslatable,)*> FunctionMetadata<($($T,)*)> for fn($($T,)*) {
-            fn entity(&self) -> FunctionMetadataEntity {
-                FunctionMetadataEntity {
-                    arguments: vec![$(PhantomData::<$T>.entity()),+],
-                    retval: None,
-                    path: self.path(),
-                }
-            }
-        }
-        impl<$($T: SqlTranslatable,)*> FunctionMetadata<($($T,)*)> for unsafe fn($($T,)*) {
-            fn entity(&self) -> FunctionMetadataEntity {
-                FunctionMetadataEntity {
-                    arguments: vec![$(PhantomData::<$T>.entity()),+],
-                    retval: None,
+                    retval: PhantomData::<R>.entity(),
                     path: self.path(),
                 }
             }

--- a/pgrx-sql-entity-graph/src/metadata/function_metadata.rs
+++ b/pgrx-sql-entity-graph/src/metadata/function_metadata.rs
@@ -30,7 +30,7 @@ type FunctionPointer = fn(i32) -> String;
 let marker: FunctionPointer = floof;
 let metadata = pgrx_sql_entity_graph::metadata::FunctionMetadata::entity(&marker);
 assert_eq!(
-    metadata.retval.unwrap().return_sql,
+    metadata.retval.return_sql,
     Ok(Returns::One(SqlMapping::As("TEXT".to_string()))),
 );
 ```

--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -117,10 +117,7 @@ pub unsafe trait SqlTranslatable {
     }
 }
 
-unsafe impl<E> SqlTranslatable for Result<(), E>
-where
-    E: Any + Display,
-{
+unsafe impl SqlTranslatable for () {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Err(ArgumentError::NotValidAsArgument("()"))
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -226,7 +226,7 @@ impl ToSql for PgExternEntity {
                         _ => false,
                     })
                     .ok_or_else(|| eyre!("Could not find return type in graph."))?;
-                let metadata_retval = self.metadata.retval.clone().ok_or_else(|| eyre!("Macro expansion time and SQL resolution time had differing opinions about the return value existing"))?;
+                let metadata_retval = self.metadata.retval.clone();
                 let sql_type = match metadata_retval.return_sql {
                     Ok(Returns::One(SqlMapping::As(ref sql))) => sql.clone(),
                     Ok(Returns::One(SqlMapping::Composite { array_brackets })) => fmt::with_array_brackets(ty.composite_type.unwrap().into(), array_brackets),
@@ -256,7 +256,7 @@ impl ToSql for PgExternEntity {
                         _ => false,
                     })
                     .ok_or_else(|| eyre!("Could not find return type in graph."))?;
-                let metadata_retval = self.metadata.retval.clone().ok_or_else(|| eyre!("Macro expansion time and SQL resolution time had differing opinions about the return value existing"))?;
+                let metadata_retval = self.metadata.retval.clone();
                 let sql_type = match metadata_retval.return_sql {
                         Ok(Returns::SetOf(SqlMapping::As(ref sql))) => sql.clone(),
                         Ok(Returns::SetOf(SqlMapping::Composite { array_brackets })) => fmt::with_array_brackets(ty.composite_type.unwrap().into(), array_brackets),
@@ -272,7 +272,7 @@ impl ToSql for PgExternEntity {
             }
             PgExternReturnEntity::Iterated { tys: table_items, optional: _, result: _ } => {
                 let mut items = String::new();
-                let metadata_retval = self.metadata.retval.clone().ok_or_else(|| eyre!("Macro expansion time and SQL resolution time had differing opinions about the return value existing"))?;
+                let metadata_retval = self.metadata.retval.clone();
                 let metadata_retval_sqls: Vec<String> = match metadata_retval.return_sql {
                         Ok(Returns::Table(variants)) => {
                             variants.iter().enumerate().map(|(idx, variant)| {


### PR DESCRIPTION
Aside from imposing a few stylistic choices on pgrx-sql-entity-graph, FunctionMetadata had its second generic removed after some consulting with type system experts who expressed it is unlikely to be necessary. Indeed, everything seems to be unaffected by this.

In doing this, it reveals that FunctionMetadataEntity is only using Option to handle a single return type: `()`. Removing this allows simplifying the handling for function pointers that return `-> ()`... of which you might remember there are a lot, given that is any function without an explicit other return type.