### PR TITLE
Add how-to for installing on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ and `double`. This may not be "unsound" in itself, as it is "merely" illogical,
 but it may undermine otherwise-reasonable safety assumptions of PGRX extensions.
 We do not plan to add support without considerable ongoing technical and financial contributions.
 
-<details>
-   <summary>How to: GCC 7 on CentOS 7</summary>
+<details style="border: 1px solid; padding: 0.25em 0.5em 0;">
+   <summary><i>How to:</i> <b>GCC 7 on CentOS 7</b></summary>
 
 It is not recommended to use CentOS 7 for PGRX development, even if it works.
 
@@ -104,8 +104,8 @@ scl enable devtoolset-7 bash
 ```
 </details>
 
-<details>
-   <summary>How to: Homebrew on macOS</summary>
+<details style="border: 1px solid; padding: 0.25em 0.5em 0;">
+   <summary><i>How to:</i> <b>Homebrew on macOS</b></summary>
 
 As macOS provides no package manager, it is recommended to use https://brew.sh for C dependencies.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ scl enable devtoolset-7 bash
 ```
 </details>
 
+<details>
+   <summary>How to: Homebrew on macOS</summary>
+
+As macOS provides no package manager, it is recommended to use https://brew.sh for C dependencies.
+
+In particular, you will probably need these if you don't have them already:
+
+```zsh
+brew install git icu4c pkg-config
+```
+</details>
+
 ## Getting Started
 
 

--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -16,6 +16,10 @@ $ cargo install --locked cargo-pgrx
 
 As new versions of `pgrx` are released, you'll want to make sure you run this command again to update it. You should also reinstall `cargo-pgrx` whenever you update `rustc` so that the same compiler is used to build `cargo-pgrx` and your Postgres extensions. You can force `cargo` to reinstall an existing crate by passing `--force`.
 
+Note that some of the features of PGRX involve compiling C code, including `cargo pgrx init`, and
+as such you will also need a toolchain for doing so and potentially must provide various libraries.
+Normally, Rust requires a C toolchain anyways, but it does not require e.g. pkg-config.
+
 ## Usage
 
 ```console


### PR DESCRIPTION
The errors emitted during build for the pkg-config problem, in particular, can be a bit cryptic and misleading (pointing to icu4c instead), so suggest people use brew to install the relevant packages. Fixes https://github.com/pgcentralfoundation/pgrx/issues/1434

Co-authored-by: @notgyro