### PR TITLE
Add license check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -353,6 +353,9 @@ jobs:
     - name: Run rustfmt
       run: cargo fmt --all -- --check
 
+    - name: Run license check
+      run: ./ci/license-check.sh
+
     - name: Install cargo-pgrx
       run: cargo install --path cargo-pgrx/ --debug --force
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        version: []
+        version: ["postgres-15"]
         # version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,8 @@ jobs:
 
     strategy:
       matrix:
-        version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
+        version: []
+        # version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
 
     steps:
     - uses: actions/checkout@v3
@@ -354,7 +355,7 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Run license check
-      run: ./ci/license-check.sh
+      run: cargo install cargo-deny --force && ./ci/license-check.sh
 
     - name: Install cargo-pgrx
       run: cargo install --path cargo-pgrx/ --debug --force

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        version: ["postgres-15"]
-        # version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
+        version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arrays"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -277,7 +277,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytea"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "libflate",
  "pgrx",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "custom_libname"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "custom_types"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "maplit",
  "pgrx",
@@ -658,7 +658,7 @@ checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "datetime"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "errors"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "operators"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "pgtrybuilder"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "range"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -2219,7 +2219,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shmem"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "heapless",
  "pgrx",
@@ -2288,7 +2288,7 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "srf"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "strings"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",

--- a/ci/license-check.sh
+++ b/ci/license-check.sh
@@ -1,0 +1,2 @@
+cargo deny check licenses
+cd pgrx && cargo deny check licenses

--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,7 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
-    # "Unicode-DFS-2016",
+    "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
     "MPL-2.0"
