### PR TITLE
Allow `detail` argument and trailing commas in `ereport!`

### DIFF
--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -336,77 +336,84 @@ macro_rules! function_name {
 /// ```
 #[macro_export]
 macro_rules! ereport {
-    (ERROR, $errcode:expr, $message:expr) => {
+    (ERROR, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::ERROR);
         unreachable!();
     };
 
-    (PANIC, $errcode:expr, $message:expr) => {
+    (PANIC, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::PANIC);
         unreachable!();
     };
 
-    (FATAL, $errcode:expr, $message:expr) => {
+    (FATAL, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::FATAL);
         unreachable!();
     };
 
-    (WARNING, $errcode:expr, $message:expr) => {
+    (WARNING, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::WARNING)
     };
 
-    (NOTICE, $errcode:expr, $message:expr) => {
+    (NOTICE, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::NOTICE)
     };
 
-    (INFO, $errcode:expr, $message:expr) => {
+    (INFO, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::INFO)
     };
 
-    (LOG, $errcode:expr, $message:expr) => {
+    (LOG, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::LOG)
     };
 
-    (DEBUG5, $errcode:expr, $message:expr) => {
+    (DEBUG5, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG5)
     };
 
-    (DEBUG4, $errcode:expr, $message:expr) => {
+    (DEBUG4, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG4)
     };
 
-    (DEBUG3, $errcode:expr, $message:expr) => {
+    (DEBUG3, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG3)
     };
 
-    (DEBUG2, $errcode:expr, $message:expr) => {
+    (DEBUG2, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG2)
     };
 
-    (DEBUG1, $errcode:expr, $message:expr) => {
+    (DEBUG1, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG1)
     };
 
-    ($loglevel:expr, $errcode:expr, $message:expr) => {
+    ($loglevel:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .report($loglevel);
-    };
-
-    ($loglevel:expr, $errcode:expr, $message:expr, $detail:expr) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_detail($detail)
+            $(.set_detail($detail))?
             .report($loglevel);
     };
 }


### PR DESCRIPTION
I use `ereport!` because I like to include a `detail` entry but it comes with some inconveniences. When I would write the following snippet in my `Err` match arms, compiler would complain about mismatch types being output from the match arms thus requiring the inclusion of `unreachable!` in my code.

```rust
pgrx::ereport!(
    PgLogLevel::ERROR,
    PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
    format!("{} failed", stringify!(snowflake_pool_stats)),
    err.to_string()
);

// necessary to satisfy the compiler
unreachable!()
```

After looking at the macro src for `ereport!` I realized why I started writing `PgLogLevel::ERROR` rather than simply `ERROR`; the `ERROR` case didn't support a `detail` argument.

Going forward, I would like to use the dedicated macros for the common use cases of logging/aborting so hopefully someone will find these proposed changes to be a worthwhile improvement.