### PR TITLE
Remove `impl Display for pg_sys::Oid`

### DIFF
--- a/pgrx-pg-sys/src/submodules/oids.rs
+++ b/pgrx-pg-sys/src/submodules/oids.rs
@@ -87,18 +87,6 @@ impl Default for Oid {
     }
 }
 
-impl fmt::Display for Oid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match PgOid::from(*self) {
-            PgOid::Invalid => write!(f, "oid={{#0, Invalid OID}}"),
-            // if we think we know the name, include it
-            PgOid::BuiltIn(builtin) => write!(f, "oid={{#{}, builtin: {:?}}}", self.0, builtin),
-            // no idea? print it anyways!
-            PgOid::Custom(oid) => write!(f, "oid=#{}", oid.0),
-        }
-    }
-}
-
 /// De facto available via SPI
 impl From<u32> for Oid {
     fn from(word: u32) -> Oid {

--- a/pgrx-pg-sys/src/submodules/oids.rs
+++ b/pgrx-pg-sys/src/submodules/oids.rs
@@ -11,7 +11,6 @@
 use crate as pg_sys;
 use crate::BuiltinOid;
 use crate::Datum;
-use core::fmt;
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };

--- a/pgrx-tests/src/tests/from_into_datum_tests.rs
+++ b/pgrx-tests/src/tests/from_into_datum_tests.rs
@@ -27,7 +27,7 @@ mod tests {
             )
         };
         assert!(result.is_err());
-        assert_eq!("Postgres type boolean oid={#16, builtin: BOOLOID} is not compatible with the Rust type alloc::string::String oid={#25, builtin: TEXTOID}", result.unwrap_err().to_string());
+        assert_eq!("Postgres type boolean (Oid(16)) is not compatible with the Rust type alloc::string::String (Oid(25))", result.unwrap_err().to_string());
     }
 
     #[pg_extern]

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -18,7 +18,7 @@ use std::num::NonZeroUsize;
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum TryFromDatumError {
-    #[error("Postgres type {datum_type} oid#{datum_oid:?} is not compatible with the Rust type {rust_type} oid#{rust_oid:?}")]
+    #[error("Postgres type {datum_type} ({datum_oid:?}) is not compatible with the Rust type {rust_type} ({rust_oid:?})")]
     IncompatibleTypes {
         rust_type: &'static str,
         rust_oid: pg_sys::Oid,

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -18,7 +18,7 @@ use std::num::NonZeroUsize;
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum TryFromDatumError {
-    #[error("Postgres type {datum_type} {datum_oid} is not compatible with the Rust type {rust_type} {rust_oid}")]
+    #[error("Postgres type {datum_type} oid#{datum_oid:?} is not compatible with the Rust type {rust_type} oid#{rust_oid:?}")]
     IncompatibleTypes {
         rust_type: &'static str,
         rust_oid: pg_sys::Oid,

--- a/pgrx/src/fn_call.rs
+++ b/pgrx/src/fn_call.rs
@@ -81,7 +81,7 @@ pub enum FnCallError {
     #[error("Functions with argument or return types of `internal` are not supported")]
     InternalTypeNotSupported,
 
-    #[error("The requested return type `{0}` is not compatible with the actual return type `{1}`")]
+    #[error("The requested return type OID `{0:?}` is not compatible with the actual return type OID `{1:?}`")]
     IncompatibleReturnType(pg_sys::Oid, pg_sys::Oid),
 
     #[error("Function call has more arguments than are supported")]

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -33,10 +33,10 @@ pub enum PgHeapTupleError {
     #[error("The specified composite type, {0}, does not exist")]
     NoSuchType(String),
 
-    #[error("The specified composite type, {0}, does not exist")]
+    #[error("The specified composite type, {0:?}, does not exist")]
     NoSuchTypeOid(pg_sys::Oid),
 
-    #[error("Oid `{0}` is not a composite type")]
+    #[error("Oid `{0:?}` is not a composite type")]
     NotACompositeType(pg_sys::Oid),
 }
 
@@ -169,7 +169,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByPostgres> {
         }
     }
 
-    /// Consumes a `[PgHeapTuple]` considered to be allocated by Postgres and transforms it into one
+    /// Consumes a [`PgHeapTuple`] considered to be allocated by Postgres and transforms it into one
     /// that is considered allocated by Rust.  This is accomplished by copying the underlying [pg_sys::HeapTupleData].
     pub fn into_owned(self) -> PgHeapTuple<'a, AllocatedByRust> {
         let copy = unsafe { pg_sys::heap_copytuple(self.tuple.into_pg()) };
@@ -244,7 +244,7 @@ impl<'a> PgHeapTuple<'a, AllocatedByRust> {
         .execute()
     }
 
-    /// Create a new [PgHeapTuple] from a [PgTupleDesc] from an iterator of Datums.
+    /// Create a new [PgHeapTuple] from a [PgTupleDesc] and an iterator of Datums.
     ///
     /// ## Errors
     /// - [PgHeapTupleError::IncorrectAttributeCount] if the number of items in the iterator


### PR DESCRIPTION
In conversations with @eeeebbbbrrrr, this proved confusing, so yeet it. It was only really there for error messages, so fix the error messaging sites instead.