### PR TITLE
Replace dependency on `dirs` with `home`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,27 +697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,17 +1126,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
-dependencies = [
- "bitflags 2.4.2",
- "libc",
- "redox_syscall",
-]
 
 [[package]]
 name = "line-wrap"
@@ -1410,12 +1387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,8 +1503,8 @@ name = "pgrx-pg-config"
 version = "0.12.0-alpha.0"
 dependencies = [
  "cargo_toml",
- "dirs",
  "eyre",
+ "home",
  "owo-colors",
  "pathsearch",
  "serde",
@@ -1869,17 +1840,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -28,7 +28,7 @@ eyre.workspace = true
 owo-colors.workspace = true
 url.workspace = true
 
-dirs = "5.0.1"
+home = "0.5.9"
 pathsearch = "0.2.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -633,7 +633,7 @@ impl Pgrx {
     pub fn home() -> Result<PathBuf, PgrxHomeError> {
         let pgrx_home = std::env::var("PGRX_HOME").map_or_else(
             |_| {
-                let mut pgrx_home = match dirs::home_dir() {
+                let mut pgrx_home = match home::home_dir() {
                     Some(home) => home,
                     None => return Err(PgrxHomeError::NoHomeDirectory),
                 };


### PR DESCRIPTION

The `dirs` crate recently [started depending](https://github.com/dirs-dev/dirs-sys-rs/commit/e169da7af901eb621e5d244efe960f4da8ed150d) on the `options-ext` crate
which uses copyleft license (MPL). This (unnecessary) dependency causes
licensing issues for various users by possibly poisoning the dependency
tree of their projects.

This change replaces the `dirs` crate with `home`. The `home` crate is
maintained by the cargo team and offers the same functionality.

As a bonus, this change also results in a slightly smaller dependency
tree.

- https://github.com/artichoke/artichoke/pull/2564
- https://github.com/pyrossh/rust-embed/issues/231
- https://github.com/juhaku/utoipa/issues/834
- https://github.com/harryfei/which-rs/pull/78