### PR TITLE
fix issue #1437

### DIFF
--- a/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
@@ -121,7 +121,7 @@ impl ToEntityGraphTokens for PostgresEnum {
         let (_static_impl_generics, static_ty_generics, static_where_clauses) =
             static_generics.split_for_impl();
 
-        let variants = self.variants.iter();
+        let variants = self.variants.iter().map(|variant| variant.ident.clone());
         let sql_graph_entity_fn_name =
             syn::Ident::new(&format!("__pgrx_internals_enum_{}", name), Span::call_site());
 

--- a/pgrx-tests/src/tests/enum_type_tests.rs
+++ b/pgrx-tests/src/tests/enum_type_tests.rs
@@ -9,8 +9,9 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-#[derive(PostgresEnum, PartialEq, Debug)]
+#[derive(PostgresEnum, PartialEq, Debug, Default)]
 pub enum Foo {
+    #[default]
     One,
     Two,
     Three,


### PR DESCRIPTION
This fixes issue #1437.

The problem here is that we were blindly converting the entire `syn::Variant` value to the Postgres enum variant name when in fact all we want is its `Ident` value.