### PR TITLE
Use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ version = "0.1.1"
 dependencies = [
  "clap",
  "owo-colors",
- "toml_edit 0.20.7",
+ "toml_edit",
  "walkdir",
 ]
 
@@ -2623,7 +2623,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2633,17 +2633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,9 @@ pgrx-pg-config= { path = "./pgrx-pg-config/", version = "=0.12.0-alpha.0" }
 eyre = "0.6.9"
 libc = "0.2"
 owo-colors = "3.5" # for output highlighting
+unescape = "0.1.0" # for escaped-character-handling
 url = "2.4.1" # the non-existent std::web
+walkdir = "2" # directory recursion
 
 [profile.dev]
 # Only include line tables in debuginfo. This reduces the size of target/ (after

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ pgrx-pg-config= { path = "./pgrx-pg-config/", version = "=0.12.0-alpha.0" }
 eyre = "0.6.9"
 libc = "0.2"
 owo-colors = "3.5" # for output highlighting
+url = "2.4.1" # the non-existent std::web
 
 [profile.dev]
 # Only include line tables in debuginfo. This reduces the size of target/ (after

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ cargo-pgrx = { path = "cargo-pgrx" }
 pgrx-macros = { path = "./pgrx-macros", version = "=0.12.0-alpha.0" }
 pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.0-alpha.0" }
 pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.0-alpha.0" }
-pgrx-pg-config= { path = "./pgrx-pg-config/", version = "=0.12.0-alpha.0" }
+pgrx-pg-config = { path = "./pgrx-pg-config/", version = "=0.12.0-alpha.0" }
 
 cargo_toml = "0.16" # used for building projects
 eyre = "0.6.9" # simplifies error-handling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,11 @@ pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.0-alpha.0" }
 pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.0-alpha.0" }
 pgrx-pg-config= { path = "./pgrx-pg-config/", version = "=0.12.0-alpha.0" }
 
-eyre = "0.6.9"
-libc = "0.2"
+cargo_toml = "0.16" # used for building projects
+eyre = "0.6.9" # simplifies error-handling
+libc = "0.2" # FFI compat
 owo-colors = "3.5" # for output highlighting
+regex = "1.1" # used for build/test
 unescape = "0.1.0" # for escaped-character-handling
 url = "2.4.1" # the non-existent std::web
 walkdir = "2" # directory recursion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ eyre = "0.6.9" # simplifies error-handling
 libc = "0.2" # FFI compat
 owo-colors = "3.5" # for output highlighting
 regex = "1.1" # used for build/test
+thiserror = "1"
 unescape = "0.1.0" # for escaped-character-handling
 url = "2.4.1" # the non-existent std::web
 walkdir = "2" # directory recursion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,20 @@ members = [
     "pgrx-examples/spi_srf",
 ]
 
+
+[workspace.metadata.local-install]
+cargo-pgrx = { path = "cargo-pgrx" }
+
+[workspace.dependencies]
+pgrx-macros = { path = "./pgrx-macros", version = "=0.12.0-alpha.0" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.0-alpha.0" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.0-alpha.0" }
+pgrx-pg-config= { path = "./pgrx-pg-config/", version = "=0.12.0-alpha.0" }
+
+eyre = "0.6.9"
+libc = "0.2"
+owo-colors = "3.5" # for output highlighting
+
 [profile.dev]
 # Only include line tables in debuginfo. This reduces the size of target/ (after
 # running tests) by almost half, while keeping the part of debuginfo which
@@ -59,6 +73,3 @@ debug = 'line-tables-only'
 
 [profile.dev.build-override]
 opt-level = 3
-
-[workspace.metadata.local-install]
-cargo-pgrx = { path = "cargo-pgrx" }

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -27,13 +27,14 @@ edition = "2021"
 pgrx-pg-config.workspace = true
 pgrx-sql-entity-graph.workspace = true
 
+cargo_toml.workspace = true
 eyre.workspace = true
 owo-colors.workspace = true
+regex.workspace = true
 unescape.workspace = true
 url.workspace = true
 
 cargo_metadata = "0.17.0"
