### PR TITLE
Handle RUSTFLAGS better

### DIFF
--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -526,8 +526,8 @@ fn create_stub(
     so_rustc_invocation.stderr(Stdio::inherit());
 
     if let Ok(rustc_flags_str) = std::env::var("RUSTFLAGS") {
-        if !rustc_flags_str.trim().is_empty() {
-            let rustc_flags = rustc_flags_str.split(' ').collect::<Vec<_>>();
+        let rustc_flags = rustc_flags_str.split_whitespace().collect::<Vec<_>>();
+        if !rustc_flags.is_empty() {
             so_rustc_invocation.args(rustc_flags);
         }
     }


### PR DESCRIPTION
This cleans up PR #1435 as per
(https://github.com/pgcentralfoundation/pgrx/pull/1435#issuecomment-1859360044).

What we probably really want is a legit "RUSTFLAGS" parser.  I don't feel like writing and testing one and a quick search didn't find anything on crates.io.  So splitting on whitespace will have to be Good Enough.