### PR TITLE
Remove unused attrs on `Pg_magic_func`

### DIFF
--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -225,8 +225,6 @@ macro_rules! pg_magic_func {
     () => {
         #[no_mangle]
         #[allow(non_snake_case)]
-        #[allow(unused)]
-        #[link_name = "Pg_magic_func"]
         #[doc(hidden)]
         pub extern "C" fn Pg_magic_func() -> &'static ::pgrx::pg_sys::Pg_magic_struct {
             static MY_MAGIC: ::pgrx::pg_sys::Pg_magic_struct = ::pgrx::pg_sys::Pg_magic_struct {


### PR DESCRIPTION
- `allow(unused)` is redundant with `pub`
- `link_name` is redundant with `no_mangle`