### PR TITLE
Bounds-checking debug assertions for array access

### DIFF
--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -189,12 +189,14 @@ impl<'mcx, T: UnboxDatum> Array<'mcx, T> {
     #[allow(clippy::option_option)]
     #[inline]
     pub fn get<'arr>(&'arr self, index: usize) -> Option<Option<T::As<'arr>>> {
-        // Technically this should be covered by the null_slice check, 
+        // Technically this should be covered by the null_slice check,
         // but that assumes the null bitmap is well-formed (i.e. equal in
-        // length to the array), which might be worth double-checking in 
-        // debug builds. 
+        // length to the array), which might be worth double-checking in
+        // debug builds.
         #[cfg(debug_assertions)]
-        if index >= self.raw.len() { return None };
+        if index >= self.raw.len() {
+            return None;
+        };
 
         let Some(is_null) = self.null_slice.get(index) else { return None };
         if is_null {
@@ -244,14 +246,12 @@ impl<'mcx, T: UnboxDatum> Array<'mcx, T> {
                 debug_assert!(self.is_within_bounds(ptr));
                 // Prevent a datum that begins inside the array but would end
                 // outside the array from being dereferenced.
-                debug_assert!(
-                    self.is_within_bounds_inclusive(
-                        ptr.wrapping_add(unsafe { self.slide_impl.hop_size(ptr) })
-                    )
-                );
+                debug_assert!(self.is_within_bounds_inclusive(
+                    ptr.wrapping_add(unsafe { self.slide_impl.hop_size(ptr) })
+                ));
 
                 unsafe { self.slide_impl.bring_it_back_now(self, ptr) }
-            },
+            }
         }
     }
 

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -278,13 +278,25 @@ impl<'mcx, T: UnboxDatum> Array<'mcx, T> {
     /// position for a pointer to be in, but not valid to dereference.
     #[inline]
     pub(crate) fn is_within_bounds(&self, ptr: *const u8) -> bool {
-        (self.raw.data_ptr() <= ptr) && (ptr < self.raw.end_ptr())
+        // Cast to usize, to prevent LLVM from doing counterintuitive things
+        // with pointer equality.
+        // See https://github.com/pgcentralfoundation/pgrx/pull/1514#discussion_r1480447846
+        let ptr: usize = ptr as usize;
+        let data_ptr = self.raw.data_ptr() as usize;
+        let end_ptr = self.raw.end_ptr() as usize;
+        (data_ptr <= ptr) && (ptr < end_ptr)
     }
     /// Similar to [`Self::is_within_bounds()`], but also returns true for the
     /// 1-past-end position.
     #[inline]
     pub(crate) fn is_within_bounds_inclusive(&self, ptr: *const u8) -> bool {
-        (self.raw.data_ptr() <= ptr) && (ptr <= self.raw.end_ptr())
+        // Cast to usize, to prevent LLVM from doing counterintuitive things
+        // with pointer equality.
+        // See https://github.com/pgcentralfoundation/pgrx/pull/1514#discussion_r1480447846
+        let ptr = ptr as usize;
+        let data_ptr = self.raw.data_ptr() as usize;
+        let end_ptr = self.raw.end_ptr() as usize;
+        (data_ptr <= ptr) && (ptr <= end_ptr)
     }
 }
 

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -193,7 +193,7 @@ impl<'mcx, T: UnboxDatum> Array<'mcx, T> {
         if is_null {
             return Some(None);
         }
-        
+
         // This assertion should only fail if null_slice is longer than the
         // actual array,thanks to the check above.
         debug_assert!(index < self.raw.len());

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -285,7 +285,7 @@ impl<'mcx, T: UnboxDatum> Array<'mcx, T> {
     pub(crate) fn is_within_bounds(&self, ptr: *const u8) -> bool {
         (self.raw.data_ptr() <= ptr) && (ptr < self.raw.end_ptr())
     }
-    /// Similar to [is_within_bounds()], but also returns true for the
+    /// Similar to [`Self::is_within_bounds()`], but also returns true for the
     /// 1-past-end position.
     #[inline]
     pub(crate) fn is_within_bounds_inclusive(&self, ptr: *const u8) -> bool {


### PR DESCRIPTION
This introduces several `debug_assert!()` calls around any attempt to dereference an element in a Postgres array, in order to catch memory bugs. It was written to resolve pgcentralfoundation/pgrx#1195. 

If RawArray's `end_ptr()` ever pointed at something other than one byte past the end of the array's buffer, this might fail to catch memory bugs. However, it should be pointing to the end of the ArrayType's varlena, which includes the ArrayType header, its null bitmap, and its data, so this should work.