### PR TITLE
Remove atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,17 +148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,7 +339,6 @@ dependencies = [
 name = "cargo-pgrx"
 version = "0.11.2"
 dependencies = [
- "atty",
  "bzip2",
  "cargo_metadata",
  "cargo_toml",
@@ -365,7 +353,7 @@ dependencies = [
  "nix",
  "object",
  "once_cell",
- "owo-colors",
+ "owo-colors 4.0.0",
  "pgrx-pg-config",
  "pgrx-sql-entity-graph",
  "prettyplease",
@@ -519,7 +507,7 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors",
+ "owo-colors 3.5.0",
  "tracing-error",
 ]
 
@@ -530,7 +518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
 dependencies = [
  "once_cell",
- "owo-colors",
+ "owo-colors 3.5.0",
  "tracing-core",
  "tracing-error",
 ]
@@ -1038,15 +1026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,12 +1059,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
 ]
-
-[[package]]
-name = "is_ci"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itoa"
@@ -1470,9 +1443,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-dependencies = [
- "supports-color",
-]
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parking_lot"
@@ -1581,7 +1557,7 @@ dependencies = [
  "cargo_toml",
  "dirs",
  "eyre",
- "owo-colors",
+ "owo-colors 4.0.0",
  "pathsearch",
  "serde",
  "serde_derive",
@@ -1616,10 +1592,9 @@ dependencies = [
 name = "pgrx-sql-entity-graph"
 version = "0.11.2"
 dependencies = [
- "atty",
  "convert_case",
  "eyre",
- "owo-colors",
+ "owo-colors 4.0.0",
  "petgraph",
  "proc-macro2",
  "quote",
@@ -1636,7 +1611,7 @@ dependencies = [
  "eyre",
  "libc",
  "once_cell",
- "owo-colors",
+ "owo-colors 4.0.0",
  "pgrx",
  "pgrx-macros",
  "pgrx-pg-config",
@@ -1656,7 +1631,7 @@ name = "pgrx-version-updater"
 version = "0.1.1"
 dependencies = [
  "clap",
- "owo-colors",
+ "owo-colors 4.0.0",
  "toml_edit 0.20.7",
  "walkdir",
 ]
@@ -2437,16 +2412,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "supports-color"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
-dependencies = [
- "atty",
- "is_ci",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
  "nix",
  "object",
  "once_cell",
- "owo-colors 4.0.0",
+ "owo-colors",
  "pgrx-pg-config",
  "pgrx-sql-entity-graph",
  "prettyplease",
@@ -507,7 +507,7 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors 3.5.0",
+ "owo-colors",
  "tracing-error",
 ]
 
@@ -518,7 +518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
 dependencies = [
  "once_cell",
- "owo-colors 3.5.0",
+ "owo-colors",
  "tracing-core",
  "tracing-error",
 ]
@@ -1445,12 +1445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
-name = "owo-colors"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,7 +1551,7 @@ dependencies = [
  "cargo_toml",
  "dirs",
  "eyre",
- "owo-colors 4.0.0",
+ "owo-colors",
  "pathsearch",
  "serde",
  "serde_derive",
@@ -1594,7 +1588,7 @@ version = "0.11.2"
 dependencies = [
  "convert_case",
  "eyre",
- "owo-colors 4.0.0",
+ "owo-colors",
  "petgraph",
  "proc-macro2",
  "quote",
@@ -1611,7 +1605,7 @@ dependencies = [
  "eyre",
  "libc",
  "once_cell",
- "owo-colors 4.0.0",
+ "owo-colors",
  "pgrx",
  "pgrx-macros",
  "pgrx-pg-config",
@@ -1631,7 +1625,7 @@ name = "pgrx-version-updater"
 version = "0.1.1"
 dependencies = [
  "clap",
- "owo-colors 4.0.0",
+ "owo-colors",
  "toml_edit 0.20.7",
  "walkdir",
 ]

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -24,13 +24,12 @@ exclude = [ "*.png" ]
 edition = "2021"
 
 [dependencies]
-atty = "0.2.14"
 cargo_metadata = "0.17.0"
 cargo_toml = "0.16.3"
 clap = { version = "4.4.2", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.11.0", features = [ "cargo_metadata" ] }
 semver = "1.0.20"
-owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
+owo-colors = { version = "4" }
 env_proxy = "0.4.1"
 pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.11.2" }
 pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.2" }

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -29,7 +29,7 @@ cargo_toml = "0.16.3"
 clap = { version = "4.4.2", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.11.0", features = [ "cargo_metadata" ] }
 semver = "1.0.20"
-owo-colors = { version = "4" }
+owo-colors = { version = "3.5" }
 env_proxy = "0.4.1"
 pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.11.2" }
 pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.11.2" }

--- a/cargo-pgrx/src/main.rs
+++ b/cargo-pgrx/src/main.rs
@@ -18,7 +18,7 @@ mod pgrx_pg_sys_stub;
 pub(crate) mod env;
 pub(crate) mod profile;
 
-use atty::Stream;
+use std::io::{self, IsTerminal};
 use clap::Parser;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::layer::SubscriberExt;
@@ -61,9 +61,10 @@ impl CommandExecute for CargoSubcommands {
 }
 
 fn main() -> color_eyre::Result<()> {
+    let stderr_is_tty = io::stderr().is_terminal();
     env::initialize();
     color_eyre::config::HookBuilder::default()
-        .theme(if !atty::is(Stream::Stderr) {
+        .theme(if stderr_is_tty {
             color_eyre::config::Theme::new()
         } else {
             color_eyre::config::Theme::default()
@@ -74,7 +75,7 @@ fn main() -> color_eyre::Result<()> {
 
     // Initialize tracing with tracing-error, and eyre
     let fmt_layer = tracing_subscriber::fmt::Layer::new()
-        .with_ansi(atty::is(Stream::Stderr))
+        .with_ansi(stderr_is_tty)
         .with_writer(std::io::stderr)
         .pretty();
 

--- a/cargo-pgrx/src/main.rs
+++ b/cargo-pgrx/src/main.rs
@@ -18,8 +18,8 @@ mod pgrx_pg_sys_stub;
 pub(crate) mod env;
 pub(crate) mod profile;
 
-use std::io::{self, IsTerminal};
 use clap::Parser;
+use std::io::{self, IsTerminal};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 dirs = "5.0.1"
 eyre = "0.6.8"
 pathsearch = "0.2.0"
-owo-colors = "3.5.0"
+owo-colors = "4"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 dirs = "5.0.1"
 eyre = "0.6.8"
 pathsearch = "0.2.0"
-owo-colors = "4"
+owo-colors = "3.5"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -34,5 +34,5 @@ syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsi
 unescape = "0.1.0"
 
 # colorized sql output
-owo-colors = { version = "4", optional = true }
+owo-colors = { version = "3.5", optional = true }
 syntect = { version = "5.1.0", default-features = false, features = ["default-fancy"], optional = true }

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 edition = "2021"
 
 [features]
-syntax-highlighting = ["dep:syntect", "dep:owo-colors", "dep:atty"]
+syntax-highlighting = ["dep:syntect", "dep:owo-colors"]
 no-schema-generation = []
 
 [dependencies]
@@ -34,6 +34,5 @@ syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsi
 unescape = "0.1.0"
 
 # colorized sql output
-atty = { version = "0.2.14", optional = true }
-owo-colors = { version = "3.5.0", optional = true }
+owo-colors = { version = "4", optional = true }
 syntect = { version = "5.1.0", default-features = false, features = ["default-fancy"], optional = true }

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -270,7 +270,8 @@ impl PgrxSql {
 
         #[cfg(feature = "syntax-highlighting")]
         {
-            if atty::is(atty::Stream::Stdout) {
+            use std::io::{stdout, IsTerminal};
+            if stdout().is_terminal() {
                 self.write_highlighted(out, &generated)?;
             } else {
                 write!(*out, "{}", generated)?;

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -45,7 +45,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 clap-cargo = "0.11.0"
-owo-colors = "4"
+owo-colors = "3.5"
 once_cell = "1.18.0"
 libc = "0.2.149"
 pgrx-macros = { path = "../pgrx-macros", version = "=0.11.2" }

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -45,7 +45,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 clap-cargo = "0.11.0"
-owo-colors = "3.5.0"
+owo-colors = "4"
 once_cell = "1.18.0"
 libc = "0.2.149"
 pgrx-macros = { path = "../pgrx-macros", version = "=0.11.2" }

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -18,6 +18,6 @@ description = "Standalone tool to update PGRX Cargo.toml versions and dependenci
 
 [dependencies]
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
-owo-colors = "4"
+owo-colors = "3.5"
 toml_edit = { version = "0.20.2" }
 walkdir = "2"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -18,6 +18,6 @@ description = "Standalone tool to update PGRX Cargo.toml versions and dependenci
 
 [dependencies]
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
-owo-colors = "3.5.0"
+owo-colors = "4"
 toml_edit = { version = "0.20.2" }
 walkdir = "2"


### PR DESCRIPTION
Requires tweaking owo-color features to reduce exposure via transitive deps.

Addresses a security alert that essentially doesn't apply to pgrx due to being Windows-only, but still annoys me to have on my dashboard.