### PR TITLE
chore: remove unneeded namespace in examples

### DIFF
--- a/cargo-pgrx/src/templates/bgworker_lib_rs
+++ b/cargo-pgrx/src/templates/bgworker_lib_rs
@@ -2,7 +2,7 @@ use pgrx::bgworkers::*;
 use pgrx::prelude::*;
 use std::time::Duration;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 /*
 In order to use this bgworker with a cargo-pgrx managed database, you'll need to add this line to

--- a/cargo-pgrx/src/templates/lib_rs
+++ b/cargo-pgrx/src/templates/lib_rs
@@ -1,6 +1,6 @@
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn hello_{name}() -> &'static str {{

--- a/nix/templates/default/src/lib.rs
+++ b/nix/templates/default/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn hello() -> &'static str {

--- a/pgrx-examples/aggregate/src/lib.rs
+++ b/pgrx-examples/aggregate/src/lib.rs
@@ -10,11 +10,11 @@
 use core::ffi::CStr;
 use pgrx::aggregate::*;
 use pgrx::prelude::*;
-use pgrx::{pgrx, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
+use pgrx::{PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -11,7 +11,7 @@ use pgrx::prelude::*;
 use pgrx::Array;
 use serde::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn sq_euclid_pgrx(a: Array<f32>, b: Array<f32>) -> f32 {

--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::panic::catch_unwind;
 use std::process::Command;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn panic(s: &str) -> bool {

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
     this background worker
 */
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_guard]
 pub extern "C" fn _PG_init() {

--- a/pgrx-examples/bytea/src/lib.rs
+++ b/pgrx-examples/bytea/src/lib.rs
@@ -11,7 +11,7 @@ use libflate::gzip::{Decoder, Encoder};
 use pgrx::prelude::*;
 use std::io::{Read, Write};
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 /// gzip bytes.  Postgres will automatically convert `text`/`varchar` data into `bytea`
 #[pg_extern]

--- a/pgrx-examples/composite_type/src/lib.rs
+++ b/pgrx-examples/composite_type/src/lib.rs
@@ -23,7 +23,7 @@ using composite types.
 use pgrx::{opname, pg_operator, prelude::*, Aggregate};
 
 // All `pgrx` extensions will do this:
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 /* Composite types must be defined either before they are used.
 

--- a/pgrx-examples/custom_libname/src/lib.rs
+++ b/pgrx-examples/custom_libname/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn hello_custom_libname() -> &'static str {

--- a/pgrx-examples/custom_sql/src/lib.rs
+++ b/pgrx-examples/custom_sql/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_schema]
 mod home {

--- a/pgrx-examples/datetime/src/lib.rs
+++ b/pgrx-examples/datetime/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use rand::Rng;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern(name = "to_iso_string", immutable, parallel_safe)]
 fn to_iso_string(tsz: TimestampWithTimeZone) -> String {

--- a/pgrx-examples/errors/src/lib.rs
+++ b/pgrx-examples/errors/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::{error, info, warning, PgRelation, FATAL, PANIC};
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn array_with_null_and_panic(input: Vec<Option<i32>>) -> i64 {

--- a/pgrx-examples/nostd/src/lib.rs
+++ b/pgrx-examples/nostd/src/lib.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use alloc::string::String;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 /// standard Rust equality/comparison derives
 #[derive(Eq, PartialEq, Ord, Hash, PartialOrd)]

--- a/pgrx-examples/operators/src/lib.rs
+++ b/pgrx-examples/operators/src/lib.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 mod derived;
 mod pgvarlena;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[derive(PostgresType, Serialize, Deserialize, Eq, PartialEq)]
 pub struct MyType {

--- a/pgrx-examples/pgtrybuilder/src/lib.rs
+++ b/pgrx-examples/pgtrybuilder/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::pg_sys::panic::CaughtError;
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn is_valid_number(i: i32) -> i32 {

--- a/pgrx-examples/range/src/lib.rs
+++ b/pgrx-examples/range/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn range(s: i32, e: i32) -> pgrx::Range<i32> {

--- a/pgrx-examples/schemas/src/lib.rs
+++ b/pgrx-examples/schemas/src/lib.rs
@@ -13,7 +13,7 @@
 use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[derive(PostgresType, Serialize, Deserialize)]
 pub struct MyType(pub(crate) String);

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -16,7 +16,7 @@ use serde::*;
 use std::iter::Iterator;
 use std::sync::atomic::Ordering;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 // types behind a `LwLock` must derive/implement `Copy` and `Clone`
 #[derive(Copy, Clone)]

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::{info, spi, IntoDatum};
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 extension_sql!(
     r#"

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::IntoDatum;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 extension_sql!(
     r#"

--- a/pgrx-examples/srf/src/lib.rs
+++ b/pgrx-examples/srf/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn generate_series(start: i64, finish: i64, step: default!(i64, 1)) -> SetOfIterator<'static, i64> {

--- a/pgrx-examples/strings/src/lib.rs
+++ b/pgrx-examples/strings/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn return_static() -> &'static str {

--- a/pgrx-examples/triggers/src/lib.rs
+++ b/pgrx-examples/triggers/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::WhoAllocated;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[derive(thiserror::Error, Debug)]
 enum TriggerError {

--- a/pgrx-examples/versioned_custom_libname_so/src/lib.rs
+++ b/pgrx-examples/versioned_custom_libname_so/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn hello_versioned_custom_libname_so() -> &'static str {

--- a/pgrx-examples/versioned_so/src/lib.rs
+++ b/pgrx-examples/versioned_so/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+pg_module_magic!();
 
 #[pg_extern]
 fn hello_versioned_so() -> &'static str {

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -65,4 +65,3 @@ seahash = "4.1.0" # derive(PostgresHash)
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
 serde_json = "1.0" # everything JSON
-

--- a/pgrx/src/aggregate.rs
+++ b/pgrx/src/aggregate.rs
@@ -26,7 +26,7 @@ the trait itself has several items, only a few are required, the macro will fill
 use pgrx::prelude::*;
 use serde::{Serialize, Deserialize};
 
-// pgrx::pg_module_magic!(); // Uncomment this outside of docs!
+// pg_module_magic!(); // Uncomment this outside of docs!
 
 #[derive(Copy, Clone, Default, PostgresType, Serialize, Deserialize)]
 pub struct DemoSum {


### PR DESCRIPTION
Remove `pgrx::` in `pgrx::pg_module_magic!();` because `use pgrx::prelude::*;` already includes that.

This is part of the `unused_qualifications` build lint. I will submit another PR after running this:

```bash
RUSTFLAGS='-W unused_qualifications' cargo check --workspace --all-targets
```