### PR TITLE
Allow to build cargo-pgrx either with rustls (default) or native-tls

### DIFF
--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -38,7 +38,7 @@ prettyplease = "0.2.15"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
 regex = "1.10.0"
-ureq = "2.8.0"
+ureq = { version = "2.8.0", default-features = false, features = [ "gzip" ] }
 url = "2.4.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
@@ -62,5 +62,6 @@ bzip2 = "0.4.4"
 tar = "0.4.40"
 
 [features]
-default = ["ureq/native-tls"]
+default = ["rustls"]
+native-tls = ["ureq/native-tls"]
 rustls = ["ureq/tls"]


### PR DESCRIPTION
ureq defines `default = ["tls", "gzip"]`, so "tls" feature (rustls) is currently always enabled even when native-tls is preferred, i.e. both rustls and native-tls is built if openssl headers are available and the user cannot opt-out from using rustls. This also disallows building cargo-pgrx on platforms not supported by the ring crate (dependency of rustls).

This should also solve #1430 if `cargo-pgrx` is built with `--no-default-features --features native-tls`.

Supersedes #1442