### PR TITLE
Use native-certs with ureq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,6 +2923,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "rustls",
+ "rustls-native-certs",
  "rustls-webpki",
  "url",
  "webpki-roots",

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -64,4 +64,7 @@ tar = "0.4.40"
 [features]
 default = ["rustls"]
 native-tls = ["ureq/native-tls"]
-rustls = ["ureq/tls"]
+rustls = [
+    "ureq/tls",
+    "ureq/native-certs" # induces rustls to use the OS-level root of trust
+]


### PR DESCRIPTION
I at first had settled down to write up something using `rustls_native_certs` but then I actually noticed ureq simply enables this with a feature.

This should fully solve #1430 for both features now (rustls and native-tls).