### PR TITLE
Remove unused source-mapping code

### DIFF
--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -181,9 +181,6 @@ where
                 Ok(SqlMapping::Composite { array_brackets: _ }) => {
                     Ok(SqlMapping::Composite { array_brackets: true })
                 }
-                Ok(SqlMapping::Source { array_brackets: _ }) => {
-                    Ok(SqlMapping::Source { array_brackets: true })
-                }
                 Ok(SqlMapping::Skip) => Ok(SqlMapping::Skip),
                 err @ Err(_) => err,
             },
@@ -199,9 +196,6 @@ where
                 }
                 Ok(Returns::One(SqlMapping::Composite { array_brackets: _ })) => {
                     Ok(Returns::One(SqlMapping::Composite { array_brackets: true }))
-                }
-                Ok(Returns::One(SqlMapping::Source { array_brackets: _ })) => {
-                    Ok(Returns::One(SqlMapping::Source { array_brackets: true }))
                 }
                 Ok(Returns::One(SqlMapping::Skip)) => Ok(Returns::One(SqlMapping::Skip)),
                 Ok(Returns::SetOf(_)) => Err(ReturnsError::SetOfInArray),
@@ -230,15 +224,6 @@ unsafe impl SqlTranslatable for i32 {
     }
     fn return_sql() -> Result<Returns, ReturnsError> {
         Ok(Returns::One(SqlMapping::literal("INT")))
-    }
-}
-
-unsafe impl SqlTranslatable for u32 {
-    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
-        Ok(SqlMapping::Source { array_brackets: false })
-    }
-    fn return_sql() -> Result<Returns, ReturnsError> {
-        Ok(Returns::One(SqlMapping::Source { array_brackets: false }))
     }
 }
 

--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -65,10 +65,6 @@ pub enum SqlMapping {
     Composite {
         array_brackets: bool,
     },
-    /// Some types are still directly from source
-    Source {
-        array_brackets: bool,
-    },
     /// Placeholder for some types with no simple translation
     Skip,
 }

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -426,12 +426,6 @@ impl PgrxSql {
         })
     }
 
-    pub fn source_only_to_sql_type(&self, _ty_source: &str) -> Option<String> {
-        // HACK for `Result<T, E>`
-        // ...well, actually, nothing!
-        None
-    }
-
     pub fn get_module_pathname(&self) -> String {
         if self.versioned_so {
             let extname = &self.extension_name;

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -915,7 +915,6 @@ where
             SqlMapping::As(sql) => Ok(SqlMapping::As(format!("{sql}[]"))),
             SqlMapping::Skip => Err(ArgumentError::SkipInArray),
             SqlMapping::Composite { .. } => Ok(SqlMapping::Composite { array_brackets: true }),
-            SqlMapping::Source { .. } => Ok(SqlMapping::Source { array_brackets: true }),
         }
     }
 
@@ -926,9 +925,6 @@ where
             }
             Returns::One(SqlMapping::Composite { array_brackets: _ }) => {
                 Ok(Returns::One(SqlMapping::Composite { array_brackets: true }))
-            }
-            Returns::One(SqlMapping::Source { array_brackets: _ }) => {
-                Ok(Returns::One(SqlMapping::Source { array_brackets: true }))
             }
             Returns::One(SqlMapping::Skip) => Err(ReturnsError::SkipInArray),
             Returns::SetOf(_) => Err(ReturnsError::SetOfInArray),
@@ -946,7 +942,6 @@ where
             SqlMapping::As(sql) => Ok(SqlMapping::As(format!("{sql}[]"))),
             SqlMapping::Skip => Err(ArgumentError::SkipInArray),
             SqlMapping::Composite { .. } => Ok(SqlMapping::Composite { array_brackets: true }),
-            SqlMapping::Source { .. } => Ok(SqlMapping::Source { array_brackets: true }),
         }
     }
 
@@ -957,9 +952,6 @@ where
             }
             Returns::One(SqlMapping::Composite { array_brackets: _ }) => {
                 Ok(Returns::One(SqlMapping::Composite { array_brackets: true }))
-            }
-            Returns::One(SqlMapping::Source { array_brackets: _ }) => {
-                Ok(Returns::One(SqlMapping::Source { array_brackets: true }))
             }
             Returns::One(SqlMapping::Skip) => Err(ReturnsError::SkipInArray),
             Returns::SetOf(_) => Err(ReturnsError::SetOfInArray),


### PR DESCRIPTION
The code for `SqlMapping::Source` and `source_only_to_sql_type` has been dead code for some time. I am become garbage collector, destroyer of code.