### PR TITLE
Alternative input syntax for `elog` macros

### DIFF
--- a/pgrx-pg-sys/src/lib.rs
+++ b/pgrx-pg-sys/src/lib.rs
@@ -32,6 +32,15 @@ mod node;
 mod port;
 pub mod submodules;
 
+// Due to the way the `ereport` macros are defined, we need to use a duplicate of `ereport` for internal use... :(
+//
+// ## Compiler Error Message
+//
+// macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+// this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+// for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
+pub(crate) use submodules::elog::internal_ereport;
+
 #[cfg(feature = "cshim")]
 pub use cshim::*;
 

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -103,6 +103,36 @@ impl From<i32> for PgLogLevel {
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG5` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// debug5!("a simple message");
+/// debug5!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// debug5! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// debug5! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// debug5! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! debug5 {
     (
@@ -136,6 +166,36 @@ macro_rules! debug5 {
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG4` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// debug4!("a simple message");
+/// debug4!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// debug4! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// debug4! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// debug4! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! debug4 {
     (
@@ -169,6 +229,36 @@ macro_rules! debug4 {
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG3` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// debug3!("a simple message");
+/// debug3!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// debug3! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// debug3! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// debug3! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! debug3 {
     (
@@ -202,6 +292,36 @@ macro_rules! debug3 {
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG2` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// debug2!("a simple message");
+/// debug2!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// debug2! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// debug2! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// debug2! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! debug2 {
     (
@@ -235,6 +355,36 @@ macro_rules! debug2 {
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG1` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// debug1!("a simple message");
+/// debug1!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// debug1! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// debug1! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// debug1! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! debug1 {
     (
@@ -268,6 +418,36 @@ macro_rules! debug1 {
 ///
 /// The output these logs goes to the PostgreSQL log file at `LOG` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// log!("a simple message");
+/// log!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// log! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// log! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// log! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! log {
     (
@@ -298,6 +478,36 @@ macro_rules! log {
 ///
 /// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// info!("a simple message");
+/// info!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// info! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// info! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// info! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! info {
     (
@@ -328,6 +538,36 @@ macro_rules! info {
 ///
 /// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// notice!("a simple message");
+/// notice!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// notice! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// notice! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// notice! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! notice {
     (
@@ -358,6 +598,36 @@ macro_rules! notice {
 ///
 /// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// warning!("a simple message");
+/// warning!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// warning! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// warning! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// warning! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! warning {
     (
@@ -388,6 +658,36 @@ macro_rules! warning {
 ///
 /// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// error!("a simple message");
+/// error!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// error! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// error! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// error! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[macro_export]
 macro_rules! error {
     (
@@ -420,6 +720,36 @@ macro_rules! error {
 ///
 /// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// FATAL!("a simple message");
+/// FATAL!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// FATAL! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// FATAL! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// FATAL! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! FATAL {
@@ -453,6 +783,36 @@ macro_rules! FATAL {
 ///
 /// This macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
+///
+/// ## Adding Details and Hints
+///
+/// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
+/// After the string literal to be used as the message and any formatting arguments, add a semicolon.
+/// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
+/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
+/// separately but `detail` must come before `hint` and both must end with a semicolon.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// // just like `println!` and `format!`
+/// PANIC!("a simple message");
+/// PANIC!("or a formatted message: {:?}", "pgrx rocks!");
+/// // include details and hints
+/// PANIC! {
+///     "add details if you want";
+///     detail = "...";
+/// }
+/// PANIC! {
+///     "or a message with just a hint";
+///     hint = "...";
+/// }
+/// PANIC! {
+///     "put it all together for {} {}", "great", "success!";
+///     detail = "extra {}", "info";
+///     hint = "{} helpful", "very";
+/// }
+/// ```
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! PANIC {
@@ -508,11 +868,14 @@ macro_rules! function_name {
 /// This macro is necessary when one needs to supply a specific SQL error code as part of their
 /// error message.
 ///
+/// ## Simple Usage
+///
 /// The argument order is:
 /// - `log_level: [PgLogLevel]`
 /// - `error_code: [PgSqlErrorCode]`
 /// - `message: String`
 /// - (optional) `detail: String`
+/// - (optional) `hint: String`
 ///
 /// ## Examples
 ///
@@ -529,6 +892,47 @@ macro_rules! function_name {
 /// # use pgrx_pg_sys::errcodes::PgSqlErrorCode;
 /// ereport!(PgLogLevel::LOG, PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, "this is just a message"); // log output only
 /// ```
+///
+/// ## Alternative Usage
+///
+/// Use this invocation style if you need to include a hint but not a detail. This syntax does not prohibit
+/// the use of a detail, but because the simple usage takes it's arguments by position, it isn't possible to
+/// use that syntax and include a hint without a detail.
+///
+/// The argument order is for the first three arguments is the same as the simple usage:
+/// - `log_level: [PgLogLevel]`
+/// - `error_code: [PgSqlErrorCode]`
+/// - `message: String`
+///
+/// After the message, include a semicolon and then assign an expression resulting in a String to `detail` or `hint`.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use pgrx_pg_sys::ereport;
+/// # use pgrx_pg_sys::elog::PgLogLevel;
+/// # use pgrx_pg_sys::errcodes::PgSqlErrorCode;
+/// // abort the transaction
+/// ereport! {
+///     PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, "oh noes!";
+///     hint = "check earlier logs for more info";
+/// }
+/// ```
+///
+/// ```rust,no_run
+/// # use pgrx_pg_sys::ereport;
+/// # use pgrx_pg_sys::elog::PgLogLevel;
+/// # use pgrx_pg_sys::errcodes::PgSqlErrorCode;
+/// ereport! {
+///     PgLogLevel::LOG, PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, "this is just a message";
+///     detail = "but wait, there's more!";
+///     hint = "there are easier macros to log simple messages like this...";
+/// }
+/// ```
+///
+/// > _**NOTE**: the message/detail/hint arguments don't actually need to result in an owned `String`.
+/// > The trait bounds for the underlying functions are `Into<String>`, so any type that implements
+/// `Into<String>` will work too._
 #[macro_export]
 macro_rules! ereport {
     (ERROR, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -109,8 +109,7 @@ impl From<i32> for PgLogLevel {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -140,16 +139,64 @@ macro_rules! debug5 {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::DEBUG5,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG5,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG5,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG5,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -174,8 +221,7 @@ macro_rules! debug5 {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -205,16 +251,64 @@ macro_rules! debug4 {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::DEBUG4,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG4,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG4,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG4,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -239,8 +333,7 @@ macro_rules! debug4 {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -270,16 +363,64 @@ macro_rules! debug3 {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::DEBUG3,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG3,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG3,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG3,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -304,8 +445,7 @@ macro_rules! debug3 {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -335,16 +475,64 @@ macro_rules! debug2 {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::DEBUG2,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG2,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG2,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG2,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -369,8 +557,7 @@ macro_rules! debug2 {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -400,16 +587,64 @@ macro_rules! debug1 {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::DEBUG1,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG1,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG1,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG1,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -434,8 +669,7 @@ macro_rules! debug1 {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -465,16 +699,64 @@ macro_rules! log {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::LOG,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::LOG,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::LOG,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::LOG,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -496,8 +778,7 @@ macro_rules! log {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -527,16 +808,64 @@ macro_rules! info {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::INFO,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::INFO,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::INFO,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::INFO,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -558,8 +887,7 @@ macro_rules! info {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -589,16 +917,64 @@ macro_rules! notice {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::NOTICE,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::NOTICE,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::NOTICE,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::NOTICE,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -620,8 +996,7 @@ macro_rules! notice {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -651,16 +1026,64 @@ macro_rules! warning {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::WARNING,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::WARNING,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::WARNING,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::WARNING,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
         }
     );
@@ -682,8 +1105,7 @@ macro_rules! warning {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -713,16 +1135,67 @@ macro_rules! error {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::ERROR,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::ERROR,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::ERROR,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::ERROR,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
             unreachable!()
         }
@@ -746,8 +1219,7 @@ macro_rules! error {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -778,16 +1250,67 @@ macro_rules! FATAL {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::FATAL,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::FATAL,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::FATAL,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::FATAL,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
             unreachable!()
         }
@@ -811,8 +1334,7 @@ macro_rules! FATAL {
 /// Additionally, you can use specify a `detail` and/or `hint` to be included with the report.
 /// After the string literal to be used as the message and any formatting arguments, add a semicolon.
 /// Then assign a string literal to `detail` or `hint`, optionally followed by a list of
-/// comma separated formatting arguments. The `detail` and `hint` options can be used together or
-/// separately but `detail` must come before `hint` and both must end with a semicolon.
+/// comma separated formatting arguments.
 ///
 /// ## Examples
 ///
@@ -843,16 +1365,67 @@ macro_rules! PANIC {
     (
         $msg:literal $(, $msg_args:expr)*;
         $(detail = $detail:literal $(, $detail_args:expr)*)?;
-        $(hint = $hint:literal $(, $hint_args:expr)*)?;
     ) => (
         {
+            extern crate core;
             extern crate alloc;
             $crate::ereport!(
                 $crate::elog::PgLogLevel::PANIC,
                 $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
-                alloc::format!($msg $(, $msg_args)*).as_str();
-                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
-                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::PANIC,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::PANIC,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
+            );
+            unreachable!()
+        }
+    );
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate core;
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::PANIC,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!("{}", core::format_args!($msg $(, $msg_args)*));
+                $(detail = alloc::format!("{}", core::format_args!($detail $(, $detail_args)*));)?
+                $(hint = alloc::format!("{}", core::format_args!($hint $(, $hint_args)*));)?
             );
             unreachable!()
         }
@@ -1083,6 +1656,17 @@ macro_rules! ereport {
     ) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_detail($detail)
+            .report($loglevel);
+    };
+
+    (
+        $loglevel:expr, $errcode:expr, $message:expr;
+        hint = $hint:expr;
+        detail = $detail:expr;
+    ) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_detail($detail)
+            .set_hint($hint)
             .report($loglevel);
     };
 

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -115,6 +115,8 @@ impl From<i32> for PgLogLevel {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::debug5;
+///
 /// // just like `println!` and `format!`
 /// debug5!("a simple message");
 /// debug5!("or a formatted message: {:?}", "pgrx rocks!");
@@ -178,6 +180,8 @@ macro_rules! debug5 {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::debug4;
+///
 /// // just like `println!` and `format!`
 /// debug4!("a simple message");
 /// debug4!("or a formatted message: {:?}", "pgrx rocks!");
@@ -241,6 +245,8 @@ macro_rules! debug4 {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::debug3;
+///
 /// // just like `println!` and `format!`
 /// debug3!("a simple message");
 /// debug3!("or a formatted message: {:?}", "pgrx rocks!");
@@ -304,6 +310,8 @@ macro_rules! debug3 {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::debug2;
+///
 /// // just like `println!` and `format!`
 /// debug2!("a simple message");
 /// debug2!("or a formatted message: {:?}", "pgrx rocks!");
@@ -367,6 +375,8 @@ macro_rules! debug2 {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::debug1;
+///
 /// // just like `println!` and `format!`
 /// debug1!("a simple message");
 /// debug1!("or a formatted message: {:?}", "pgrx rocks!");
@@ -430,6 +440,8 @@ macro_rules! debug1 {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::log;
+///
 /// // just like `println!` and `format!`
 /// log!("a simple message");
 /// log!("or a formatted message: {:?}", "pgrx rocks!");
@@ -490,6 +502,8 @@ macro_rules! log {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::info;
+///
 /// // just like `println!` and `format!`
 /// info!("a simple message");
 /// info!("or a formatted message: {:?}", "pgrx rocks!");
@@ -550,6 +564,8 @@ macro_rules! info {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::notice;
+///
 /// // just like `println!` and `format!`
 /// notice!("a simple message");
 /// notice!("or a formatted message: {:?}", "pgrx rocks!");
@@ -610,6 +626,8 @@ macro_rules! notice {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::warning;
+///
 /// // just like `println!` and `format!`
 /// warning!("a simple message");
 /// warning!("or a formatted message: {:?}", "pgrx rocks!");
@@ -670,6 +688,8 @@ macro_rules! warning {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::error;
+///
 /// // just like `println!` and `format!`
 /// error!("a simple message");
 /// error!("or a formatted message: {:?}", "pgrx rocks!");
@@ -732,6 +752,8 @@ macro_rules! error {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::FATAL;
+///
 /// // just like `println!` and `format!`
 /// FATAL!("a simple message");
 /// FATAL!("or a formatted message: {:?}", "pgrx rocks!");
@@ -795,6 +817,8 @@ macro_rules! FATAL {
 /// ## Examples
 ///
 /// ```rust,no_run
+/// use pgrx_pg_sys::PANIC;
+///
 /// // just like `println!` and `format!`
 /// PANIC!("a simple message");
 /// PANIC!("or a formatted message: {:?}", "pgrx rocks!");

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -105,12 +105,28 @@ impl From<i32> for PgLogLevel {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug5 {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG5,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `debug4` log level.
@@ -122,12 +138,28 @@ macro_rules! debug5 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug4 {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG4,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `debug3` log level.
@@ -139,12 +171,28 @@ macro_rules! debug4 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug3 {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG3,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `debug2` log level.
@@ -156,12 +204,28 @@ macro_rules! debug3 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug2 {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG2,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `debug1` log level.
@@ -173,12 +237,28 @@ macro_rules! debug2 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug1 {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::DEBUG1,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `log` log level.
@@ -190,12 +270,28 @@ macro_rules! debug1 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! log {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::LOG,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::LOG, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `info` log level.
@@ -204,12 +300,28 @@ macro_rules! log {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! info {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::INFO,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::INFO, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `notice` log level.
@@ -218,12 +330,28 @@ macro_rules! info {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! notice {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::NOTICE,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `warning` log level.
@@ -232,12 +360,28 @@ macro_rules! notice {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! warning {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::WARNING,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::WARNING, $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING, alloc::format!($($arg)*).as_str());
         }
-    )
+    );
 }
 
 /// Log to Postgres' `error` log level.  This will abort the current Postgres transaction.
@@ -246,6 +390,23 @@ macro_rules! warning {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! error {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::ERROR,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+            unreachable!()
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
@@ -262,13 +423,30 @@ macro_rules! error {
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! FATAL {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::FATAL,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+            unreachable!()
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::FATAL, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
             unreachable!()
         }
-    )
+    );
 }
 
 /// Log to Postgres' `panic` log level.  This will cause the entire Postgres cluster to crash.
@@ -278,13 +456,30 @@ macro_rules! FATAL {
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! PANIC {
+    (
+        $msg:literal $(, $msg_args:expr)*;
+        $(detail = $detail:literal $(, $detail_args:expr)*)?;
+        $(hint = $hint:literal $(, $hint_args:expr)*)?;
+    ) => (
+        {
+            extern crate alloc;
+            $crate::ereport!(
+                $crate::elog::PgLogLevel::PANIC,
+                $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                alloc::format!($msg $(, $msg_args)*).as_str();
+                $(detail = alloc::format!($detail $(, $detail_args)*).as_str();)?
+                $(hint = alloc::format!($hint $(, $hint_args)*).as_str();)?
+            );
+            unreachable!()
+        }
+    );
     ($($arg:tt)*) => (
         {
             extern crate alloc;
             $crate::ereport!($crate::elog::PgLogLevel::PANIC, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
             unreachable!()
         }
-    )
+    );
 }
 
 // shamelessly borrowed from https://docs.rs/stdext/0.2.1/src/stdext/macros.rs.html#61-72
@@ -336,84 +531,161 @@ macro_rules! function_name {
 /// ```
 #[macro_export]
 macro_rules! ereport {
-    (ERROR, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::ERROR);
+    (ERROR, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::ERROR, $errcode, $message $(, $($tt)*)?);
         unreachable!();
     };
 
-    (PANIC, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::PANIC);
+    (ERROR, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::ERROR, $errcode, $message $(; $($tt)*)?);
         unreachable!();
     };
 
-    (FATAL, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::FATAL);
+    (PANIC, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::PANIC, $errcode, $message $(, $($tt)*)?);
         unreachable!();
     };
 
-    (WARNING, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::WARNING)
+    (PANIC, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::PANIC, $errcode, $message $(; $($tt)*)?);
+        unreachable!();
     };
 
-    (NOTICE, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::NOTICE)
+    (FATAL, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::FATAL, $errcode, $message $(, $($tt)*)?);
+        unreachable!();
     };
 
-    (INFO, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::INFO)
+    (FATAL, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::FATAL, $errcode, $message $(; $($tt)*)?);
+        unreachable!();
     };
 
-    (LOG, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::LOG)
+    (WARNING, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::WARNING, $errcode, $message $(, $($tt)*)?)
     };
 
-    (DEBUG5, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG5)
+    (WARNING, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::WARNING, $errcode, $message $(; $($tt)*)?)
     };
 
-    (DEBUG4, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG4)
+    (NOTICE, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $errcode, $message $(, $($tt)*)?)
     };
 
-    (DEBUG3, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG3)
+    (NOTICE, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $errcode, $message $(; $($tt)*)?)
     };
 
-    (DEBUG2, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG2)
+    (INFO, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::INFO, $errcode, $message $(, $($tt)*)?)
     };
 
-    (DEBUG1, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG1)
+    (INFO, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::INFO, $errcode, $message $(; $($tt)*)?)
     };
 
-    ($loglevel:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (LOG, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::LOG, $errcode, $message $(, $($tt)*)?)
+    };
+
+    (LOG, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::LOG, $errcode, $message $(; $($tt)*)?)
+    };
+
+    (DEBUG5, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $errcode, $message $(, $($tt)*)?)
+    };
+
+    (DEBUG5, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $errcode, $message $(; $($tt)*)?)
+    };
+
+    (DEBUG4, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $errcode, $message $(, $($tt)*)?)
+    };
+
+    (DEBUG4, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $errcode, $message $(; $($tt)*)?)
+    };
+
+    (DEBUG3, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $errcode, $message $(, $($tt)*)?)
+    };
+
+    (DEBUG3, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $errcode, $message $(; $($tt)*)?)
+    };
+
+    (DEBUG2, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $errcode, $message $(, $($tt)*)?)
+    };
+
+    (DEBUG2, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $errcode, $message $(; $($tt)*)?)
+    };
+
+    (DEBUG1, $errcode:expr, $message:expr $(, $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $errcode, $message $(, $($tt)*)?)
+    };
+
+    (DEBUG1, $errcode:expr, $message:expr $(; $($tt:tt)*)?) => {
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $errcode, $message $(; $($tt)*)?)
+    };
+
+    (
+        $loglevel:expr, $errcode:expr, $message:expr $(;)?
+    ) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
+            .report($loglevel);
+    };
+
+    (
+        $loglevel:expr, $errcode:expr, $message:expr;
+        hint = $hint:expr;
+    ) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_hint($hint)
+            .report($loglevel);
+    };
+
+    (
+        $loglevel:expr, $errcode:expr, $message:expr;
+        detail = $detail:expr;
+    ) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_detail($detail)
+            .report($loglevel);
+    };
+
+    (
+        $loglevel:expr, $errcode:expr, $message:expr;
+        detail = $detail:expr;
+        hint = $hint:expr;
+    ) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_detail($detail)
+            .set_hint($hint)
+            .report($loglevel);
+    };
+
+    (
+        $loglevel:expr, $errcode:expr, $message:expr $(,)?
+    ) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .report($loglevel);
+    };
+
+    ($loglevel:expr, $errcode:expr, $message:expr, $detail:expr $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_detail($detail)
+            .report($loglevel);
+    };
+
+    ($loglevel:expr, $errcode:expr, $message:expr, $detail:expr, $hint:expr $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_detail($detail)
+            .set_hint($hint)
             .report($loglevel);
     };
 }

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -52,7 +52,11 @@ where
                     any.downcast::<ErrorReport>().unwrap().report(PgLogLevel::ERROR);
                     unreachable!();
                 } else {
-                    ereport!(ERROR, PgSqlErrorCode::ERRCODE_DATA_EXCEPTION, &format!("{}", e));
+                    internal_ereport!(
+                        ERROR,
+                        PgSqlErrorCode::ERRCODE_DATA_EXCEPTION,
+                        format!("{}", e)
+                    );
                 }
             }
         }

--- a/pgrx-tests/tests/ui.rs
+++ b/pgrx-tests/tests/ui.rs
@@ -6,4 +6,5 @@ use trybuild::TestCases;
 fn ui() {
     let t = TestCases::new();
     t.compile_fail("tests/ui/*.rs");
+    t.compile_fail("tests/ui/elog/**/*.rs");
 }

--- a/pgrx-tests/tests/ui/elog/argument-order/detail_first.rs
+++ b/pgrx-tests/tests/ui/elog/argument-order/detail_first.rs
@@ -1,0 +1,11 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn detail_first_is_invalid() {
+    log!(
+        detail = "detail";
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/argument-order/detail_first.stderr
+++ b/pgrx-tests/tests/ui/elog/argument-order/detail_first.stderr
@@ -1,0 +1,10 @@
+error: The alternative invocation requires `message` to be specified first.
+  --> tests/ui/elog/argument-order/detail_first.rs:7:5
+   |
+7  | /     log!(
+8  | |         detail = "detail";
+9  | |         message = "...";
+10 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `log` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/detail_before_message.rs
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/detail_before_message.rs
@@ -1,0 +1,13 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_detail_before_message_is_invalid() {
+    ereport!(
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        detail = "detail";
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/detail_before_message.stderr
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/detail_before_message.stderr
@@ -1,0 +1,12 @@
+error: The alternative invocation style requires `message` argument to be specified after `errcode`.
+  --> tests/ui/elog/argument-order/ereport/detail_before_message.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG;
+9  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+10 | |         detail = "detail";
+11 | |         message = "...";
+12 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/hint_before_message.rs
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/hint_before_message.rs
@@ -1,0 +1,13 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_hint_before_message_is_invalid() {
+    ereport!(
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        hint = "hint";
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/hint_before_message.stderr
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/hint_before_message.stderr
@@ -1,0 +1,12 @@
+error: The alternative invocation style requires `message` argument to be specified after `errcode`.
+  --> tests/ui/elog/argument-order/ereport/hint_before_message.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG;
+9  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+10 | |         hint = "hint";
+11 | |         message = "...";
+12 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_errcode.rs
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_errcode.rs
@@ -1,0 +1,11 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_errcode_is_required() {
+    ereport!(
+        loglevel = PgLogLevel::LOG;
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_errcode.stderr
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_errcode.stderr
@@ -1,0 +1,10 @@
+error: The alternative invocation style requires `errcode` argument to be specified after `loglevel`.
+  --> tests/ui/elog/argument-order/ereport/omit_errcode.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG;
+9  | |         message = "...";
+10 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_loglevel.rs
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_loglevel.rs
@@ -1,0 +1,11 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_loglevel_is_required() {
+    ereport!(
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_loglevel.stderr
+++ b/pgrx-tests/tests/ui/elog/argument-order/ereport/omit_loglevel.stderr
@@ -1,0 +1,10 @@
+error: The alternative invocation style requires `loglevel` argument to be specified first.
+  --> tests/ui/elog/argument-order/ereport/omit_loglevel.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+9  | |         message = "...";
+10 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/argument-order/hint_first.rs
+++ b/pgrx-tests/tests/ui/elog/argument-order/hint_first.rs
@@ -1,0 +1,11 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn hint_first_is_invalid() {
+    log!(
+        hint = "hint";
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/argument-order/hint_first.stderr
+++ b/pgrx-tests/tests/ui/elog/argument-order/hint_first.stderr
@@ -1,0 +1,10 @@
+error: The alternative invocation requires `message` to be specified first.
+  --> tests/ui/elog/argument-order/hint_first.rs:7:5
+   |
+7  | /     log!(
+8  | |         hint = "hint";
+9  | |         message = "...";
+10 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `log` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_detail.rs
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_detail.rs
@@ -1,0 +1,13 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_detail_must_terminate_with_semicolon() {
+    ereport!(
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        detail = "detail",
+    );
+}

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_detail.stderr
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_detail.stderr
@@ -1,0 +1,12 @@
+error: The alternative invocation style requires component sections to be terminated with a semicolon.
+  --> tests/ui/elog/semicolon-terminators/ereport_detail.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG;
+9  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+10 | |         message = "...";
+11 | |         detail = "detail",
+12 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_errcode.rs
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_errcode.rs
@@ -1,0 +1,12 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_errcode_must_terminate_with_semicolon() {
+    ereport!(
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_errcode.stderr
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_errcode.stderr
@@ -1,0 +1,11 @@
+error: The alternative invocation style requires component sections to be terminated with a semicolon.
+  --> tests/ui/elog/semicolon-terminators/ereport_errcode.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG;
+9  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
+10 | |         message = "...";
+11 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_hint.rs
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_hint.rs
@@ -1,0 +1,14 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_hint_must_terminate_with_semicolon() {
+    ereport!(
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        detail = "detail";
+        hint = "hint",
+    );
+}

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_hint.stderr
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_hint.stderr
@@ -1,0 +1,13 @@
+error: The alternative invocation style requires component sections to be terminated with a semicolon.
+  --> tests/ui/elog/semicolon-terminators/ereport_hint.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG;
+9  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+10 | |         message = "...";
+11 | |         detail = "detail";
+12 | |         hint = "hint",
+13 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_loglevel.rs
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_loglevel.rs
@@ -1,0 +1,12 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_loglevel_must_terminate_with_semicolon() {
+    ereport!(
+        loglevel = PgLogLevel::LOG,
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+    );
+}

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_loglevel.stderr
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_loglevel.stderr
@@ -1,0 +1,11 @@
+error: The alternative invocation style requires component sections to be terminated with a semicolon.
+  --> tests/ui/elog/semicolon-terminators/ereport_loglevel.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG,
+9  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+10 | |         message = "...";
+11 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_message.rs
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_message.rs
@@ -1,0 +1,12 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+#[pg_extern]
+fn ereport_message_must_terminate_with_semicolon() {
+    ereport!(
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...",
+    );
+}

--- a/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_message.stderr
+++ b/pgrx-tests/tests/ui/elog/semicolon-terminators/ereport_message.stderr
@@ -1,0 +1,11 @@
+error: The alternative invocation style requires component sections to be terminated with a semicolon.
+  --> tests/ui/elog/semicolon-terminators/ereport_message.rs:7:5
+   |
+7  | /     ereport!(
+8  | |         loglevel = PgLogLevel::LOG;
+9  | |         errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+10 | |         message = "...",
+11 | |     );
+   | |_____^
+   |
+   = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/valid_usage_and_help_messages.rs
+++ b/pgrx-tests/tests/ui/elog/valid_usage_and_help_messages.rs
@@ -1,0 +1,121 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+// none of these should fail to compile
+
+#[pg_extern]
+fn simple_syntax_works() {
+    log!("...");
+    log!("...",);
+    log!("{}", "...");
+}
+
+#[pg_extern]
+fn ereport_simple_syntax_works() {
+    ereport!(LOG, PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, "...");
+    ereport!(LOG, PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, "...", "detail", "hint");
+}
+
+#[pg_extern]
+fn alternative_syntax_works() {
+    log!(
+        message = "...";
+    );
+    log!(
+        message = "...";
+        detail = "detail";
+    );
+    log!(
+        message = "...";
+        detail = "detail";
+        hint = "hint";
+    );
+    log!(
+        message = "{}", "...";
+    );
+    log!(
+        message = "{}", "...";
+        detail = "{}", "detail";
+    );
+    log!(
+        message = "{}", "...";
+        hint = "{}", "hint";
+    );
+    log!(
+        message = "{}", "...";
+        detail = "{}", "detail";
+        hint = "{}", "hint";
+    );
+}
+
+#[pg_extern]
+fn ereport_alternative_syntax_shorthand_works() {
+    ereport! {
+        loglevel = LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+    }
+    ereport! {
+        loglevel = LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        detail = "detail";
+    }
+    ereport! {
+        loglevel = LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        hint = "hint";
+    }
+    ereport! {
+        loglevel = LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        detail = "detail";
+        hint = "hint";
+    }
+}
+
+#[pg_extern]
+fn ereport_alternative_syntax_longhand_works() {
+    ereport! {
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+    }
+    ereport! {
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        detail = "detail";
+    }
+    ereport! {
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        hint = "hint";
+    }
+    ereport! {
+        loglevel = PgLogLevel::LOG;
+        errcode = PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION;
+        message = "...";
+        detail = "detail";
+        hint = "hint";
+    }
+}
+
+#[pg_extern]
+fn help_messages() {
+    log!();
+    info!();
+    notice!();
+    warning!();
+    error!();
+    debug1!();
+    debug2!();
+    debug3!();
+    debug4!();
+    debug5!();
+    ereport!();
+}

--- a/pgrx-tests/tests/ui/elog/valid_usage_and_help_messages.stderr
+++ b/pgrx-tests/tests/ui/elog/valid_usage_and_help_messages.stderr
@@ -1,0 +1,395 @@
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         log!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         log! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:110:5
+    |
+110 |     log!();
+    |     ^^^^^^
+    |
+    = note: this error originates in the macro `log` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         info!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         info! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:111:5
+    |
+111 |     info!();
+    |     ^^^^^^^
+    |
+    = note: this error originates in the macro `info` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         notice!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         notice! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:112:5
+    |
+112 |     notice!();
+    |     ^^^^^^^^^
+    |
+    = note: this error originates in the macro `notice` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         warning!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         warning! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:113:5
+    |
+113 |     warning!();
+    |     ^^^^^^^^^^
+    |
+    = note: this error originates in the macro `warning` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         error!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         error! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:114:5
+    |
+114 |     error!();
+    |     ^^^^^^^^
+    |
+    = note: this error originates in the macro `error` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         debug1!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         debug1! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:115:5
+    |
+115 |     debug1!();
+    |     ^^^^^^^^^
+    |
+    = note: this error originates in the macro `debug1` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         debug2!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         debug2! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:116:5
+    |
+116 |     debug2!();
+    |     ^^^^^^^^^
+    |
+    = note: this error originates in the macro `debug2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         debug3!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         debug3! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:117:5
+    |
+117 |     debug3!();
+    |     ^^^^^^^^^
+    |
+    = note: this error originates in the macro `debug3` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         debug4!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         debug4! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:118:5
+    |
+118 |     debug4!();
+    |     ^^^^^^^^^
+    |
+    = note: this error originates in the macro `debug4` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       # Simple Usage
+
+       ## Required arguments:
+         - string literal
+
+       ## Optional arguments:
+         - formatting arguments
+
+       ## Example
+         debug5!("{}", 42);
+
+       # Alternative Usage
+
+       ## Required arguments:
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Example
+         debug5! {
+           message = "...";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }
+
+   --> tests/ui/elog/success_cases.rs:119:5
+    |
+119 |     debug5!();
+    |     ^^^^^^^^^
+    |
+    = note: this error originates in the macro `debug5` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Invalid invocation
+
+       ## Required arguments:
+         - loglevel: [PgLogLevel]
+         - errcode: [PgSqlErrorCode]
+         - message: impl Into<String>
+
+       ## Optional arguments:
+         - detail: impl Into<String>
+         - hint: impl Into<String>
+
+       ## Simple Usage
+         ereport!(
+           PgLogLevel::ERROR,
+           PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+           "invalid input",
+           "extra detail",
+           "plus a hint",
+         );
+
+       ## Alternative Usage
+         ereport! {{
+           loglevel = PgLogLevel::ERROR;
+           errcode = PgSqlErrorCode::ERRCODE_INTERNAL_ERROR;
+           message = "invalid input";
+           detail = "extra detail";
+           hint = "plus a hint";
+         }}
+
+   --> tests/ui/elog/success_cases.rs:120:5
+    |
+120 |     ereport!();
+    |     ^^^^^^^^^^
+    |
+    = note: this error originates in the macro `ereport` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/ui/elog/valid_usage_and_help_messages.stderr
+++ b/pgrx-tests/tests/ui/elog/valid_usage_and_help_messages.stderr
@@ -27,7 +27,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:110:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:110:5
     |
 110 |     log!();
     |     ^^^^^^
@@ -63,7 +63,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:111:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:111:5
     |
 111 |     info!();
     |     ^^^^^^^
@@ -99,7 +99,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:112:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:112:5
     |
 112 |     notice!();
     |     ^^^^^^^^^
@@ -135,7 +135,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:113:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:113:5
     |
 113 |     warning!();
     |     ^^^^^^^^^^
@@ -171,7 +171,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:114:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:114:5
     |
 114 |     error!();
     |     ^^^^^^^^
@@ -207,7 +207,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:115:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:115:5
     |
 115 |     debug1!();
     |     ^^^^^^^^^
@@ -243,7 +243,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:116:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:116:5
     |
 116 |     debug2!();
     |     ^^^^^^^^^
@@ -279,7 +279,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:117:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:117:5
     |
 117 |     debug3!();
     |     ^^^^^^^^^
@@ -315,7 +315,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:118:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:118:5
     |
 118 |     debug4!();
     |     ^^^^^^^^^
@@ -351,7 +351,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }
 
-   --> tests/ui/elog/success_cases.rs:119:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:119:5
     |
 119 |     debug5!();
     |     ^^^^^^^^^
@@ -387,7 +387,7 @@ error: Invalid invocation
            hint = "plus a hint";
          }}
 
-   --> tests/ui/elog/success_cases.rs:120:5
+   --> tests/ui/elog/valid_usage_and_help_messages.rs:120:5
     |
 120 |     ereport!();
     |     ^^^^^^^^^^


### PR DESCRIPTION
# tl;dr

I recently proposed some slight adjustments to the `ereport` macro to allow `detail` to be passed in all cases. After thinking it through, I decided to further improve the usability of all the reporting macros.

## Goals

- [x] Allow `detail` and `hint` to be specified in all reporting macros
- [x] No breaking changes
- [x] Support formatting arguments for `detail` and `hint` just like the `message`
- [x] `hint` can be provided without needing to also provide `detail`
- [x] `hint` can be provided before `detail`

## Notes

- I updated the docs for each macro to reflect these changes 

## Examples

```rust
pgrx::error!(
    message = "something went wrong";
    detail = "original error: {}", err.to_string();
    hint = "check your `.env` file";
);
```