### PR TITLE
chore: inline format args

### DIFF
--- a/cargo-pgrx/src/command/get.rs
+++ b/cargo-pgrx/src/command/get.rs
@@ -41,7 +41,7 @@ impl CommandExecute for Get {
                 .wrap_err("Couldn't get manifest path")?;
 
         if let Some(value) = get_property(package_manifest_path, &self.name)? {
-            println!("{}", value);
+            println!("{value}");
         }
         Ok(())
     }

--- a/cargo-pgrx/src/command/info.rs
+++ b/cargo-pgrx/src/command/info.rs
@@ -82,6 +82,6 @@ fn version(ver: &str) -> Cow<str> {
     if ver.starts_with("pg") {
         Cow::Borrowed(ver)
     } else {
-        Cow::Owned(format!("pg{}", ver))
+        Cow::Owned(format!("pg{ver}"))
     }
 }

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -132,7 +132,7 @@ impl CommandExecute for Init {
                         .as_ref()
                         .unwrap() // We just set this
                         .get(pgver)
-                        .wrap_err_with(|| format!("{} is not a known Postgres version", pgver))?
+                        .wrap_err_with(|| format!("{pgver} is not a known Postgres version"))?
                         .clone()
                 } else {
                     let config = PgConfig::new_with_defaults(pg_config_path.as_str().into());
@@ -207,7 +207,7 @@ pub(crate) fn init_pgrx(pgrx: &Pgrx, init: &Init) -> eyre::Result<()> {
 
     output_configs.sort_by(|a, b| {
         a.major_version()
-            .unwrap_or_else(|e| panic!("{e}:  could not determine major version for: `{:?}`", a))
+            .unwrap_or_else(|e| panic!("{e}:  could not determine major version for: `{a:?}`"))
             .cmp(&b.major_version().ok().expect("could not determine major version"))
     });
     for pg_config in output_configs.iter() {
@@ -445,7 +445,7 @@ fn configure_postgres(pg_config: &PgConfig, pgdir: &PathBuf, init: &Init) -> eyr
     if cfg!(target_os = "macos") && pg_config.major_version().unwrap_or(0) == 16 {
         fixup_homebrew_for_icu(&mut command);
     }
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     tracing::debug!(command = %command_str, "Running");
     let child = command.spawn()?;
     let output = child.wait_with_output()?;
@@ -481,7 +481,7 @@ fn make_postgres(pg_config: &PgConfig, pgdir: &PathBuf, init: &Init) -> eyre::Re
         command.env_remove(var);
     }
 
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     tracing::debug!(command = %command_str, "Running");
     let child = init.jobserver.get().unwrap().configure_and_run(&mut command, |cmd| cmd.spawn())?;
     let output = child.wait_with_output()?;
@@ -522,7 +522,7 @@ fn make_install_postgres(
         command.env_remove(var);
     }
 
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     tracing::debug!(command = %command_str, "Running");
     let child = init.jobserver.get().unwrap().configure_and_run(&mut command, |cmd| cmd.spawn())?;
     let output = child.wait_with_output()?;
@@ -611,7 +611,7 @@ pub(crate) fn initdb(bindir: &PathBuf, datadir: &PathBuf) -> eyre::Result<()> {
         .arg("-D")
         .arg(datadir);
 
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     tracing::debug!(command = %command_str, "Running");
 
     let output = command.output().wrap_err_with(|| eyre!("unable to execute: {}", command_str))?;

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -196,7 +196,7 @@ pub(crate) fn install_extension(
         } else {
             "so"
         };
-        dest.push(format!("{}.{}", so_name, so_extension));
+        dest.push(format!("{so_name}.{so_extension}"));
 
         // Remove the existing shared libraries if present. This is a workaround for an
         // issue highlighted by the following apple documentation:
@@ -332,11 +332,11 @@ pub(crate) fn build_extension(
     }
 
     let command = command.stderr(Stdio::inherit());
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     println!("{} extension with features {}", "    Building".bold().green(), features_arg.cyan());
     println!("{} command {}", "     Running".bold().green(), command_str.cyan());
     let cargo_output =
-        command.output().wrap_err_with(|| format!("failed to spawn cargo: {}", command_str))?;
+        command.output().wrap_err_with(|| format!("failed to spawn cargo: {command_str}"))?;
     if !cargo_output.status.success() {
         // We explicitly do not want to return a spantraced error here.
         std::process::exit(1)
@@ -355,7 +355,7 @@ fn get_target_sql_file(
 
     let (_, extname) = find_control_file(&manifest_path)?;
     let version = get_version(&manifest_path)?;
-    dest.push(format!("{}--{}.sql", extname, version));
+    dest.push(format!("{extname}--{version}.sql"));
 
     Ok(dest)
 }
@@ -397,7 +397,7 @@ fn copy_sql_files(
             if let Ok(sql) = sql {
                 let filename = sql.file_name().into_string().unwrap();
 
-                if filename.starts_with(&format!("{}--", extname)) && filename.ends_with(".sql") {
+                if filename.starts_with(&format!("{extname}--")) && filename.ends_with(".sql") {
                     let mut dest = base_directory.clone();
                     dest.push(extdir);
                     dest.push(filename);

--- a/cargo-pgrx/src/command/new.rs
+++ b/cargo-pgrx/src/command/new.rs
@@ -79,7 +79,7 @@ fn create_directory_structure(path: &PathBuf) -> Result<(), std::io::Error> {
 fn create_control_file(path: &PathBuf, name: &str) -> Result<(), std::io::Error> {
     let mut filename = path.clone();
 
-    filename.push(format!("{}.control", name));
+    filename.push(format!("{name}.control"));
     let mut file = std::fs::File::create(filename)?;
 
     file.write_all(format!(include_str!("../templates/control"), name = name).as_bytes())?;

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -150,6 +150,6 @@ pub(crate) fn build_base_path(
     let extname = get_property(manifest_path, "extname")?
         .ok_or(eyre!("could not determine extension name"))?;
     target_dir.push(profile.target_subdir());
-    target_dir.push(format!("{}-pg{}", extname, pgver));
+    target_dir.push(format!("{extname}-pg{pgver}"));
     Ok(target_dir)
 }

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -257,7 +257,7 @@ pub(crate) fn generate_schema(
         }
 
         let command = command.stderr(Stdio::inherit());
-        let command_str = format!("{:?}", command);
+        let command_str = format!("{command:?}");
         eprintln!(
             "{} for SQL generation with features `{}`",
             "    Building".bold().green(),
@@ -266,7 +266,7 @@ pub(crate) fn generate_schema(
 
         tracing::debug!(command = %command_str, "Running");
         let cargo_output =
-            command.output().wrap_err_with(|| format!("failed to spawn cargo: {}", command_str))?;
+            command.output().wrap_err_with(|| format!("failed to spawn cargo: {command_str}"))?;
         tracing::trace!(status_code = %cargo_output.status, command = %command_str, "Finished");
 
         if !cargo_output.status.success() {
@@ -413,7 +413,7 @@ pub(crate) fn generate_schema(
         for symbol_to_call in fns_to_call {
             let symbol: libloading::os::unix::Symbol<unsafe extern "Rust" fn() -> pgrx_sql_entity_graph::SqlGraphEntity> =
                 lib.get(symbol_to_call.as_bytes()).unwrap_or_else(|_|
-                    panic!("Couldn't call {:#?}", symbol_to_call));
+                    panic!("Couldn't call {symbol_to_call:#?}"));
             let entity = symbol();
             entities.push(entity);
         }
@@ -541,7 +541,7 @@ fn create_stub(
             .ok_or(eyre!("could not call postmaster_stub_file.to_str()"))?,
     ]);
 
-    let so_rustc_invocation_str = format!("{:?}", so_rustc_invocation);
+    let so_rustc_invocation_str = format!("{so_rustc_invocation:?}");
     tracing::debug!(command = %so_rustc_invocation_str, "Running");
     let output = so_rustc_invocation.output().wrap_err_with(|| {
         eyre!("could not invoke `rustc` on {}", &postmaster_stub_file.display())

--- a/cargo-pgrx/src/command/start.rs
+++ b/cargo-pgrx/src/command/start.rs
@@ -102,7 +102,7 @@ pub(crate) fn start_postgres(pg_config: &PgConfig) -> eyre::Result<()> {
         .arg("-l")
         .arg(&logfile);
 
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     let output = command.output()?;
 
     if !output.status.success() {

--- a/cargo-pgrx/src/command/status.rs
+++ b/cargo-pgrx/src/command/status.rs
@@ -68,7 +68,7 @@ pub(crate) fn status_postgres(pg_config: &PgConfig) -> eyre::Result<bool> {
     pg_ctl.push("pg_ctl");
     let mut command = process::Command::new(pg_ctl);
     command.stdout(Stdio::piped()).stderr(Stdio::piped()).arg("status").arg("-D").arg(&datadir);
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     tracing::debug!(command = %command_str, "Running");
 
     let output = command.output()?;

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -173,7 +173,7 @@ pub fn test_extension(
         command.arg(testname.as_ref());
     }
 
-    eprintln!("{:?}", command);
+    eprintln!("{command:?}");
 
     tracing::debug!(command = ?command, "Running");
     let status = command.status().wrap_err("failed to run cargo test")?;

--- a/cargo-pgrx/src/command/version.rs
+++ b/cargo-pgrx/src/command/version.rs
@@ -39,7 +39,7 @@ mod rss {
             let response = http_client
                 .get(VERSIONS_RSS_URL)
                 .call()
-                .wrap_err_with(|| format!("unable to retrieve {}", VERSIONS_RSS_URL))?;
+                .wrap_err_with(|| format!("unable to retrieve {VERSIONS_RSS_URL}"))?;
 
             let rss: Rss = match serde_xml_rs::from_str(&response.into_string()?) {
                 Ok(rss) => rss,
@@ -66,8 +66,7 @@ mod rss {
                         // fill in the latest minor version number and its url
                         known_pgver.minor = PgMinorVersion::Release(minor);
                         known_pgver.url = Some(Url::parse(
-                                &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2",
-                                         major = major, minor = minor)
+                                &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2")
                             )?);
                     }
                 }

--- a/cargo-pgrx/src/main.rs
+++ b/cargo-pgrx/src/main.rs
@@ -83,12 +83,12 @@ fn main() -> color_eyre::Result<()> {
             };
             let filter_layer = EnvFilter::new("warn");
             filter_layer
-                .add_directive(format!("cargo_pgrx={}", log_level).parse()?)
-                .add_directive(format!("pgrx={}", log_level).parse()?)
-                .add_directive(format!("pgrx_macros={}", log_level).parse()?)
-                .add_directive(format!("pgrx_tests={}", log_level).parse()?)
-                .add_directive(format!("pgrx_pg_sys={}", log_level).parse()?)
-                .add_directive(format!("pgrx_utils={}", log_level).parse()?)
+                .add_directive(format!("cargo_pgrx={log_level}").parse()?)
+                .add_directive(format!("pgrx={log_level}").parse()?)
+                .add_directive(format!("pgrx_macros={log_level}").parse()?)
+                .add_directive(format!("pgrx_tests={log_level}").parse()?)
+                .add_directive(format!("pgrx_pg_sys={log_level}").parse()?)
+                .add_directive(format!("pgrx_utils={log_level}").parse()?)
         }
     };
 

--- a/cargo-pgrx/src/metadata.rs
+++ b/cargo-pgrx/src/metadata.rs
@@ -33,7 +33,7 @@ pub fn validate(
     metadata: &Metadata,
 ) -> eyre::Result<()> {
     let cargo_pgrx_version = env!("CARGO_PKG_VERSION");
-    let cargo_pgrx_version_req = VersionReq::parse(&format!("~{}", cargo_pgrx_version))?;
+    let cargo_pgrx_version_req = VersionReq::parse(&format!("~{cargo_pgrx_version}"))?;
 
     let pgrx_packages = metadata.packages.iter().filter(|package| {
         package.name == "pgrx"

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -184,12 +184,12 @@ pub fn pg_cast(attr: TokenStream, item: TokenStream) -> TokenStream {
                     {
                         "implicit" => cast = PgCast::Implicit,
                         "assignment" => cast = PgCast::Assignment,
-                        other => panic!("Unrecognized pg_cast option: {}. ", other),
+                        other => panic!("Unrecognized pg_cast option: {other}. "),
                     }
                 }
             }
             Err(err) => {
-                panic!("Failed to parse attribute to pg_cast: {}", err)
+                panic!("Failed to parse attribute to pg_cast: {err}")
             }
         }
         // `pg_cast` does not support other `pg_extern` attributes for now, pass an empty attribute token stream.
@@ -795,8 +795,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     let name = &ast.ident;
     let generics = &ast.generics;
     let has_lifetimes = generics.lifetimes().next();
-    let funcname_in = Ident::new(&format!("{}_in", name).to_lowercase(), name.span());
-    let funcname_out = Ident::new(&format!("{}_out", name).to_lowercase(), name.span());
+    let funcname_in = Ident::new(&format!("{name}_in").to_lowercase(), name.span());
+    let funcname_out = Ident::new(&format!("{name}_out").to_lowercase(), name.span());
     let mut args = parse_postgres_type_args(&ast.attrs);
     let mut stream = proc_macro2::TokenStream::new();
 

--- a/pgrx-macros/src/operators.rs
+++ b/pgrx-macros/src/operators.rs
@@ -93,7 +93,7 @@ pub(crate) fn deriving_postgres_hash(ast: DeriveInput) -> syn::Result<proc_macro
 ///
 /// ["optimization hints"]: https://www.postgresql.org/docs/current/xoper-optimization.html
 pub fn derive_pg_eq(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_eq", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_eq").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_operator(immutable, parallel_safe)]
@@ -122,7 +122,7 @@ pub fn derive_pg_eq(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
 ///
 /// See `derive_pg_eq` for the implications of this assumption.
 pub fn derive_pg_ne(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_ne", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_ne").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_operator(immutable, parallel_safe)]
@@ -138,7 +138,7 @@ pub fn derive_pg_ne(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
 }
 
 pub fn derive_pg_lt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_lt", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_lt").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_operator(immutable, parallel_safe)]
@@ -155,7 +155,7 @@ pub fn derive_pg_lt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
 }
 
 pub fn derive_pg_gt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_gt", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_gt").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_operator(immutable, parallel_safe)]
@@ -171,7 +171,7 @@ pub fn derive_pg_gt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
 }
 
 pub fn derive_pg_le(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_le", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_le").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_operator(immutable, parallel_safe)]
@@ -187,7 +187,7 @@ pub fn derive_pg_le(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
 }
 
 pub fn derive_pg_ge(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_ge", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_ge").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_operator(immutable, parallel_safe)]
@@ -203,7 +203,7 @@ pub fn derive_pg_ge(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
 }
 
 pub fn derive_pg_cmp(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_cmp", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_cmp").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
@@ -228,7 +228,7 @@ pub fn derive_pg_cmp(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macr
 /// Postgres is no different: this hashing is for the explicit purpose of equality checks,
 /// and it also needs to be able to reason from hash equality to actual equality.
 pub fn derive_pg_hash(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    let pg_name = Ident::new(&format!("{}_hash", name).to_lowercase(), name.span());
+    let pg_name = Ident::new(&format!("{name}_hash").to_lowercase(), name.span());
     quote! {
         #[allow(non_snake_case)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -68,9 +68,9 @@ impl Display for PgMinorVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             PgMinorVersion::Latest => write!(f, ".LATEST"),
-            PgMinorVersion::Release(v) => write!(f, ".{}", v),
-            PgMinorVersion::Beta(v) => write!(f, "beta{}", v),
-            PgMinorVersion::Rc(v) => write!(f, "rc{}", v),
+            PgMinorVersion::Release(v) => write!(f, ".{v}"),
+            PgMinorVersion::Beta(v) => write!(f, "beta{v}"),
+            PgMinorVersion::Rc(v) => write!(f, "rc{v}"),
         }
     }
 }
@@ -294,7 +294,7 @@ impl PgConfig {
             None => {
                 let major = self.major_version()?;
                 let minor = self.minor_version()?;
-                let version = format!("{}{}", major, minor);
+                let version = format!("{major}{minor}");
                 Ok(version)
             }
         }
@@ -713,7 +713,7 @@ pub fn createdb(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
 
     let child = command.spawn().wrap_err_with(|| {
         format!("Failed to spawn process for creating database using command: '{command_str}': ")
@@ -755,7 +755,7 @@ fn does_db_exist(pg_config: &PgConfig, dbname: &str) -> eyre::Result<bool> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let command_str = format!("{:?}", command);
+    let command_str = format!("{command:?}");
     let output = command.output()?;
 
     if !output.status.success() {

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -114,7 +114,7 @@ fn main() -> eyre::Result<()> {
     // dump the environment for debugging if asked
     if env_tracked("PGRX_BUILD_VERBOSE").as_deref() == Some("true") {
         for (k, v) in std::env::vars() {
-            eprintln!("{}={}", k, v);
+            eprintln!("{k}={v}");
         }
     }
 
@@ -268,14 +268,14 @@ fn generate_bindings(
 ) -> eyre::Result<()> {
     let mut include_h = build_paths.manifest_dir.clone();
     include_h.push("include");
-    include_h.push(format!("pg{}.h", major_version));
+    include_h.push(format!("pg{major_version}.h"));
 
     let bindgen_output = get_bindings(major_version, pg_config, &include_h)
-        .wrap_err_with(|| format!("bindgen failed for pg{}", major_version))?;
+        .wrap_err_with(|| format!("bindgen failed for pg{major_version}"))?;
 
     let oids = extract_oids(&bindgen_output);
     let rewritten_items = rewrite_items(&bindgen_output, &oids)
-        .wrap_err_with(|| format!("failed to rewrite items for pg{}", major_version))?;
+        .wrap_err_with(|| format!("failed to rewrite items for pg{major_version}"))?;
     let oids = format_builtin_oid_impl(oids);
 
     let dest_dirs = if is_for_release {
@@ -285,7 +285,7 @@ fn generate_bindings(
     };
     for dest_dir in dest_dirs {
         let mut bindings_file = dest_dir.clone();
-        bindings_file.push(&format!("pg{}.rs", major_version));
+        bindings_file.push(&format!("pg{major_version}.rs"));
         write_rs_file(
             rewritten_items.clone(),
             &bindings_file,
@@ -303,7 +303,7 @@ fn generate_bindings(
         })?;
 
         let mut oids_file = dest_dir.clone();
-        oids_file.push(&format!("pg{}_oids.rs", major_version));
+        oids_file.push(&format!("pg{major_version}_oids.rs"));
         write_rs_file(oids.clone(), &oids_file, quote! {}).wrap_err_with(|| {
             format!(
                 "Unable to write oids file for pg{} to `{}`",
@@ -712,7 +712,7 @@ fn run_bindgen(
     eprintln!("Generating bindings for pg{major_version}");
     let configure = pg_config.configure()?;
     let preferred_clang: Option<&std::path::Path> = configure.get("CLANG").map(|s| s.as_ref());
-    eprintln!("pg_config --configure CLANG = {:?}", preferred_clang);
+    eprintln!("pg_config --configure CLANG = {preferred_clang:?}");
     let (autodetect, includes) = build::clang::detect_include_paths_for(preferred_clang);
     let mut binder = bindgen::Builder::default();
     binder = add_blocklists(binder);
@@ -734,7 +734,7 @@ fn run_bindgen(
         .formatter(bindgen::Formatter::None)
         .layout_tests(false)
         .generate()
-        .wrap_err_with(|| format!("Unable to generate bindings for pg{}", major_version))?;
+        .wrap_err_with(|| format!("Unable to generate bindings for pg{major_version}"))?;
 
     Ok(bindings.to_string())
 }
@@ -840,10 +840,10 @@ fn build_shim(
     build_shim_for_version(shim_src, shim_dst, pg_config)?;
 
     // no matter what, tell rustc to link to the library that was built for the feature we're currently building
-    let envvar_name = format!("CARGO_FEATURE_PG{}", major_version);
+    let envvar_name = format!("CARGO_FEATURE_PG{major_version}");
     if env_tracked(&envvar_name).is_some() {
         println!("cargo:rustc-link-search={}", shim_dst.display());
-        println!("cargo:rustc-link-lib=static=pgrx-cshim-{}", major_version);
+        println!("cargo:rustc-link-lib=static=pgrx-cshim-{major_version}");
     }
 
     Ok(())
@@ -857,7 +857,7 @@ fn build_shim_for_version(
     let path_env = prefix_path(pg_config.parent_path());
     let major_version = pg_config.major_version()?;
 
-    eprintln!("PATH for build_shim={}", path_env);
+    eprintln!("PATH for build_shim={path_env}");
     eprintln!("shim_src={}", shim_src.display());
     eprintln!("shim_dst={}", shim_dst.display());
 
@@ -877,13 +877,13 @@ fn build_shim_for_version(
     let rc = run_command(
         Command::new(make)
             .arg("clean")
-            .arg(&format!("libpgrx-cshim-{}.a", major_version))
-            .env("PG_TARGET_VERSION", format!("{}", major_version))
+            .arg(&format!("libpgrx-cshim-{major_version}.a"))
+            .env("PG_TARGET_VERSION", format!("{major_version}"))
             .env("PATH", path_env)
             .env_remove("TARGET")
             .env_remove("HOST")
             .current_dir(shim_dst),
-        &format!("shim for PG v{}", major_version),
+        &format!("shim for PG v{major_version}"),
     )?;
 
     if rc.status.code().unwrap() != 0 {
@@ -997,8 +997,8 @@ fn run_command(mut command: &mut Command, version: &str) -> eyre::Result<Output>
         .env_remove("OUT_DIR")
         .env_remove("NUM_JOBS");
 
-    eprintln!("[{}] {:?}", version, command);
-    dbg.push_str(&format!("[{}] -------- {:?} -------- \n", version, command));
+    eprintln!("[{version}] {command:?}");
+    dbg.push_str(&format!("[{version}] -------- {command:?} -------- \n"));
 
     let output = command.output()?;
     let rc = output.clone();
@@ -1006,21 +1006,21 @@ fn run_command(mut command: &mut Command, version: &str) -> eyre::Result<Output>
     if !output.stdout.is_empty() {
         for line in String::from_utf8(output.stdout).unwrap().lines() {
             if line.starts_with("cargo:") {
-                dbg.push_str(&format!("{}\n", line));
+                dbg.push_str(&format!("{line}\n"));
             } else {
-                dbg.push_str(&format!("[{}] [stdout] {}\n", version, line));
+                dbg.push_str(&format!("[{version}] [stdout] {line}\n"));
             }
         }
     }
 
     if !output.stderr.is_empty() {
         for line in String::from_utf8(output.stderr).unwrap().lines() {
-            dbg.push_str(&format!("[{}] [stderr] {}\n", version, line));
+            dbg.push_str(&format!("[{version}] [stderr] {line}\n"));
         }
     }
-    dbg.push_str(&format!("[{}] /----------------------------------------\n", version));
+    dbg.push_str(&format!("[{version}] /----------------------------------------\n"));
 
-    eprintln!("{}", dbg);
+    eprintln!("{dbg}");
     Ok(rc)
 }
 

--- a/pgrx-pg-sys/build/clang.rs
+++ b/pgrx-pg-sys/build/clang.rs
@@ -112,7 +112,7 @@ pub(crate) fn detect_include_paths_for(
     }
     // If we have anything better to recommend, don't autodetect!
     let autodetect = paths.is_empty();
-    eprintln!("Found include dirs {:?}", paths);
+    eprintln!("Found include dirs {paths:?}");
     (autodetect, paths)
 }
 

--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -177,7 +177,7 @@ impl ToSql for PgAggregateEntity {
 
         if let Some(value) = self.finalfunc {
             optional_attributes.push((
-                format!("\tFINALFUNC = {}\"{}\"", schema, value),
+                format!("\tFINALFUNC = {schema}\"{value}\""),
                 format!("/* {}::final */", self.full_path),
             ));
         }
@@ -189,43 +189,43 @@ impl ToSql for PgAggregateEntity {
         }
         if let Some(value) = self.combinefunc {
             optional_attributes.push((
-                format!("\tCOMBINEFUNC = {}\"{}\"", schema, value),
+                format!("\tCOMBINEFUNC = {schema}\"{value}\""),
                 format!("/* {}::combine */", self.full_path),
             ));
         }
         if let Some(value) = self.serialfunc {
             optional_attributes.push((
-                format!("\tSERIALFUNC = {}\"{}\"", schema, value),
+                format!("\tSERIALFUNC = {schema}\"{value}\""),
                 format!("/* {}::serial */", self.full_path),
             ));
         }
         if let Some(value) = self.deserialfunc {
             optional_attributes.push((
-                format!("\tDESERIALFUNC ={} \"{}\"", schema, value),
+                format!("\tDESERIALFUNC ={schema} \"{value}\""),
                 format!("/* {}::deserial */", self.full_path),
             ));
         }
         if let Some(value) = self.initcond {
             optional_attributes.push((
-                format!("\tINITCOND = '{}'", value),
+                format!("\tINITCOND = '{value}'"),
                 format!("/* {}::INITIAL_CONDITION */", self.full_path),
             ));
         }
         if let Some(value) = self.msfunc {
             optional_attributes.push((
-                format!("\tMSFUNC = {}\"{}\"", schema, value),
+                format!("\tMSFUNC = {schema}\"{value}\""),
                 format!("/* {}::moving_state */", self.full_path),
             ));
         }
         if let Some(value) = self.minvfunc {
             optional_attributes.push((
-                format!("\tMINVFUNC = {}\"{}\"", schema, value),
+                format!("\tMINVFUNC = {schema}\"{value}\""),
                 format!("/* {}::moving_state_inverse */", self.full_path),
             ));
         }
         if let Some(value) = self.mfinalfunc {
             optional_attributes.push((
-                format!("\tMFINALFUNC = {}\"{}\"", schema, value),
+                format!("\tMFINALFUNC = {schema}\"{value}\""),
                 format!("/* {}::moving_state_finalize */", self.full_path),
             ));
         }
@@ -237,13 +237,13 @@ impl ToSql for PgAggregateEntity {
         }
         if let Some(value) = self.minitcond {
             optional_attributes.push((
-                format!("\tMINITCOND = '{}'", value),
+                format!("\tMINITCOND = '{value}'"),
                 format!("/* {}::MOVING_INITIAL_CONDITION */", self.full_path),
             ));
         }
         if let Some(value) = self.sortop {
             optional_attributes.push((
-                format!("\tSORTOP = \"{}\"", value),
+                format!("\tSORTOP = \"{value}\""),
                 format!("/* {}::SORT_OPERATOR */", self.full_path),
             ));
         }
@@ -296,7 +296,7 @@ impl ToSql for PgAggregateEntity {
         if let Some(value) = &self.mstype {
             let mstype_sql = map_ty(value).wrap_err("Mapping moving state type")?;
             optional_attributes.push((
-                format!("\tMSTYPE = {}", mstype_sql),
+                format!("\tMSTYPE = {mstype_sql}"),
                 format!("/* {}::MovingState = {} */", self.full_path, value.full_path),
             ));
         }
@@ -305,9 +305,7 @@ impl ToSql for PgAggregateEntity {
         for (index, (optional_attribute, comment)) in optional_attributes.iter().enumerate() {
             let optional_attribute_string = format!(
                 "{optional_attribute}{maybe_comma} {comment}{maybe_newline}",
-                optional_attribute = optional_attribute,
                 maybe_comma = if index == optional_attributes.len() - 1 { "" } else { "," },
-                comment = comment,
                 maybe_newline = if index == optional_attributes.len() - 1 { "" } else { "\n" }
             );
             optional_attributes_string += &optional_attribute_string;
@@ -359,7 +357,7 @@ impl ToSql for PgAggregateEntity {
                        maybe_comma = if needs_comma { ", " } else { " " },
                        full_path = arg.used_ty.full_path,
                        name = if let Some(name) = arg.name {
-                           format!(r#""{}" "#, name)
+                           format!(r#""{name}" "#)
                        } else { "".to_string() },
                 );
                 args.push(buf);

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -292,7 +292,7 @@ impl PgAggregate {
 
         let fn_state_name = if let Some(found) = fn_state {
             let fn_name =
-                Ident::new(&format!("{}_state", snake_case_target_ident), found.sig.ident.span());
+                Ident::new(&format!("{snake_case_target_ident}_state"), found.sig.ident.span());
             let pg_extern_attr = pg_extern_attr(found);
 
             pg_externs.push(parse_quote! {
@@ -318,7 +318,7 @@ impl PgAggregate {
         let fn_combine = get_impl_func_by_name(&item_impl_snapshot, "combine");
         let fn_combine_name = if let Some(found) = fn_combine {
             let fn_name =
-                Ident::new(&format!("{}_combine", snake_case_target_ident), found.sig.ident.span());
+                Ident::new(&format!("{snake_case_target_ident}_combine"), found.sig.ident.span());
             let pg_extern_attr = pg_extern_attr(found);
             pg_externs.push(parse_quote! {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
@@ -344,10 +344,8 @@ impl PgAggregate {
 
         let fn_finalize = get_impl_func_by_name(&item_impl_snapshot, "finalize");
         let fn_finalize_name = if let Some(found) = fn_finalize {
-            let fn_name = Ident::new(
-                &format!("{}_finalize", snake_case_target_ident),
-                found.sig.ident.span(),
-            );
+            let fn_name =
+                Ident::new(&format!("{snake_case_target_ident}_finalize"), found.sig.ident.span());
             let pg_extern_attr = pg_extern_attr(found);
 
             if !direct_args_with_names.is_empty() {
@@ -390,7 +388,7 @@ impl PgAggregate {
         let fn_serial = get_impl_func_by_name(&item_impl_snapshot, "serial");
         let fn_serial_name = if let Some(found) = fn_serial {
             let fn_name =
-                Ident::new(&format!("{}_serial", snake_case_target_ident), found.sig.ident.span());
+                Ident::new(&format!("{snake_case_target_ident}_serial"), found.sig.ident.span());
             let pg_extern_attr = pg_extern_attr(found);
             pg_externs.push(parse_quote! {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
@@ -416,10 +414,8 @@ impl PgAggregate {
 
         let fn_deserial = get_impl_func_by_name(&item_impl_snapshot, "deserial");
         let fn_deserial_name = if let Some(found) = fn_deserial {
-            let fn_name = Ident::new(
-                &format!("{}_deserial", snake_case_target_ident),
-                found.sig.ident.span(),
-            );
+            let fn_name =
+                Ident::new(&format!("{snake_case_target_ident}_deserial"), found.sig.ident.span());
             let pg_extern_attr = pg_extern_attr(found);
             pg_externs.push(parse_quote! {
                 #[allow(non_snake_case, clippy::too_many_arguments)]
@@ -446,7 +442,7 @@ impl PgAggregate {
         let fn_moving_state = get_impl_func_by_name(&item_impl_snapshot, "moving_state");
         let fn_moving_state_name = if let Some(found) = fn_moving_state {
             let fn_name = Ident::new(
-                &format!("{}_moving_state", snake_case_target_ident),
+                &format!("{snake_case_target_ident}_moving_state"),
                 found.sig.ident.span(),
             );
             let pg_extern_attr = pg_extern_attr(found);
@@ -485,7 +481,7 @@ impl PgAggregate {
             get_impl_func_by_name(&item_impl_snapshot, "moving_state_inverse");
         let fn_moving_state_inverse_name = if let Some(found) = fn_moving_state_inverse {
             let fn_name = Ident::new(
-                &format!("{}_moving_state_inverse", snake_case_target_ident),
+                &format!("{snake_case_target_ident}_moving_state_inverse"),
                 found.sig.ident.span(),
             );
             let pg_extern_attr = pg_extern_attr(found);
@@ -522,7 +518,7 @@ impl PgAggregate {
         let fn_moving_finalize = get_impl_func_by_name(&item_impl_snapshot, "moving_finalize");
         let fn_moving_finalize_name = if let Some(found) = fn_moving_finalize {
             let fn_name = Ident::new(
-                &format!("{}_moving_finalize", snake_case_target_ident),
+                &format!("{snake_case_target_ident}_moving_finalize"),
                 found.sig.ident.span(),
             );
             let pg_extern_attr = pg_extern_attr(found);
@@ -619,7 +615,7 @@ impl ToEntityGraphTokens for PgAggregate {
         let snake_case_target_ident =
             Ident::new(&target_ident.to_string().to_case(Case::Snake), target_ident.span());
         let sql_graph_entity_fn_name = syn::Ident::new(
-            &format!("__pgrx_internals_aggregate_{}", snake_case_target_ident),
+            &format!("__pgrx_internals_aggregate_{snake_case_target_ident}"),
             target_ident.span(),
         );
 

--- a/pgrx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/entity.rs
@@ -72,8 +72,7 @@ impl ToSql for ExtensionSqlEntity {
     fn to_sql(&self, _context: &PgrxSql) -> eyre::Result<String> {
         let ExtensionSqlEntity { file, line, sql, creates, requires, .. } = self;
         let creates = if !creates.is_empty() {
-            let joined =
-                creates.iter().map(|i| format!("--   {}", i)).collect::<Vec<_>>().join("\n");
+            let joined = creates.iter().map(|i| format!("--   {i}")).collect::<Vec<_>>().join("\n");
             format!(
                 "\
                 -- creates:\n\
@@ -84,7 +83,7 @@ impl ToSql for ExtensionSqlEntity {
         };
         let requires = if !requires.is_empty() {
             let joined =
-                requires.iter().map(|i| format!("--   {}", i)).collect::<Vec<_>>().join("\n");
+                requires.iter().map(|i| format!("--   {i}")).collect::<Vec<_>>().join("\n");
             format!(
                 "\
                -- requires:\n\
@@ -156,14 +155,14 @@ impl SqlDeclaredEntity {
                 .ok_or_else(|| eyre::eyre!("Did not get SQL for `{}`", name))?
                 .to_string(),
             name: name.to_string(),
-            option: format!("Option<{}>", name),
-            vec: format!("Vec<{}>", name),
-            vec_option: format!("Vec<Option<{}>>", name),
-            option_vec: format!("Option<Vec<{}>>", name),
-            option_vec_option: format!("Option<Vec<Option<{}>>", name),
-            array: format!("Array<{}>", name),
-            option_array: format!("Option<{}>", name),
-            varlena: format!("Varlena<{}>", name),
+            option: format!("Option<{name}>"),
+            vec: format!("Vec<{name}>"),
+            vec_option: format!("Vec<Option<{name}>>"),
+            option_vec: format!("Option<Vec<{name}>>"),
+            option_vec_option: format!("Option<Vec<Option<{name}>>"),
+            array: format!("Array<{name}>"),
+            option_array: format!("Option<{name}>"),
+            varlena: format!("Varlena<{name}>"),
             pg_box: vec![
                 format!("pgrx::pgbox::PgBox<{}>", name),
                 format!("pgrx::pgbox::PgBox<{}, pgrx::pgbox::AllocatedByRust>", name),

--- a/pgrx-sql-entity-graph/src/extension_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/mod.rs
@@ -276,7 +276,7 @@ impl Parse for ExtensionSqlAttribute {
             other => {
                 return Err(syn::Error::new(
                     ident.span(),
-                    format!("Unknown extension_sql attribute: {}", other),
+                    format!("Unknown extension_sql attribute: {other}"),
                 ))
             }
         };

--- a/pgrx-sql-entity-graph/src/extern_args.rs
+++ b/pgrx-sql-entity-graph/src/extern_args.rs
@@ -51,7 +51,7 @@ impl core::fmt::Display for ExternArgs {
             ExternArgs::NoGuard => Ok(()),
             ExternArgs::Schema(_) => Ok(()),
             ExternArgs::Name(_) => Ok(()),
-            ExternArgs::Cost(cost) => write!(f, "COST {}", cost),
+            ExternArgs::Cost(cost) => write!(f, "COST {cost}"),
             ExternArgs::Requires(_) => Ok(()),
         }
     }

--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for ArgumentError {
                 write!(f, "A Datum as an argument means that `sql = \"...\"` must be set in the declaration")
             }
             ArgumentError::NotValidAsArgument(type_name) => {
-                write!(f, "`{}` is not able to be used as a function argument", type_name)
+                write!(f, "`{type_name}` is not able to be used as a function argument")
             }
         }
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -104,7 +104,7 @@ impl ToSql for PgExternEntity {
         let module_pathname = &context.get_module_pathname();
         let schema = self
             .schema
-            .map(|schema| format!("{}.", schema))
+            .map(|schema| format!("{schema}."))
             .unwrap_or_else(|| context.schema_prefix_for(&self_index));
         let arguments = if !self.fn_args.is_empty() {
             let mut args = Vec::new();
@@ -280,7 +280,7 @@ impl ToSql for PgExternEntity {
                     );
                     items.push_str(&item);
                 }
-                format!("RETURNS TABLE ({}\n)", items)
+                format!("RETURNS TABLE ({items}\n)")
             }
             PgExternReturnEntity::Trigger => String::from("RETURNS trigger"),
         };
@@ -332,7 +332,7 @@ impl ToSql for PgExternEntity {
                     "-- requires:\n{}\n",
                     requires_attrs
                         .iter()
-                        .map(|i| format!("--   {}", i))
+                        .map(|i| format!("--   {i}"))
                         .collect::<Vec<_>>()
                         .join("\n")
                 )
@@ -352,16 +352,16 @@ impl ToSql for PgExternEntity {
         if let Some(op) = &self.operator {
             let mut optionals = vec![];
             if let Some(it) = op.commutator {
-                optionals.push(format!("\tCOMMUTATOR = {}", it));
+                optionals.push(format!("\tCOMMUTATOR = {it}"));
             };
             if let Some(it) = op.negator {
-                optionals.push(format!("\tNEGATOR = {}", it));
+                optionals.push(format!("\tNEGATOR = {it}"));
             };
             if let Some(it) = op.restrict {
-                optionals.push(format!("\tRESTRICT = {}", it));
+                optionals.push(format!("\tRESTRICT = {it}"));
             };
             if let Some(it) = op.join {
-                optionals.push(format!("\tJOIN = {}", it));
+                optionals.push(format!("\tJOIN = {it}"));
             };
             if op.hashes {
                 optionals.push(String::from("\tHASHES"));
@@ -452,7 +452,7 @@ impl ToSql for PgExternEntity {
 
             let schema = self
                 .schema
-                .map(|schema| format!("{}.", schema))
+                .map(|schema| format!("{schema}."))
                 .unwrap_or_else(|| context.schema_prefix_for(&self_index));
 
             let operator_sql = format!("\n\n\

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -311,7 +311,7 @@ impl PgExtern {
         let hrtb = if lifetimes.is_empty() { None } else { Some(quote! { for<#(#lifetimes),*> }) };
 
         let sql_graph_entity_fn_name =
-            syn::Ident::new(&format!("__pgrx_internals_fn_{}", ident), Span::call_site());
+            syn::Ident::new(&format!("__pgrx_internals_fn_{ident}"), Span::call_site());
         quote_spanned! { self.func.sig.span() =>
             #[no_mangle]
             #[doc(hidden)]

--- a/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
@@ -65,7 +65,7 @@ impl Parse for SearchPathList {
         Ok(Self {
             fields: input
                 .parse_terminated(SearchPath::parse)
-                .unwrap_or_else(|_| panic!("Got {}", input)),
+                .unwrap_or_else(|_| panic!("Got {input}")),
         })
     }
 }

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -261,7 +261,7 @@ impl PgrxSql {
             create_dir_all(parent)?;
         }
         let mut out = File::create(path)?;
-        write!(out, "{}", generated)?;
+        write!(out, "{generated}")?;
         Ok(())
     }
 
@@ -274,13 +274,13 @@ impl PgrxSql {
             if stdout().is_terminal() {
                 self.write_highlighted(out, &generated)?;
             } else {
-                write!(*out, "{}", generated)?;
+                write!(*out, "{generated}")?;
             }
         }
 
         #[cfg(not(feature = "syntax-highlighting"))]
         {
-            write!(*out, "{}", generated)?;
+            write!(*out, "{generated}")?;
         }
 
         Ok(())
@@ -307,7 +307,7 @@ impl PgrxSql {
                 // Concept from https://github.com/sharkdp/bat/blob/1b030dc03b906aa345f44b8266bffeea77d763fe/src/terminal.rs#L6
                 for (style, content) in ranges {
                     if style.foreground.a == 0x01 {
-                        write!(*out, "{}", content)?;
+                        write!(*out, "{content}")?;
                     } else {
                         write!(*out, "{}", content.color(XtermColors::from(style.foreground.r)))?;
                     }
@@ -315,7 +315,7 @@ impl PgrxSql {
                 write!(*out, "\x1b[0m")?;
             }
         } else {
-            write!(*out, "{}", generated)?;
+            write!(*out, "{generated}")?;
         }
         Ok(())
     }
@@ -381,7 +381,7 @@ impl PgrxSql {
             create_dir_all(parent)?;
         }
         let mut out = File::create(path)?;
-        write!(out, "{:?}", generated)?;
+        write!(out, "{generated:?}")?;
         Ok(())
     }
 
@@ -432,7 +432,7 @@ impl PgrxSql {
             let extname = &self.extension_name;
             let extver = &self.control.default_version;
             // Note: versioned so-name format must agree with cargo pgrx
-            format!("$libdir/{}-{}", extname, extver)
+            format!("$libdir/{extname}-{extver}")
         } else {
             String::from("MODULE_PATHNAME")
         }

--- a/pgrx-sql-entity-graph/src/postgres_enum/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_enum/entity.rs
@@ -83,7 +83,7 @@ impl ToSql for PostgresEnumEntity {
             variants = self
                 .variants
                 .iter()
-                .map(|variant| format!("\t'{}'", variant))
+                .map(|variant| format!("\t'{variant}'"))
                 .collect::<Vec<_>>()
                 .join(",\n")
                 + "\n",

--- a/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
@@ -123,7 +123,7 @@ impl ToEntityGraphTokens for PostgresEnum {
 
         let variants = self.variants.iter().map(|variant| variant.ident.clone());
         let sql_graph_entity_fn_name =
-            syn::Ident::new(&format!("__pgrx_internals_enum_{}", name), Span::call_site());
+            syn::Ident::new(&format!("__pgrx_internals_enum_{name}"), Span::call_site());
 
         let to_sql_config = &self.to_sql_config;
 

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -204,8 +204,8 @@ impl Parse for CodeEnrichment<PostgresTypeDerive> {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let ItemStruct { attrs, ident, generics, .. } = input.parse()?;
         let to_sql_config = ToSqlConfig::from_attributes(attrs.as_slice())?.unwrap_or_default();
-        let in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
-        let out_fn = Ident::new(&format!("{}_out", ident).to_lowercase(), ident.span());
+        let in_fn = Ident::new(&format!("{ident}_in").to_lowercase(), ident.span());
+        let out_fn = Ident::new(&format!("{ident}_out").to_lowercase(), ident.span());
         PostgresTypeDerive::new(ident, generics, in_fn, out_fn, to_sql_config)
     }
 }

--- a/pgrx-sql-entity-graph/src/to_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/entity.rs
@@ -81,7 +81,6 @@ impl ToSqlConfigEntity {
                 {sql_anchor_comment}\n\
                 {content}\n\
             ",
-                content = content,
                 sql_anchor_comment = entity.sql_anchor_comment()
             )));
         }
@@ -101,7 +100,6 @@ impl ToSqlConfigEntity {
                         {sql_anchor_comment}\n\
                         {content}\
                     ",
-                        content = content,
                         sql_anchor_comment = entity.sql_anchor_comment(),
                     )))
                 }

--- a/pgrx-version-updater/src/main.rs
+++ b/pgrx-version-updater/src/main.rs
@@ -105,7 +105,7 @@ fn query_toml(query_args: &QueryCargoVersionArgs) {
     // the root of a PGRX checkout directory
     let filepath = match &query_args.file_path {
         Some(path) => {
-            fullpath(path).expect(format!("Could not get full path for file: {}", path).as_str())
+            fullpath(path).expect(format!("Could not get full path for file: {path}").as_str())
         }
         None => {
             let mut current_dir = env::current_dir().expect("Could not get current_dir!");
@@ -150,7 +150,7 @@ fn update_files(args: &UpdateFilesArgs) {
     let mut exclude_version_files = HashSet::new();
     for file in &args.exclude_from_version_change {
         exclude_version_files.insert(
-            fullpath(file).expect(format!("Could not get full path for file: {}", file).as_str()),
+            fullpath(file).expect(format!("Could not get full path for file: {file}").as_str()),
         );
     }
 
@@ -199,7 +199,7 @@ fn update_files(args: &UpdateFilesArgs) {
     // Loop through all files that are included for dependency updates via CLI params
     for file in &args.include_for_dep_updates {
         let filepath =
-            fullpath(file).expect(format!("Could not get full path for file {}", file).as_str());
+            fullpath(file).expect(format!("Could not get full path for file {file}").as_str());
 
         let mut output = format!(
             "{} Cargo.toml file at {} for processing",
@@ -441,12 +441,11 @@ fn parse_new_version(current_version_specifier: &str, new_version: &str) -> Stri
                 result.push_str(new_version);
             } else {
                 panic!(
-                    "Could not find an actual version in specifier: '{}'",
-                    current_version_specifier
+                    "Could not find an actual version in specifier: '{current_version_specifier}'"
                 );
             }
         }
-        None => panic!("Version specifier '{}' is not valid!", current_version_specifier),
+        None => panic!("Version specifier '{current_version_specifier}' is not valid!"),
     }
 
     result


### PR DESCRIPTION
Inlining format args makes code more readable, shorter, and in some cases can gain some performance advantages (when accidentally using unneeded references as params)

I ran this command, and manually reverted some questionable cases:

```bash
cargo clippy --workspace --allow-dirty --fix --benches --tests --bins --all-features -- -A clippy::all -W clippy::uninlined_format_args
```

Note that I specifically did **not** inline format args in cases where some args are inlinable and some args are not (i.e. expressions).   I did notice a few cases like this in the code though, so it is clear the project is OK with such cases.