### PR TITLE
Prepare pgrx v0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,30 +75,30 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "atty",
  "cargo_metadata",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.9"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ca43acc1b21c6cc2d1d3129c19e323a613935b5bc28fb3b33b5b2e5fb00030"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.9"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core2"
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
 ]
@@ -709,7 +709,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -762,12 +762,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -996,9 +996,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -1143,7 +1143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1180,9 +1180,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -1263,7 +1263,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1381,9 +1381,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -1413,9 +1413,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
@@ -1473,7 +1473,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.1",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bindgen",
  "clang-sys",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "atty",
  "convert_case",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1961,16 +1961,16 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2011,15 +2011,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2310,7 +2310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2480,7 +2480,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2499,7 +2499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2608,7 +2608,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3016,9 +3016,9 @@ checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3077,7 +3077,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -3086,13 +3095,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -3102,10 +3126,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3114,10 +3150,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3126,10 +3174,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3138,10 +3198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "winnow"
-version = "0.5.19"
+name = "windows_x86_64_msvc"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0383266b19108dfc6314a56047aa545a1b4d1be60e799b4dbdd407b56402704b"
 dependencies = [
  "memchr",
 ]
@@ -3172,18 +3238,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
@@ -33,8 +33,8 @@ semver = "1.0.20"
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
 env_proxy = "0.4.1"
 num_cpus = "1.16.0"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.11.1" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.1" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.11.2" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.2" }
 prettyplease = "0.2.15"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -17,10 +17,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.11.1"
+pgrx = "=0.11.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.11.1"
+pgrx-tests = "=0.11.2"
 
 [profile.dev]
 panic = "unwind"

--- a/nix/templates/default/Cargo.toml
+++ b/nix/templates/default/Cargo.toml
@@ -27,10 +27,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.11.1"
+pgrx = "=0.11.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.11.1"
+pgrx-tests = "=0.11.2"
 tempfile = "3.2.0"
 once_cell = "1.7.2"
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"
@@ -31,7 +31,7 @@ rustc-args = ["--cfg", "docsrs"]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.1" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.2" }
 proc-macro2 = "1.0.69"
 quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-sys"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
@@ -40,8 +40,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.11.1" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.11.1" }
+pgrx-macros = { path = "../pgrx-macros/", version = "=0.11.2" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.11.2" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
@@ -50,7 +50,7 @@ libc = "0.2"
 [build-dependencies]
 bindgen = { version = "0.68.1", default-features = false, features = ["runtime"] }
 clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.11.1" }
+pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.11.2" }
 proc-macro2 = "1.0.69"
 quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }

--- a/pgrx-pg-sys/src/include/pg12.rs
+++ b/pgrx-pg-sys/src/include/pg12.rs
@@ -31587,6 +31587,27 @@ extern "C" {
         typeName: *const ::std::os::raw::c_char,
         typeNamespace: Oid,
     ) -> bool;
