### PR TITLE
Include rule utils header

### DIFF
--- a/pgrx-pg-sys/include/pg12.h
+++ b/pgrx-pg-sys/include/pg12.h
@@ -147,6 +147,7 @@
 #include "utils/palloc.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
+#include "utils/ruleutils.h"
 #include "utils/sampling.h"
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -144,6 +144,7 @@
 #include "utils/palloc.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
+#include "utils/ruleutils.h"
 #include "utils/sampling.h"
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -144,6 +144,7 @@
 #include "utils/palloc.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
+#include "utils/ruleutils.h"
 #include "utils/sampling.h"
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -145,6 +145,7 @@
 #include "utils/palloc.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
+#include "utils/ruleutils.h"
 #include "utils/sampling.h"
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -145,6 +145,7 @@
 #include "utils/palloc.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
+#include "utils/ruleutils.h"
 #include "utils/sampling.h"
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"


### PR DESCRIPTION

The rule utils header contains useful fonctions such as `deparse_expression()`.

