### PR TITLE
Disable ureq defaults to avoid enabling both native-tls and rustls

### DIFF
--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -38,7 +38,7 @@ prettyplease = "0.2.15"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
 regex = "1.10.0"
-ureq = "2.8.0"
+ureq = { version = "2.8.0", default-features = false, features = [ "gzip" ] }
 url = "2.4.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"


### PR DESCRIPTION
ureq defines `default = ["tls", "gzip"]`, so "tls" feature (rustls) is currently always enabled even when native-tls is preferred. This makes disallows building cargo-pgrx on platforms not supported by the ring crate (dependency of rustls).