### PR TITLE
Simplify color-eyre initialization

### DIFF
--- a/cargo-pgrx/src/main.rs
+++ b/cargo-pgrx/src/main.rs
@@ -63,13 +63,7 @@ impl CommandExecute for CargoSubcommands {
 fn main() -> color_eyre::Result<()> {
     let stderr_is_tty = io::stderr().is_terminal();
     env::initialize();
-    color_eyre::config::HookBuilder::default()
-        .theme(if stderr_is_tty {
-            color_eyre::config::Theme::new()
-        } else {
-            color_eyre::config::Theme::default()
-        })
-        .install()?;
+    color_eyre::config::HookBuilder::default().theme(color_eyre::config::Theme::new()).install()?;
 
     let cargo_cli = CargoCommand::parse();
 


### PR DESCRIPTION
I mentioned that the bool was flipped here: https://github.com/pgcentralfoundation/pgrx/pull/1494#discussion_r1468206496

But it turns out Theme::new() and Theme::default() are the same anyway https://docs.rs/color-eyre/latest/src/color_eyre/config.rs.html#84-86, so the branch can be removed.