### PR TITLE
Manually staticize lifetimes in pgrx tests

### DIFF
--- a/pgrx-examples/srf/src/lib.rs
+++ b/pgrx-examples/srf/src/lib.rs
@@ -33,15 +33,15 @@ fn random_values(num_rows: i32) -> TableIterator<'static, (name!(index, i32), na
 }
 
 #[pg_extern]
-fn result_table<'a>() -> Result<
-    Option<::pgrx::iter::TableIterator<'a, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+fn result_table() -> Result<
+    Option<::pgrx::iter::TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
     Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
 }
 
 #[pg_extern]
-fn one_col<'a>() -> TableIterator<'a, (name!(a, Option<i32>),)> {
+fn one_col() -> TableIterator<'static, (name!(a, Option<i32>),)> {
     TableIterator::new(std::iter::once((Some(42),)))
 }
 

--- a/pgrx-tests/src/tests/lifetime_tests.rs
+++ b/pgrx-tests/src/tests/lifetime_tests.rs
@@ -24,17 +24,17 @@ fn type_with_lifetime<'s>(_value: Option<CustomType<'s>>) {}
 fn type_ref_with_lifetime<'a>(_value: &'a str) {}
 
 #[pg_extern]
-fn returns_lifetime<'a>() -> Option<CustomType<'a>> {
+fn returns_lifetime() -> Option<CustomType<'static>> {
     None
 }
 
 #[pg_extern]
-fn returns_ref_with_lifetime<'a>() -> &'a str {
+fn returns_ref_with_lifetime() -> &'static str {
     ""
 }
 
 #[pg_extern]
-fn returns_option_ref_with_lifetime<'a>() -> Option<&'a str> {
+fn returns_option_ref_with_lifetime() -> Option<&'static str> {
     None
 }
 

--- a/pgrx-tests/src/tests/pg_extern_tests.rs
+++ b/pgrx-tests/src/tests/pg_extern_tests.rs
@@ -31,10 +31,10 @@ mod tests {
 
     // exists just to make sure the code compiles -- tickles the bug behind PR #807
     #[pg_extern]
-    fn returns_named_tuple_with_rust_reserved_keyword<'a>(/*
+    fn returns_named_tuple_with_rust_reserved_keyword(/*
                                  `type` is a reserved Rust keyword, but we still need to be able to parse it for SQL generation 
                                                         */
-    ) -> TableIterator<'a, (name!(type, String), name!(i, i32))> {
+    ) -> TableIterator<'static, (name!(type, String), name!(i, i32))> {
         unimplemented!()
     }
 

--- a/pgrx-tests/src/tests/srf_tests.rs
+++ b/pgrx-tests/src/tests/srf_tests.rs
@@ -94,63 +94,63 @@ fn split_table_with_borrow<'a>(
 }
 
 #[pg_extern]
-fn result_table_1<'a>() -> Result<
-    Option<::pgrx::iter::TableIterator<'a, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+fn result_table_1() -> Result<
+    Option<::pgrx::iter::TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
     Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
 }
 
 #[pg_extern]
-fn result_table_2<'a>() -> Result<
-    Option<pgrx::iter::TableIterator<'a, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+fn result_table_2() -> Result<
+    Option<pgrx::iter::TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
     Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
 }
 
 #[pg_extern]
-fn result_table_3<'a>() -> Result<
-    Option<TableIterator<'a, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+fn result_table_3() -> Result<
+    Option<TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
     Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
 }
 
 #[pg_extern]
-fn result_table_4_err<'a>() -> Result<
-    Option<TableIterator<'a, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+fn result_table_4_err() -> Result<
+    Option<TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
     Err("oh no")?
 }
 
 #[pg_extern]
-fn result_table_5_none<'a>() -> Result<
-    Option<TableIterator<'a, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+fn result_table_5_none() -> Result<
+    Option<TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
     Ok(None)
 }
 
 #[pg_extern]
-fn one_col<'a>() -> TableIterator<'a, (name!(a, i32),)> {
+fn one_col() -> TableIterator<'static, (name!(a, i32),)> {
     TableIterator::new(std::iter::once((42,)))
 }
 
 #[pg_extern]
-fn one_col_option<'a>() -> Option<TableIterator<'a, (name!(a, i32),)>> {
+fn one_col_option() -> Option<TableIterator<'static, (name!(a, i32),)>> {
     Some(TableIterator::new(std::iter::once((42,))))
 }
 
 #[pg_extern]
-fn one_col_result<'a>() -> Result<TableIterator<'a, (name!(a, i32),)>, Box<dyn std::error::Error>> {
+fn one_col_result() -> Result<TableIterator<'static, (name!(a, i32),)>, Box<dyn std::error::Error>> {
     Ok(TableIterator::new(std::iter::once((42,))))
 }
 
 #[pg_extern]
-fn one_col_result_option<'a>(
-) -> Result<Option<TableIterator<'a, (name!(a, i32),)>>, Box<dyn std::error::Error>> {
+fn one_col_result_option(
+) -> Result<Option<TableIterator<'static, (name!(a, i32),)>>, Box<dyn std::error::Error>> {
     Ok(Some(TableIterator::new(std::iter::once((42,)))))
 }
 

--- a/pgrx-tests/src/tests/srf_tests.rs
+++ b/pgrx-tests/src/tests/srf_tests.rs
@@ -144,7 +144,8 @@ fn one_col_option() -> Option<TableIterator<'static, (name!(a, i32),)>> {
 }
 
 #[pg_extern]
-fn one_col_result() -> Result<TableIterator<'static, (name!(a, i32),)>, Box<dyn std::error::Error>> {
+fn one_col_result() -> Result<TableIterator<'static, (name!(a, i32),)>, Box<dyn std::error::Error>>
+{
     Ok(TableIterator::new(std::iter::once((42,))))
 }
 


### PR DESCRIPTION
These all are actually lifetimes bound by their invocation site, which means that they return any lifetime which is named, instead of a lifetime that is bound by the input types in a logical way. This means that these lifetimes might as well be `'static`, for all it would (not) matter.

An important detail is that while this pattern is normally acceptable _and useful_ in Rust code, in pgrx it should be rejected for now because the lifetimes on the actually-called-by-Postgres function are defined, essentially, by a function _pointer_. These lifetimes cannot be coherently described to a function pointer. Thus, they form a sort of impedance mismatch: when you call this function from Rust code, you get a constraint that doesn't actually exist in the code that will run in Postgres. The difference is confusing, allowing you to write code relying on the compiler's lifetime checks and even fail to call it in certain ways, seemingly satisfying the soundness requirements. Then suddenly the assumption those compiler checks are founded on evaporates in the actual runtime execution, leading to undefined behavior.

I hope to fix a number of these problems relatively soon, but first thing's first: The removal of illusions. If this code is unsound now, then in truth it already was.

This effectively serves as a followup to https://github.com/pgcentralfoundation/pgrx/pull/1457 and it is part of what enables solving https://github.com/pgcentralfoundation/pgrx/issues/1383 by not requiring the pervasive use of that hack.