-cargo_toml = "0.16.3"
 clap = { version = "4.4.2", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.11.0", features = [ "cargo_metadata" ] }
 semver = "1.0.20"
@@ -41,7 +42,6 @@ env_proxy = "0.4.1"
 prettyplease = "0.2.15"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
-regex = "1.10.0"
 ureq = { version = "2.8.0", default-features = false, features = [ "gzip" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -29,6 +29,8 @@ pgrx-sql-entity-graph.workspace = true
 
 eyre.workspace = true
 owo-colors.workspace = true
+unescape.workspace = true
+url.workspace = true
 
 cargo_metadata = "0.17.0"
 cargo_toml = "0.16.3"
@@ -41,12 +43,10 @@ proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
 regex = "1.10.0"
 ureq = { version = "2.8.0", default-features = false, features = [ "gzip" ] }
-url = "2.4.1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde-xml-rs = "0.6.0"
 syn = { version = "2.0.18", features = [ "extra-traits", "full", "fold", "parsing" ] }
-unescape = "0.1.0"
 libloading = "0.8.1"
 object = "0.32.1"
 once_cell = "1.18.0"

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -24,15 +24,18 @@ exclude = [ "*.png" ]
 edition = "2021"
 
 [dependencies]
+pgrx-pg-config.workspace = true
+pgrx-sql-entity-graph.workspace = true
+
+eyre.workspace = true
+owo-colors.workspace = true
+
 cargo_metadata = "0.17.0"
 cargo_toml = "0.16.3"
 clap = { version = "4.4.2", features = [ "env", "suggestions", "cargo", "derive", "wrap_help" ] }
 clap-cargo = { version = "0.11.0", features = [ "cargo_metadata" ] }
 semver = "1.0.20"
-owo-colors = { version = "3.5" }
 env_proxy = "0.4.1"
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.12.0-alpha.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.12.0-alpha.0" }
 prettyplease = "0.2.15"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
@@ -47,7 +50,6 @@ unescape = "0.1.0"
 libloading = "0.8.1"
 object = "0.32.1"
 once_cell = "1.18.0"
-eyre = "0.6.8"
 color-eyre = "0.6.2"
 tracing = "0.1"
 tracing-error = "0.2.0"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -30,11 +30,14 @@ rustc-args = ["--cfg", "docsrs"]
 [features]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 
+
 [dependencies]
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.12.0-alpha.0" }
+pgrx-sql-entity-graph.workspace = true
+
 proc-macro2 = "1.0.69"
 quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
+
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] } # for Documentation examples

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -23,10 +23,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+eyre.workspace = true
+owo-colors.workspace = true
+
 dirs = "5.0.1"
-eyre = "0.6.8"
 pathsearch = "0.2.0"
-owo-colors = "3.5"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -23,6 +23,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cargo_toml.workspace = true
 eyre.workspace = true
 owo-colors.workspace = true
 url.workspace = true
@@ -33,4 +34,3 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.8.2"
-cargo_toml = "0.16.3"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -25,6 +25,7 @@ edition = "2021"
 [dependencies]
 eyre.workspace = true
 owo-colors.workspace = true
+url.workspace = true
 
 dirs = "5.0.1"
 pathsearch = "0.2.0"
@@ -32,5 +33,4 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.8.2"
-url = "2.4.1"
 cargo_toml = "0.16.3"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -38,22 +38,26 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+pgrx-macros.workspace = true
+pgrx-sql-entity-graph.workspace = true
+
+libc.workspace = true
+
 memoffset = "0.9.0"
-pgrx-macros = { path = "../pgrx-macros/", version = "=0.12.0-alpha.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph/", version = "=0.12.0-alpha.0" }
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
-libc = "0.2"
 
 [build-dependencies]
+pgrx-pg-config.workspace = true
+
+eyre.workspace = true
+
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
-pgrx-pg-config= { path = "../pgrx-pg-config/", version = "=0.12.0-alpha.0" }
 proc-macro2 = "1.0.69"
 quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
-eyre = "0.6.8"
 shlex = "1.3" # shell lexing, also used by many of our deps
 once_cell = "1.18.0"
 walkdir = "2"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -52,6 +52,7 @@ sptr = "0.3"
 pgrx-pg-config.workspace = true
 
 eyre.workspace = true
+walkdir.workspace = true
 
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
@@ -60,4 +61,3 @@ quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 shlex = "1.3" # shell lexing, also used by many of our deps
 once_cell = "1.18.0"
-walkdir = "2"

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -25,8 +25,9 @@ syntax-highlighting = ["dep:syntect", "dep:owo-colors"]
 no-schema-generation = []
 
 [dependencies]
+eyre.workspace = true
+
 convert_case = "0.6.0"
-eyre = "0.6.8"
 petgraph = "0.6.4"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
@@ -34,5 +35,5 @@ syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsi
 unescape = "0.1.0"
 
 # colorized sql output
-owo-colors = { version = "3.5", optional = true }
+owo-colors = { optional = true, workspace = true }
 syntect = { version = "5.1.0", default-features = false, features = ["default-fancy"], optional = true }

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -26,13 +26,13 @@ no-schema-generation = []
 
 [dependencies]
 eyre.workspace = true
+unescape.workspace = true
 
 convert_case = "0.6.0"
 petgraph = "0.6.4"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
 syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
-unescape = "0.1.0"
 
 # colorized sql output
 owo-colors = { optional = true, workspace = true }

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -50,6 +50,7 @@ pgrx-pg-config.workspace = true
 eyre.workspace = true
 libc.workspace = true
 regex.workspace = true
+thiserror.workspace = true
 owo-colors.workspace = true
 
 clap-cargo = "0.11.0"
@@ -59,7 +60,6 @@ proptest = { version = "1", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 sysinfo = "0.29.10"
-thiserror = "1.0"
 rand = "0.8.5"
 
 [dependencies.pgrx] # Not unified in workspace due to default-features key

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -44,27 +44,29 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+pgrx-macros.workspace = true
+pgrx-pg-config.workspace = true
+
+eyre.workspace = true
+libc.workspace = true
+owo-colors.workspace = true
+
 clap-cargo = "0.11.0"
-owo-colors = "3.5"
 once_cell = "1.18.0"
-libc = "0.2.149"
-pgrx-macros = { path = "../pgrx-macros", version = "=0.12.0-alpha.0" }
-pgrx-pg-config = { path = "../pgrx-pg-config", version = "=0.12.0-alpha.0" }
 postgres = "0.19.7"
 proptest = { version = "1", optional = true }
 regex = "1.10.0"
 serde = "1.0"
 serde_json = "1.0"
 sysinfo = "0.29.10"
-eyre = "0.6.8"
 thiserror = "1.0"
 rand = "0.8.5"
+
+[dependencies.pgrx] # Not unified in workspace due to default-features key
+path = "../pgrx"
+default-features = false
+version = "=0.12.0-alpha.0"
 
 [dev-dependencies]
 eyre = "0.6.8"  # testing functions that return `eyre::Result`
 trybuild = "1"
-
-[dependencies.pgrx]
-path = "../pgrx"
-default-features = false
-version = "=0.12.0-alpha.0"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -68,5 +68,5 @@ default-features = false
 version = "=0.12.0-alpha.0"
 
 [dev-dependencies]
-eyre = "0.6.8"  # testing functions that return `eyre::Result`
+eyre.workspace = true # testing functions that return `eyre::Result`
 trybuild = "1"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -49,13 +49,13 @@ pgrx-pg-config.workspace = true
 
 eyre.workspace = true
 libc.workspace = true
+regex.workspace = true
 owo-colors.workspace = true
 
 clap-cargo = "0.11.0"
 once_cell = "1.18.0"
 postgres = "0.19.7"
 proptest = { version = "1", optional = true }
-regex = "1.10.0"
 serde = "1.0"
 serde_json = "1.0"
 sysinfo = "0.29.10"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -21,4 +21,4 @@ owo-colors.workspace = true
 walkdir.workspace = true
 
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
-toml_edit = { version = "0.20.2" }
+toml_edit = { version = "0.21" }

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -17,7 +17,8 @@ license = "MIT"
 description = "Standalone tool to update PGRX Cargo.toml versions and dependencies in preparation for a release."
 
 [dependencies]
+owo-colors.workspace = true
+
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
-owo-colors = "3.5"
 toml_edit = { version = "0.20.2" }
 walkdir = "2"

--- a/pgrx-version-updater/Cargo.toml
+++ b/pgrx-version-updater/Cargo.toml
@@ -18,7 +18,7 @@ description = "Standalone tool to update PGRX Cargo.toml versions and dependenci
 
 [dependencies]
 owo-colors.workspace = true
+walkdir.workspace = true
 
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
 toml_edit = { version = "0.20.2" }
-walkdir = "2"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -47,14 +47,13 @@ pgrx-macros.workspace = true
 pgrx-pg-sys.workspace = true
 pgrx-sql-entity-graph.workspace = true
 
+thiserror.workspace = true # error handling and logging
+
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
 seq-macro = "0.3" # impls loops in macros
 uuid = { version = "1.4.1", features = [ "v4" ] } # PgLwLock and shmem
 enum-map = "2.6.3"
-
-# error handling and logging
-thiserror = "1.0"
 
 # exposed in public API
 atomic-traits = "0.3.0" # PgAtomic and shmem init

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -43,9 +43,9 @@ no-default-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pgrx-macros = { path = "../pgrx-macros", version = "=0.12.0-alpha.0" }
-pgrx-pg-sys = { path = "../pgrx-pg-sys", version = "=0.12.0-alpha.0" }
-pgrx-sql-entity-graph = { path = "../pgrx-sql-entity-graph", version = "=0.12.0-alpha.0" }
+pgrx-macros.workspace = true
+pgrx-pg-sys.workspace = true
+pgrx-sql-entity-graph.workspace = true
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
@@ -61,7 +61,7 @@ atomic-traits = "0.3.0" # PgAtomic and shmem init
 bitflags = "2.4.0" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
 heapless = "0.8" # shmem and PgLwLock
-libc = "0.2.149" # FFI type compat
+libc.workspace = true # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)


### PR DESCRIPTION
This converts a number of dependencies to workspace dependencies so that they share a version, and does a bit of spring cleaning on the way things are organized. Some things that have complications due to features + default-features, or that I wish to remove without replacement, were not hoisted.