@@ -78,7 +78,7 @@ default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
-confidence-threshold = 0.997 # it isn't six sigma but it'll do
+confidence-threshold = 0.99999 # we got five nines!
 # Allow 1 or more licenses on a per-crate basis.
 exceptions = [
     { allow = ["LicenseRef-Ring"], name = "ring", version = "*" },

--- a/deny.toml
+++ b/deny.toml
@@ -55,7 +55,8 @@ ignore = [
 # The lint level for crates which do not have a detectable license
 unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+# This allowlist is a superset of pgrx's allowlist, including the build tools like cargo-pgrx, etc.
+# We are not as concerned about licenses that affect linked code here: most tools aren't shipped.
 allow = [
     "0BSD",
     "Apache-2.0",
@@ -64,15 +65,12 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
+    "MPL-2.0",
     "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
-    "MPL-2.0"
 ]
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    #"Nokia",
-]
+deny = []
 copyleft = "deny" # https://github.com/EmbarkStudios/cargo-deny/issues/354
 default = "deny"
 # The confidence threshold for detecting a license from license text.

--- a/deny.toml
+++ b/deny.toml
@@ -42,10 +42,8 @@ ignore = [
 # Note that CVSS values only measure severity, not risk.
 #severity-threshold =
 
-# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is true, then cargo deny will use the git executable to fetch the advisory database.
 # If this is false, then it uses a built-in git library.
-# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
-# See Git Authentication for more information about setting up git authentication.
 #git-fetch-with-cli = true
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,139 @@
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though it may still note
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-apple-darwin" },
+]
+# When creating the dependency graph used, this can be used to prune crates from the graph,
+# removing them from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned.
+# Uses Package IDs: https://doc.rust-lang.org/cargo/reference/pkgid-spec.html
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Prefer using the command line.
+all-features = true
+# If true, metadata will be collected with `--no-default-features`. Prefer using the command line.
+no-default-features = false
+# If set, these features will be enabled when collecting metadata.
+# cargo deny --features "" # will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# cargo deny --feature-depth 9001 # will take precedence over this option
+feature-depth = 1
+
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+# Note that ignored advisories can still output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities based on CVSS
+# Note that CVSS values only measure severity, not risk.
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+    "MPL-2.0"
+]
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+copyleft = "deny" # https://github.com/EmbarkStudios/cargo-deny/issues/354
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+confidence-threshold = 0.997 # it isn't six sigma but it'll do
+# Allow 1 or more licenses on a per-crate basis.
+exceptions = [
+    { allow = ["LicenseRef-Ring"], name = "ring", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information
+# and adding a clarification entry allows manually specifying licensing.
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "LicenseRef-Ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[licenses.private]
+# ignores workspace crates that aren't published
+ignore = true
+registries = [] # private registries
+
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+workspace-default-features = "allow" # for "default" features here
+external-default-features = "allow" # for "default" features in other crates
+allow = [] # "I would prefer not to." — Bartleby the Scrivener
+deny = [
+    # Wrapper crates can optionally be specified to allow only for a direct dependency
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+skip = [] #{ name = "ansi_term", version = "=0.11.0" },
+# skip but includes transitive dependencies from name to depth of N (default: infinite)
+skip-tree = [] #{ name = "ansi_term", version = "=0.11.0", depth = 20 }
+
+#[[bans.features]]
+#name = "reqwest"
+#deny = ["json"]
+#allow = []
+# If true, the allowed features must exactly match.
+#exact = true
+
+
+
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = [""]
+gitlab = [""]
+bitbucket = [""]

--- a/deny.toml
+++ b/deny.toml
@@ -61,7 +61,7 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
-    "Unicode-DFS-2016",
+    # "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
     "MPL-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,6 @@
+# Configuration for cargo deny for the workspace
+# NOTE: pgrx (the library crate) has its own deny.toml because it is linked into extensions
+
 # Note that all fields that take a lint level have these possible values:
 # * deny - An error will be produced and the check will fail
 # * warn - A warning will be produced, but the check will not fail

--- a/pgrx-examples/aggregate/Cargo.toml
+++ b/pgrx-examples/aggregate/Cargo.toml
@@ -12,6 +12,7 @@
 name = "aggregate"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/arrays/Cargo.toml
+++ b/pgrx-examples/arrays/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "arrays"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/bad_ideas/Cargo.toml
+++ b/pgrx-examples/bad_ideas/Cargo.toml
@@ -12,6 +12,7 @@
 name = "bad_ideas"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/bgworker/Cargo.toml
+++ b/pgrx-examples/bgworker/Cargo.toml
@@ -12,6 +12,7 @@
 name = "bgworker"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/bytea/Cargo.toml
+++ b/pgrx-examples/bytea/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "bytea"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/composite_type/Cargo.toml
+++ b/pgrx-examples/composite_type/Cargo.toml
@@ -12,6 +12,7 @@
 name = "composite_type"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/custom_libname/Cargo.toml
+++ b/pgrx-examples/custom_libname/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "custom_libname"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/custom_sql/Cargo.toml
+++ b/pgrx-examples/custom_sql/Cargo.toml
@@ -12,6 +12,7 @@
 name = "custom_sql"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/custom_types/Cargo.toml
+++ b/pgrx-examples/custom_types/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "custom_types"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/datetime/Cargo.toml
+++ b/pgrx-examples/datetime/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "datetime"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/errors/Cargo.toml
+++ b/pgrx-examples/errors/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "errors"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/nostd/Cargo.toml
+++ b/pgrx-examples/nostd/Cargo.toml
@@ -12,6 +12,7 @@
 name = "nostd"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/numeric/Cargo.toml
+++ b/pgrx-examples/numeric/Cargo.toml
@@ -12,6 +12,7 @@
 name = "numeric"
 version = "0.0.0"
 edition = "2021"
+publish = false
 rust-version = "1.58"
 
 [lib]

--- a/pgrx-examples/operators/Cargo.toml
+++ b/pgrx-examples/operators/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "operators"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/pgtrybuilder/Cargo.toml
+++ b/pgrx-examples/pgtrybuilder/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "pgtrybuilder"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/range/Cargo.toml
+++ b/pgrx-examples/range/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "range"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/schemas/Cargo.toml
+++ b/pgrx-examples/schemas/Cargo.toml
@@ -12,6 +12,7 @@
 name = "schemas"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/shmem/Cargo.toml
+++ b/pgrx-examples/shmem/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "shmem"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/spi/Cargo.toml
+++ b/pgrx-examples/spi/Cargo.toml
@@ -12,6 +12,7 @@
 name = "spi"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/spi_srf/Cargo.toml
+++ b/pgrx-examples/spi_srf/Cargo.toml
@@ -12,6 +12,7 @@
 name = "spi_srf"
 version = "0.0.0"
 edition = "2021"
+publish = false
 rust-version = "1.58"
 
 [lib]

--- a/pgrx-examples/srf/Cargo.toml
+++ b/pgrx-examples/srf/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "srf"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/strings/Cargo.toml
+++ b/pgrx-examples/strings/Cargo.toml
@@ -10,8 +10,9 @@
  
 [package]
 name = "strings"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/triggers/Cargo.toml
+++ b/pgrx-examples/triggers/Cargo.toml
@@ -12,6 +12,7 @@
 name = "triggers"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/versioned_custom_libname_so/Cargo.toml
+++ b/pgrx-examples/versioned_custom_libname_so/Cargo.toml
@@ -12,6 +12,7 @@
 name = "versioned_custom_libname_so"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx-examples/versioned_so/Cargo.toml
+++ b/pgrx-examples/versioned_so/Cargo.toml
@@ -12,6 +12,7 @@
 name = "versioned_so"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/pgrx/deny.toml
+++ b/pgrx/deny.toml
@@ -1,0 +1,134 @@
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though it may still note
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-apple-darwin" },
+]
+# When creating the dependency graph used, this can be used to prune crates from the graph,
+# removing them from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned.
+# Uses Package IDs: https://doc.rust-lang.org/cargo/reference/pkgid-spec.html
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Prefer using the command line.
+all-features = true
+# If true, metadata will be collected with `--no-default-features`. Prefer using the command line.
+no-default-features = false
+# If set, these features will be enabled when collecting metadata.
+# cargo deny --features "" # will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# cargo deny --feature-depth 9001 # will take precedence over this option
+feature-depth = 1
+
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+# Note that ignored advisories can still output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities based on CVSS
+# Note that CVSS values only measure severity, not risk.
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+]
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+copyleft = "deny" # https://github.com/EmbarkStudios/cargo-deny/issues/354
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+confidence-threshold = 0.997 # it isn't six sigma but it'll do
+# Allow 1 or more licenses on a per-crate basis.
+exceptions = []
+
+# Some crates don't have (easily) machine readable licensing information
+# and adding a clarification entry allows manually specifying licensing.
+# [[licenses.clarify]]
+# name = "ring"
+# version = "*"
+# expression = "LicenseRef-Ring"
+# license-files = [
+#     { path = "LICENSE", hash = 0xbd0eed23 },
+# ]
+
+[licenses.private]
+# ignores workspace crates that aren't published
+ignore = true
+registries = [] # private registries
+
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+workspace-default-features = "allow" # for "default" features here
+external-default-features = "allow" # for "default" features in other crates
+allow = [] # "I would prefer not to." — Bartleby the Scrivener
+deny = [
+    # Wrapper crates can optionally be specified to allow only for a direct dependency
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+skip = [] #{ name = "ansi_term", version = "=0.11.0" },
+# skip but includes transitive dependencies from name to depth of N (default: infinite)
+skip-tree = [] #{ name = "ansi_term", version = "=0.11.0", depth = 20 }
+
+#[[bans.features]]
+#name = "reqwest"
+#deny = ["json"]
+#allow = []
+# If true, the allowed features must exactly match.
+#exact = true
+
+
+
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = [""]
+gitlab = [""]
+bitbucket = [""]

--- a/pgrx/deny.toml
+++ b/pgrx/deny.toml
@@ -42,10 +42,8 @@ ignore = [
 # Note that CVSS values only measure severity, not risk.
 #severity-threshold =
 
-# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is true, then cargo deny will use the git executable to fetch the advisory database.
 # If this is false, then it uses a built-in git library.
-# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
-# See Git Authentication for more information about setting up git authentication.
 #git-fetch-with-cli = true
 
 

--- a/pgrx/deny.toml
+++ b/pgrx/deny.toml
@@ -59,7 +59,7 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
-    # "Unicode-DFS-2016",
+    "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
 ]

--- a/pgrx/deny.toml
+++ b/pgrx/deny.toml
@@ -52,7 +52,7 @@ ignore = [
 # The lint level for crates which do not have a detectable license
 unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+# Be more cautious about adding licenses to the library itself, as they can affect all extensions.
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
@@ -63,10 +63,7 @@ allow = [
     "Unlicense",
     "Zlib",
 ]
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    #"Nokia",
-]
+deny = []
 copyleft = "deny" # https://github.com/EmbarkStudios/cargo-deny/issues/354
 default = "deny"
 # The confidence threshold for detecting a license from license text.

--- a/pgrx/deny.toml
+++ b/pgrx/deny.toml
@@ -59,7 +59,7 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
-    "Unicode-DFS-2016",
+    # "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
 ]

--- a/pgrx/deny.toml
+++ b/pgrx/deny.toml
@@ -59,7 +59,7 @@ allow = [
     "BSL-1.0",
     "ISC",
     "MIT",
-    # "Unicode-DFS-2016",
+    "Unicode-DFS-2016",
     "Unlicense",
     "Zlib",
 ]
@@ -72,7 +72,7 @@ default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
-confidence-threshold = 0.997 # it isn't six sigma but it'll do
+confidence-threshold = 0.99999 # we got five nines!
 # Allow 1 or more licenses on a per-crate basis.
 exceptions = []
 


### PR DESCRIPTION
This uses an allow list, mostly-duplicates the deny.toml, and runs a simple shell script instead of using the action, so that the pgrx library can have an independently tracked set of licenses. This is done because the dependencies of that are liable to be actually linked into extensions as dynamic libraries.

In order to let the deny.toml have accurate reporting, the example extension crates are marked as being unpublished. I also tweaked the version on them because I didn't care about the version field in my regex-replace.

Closes #1502.