### PR TITLE
Use `composite_type!` lifetimes in pgrx-sql-entity-graph

### DIFF
--- a/pgrx-sql-entity-graph/src/composite_type.rs
+++ b/pgrx-sql-entity-graph/src/composite_type.rs
@@ -1,3 +1,7 @@
+/// Innards of a `composite_type!`
+///
+/// For SQL generation and further expansion.
+/// Use this so you don't drop the span on the floor.
 #[derive(Debug, Clone)]
 pub struct CompositeTypeMacro {
     #[allow(dead_code)]
@@ -16,13 +20,14 @@ impl syn::parse::Parse for CompositeTypeMacro {
     }
 }
 
+/// Take a `composite_type!` from a macro
 pub fn handle_composite_type_macro(mac: &syn::Macro) -> syn::Result<CompositeTypeMacro> {
     let out: CompositeTypeMacro = mac.parse_body()?;
     Ok(out)
 }
 
 impl CompositeTypeMacro {
-    /// Expands into the appropriate type, explicitly eliding the lifetime
+    /// Expands into the implementing type, explicitly eliding the lifetime
     /// if none is actually given.
     pub fn expand_with_lifetime(&self) -> syn::Type {
         let CompositeTypeMacro { lifetime, span, .. } = self.clone();

--- a/pgrx-sql-entity-graph/src/composite_type.rs
+++ b/pgrx-sql-entity-graph/src/composite_type.rs
@@ -4,7 +4,6 @@
 /// Use this so you don't drop the span on the floor.
 #[derive(Debug, Clone)]
 pub struct CompositeTypeMacro {
-    #[allow(dead_code)]
     pub(crate) lifetime: Option<syn::Lifetime>,
     pub(crate) expr: syn::Expr,
     pub(crate) span: proc_macro2::Span,

--- a/pgrx-sql-entity-graph/src/composite_type.rs
+++ b/pgrx-sql-entity-graph/src/composite_type.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, Clone)]
+pub struct CompositeTypeMacro {
+    #[allow(dead_code)]
+    pub(crate) lifetime: Option<syn::Lifetime>,
+    pub(crate) expr: syn::Expr,
+}
+
+impl syn::parse::Parse for CompositeTypeMacro {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self, syn::Error> {
+        let lifetime: Option<syn::Lifetime> = input.parse().ok();
+        let _comma: Option<syn::Token![,]> = input.parse().ok();
+        let expr = input.parse()?;
+        Ok(Self { lifetime, expr })
+    }
+}
+
+pub fn handle_composite_type_macro(mac: &syn::Macro) -> syn::Result<CompositeTypeMacro> {
+    let out: CompositeTypeMacro = mac.parse_body()?;
+    Ok(out)
+}
+
+impl CompositeTypeMacro {
+    /// Expands into the appropriate type, explicitly eliding the lifetime
+    /// if none is actually given.
+    pub fn expand_with_lifetime(&self) -> syn::Type {
+        let CompositeTypeMacro { lifetime, .. } = self;
+        let lifetime = lifetime.clone().unwrap_or_else(|| syn::Lifetime::new("'_", proc_macro2::Span::call_site()));
+        syn::parse_quote! {
+            ::pgrx::heap_tuple::PgHeapTuple<#lifetime, ::pgrx::pgbox::AllocatedByRust>
+        }
+    }
+}

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -52,6 +52,7 @@ pub use used_type::{UsedType, UsedTypeEntity};
 
 pub(crate) mod aggregate;
 pub(crate) mod control_file;
+pub(crate) mod composite_type;
 pub(crate) mod enrich;
 pub(crate) mod extension_sql;
 pub(crate) mod extern_args;

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -51,8 +51,8 @@ pub use to_sql::{ToSql, ToSqlConfig};
 pub use used_type::{UsedType, UsedTypeEntity};
 
 pub(crate) mod aggregate;
-pub(crate) mod control_file;
 pub(crate) mod composite_type;
+pub(crate) mod control_file;
 pub(crate) mod enrich;
 pub(crate) mod extension_sql;
 pub(crate) mod extern_args;

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -382,9 +382,11 @@ fn resolve_vec_inner(
                             Err(syn::Error::new(mac.span(), "`Vec<default!(T, default)>` not supported, choose `default!(Vec<T>, ident)` instead"))
                         }
                         "composite_type" => {
-                            let sql = Some(handle_composite_type_macro(mac)?);
+                            let composite_mac = handle_composite_type_macro(mac)?;
+                            let comp_ty = composite_mac.expand_with_lifetime();
+                            let sql = Some(composite_mac);
                             let ty = syn::parse_quote! {
-                                Vec<::pgrx::heap_tuple::PgHeapTuple<'static, ::pgrx::pgbox::AllocatedByRust>>
+                                Vec<#comp_ty>
                             };
                             Ok((ty, sql))
                         }
@@ -443,9 +445,11 @@ fn resolve_variadic_array_inner(
                                 Err(syn::Error::new(mac.span(), "`VariadicArray<default!(T, default)>` not supported, choose `default!(VariadicArray<T>, ident)` instead"))
                             }
                             "composite_type" => {
-                                let sql = Some(handle_composite_type_macro(mac)?);
+                                let composite_mac = handle_composite_type_macro(mac)?;
+                                let comp_ty = composite_mac.expand_with_lifetime();
+                                let sql = Some(composite_mac);
                                 let ty = syn::parse_quote! {
-                                    ::pgrx::datum::VariadicArray<'static, ::pgrx::heap_tuple::PgHeapTuple<'static, ::pgrx::pgbox::AllocatedByRust>>
+                                    ::pgrx::datum::VariadicArray<'static, #comp_ty>
                                 };
                                 Ok((ty, sql))
                             }
@@ -504,9 +508,11 @@ fn resolve_array_inner(
                                 Err(syn::Error::new(mac.span(), "`VariadicArray<default!(T, default)>` not supported, choose `default!(VariadicArray<T>, ident)` instead"))
                             }
                             "composite_type" => {
-                                let sql = Some(handle_composite_type_macro(mac)?);
+                                let composite_mac = handle_composite_type_macro(mac)?;
+                                let comp_ty = composite_mac.expand_with_lifetime();
+                                let sql = Some(composite_mac);
                                 let ty = syn::parse_quote! {
-                                    ::pgrx::datum::Array<'static, ::pgrx::heap_tuple::PgHeapTuple<'static, ::pgrx::pgbox::AllocatedByRust>>
+                                    ::pgrx::datum::Array<'static, #comp_ty>
                                 };
                                 Ok((ty, sql))
                             }
@@ -557,9 +563,11 @@ fn resolve_option_inner(
                         match archetype.ident.to_string().as_str() {
                             // Option<composite_type!(..)>
                             "composite_type" => {
-                                let sql = Some(handle_composite_type_macro(mac)?);
+                                let composite_mac = handle_composite_type_macro(mac)?;
+                                let comp_ty = composite_mac.expand_with_lifetime();
+                                let sql = Some(composite_mac);
                                 let ty = syn::parse_quote! {
-                                    Option<::pgrx::heap_tuple::PgHeapTuple<'static, ::pgrx::pgbox::AllocatedByRust>>
+                                    Option<#comp_ty>
                                 };
                                 Ok((ty, sql))
                             },

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -17,6 +17,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 */
 use std::ops::Deref;
 
+use crate::composite_type::{CompositeTypeMacro, handle_composite_type_macro};
 use crate::lifetimes::staticize_lifetimes;
 use proc_macro2::Span;
 use quote::ToTokens;
@@ -613,11 +614,6 @@ fn resolve_option_inner(
     }
 }
 
-fn handle_composite_type_macro(mac: &syn::Macro) -> syn::Result<CompositeTypeMacro> {
-    let out: CompositeTypeMacro = mac.parse_body()?;
-    Ok(out)
-}
-
 fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<String>)> {
     let out: DefaultMacro = mac.parse_body()?;
     let true_ty = out.ty;
@@ -703,21 +699,5 @@ impl Parse for DefaultMacro {
         let _comma: Token![,] = input.parse()?;
         let expr = input.parse()?;
         Ok(Self { ty, expr })
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct CompositeTypeMacro {
-    #[allow(dead_code)]
-    pub(crate) lifetime: Option<syn::Lifetime>,
-    pub(crate) expr: syn::Expr,
-}
-
-impl Parse for CompositeTypeMacro {
-    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        let lifetime: Option<syn::Lifetime> = input.parse().ok();
-        let _comma: Option<Token![,]> = input.parse().ok();
-        let expr = input.parse()?;
-        Ok(Self { lifetime, expr })
     }
 }

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -17,7 +17,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 */
 use std::ops::Deref;
 
-use crate::composite_type::{CompositeTypeMacro, handle_composite_type_macro};
+use crate::composite_type::{handle_composite_type_macro, CompositeTypeMacro};
 use crate::lifetimes::staticize_lifetimes;
 use proc_macro2::Span;
 use quote::ToTokens;


### PR DESCRIPTION
I was working on fixing the auto-staticizing lifetime issues and noticed this likely would be landable on its own. This moves out `struct CompositeTypeMacro` into its own file and starts to actually modularize the code around it a little, to start actually preserving the lifetimes in their usage during macro expansion. Because we need to also generate wrapping types, it doesn't count as much of a cleanup on its own, but that's why I'm landing it separately.