+    pub fn RelationCreateStorage(
+        rnode: RelFileNode,
+        relpersistence: ::std::os::raw::c_char,
+    ) -> SMgrRelation;
+    pub fn RelationDropStorage(rel: Relation);
+    pub fn RelationPreserveStorage(rnode: RelFileNode, atCommit: bool);
+    pub fn RelationTruncate(rel: Relation, nblocks: BlockNumber);
+    pub fn RelationCopyStorage(
+        src: SMgrRelation,
+        dst: SMgrRelation,
+        forkNum: ForkNumber,
+        relpersistence: ::std::os::raw::c_char,
+    );
+    pub fn smgrDoPendingDeletes(isCommit: bool);
+    pub fn smgrGetPendingDeletes(
+        forCommit: bool,
+        ptr: *mut *mut RelFileNode,
+    ) -> ::std::os::raw::c_int;
+    pub fn AtSubCommit_smgr();
+    pub fn AtSubAbort_smgr();
+    pub fn PostPrepare_smgr();
     pub fn CommentObject(stmt: *mut CommentStmt) -> ObjectAddress;
     pub fn DeleteComments(oid: Oid, classoid: Oid, subid: int32);
     pub fn CreateComments(

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -32692,6 +32692,33 @@ extern "C" {
         typeName: *const ::std::os::raw::c_char,
         typeNamespace: Oid,
     ) -> bool;
+    pub fn RelationCreateStorage(
+        rnode: RelFileNode,
+        relpersistence: ::std::os::raw::c_char,
+    ) -> SMgrRelation;
+    pub fn RelationDropStorage(rel: Relation);
+    pub fn RelationPreserveStorage(rnode: RelFileNode, atCommit: bool);
+    pub fn RelationPreTruncate(rel: Relation);
+    pub fn RelationTruncate(rel: Relation, nblocks: BlockNumber);
+    pub fn RelationCopyStorage(
+        src: SMgrRelation,
+        dst: SMgrRelation,
+        forkNum: ForkNumber,
+        relpersistence: ::std::os::raw::c_char,
+    );
+    pub fn RelFileNodeSkippingWAL(rnode: RelFileNode) -> bool;
+    pub fn EstimatePendingSyncsSpace() -> Size;
+    pub fn SerializePendingSyncs(maxSize: Size, startAddress: *mut ::std::os::raw::c_char);
+    pub fn RestorePendingSyncs(startAddress: *mut ::std::os::raw::c_char);
+    pub fn smgrDoPendingDeletes(isCommit: bool);
+    pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
+    pub fn smgrGetPendingDeletes(
+        forCommit: bool,
+        ptr: *mut *mut RelFileNode,
+    ) -> ::std::os::raw::c_int;
+    pub fn AtSubCommit_smgr();
+    pub fn AtSubAbort_smgr();
+    pub fn PostPrepare_smgr();
     pub fn CommentObject(stmt: *mut CommentStmt) -> ObjectAddress;
     pub fn DeleteComments(oid: Oid, classoid: Oid, subid: int32);
     pub fn CreateComments(
@@ -40909,6 +40936,7 @@ extern "C" {
     pub static mut no_such_variable: ::std::os::raw::c_int;
     pub static mut namespace_search_path: *mut ::std::os::raw::c_char;
     pub static mut object_access_hook: object_access_hook_type;
+    pub static mut wal_skip_threshold: ::std::os::raw::c_int;
     pub static mut ExplainOneQuery_hook: ExplainOneQuery_hook_type;
     pub static mut explain_get_index_name_hook: explain_get_index_name_hook_type;
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -34016,6 +34016,33 @@ extern "C" {
         rangeTypeName: *const ::std::os::raw::c_char,
         typeNamespace: Oid,
     ) -> *mut ::std::os::raw::c_char;
+    pub fn RelationCreateStorage(
+        rnode: RelFileNode,
+        relpersistence: ::std::os::raw::c_char,
+    ) -> SMgrRelation;
+    pub fn RelationDropStorage(rel: Relation);
+    pub fn RelationPreserveStorage(rnode: RelFileNode, atCommit: bool);
+    pub fn RelationPreTruncate(rel: Relation);
+    pub fn RelationTruncate(rel: Relation, nblocks: BlockNumber);
+    pub fn RelationCopyStorage(
+        src: SMgrRelation,
+        dst: SMgrRelation,
+        forkNum: ForkNumber,
+        relpersistence: ::std::os::raw::c_char,
+    );
+    pub fn RelFileNodeSkippingWAL(rnode: RelFileNode) -> bool;
+    pub fn EstimatePendingSyncsSpace() -> Size;
+    pub fn SerializePendingSyncs(maxSize: Size, startAddress: *mut ::std::os::raw::c_char);
+    pub fn RestorePendingSyncs(startAddress: *mut ::std::os::raw::c_char);
+    pub fn smgrDoPendingDeletes(isCommit: bool);
+    pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
+    pub fn smgrGetPendingDeletes(
+        forCommit: bool,
+        ptr: *mut *mut RelFileNode,
+    ) -> ::std::os::raw::c_int;
+    pub fn AtSubCommit_smgr();
+    pub fn AtSubAbort_smgr();
+    pub fn PostPrepare_smgr();
     pub fn CommentObject(stmt: *mut CommentStmt) -> ObjectAddress;
     pub fn DeleteComments(oid: Oid, classoid: Oid, subid: int32);
     pub fn CreateComments(
@@ -42963,6 +42990,7 @@ extern "C" {
     pub static LockTagTypeNames: [*const ::std::os::raw::c_char; 0usize];
     pub static mut namespace_search_path: *mut ::std::os::raw::c_char;
     pub static mut object_access_hook: object_access_hook_type;
+    pub static mut wal_skip_threshold: ::std::os::raw::c_int;
     pub static mut ExplainOneQuery_hook: ExplainOneQuery_hook_type;
     pub static mut explain_get_index_name_hook: explain_get_index_name_hook_type;
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -34317,6 +34317,34 @@ extern "C" {
         rangeTypeName: *const ::std::os::raw::c_char,
         typeNamespace: Oid,
     ) -> *mut ::std::os::raw::c_char;
+    pub fn RelationCreateStorage(
+        rnode: RelFileNode,
+        relpersistence: ::std::os::raw::c_char,
+        register_delete: bool,
+    ) -> SMgrRelation;
+    pub fn RelationDropStorage(rel: Relation);
+    pub fn RelationPreserveStorage(rnode: RelFileNode, atCommit: bool);
+    pub fn RelationPreTruncate(rel: Relation);
+    pub fn RelationTruncate(rel: Relation, nblocks: BlockNumber);
+    pub fn RelationCopyStorage(
+        src: SMgrRelation,
+        dst: SMgrRelation,
+        forkNum: ForkNumber,
+        relpersistence: ::std::os::raw::c_char,
+    );
+    pub fn RelFileNodeSkippingWAL(rnode: RelFileNode) -> bool;
+    pub fn EstimatePendingSyncsSpace() -> Size;
+    pub fn SerializePendingSyncs(maxSize: Size, startAddress: *mut ::std::os::raw::c_char);
+    pub fn RestorePendingSyncs(startAddress: *mut ::std::os::raw::c_char);
+    pub fn smgrDoPendingDeletes(isCommit: bool);
+    pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
+    pub fn smgrGetPendingDeletes(
+        forCommit: bool,
+        ptr: *mut *mut RelFileNode,
+    ) -> ::std::os::raw::c_int;
+    pub fn AtSubCommit_smgr();
+    pub fn AtSubAbort_smgr();
+    pub fn PostPrepare_smgr();
     pub fn CommentObject(stmt: *mut CommentStmt) -> ObjectAddress;
     pub fn DeleteComments(oid: Oid, classoid: Oid, subid: int32);
     pub fn CreateComments(
@@ -43483,6 +43511,7 @@ extern "C" {
     pub static mut namespace_search_path: *mut ::std::os::raw::c_char;
     pub static mut object_access_hook: object_access_hook_type;
     pub static mut object_access_hook_str: object_access_hook_type_str;
+    pub static mut wal_skip_threshold: ::std::os::raw::c_int;
     pub static mut ExplainOneQuery_hook: ExplainOneQuery_hook_type;
     pub static mut explain_get_index_name_hook: explain_get_index_name_hook_type;
     pub static mut allow_in_place_tablespaces: bool;

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -34561,6 +34561,34 @@ extern "C" {
         rangeTypeName: *const ::std::os::raw::c_char,
         typeNamespace: Oid,
     ) -> *mut ::std::os::raw::c_char;
+    pub fn RelationCreateStorage(
+        rlocator: RelFileLocator,
+        relpersistence: ::std::os::raw::c_char,
+        register_delete: bool,
+    ) -> SMgrRelation;
+    pub fn RelationDropStorage(rel: Relation);
+    pub fn RelationPreserveStorage(rlocator: RelFileLocator, atCommit: bool);
+    pub fn RelationPreTruncate(rel: Relation);
+    pub fn RelationTruncate(rel: Relation, nblocks: BlockNumber);
+    pub fn RelationCopyStorage(
+        src: SMgrRelation,
+        dst: SMgrRelation,
+        forkNum: ForkNumber,
+        relpersistence: ::std::os::raw::c_char,
+    );
+    pub fn RelFileLocatorSkippingWAL(rlocator: RelFileLocator) -> bool;
+    pub fn EstimatePendingSyncsSpace() -> Size;
+    pub fn SerializePendingSyncs(maxSize: Size, startAddress: *mut ::std::os::raw::c_char);
+    pub fn RestorePendingSyncs(startAddress: *mut ::std::os::raw::c_char);
+    pub fn smgrDoPendingDeletes(isCommit: bool);
+    pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
+    pub fn smgrGetPendingDeletes(
+        forCommit: bool,
+        ptr: *mut *mut RelFileLocator,
+    ) -> ::std::os::raw::c_int;
+    pub fn AtSubCommit_smgr();
+    pub fn AtSubAbort_smgr();
+    pub fn PostPrepare_smgr();
     pub fn CommentObject(stmt: *mut CommentStmt) -> ObjectAddress;
     pub fn DeleteComments(oid: Oid, classoid: Oid, subid: int32);
     pub fn CreateComments(
@@ -44423,6 +44451,7 @@ extern "C" {
     pub static mut namespace_search_path: *mut ::std::os::raw::c_char;
     pub static mut object_access_hook: object_access_hook_type;
     pub static mut object_access_hook_str: object_access_hook_type_str;
+    pub static mut wal_skip_threshold: ::std::os::raw::c_int;
     pub static mut Array_nulls: bool;
     pub static mut ExplainOneQuery_hook: ExplainOneQuery_hook_type;
     pub static mut explain_get_index_name_hook: explain_get_index_name_hook_type;

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-tests"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -49,8 +49,8 @@ clap-cargo = "0.11.0"
 owo-colors = "3.5.0"
 once_cell = "1.18.0"
 libc = "0.2.149"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.11.1" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.11.1" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.11.2" }
+pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.11.2" }
 postgres = "0.19.7"
 proptest = { version = "1", optional = true }
 regex = "1.10.0"
@@ -68,4 +68,4 @@ trybuild = "1"
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.11.1"
+version = "=0.11.2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"
@@ -44,9 +44,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.11.1" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.11.1" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.1" }
+pgrx-macros = { path = "../pgrx-macros", version = "=0.11.2" }
+pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.11.2" }
+pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.2" }
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes


### PR DESCRIPTION
pgrx v0.11.2 is a minor release which

- makes available the storage-related API, thanks to @silver-ymz in https://github.com/pgcentralfoundation/pgrx/pull/1409
- deprecates the `Oid::from_u32_unchecked` API... because it is actually possible to do via casting in a *query*, which makes it effectively impossible for us to not wind up providing it via some other safe API, since the source is also an easily-Copied type. Thus you can now simply use `From::from` for it. Thanks to @thomcc for this discovery, implemented by @workingjubilee in https://github.com/pgcentralfoundation/pgrx/pull/1374

As usual, `cargo install cargo-pgrx --version 0.11.2 --locked` and be on your merry way!

Thanks everyone!