### PR TITLE
Address the case when `RUSTFLAGS` environment variable is set but is empty

### DIFF
--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -526,8 +526,10 @@ fn create_stub(
     so_rustc_invocation.stderr(Stdio::inherit());
 
     if let Ok(rustc_flags_str) = std::env::var("RUSTFLAGS") {
-        let rustc_flags = rustc_flags_str.split(' ').collect::<Vec<_>>();
-        so_rustc_invocation.args(rustc_flags);
+        if !rustc_flags_str.trim().is_empty() {
+            let rustc_flags = rustc_flags_str.split(' ').collect::<Vec<_>>();
+            so_rustc_invocation.args(rustc_flags);
+        }
     }
 
     so_rustc_invocation.args([


### PR DESCRIPTION
Previously, an empty `RUSTFLAGS` would result in an error later on when we invoke `rustc`.

--- 
I could never reproduce it locally but saw it in CI on a different pgrx-based project once.

```
error: multiple input filenames provided (first two filenames are `` and `/home/runner/.pgrx/postmaster_stubs/home/runner/.pgrx/14.10/pgrx-install/bin/postmaster_stub.rs`)

Error:
   0: rustc exited with code 1

Location:
   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/schema.rs:557

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

   0: cargo_pgrx::command::schema::create_stub with postmaster_path=/home/runner/.pgrx/14.10/pgrx-install/bin/postgres postmaster_stub_dir=/home/runner/.pgrx/postmaster_stubs/home/runner/.pgrx/14.10/pgrx-install/bin
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/schema.rs:466
   1: cargo_pgrx::command::schema::generate_schema with pg_version=14.10 profile=Dev test=true path=/home/runner/.pgrx/14.10/pgrx-install/share/postgresql/extension/pronto_pgrx--0.0.1.sql features=["pg14", "pg_test"]
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/schema.rs:176
   2: cargo_pgrx::command::install::install_extension with pg_version=14.10 profile=Dev test=true features=["pg14", "pg_test"]
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/install.rs:114
   3: cargo_pgrx::command::install::execute
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/install.rs:63

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 5 frames hidden ⋮
   6: cargo_pgrx::command::schema::create_stub::h89ce909f55e57939
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/schema.rs:557
   7: cargo_pgrx::command::schema::generate_schema::h2ba00daa966b86f4
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/schema.rs:300
   8: cargo_pgrx::command::install::copy_sql_files::h31ef3c49b7f383c2
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/install.rs:371
   9: cargo_pgrx::command::install::install_extension::h1ab6177c7921219f
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/install.rs:223
  10: <cargo_pgrx::command::install::Install as cargo_pgrx::CommandExecute>::execute::hd14e1c2f34987990
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/install.rs:100
  11: <cargo_pgrx::command::pgrx::CargoPgrxSubCommands as cargo_pgrx::CommandExecute>::execute::h75590203637ce14c
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/pgrx.rs:58
  12: <cargo_pgrx::command::pgrx::Pgrx as cargo_pgrx::CommandExecute>::execute::hae21c402e182cc42
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/command/pgrx.rs:25
  13: <cargo_pgrx::CargoSubcommands as cargo_pgrx::CommandExecute>::execute::h784ffe251ea46f2b
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/main.rs:58
  14: <cargo_pgrx::CargoCommand as cargo_pgrx::CommandExecute>::execute::hcb77b1f19953376e
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/main.rs:45
  15: cargo_pgrx::main::h20c009215fa0b620
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.2/src/main.rs:111
  16: core::ops::function::FnOnce::call_once::h6642abaa92b5574c
      at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/ops/function.rs:250
                                ⋮ 15 frames hidden ⋮

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering. Run with RUST_BACKTRACE=full to include source snippets.

Location:
    /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pgrx-tests-0.11.2/src/framework.rs:372:20
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/std/src/panicking.rs:597:5
   1: core::panicking::panic_fmt
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/panicking.rs:72:14
   2: pronto_pgrx::tests::empty_index::tests::pg_issue284_empty_index
             at ./src/tests/empty_index.rs:6:5
   3: pronto_pgrx::tests::empty_index::tests::pg_issue284_empty_index::{{closure}}
             at ./src/tests/empty_index.rs:6:5
   4: core::ops::function::FnOnce::call_once
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/ops/function.rs:250:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```