### PR TITLE
Demand lifetimes for `pgrx::composite_type!`

### DIFF
--- a/pgrx-examples/composite_type/src/lib.rs
+++ b/pgrx-examples/composite_type/src/lib.rs
@@ -93,7 +93,7 @@ CREATE FUNCTION create_dog(name TEXT, scritches INT) RETURNS Dog
 ```
 */
 #[pg_extern]
-fn create_dog(name: String, scritches: i32) -> pgrx::composite_type!(DOG_COMPOSITE_TYPE) {
+fn create_dog(name: String, scritches: i32) -> pgrx::composite_type!('static, DOG_COMPOSITE_TYPE) {
     let mut dog = PgHeapTuple::new_composite_type(DOG_COMPOSITE_TYPE).unwrap();
     dog.set_by_name("name", name).unwrap();
     dog.set_by_name("scritches", scritches).unwrap();
@@ -136,7 +136,7 @@ the function.
 fn make_friendship(
     dog: pgrx::composite_type!(DOG_COMPOSITE_TYPE),
     cat: pgrx::composite_type!(CAT_COMPOSITE_TYPE),
-) -> pgrx::composite_type!(CAT_AND_DOG_FRIENDSHIP_COMPOSITE_TYPE) {
+) -> pgrx::composite_type!('static, CAT_AND_DOG_FRIENDSHIP_COMPOSITE_TYPE) {
     let mut friendship =
         PgHeapTuple::new_composite_type(CAT_AND_DOG_FRIENDSHIP_COMPOSITE_TYPE).unwrap();
     friendship.set_by_name("dog", dog).unwrap();
@@ -167,7 +167,7 @@ struct SumScritches;
 impl Aggregate for SumScritches {
     type State = i32;
     const INITIAL_CONDITION: Option<&'static str> = Some("0");
-    type Args = pgrx::name!(value, pgrx::composite_type!("Dog"));
+    type Args = pgrx::name!(value, pgrx::composite_type!('static, "Dog"));
 
     fn state(
         current: Self::State,
@@ -202,7 +202,7 @@ struct ScritchCollector;
 
 #[pg_aggregate]
 impl Aggregate for ScritchCollector {
-    type State = Option<pgrx::composite_type!("Dog")>;
+    type State = Option<pgrx::composite_type!('static, "Dog")>;
     type Args = i32;
 
     fn state(

--- a/pgrx-tests/src/tests/composite_type_tests.rs
+++ b/pgrx-tests/src/tests/composite_type_tests.rs
@@ -9,7 +9,7 @@ extension_sql!(
 );
 
 #[pg_extern(requires = ["issue1293"])]
-fn create_result() -> pgrx::composite_type!("result") {
+fn create_result() -> pgrx::composite_type!('static, "result") {
     let mut record = PgHeapTuple::new_composite_type("result").unwrap();
     record.set_by_name("score", 0.707).unwrap();
     let mut entity_records: Vec<pgrx::composite_type!("entity")> = Vec::new();

--- a/pgrx-tests/src/tests/heap_tuple.rs
+++ b/pgrx-tests/src/tests/heap_tuple.rs
@@ -302,7 +302,7 @@ mod returning {
         use super::*;
 
         #[pg_extern]
-        fn create_dog(name: String, scritches: i32) -> pgrx::composite_type!("Dog") {
+        fn create_dog(name: String, scritches: i32) -> pgrx::composite_type!('static, "Dog") {
             let mut tuple = PgHeapTuple::new_composite_type("Dog").unwrap();
 
             tuple.set_by_name("scritches", scritches).unwrap();
@@ -409,24 +409,24 @@ mod sql_generator_tests {
     #[pg_extern]
     fn exotic_signature(
         _cats: pgrx::default!(
-            Option<Vec<Option<::pgrx::composite_type!("Cat")>>>,
+            Option<Vec<Option<::pgrx::composite_type!('static, "Cat")>>>,
             "ARRAY[ROW('Sally', 0)]::Cat[]"
         ),
         _a_single_fish: pgrx::default!(
-            Option<::pgrx::composite_type!("Fish")>,
+            Option<::pgrx::composite_type!('static, "Fish")>,
             "ROW('Bob', 0)::Fish"
         ),
         _dogs: pgrx::default!(
-            Option<::pgrx::VariadicArray<::pgrx::composite_type!("Dog")>>,
+            Option<::pgrx::VariadicArray<::pgrx::composite_type!('static, "Dog")>>,
             "ARRAY[ROW('Nami', 0), ROW('Brandy', 0)]::Dog[]"
         ),
     ) -> TableIterator<
         'static,
         (
-            name!(dog, Option<::pgrx::composite_type!("Dog")>),
-            name!(cat, Option<::pgrx::composite_type!("Cat")>),
-            name!(fish, Option<::pgrx::composite_type!("Fish")>),
-            name!(related_edges, Option<Vec<::pgrx::composite_type!("AnimalFriendshipEdge")>>),
+            name!(dog, Option<::pgrx::composite_type!('static, "Dog")>),
+            name!(cat, Option<::pgrx::composite_type!('static, "Cat")>),
+            name!(fish, Option<::pgrx::composite_type!('static, "Fish")>),
+            name!(related_edges, Option<Vec<::pgrx::composite_type!('static, "AnimalFriendshipEdge")>>),
         ),
     > {
         TableIterator::new(Vec::new().into_iter())
@@ -435,7 +435,7 @@ mod sql_generator_tests {
     #[pg_extern]
     fn iterable_named_table() -> TableIterator<
         'static,
-        (name!(dog, ::pgrx::composite_type!("Dog")), name!(cat, ::pgrx::composite_type!("Cat"))),
+        (name!(dog, ::pgrx::composite_type!('static, "Dog")), name!(cat, ::pgrx::composite_type!('static, "Cat"))),
     > {
         TableIterator::new(Vec::new().into_iter())
     }
@@ -444,8 +444,8 @@ mod sql_generator_tests {
     fn iterable_named_table_optional_elems() -> TableIterator<
         'static,
         (
-            name!(dog, Option<::pgrx::composite_type!("Dog")>),
-            name!(cat, Option<::pgrx::composite_type!("Cat")>),
+            name!(dog, Option<::pgrx::composite_type!('static, "Dog")>),
+            name!(cat, Option<::pgrx::composite_type!('static, "Cat")>),
         ),
     > {
         TableIterator::once(Default::default())
@@ -455,8 +455,8 @@ mod sql_generator_tests {
     fn iterable_named_table_array_elems() -> TableIterator<
         'static,
         (
-            name!(dog, Vec<::pgrx::composite_type!("Dog")>),
-            name!(cat, Vec<::pgrx::composite_type!("Cat")>),
+            name!(dog, Vec<::pgrx::composite_type!('static, "Dog")>),
+            name!(cat, Vec<::pgrx::composite_type!('static, "Cat")>),
         ),
     > {
         TableIterator::once(Default::default())
@@ -466,8 +466,8 @@ mod sql_generator_tests {
     fn iterable_named_table_optional_array_elems() -> TableIterator<
         'static,
         (
-            name!(dog, Option<Vec<::pgrx::composite_type!("Dog")>>),
-            name!(cat, Option<Vec<::pgrx::composite_type!("Cat")>>),
+            name!(dog, Option<Vec<::pgrx::composite_type!('static, "Dog")>>),
+            name!(cat, Option<Vec<::pgrx::composite_type!('static, "Cat")>>),
         ),
     > {
         TableIterator::once(Default::default())
@@ -477,8 +477,8 @@ mod sql_generator_tests {
     fn iterable_named_table_optional_array_optional_elems() -> TableIterator<
         'static,
         (
-            name!(dog, Option<Vec<Option<::pgrx::composite_type!("Dog")>>>),
-            name!(cat, Option<Vec<Option<::pgrx::composite_type!("Cat")>>>),
+            name!(dog, Option<Vec<Option<::pgrx::composite_type!('static, "Dog")>>>),
+            name!(cat, Option<Vec<Option<::pgrx::composite_type!('static, "Cat")>>>),
         ),
     > {
         TableIterator::once(Default::default())
@@ -486,7 +486,7 @@ mod sql_generator_tests {
 
     #[allow(unused_parens)]
     #[pg_extern]
-    fn return_table_single() -> TableIterator<'static, (name!(dog, pgrx::composite_type!("Dog")),)>
+    fn return_table_single() -> TableIterator<'static, (name!(dog, pgrx::composite_type!('static, "Dog")),)>
     {
         let mut tuple = PgHeapTuple::new_composite_type("Dog").unwrap();
 
@@ -498,7 +498,7 @@ mod sql_generator_tests {
 
     #[pg_extern]
     fn return_table_single_bare(
-    ) -> TableIterator<'static, (name!(dog, pgrx::composite_type!("Dog")),)> {
+    ) -> TableIterator<'static, (name!(dog, pgrx::composite_type!('static, "Dog")),)> {
         let mut tuple = PgHeapTuple::new_composite_type("Dog").unwrap();
 
         tuple.set_by_name("scritches", 0).unwrap();
@@ -510,7 +510,7 @@ mod sql_generator_tests {
     #[pg_extern]
     fn return_table_two() -> TableIterator<
         'static,
-        (name!(dog, pgrx::composite_type!("Dog")), name!(cat, pgrx::composite_type!("Cat"))),
+        (name!(dog, pgrx::composite_type!('static, "Dog")), name!(cat, pgrx::composite_type!('static, "Cat"))),
     > {
         let mut dog_tuple = PgHeapTuple::new_composite_type("Dog").unwrap();
 
@@ -529,8 +529,8 @@ mod sql_generator_tests {
     fn return_table_two_optional() -> TableIterator<
         'static,
         (
-            name!(dog, Option<pgrx::composite_type!("Dog")>),
-            name!(cat, Option<pgrx::composite_type!("Cat")>),
+            name!(dog, Option<pgrx::composite_type!('static, "Dog")>),
+            name!(cat, Option<pgrx::composite_type!('static, "Cat")>),
         ),
     > {
         TableIterator::once((None, None))
@@ -541,11 +541,11 @@ mod sql_generator_tests {
 
     #[pg_aggregate]
     impl Aggregate for AggregateWithOrderedSetArgs {
-        type Args = name!(input, pgrx::composite_type!("Dog"));
-        type State = pgrx::composite_type!("Dog");
-        type Finalize = pgrx::composite_type!("Dog");
+        type Args = name!(input, pgrx::composite_type!('static, "Dog"));
+        type State = pgrx::composite_type!('static, "Dog");
+        type Finalize = pgrx::composite_type!('static, "Dog");
         const ORDERED_SET: bool = true;
-        type OrderedSetArgs = name!(percentile, pgrx::composite_type!("Dog"));
+        type OrderedSetArgs = name!(percentile, pgrx::composite_type!('static, "Dog"));
 
         fn state(
             mut _current: Self::State,
@@ -569,9 +569,9 @@ mod sql_generator_tests {
 
     #[pg_aggregate]
     impl Aggregate for AggregateWithMovingState {
-        type Args = pgrx::composite_type!("Dog");
-        type State = pgrx::composite_type!("Dog");
-        type MovingState = pgrx::composite_type!("Dog");
+        type Args = pgrx::composite_type!('static, "Dog");
+        type State = pgrx::composite_type!('static, "Dog");
+        type MovingState = pgrx::composite_type!('static, "Dog");
 
         fn state(
             mut _current: Self::State,
@@ -607,7 +607,7 @@ mod sql_generator_tests {
     }
 
     #[pg_extern]
-    fn generate_lots_of_dogs() -> SetOfIterator<'static, pgrx::composite_type!("Dog")> {
+    fn generate_lots_of_dogs() -> SetOfIterator<'static, pgrx::composite_type!('static, "Dog")> {
         let tuple_desc =
             pgrx::PgTupleDesc::for_composite_type("Dog").expect("Couldn't find TestType");
 

--- a/pgrx-tests/src/tests/heap_tuple.rs
+++ b/pgrx-tests/src/tests/heap_tuple.rs
@@ -426,7 +426,10 @@ mod sql_generator_tests {
             name!(dog, Option<::pgrx::composite_type!('static, "Dog")>),
             name!(cat, Option<::pgrx::composite_type!('static, "Cat")>),
             name!(fish, Option<::pgrx::composite_type!('static, "Fish")>),
-            name!(related_edges, Option<Vec<::pgrx::composite_type!('static, "AnimalFriendshipEdge")>>),
+            name!(
+                related_edges,
+                Option<Vec<::pgrx::composite_type!('static, "AnimalFriendshipEdge")>>
+            ),
         ),
     > {
         TableIterator::new(Vec::new().into_iter())
@@ -435,7 +438,10 @@ mod sql_generator_tests {
     #[pg_extern]
     fn iterable_named_table() -> TableIterator<
         'static,
-        (name!(dog, ::pgrx::composite_type!('static, "Dog")), name!(cat, ::pgrx::composite_type!('static, "Cat"))),
+        (
+            name!(dog, ::pgrx::composite_type!('static, "Dog")),
+            name!(cat, ::pgrx::composite_type!('static, "Cat")),
+        ),
     > {
         TableIterator::new(Vec::new().into_iter())
     }
@@ -486,8 +492,8 @@ mod sql_generator_tests {
 
     #[allow(unused_parens)]
     #[pg_extern]
-    fn return_table_single() -> TableIterator<'static, (name!(dog, pgrx::composite_type!('static, "Dog")),)>
-    {
+    fn return_table_single(
+    ) -> TableIterator<'static, (name!(dog, pgrx::composite_type!('static, "Dog")),)> {
         let mut tuple = PgHeapTuple::new_composite_type("Dog").unwrap();
 
         tuple.set_by_name("scritches", 0).unwrap();
@@ -510,7 +516,10 @@ mod sql_generator_tests {
     #[pg_extern]
     fn return_table_two() -> TableIterator<
         'static,
-        (name!(dog, pgrx::composite_type!('static, "Dog")), name!(cat, pgrx::composite_type!('static, "Cat"))),
+        (
+            name!(dog, pgrx::composite_type!('static, "Dog")),
+            name!(cat, pgrx::composite_type!('static, "Cat")),
+        ),
     > {
         let mut dog_tuple = PgHeapTuple::new_composite_type("Dog").unwrap();
 

--- a/pgrx-tests/src/tests/pgrx_module_qualification.rs
+++ b/pgrx-tests/src/tests/pgrx_module_qualification.rs
@@ -72,7 +72,7 @@ mod pgrx_modqual_tests {
     }
 
     #[pg_extern]
-    fn foo_composite() -> ::pgrx::composite_type!("Foo") {
+    fn foo_composite() -> ::pgrx::composite_type!('static, "Foo") {
         todo!()
     }
 

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -684,7 +684,7 @@ macro_rules! composite_type {
         ::pgrx::heap_tuple::PgHeapTuple<$lt, ::pgrx::AllocatedByRust>
     };
     ($composite_type:expr) => {
-        ::pgrx::heap_tuple::PgHeapTuple<'static, ::pgrx::AllocatedByRust>
+        ::pgrx::heap_tuple::PgHeapTuple<'_, ::pgrx::AllocatedByRust>
     };
 }
 

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -631,7 +631,7 @@ LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'scritch_wrapper';
 ```
 
-It's possibly to use `composite_type!()` inside a `default!()` macro:
+It's possible to use `composite_type!()` inside a `default!()` macro:
 
 ```rust
 use pgrx::{prelude::*, AllocatedByRust};


### PR DESCRIPTION
The `pgrx::composite_type!` macro currently assigns the `'static` lifetime if you do not give one. This is a decision of dubious soundness. Instead, demand a lifetime, or assign the anonymous lifetime. Both cases match the behavior of attempting to elide lifetimes in your usual Rust code, though with slightly worse error messages in some cases. This may require people to write `'static` in more places (and that is what the typical error suggests), but it allows noticing and fixing problems that currently are not visible, easy to understand, or easy to check.

This is the latest in this series:
- https://github.com/pgcentralfoundation/pgrx/issues/1383
- https://github.com/pgcentralfoundation/pgrx/pull/1457
- https://github.com/pgcentralfoundation/pgrx/pull/1461