### PR TITLE
chore: perf optimize arg formatting

### DIFF
--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -214,7 +214,7 @@ pub(crate) fn init_pgrx(pgrx: &Pgrx, init: &Init) -> eyre::Result<()> {
         validate_pg_config(pg_config)?;
 
         if is_root_user() {
-            println!("{} initdb as current user is root user", "   Skipping".bold().green(),);
+            println!("{} initdb as current user is root user", "   Skipping".bold().green());
         } else {
             let datadir = pg_config.data_dir()?;
             let bindir = pg_config.bin_dir()?;

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -153,7 +153,7 @@ pub(crate) fn install_extension(
     let build_command_messages =
         build_command_stream.collect::<Result<Vec<_>, std::io::Error>>()?;
 
-    println!("{} extension", "  Installing".bold().green(),);
+    println!("{} extension", "  Installing".bold().green());
     let pkgdir = make_relative(pg_config.pkglibdir()?);
     let extdir = make_relative(pg_config.extension_dir()?);
     let shlibpath = find_library_file(&manifest, &build_command_messages)?;
@@ -184,7 +184,7 @@ pub(crate) fn install_extension(
         let so_name = if versioned_so {
             let extver = get_version(&package_manifest_path)?;
             // note: versioned so-name format must agree with pgrx-utils
-            format!("{}-{}", &extname, &extver)
+            format!("{extname}-{extver}")
         } else {
             extname.clone()
         };

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -292,7 +292,7 @@ pub(crate) fn generate_schema(
     let postmaster_path = pg_config.postmaster_path().wrap_err("could not get postmaster path")?;
 
     // The next action may take a few seconds, we'd like the user to know we're thinking.
-    eprintln!("{} SQL entities", " Discovering".bold().green(),);
+    eprintln!("{} SQL entities", " Discovering".bold().green());
 
     let postmaster_stub_built = create_stub(postmaster_path, &postmaster_stub_dir)?;
 
@@ -443,7 +443,7 @@ pub(crate) fn generate_schema(
             .wrap_err_with(|| eyre!("Could not write SQL to {}", out_path.display()))?;
         output_tracking.push(out_path.to_path_buf());
     } else {
-        eprintln!("{} SQL entities to {}", "     Writing".bold().green(), "/dev/stdout".cyan(),);
+        eprintln!("{} SQL entities to {}", "     Writing".bold().green(), "/dev/stdout".cyan());
         pgrx_sql
             .write(&mut std::io::stdout())
             .wrap_err_with(|| eyre!("Could not write SQL to stdout"))?;
@@ -544,7 +544,7 @@ fn create_stub(
     let so_rustc_invocation_str = format!("{:?}", so_rustc_invocation);
     tracing::debug!(command = %so_rustc_invocation_str, "Running");
     let output = so_rustc_invocation.output().wrap_err_with(|| {
-        eyre!("could not invoke `rustc` on {}", &postmaster_stub_file.display())
+        eyre!("could not invoke `rustc` on {}", postmaster_stub_file.display())
     })?;
 
     let code = output.status.code().ok_or(eyre!("could not get status code of build"))?;

--- a/cargo-pgrx/src/command/stop.rs
+++ b/cargo-pgrx/src/command/stop.rs
@@ -93,7 +93,7 @@ pub(crate) fn stop_postgres(pg_config: &PgConfig) -> eyre::Result<()> {
     let output = command.output()?;
 
     if !output.status.success() {
-        Err(eyre!("{}", String::from_utf8(output.stderr)?,))
+        Err(eyre!("{}", String::from_utf8(output.stderr)?))
     } else {
         Ok(())
     }

--- a/cargo-pgrx/src/command/sudo_install.rs
+++ b/cargo-pgrx/src/command/sudo_install.rs
@@ -90,7 +90,7 @@ impl CommandExecute for SudoInstall {
             let status = child.wait()?;
             if !status.success() {
                 // sudo failed.  let the user know and get out now
-                eprintln!("sudo command failed with status `{}`", &format!("{status:?}").red());
+                eprintln!("sudo command failed with status `{}`", format!("{status:?}").red());
                 std::process::exit(status.code().unwrap_or(1));
             }
         }

--- a/pgrx-examples/aggregate/src/lib.rs
+++ b/pgrx-examples/aggregate/src/lib.rs
@@ -149,7 +149,7 @@ mod tests {
         let avg_state = IntegerAvgState::state(avg_state, Some(1));
         let avg_state = IntegerAvgState::state(avg_state, Some(2));
         let avg_state = IntegerAvgState::state(avg_state, Some(3));
-        assert_eq!(2, IntegerAvgState::finalize(avg_state),);
+        assert_eq!(2, IntegerAvgState::finalize(avg_state));
     }
 
     #[pg_test]

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -364,10 +364,8 @@ impl PgExtern {
 
     pub fn wrapper_func(&self) -> TokenStream2 {
         let func_name = &self.func.sig.ident;
-        let func_name_wrapper = Ident::new(
-            &format!("{}_wrapper", &self.func.sig.ident.to_string()),
-            self.func.sig.ident.span(),
-        );
+        let func_name_wrapper =
+            Ident::new(&format!("{}_wrapper", self.func.sig.ident), self.func.sig.ident.span());
         let func_generics = &self.func.sig.generics;
         let is_raw = self.extern_attrs().contains(&Attribute::Raw);
         // We use a `_` prefix to make functions with no args more satisfied during linting.

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -639,14 +639,11 @@ fn create_extension() -> eyre::Result<()> {
     let (mut client, _) = client()?;
     let extension_name = get_extension_name()?;
 
-    query_wrapper(
-        Some(format!("CREATE EXTENSION {} CASCADE;", &extension_name)),
-        None,
-        |query, _| client.simple_query(query.unwrap().as_str()),
-    )
+    query_wrapper(Some(format!("CREATE EXTENSION {extension_name} CASCADE;")), None, |query, _| {
+        client.simple_query(query.unwrap().as_str())
+    })
     .wrap_err(format!(
-        "There was an issue creating the extension '{}' in Postgres: ",
-        &extension_name
+        "There was an issue creating the extension '{extension_name}' in Postgres: "
     ))?;
 
     Ok(())

--- a/pgrx-tests/src/tests/struct_type_tests.rs
+++ b/pgrx-tests/src/tests/struct_type_tests.rs
@@ -79,7 +79,7 @@ fn complex_in(input: &core::ffi::CStr) -> PgBox<Complex, AllocatedByRust> {
 #[pg_extern(immutable)]
 fn complex_out(complex: PgBox<Complex>) -> &'static CStr {
     let mut sb = StringInfo::new();
-    sb.push_str(&format!("{}, {}", &complex.x, &complex.y));
+    sb.push_str(&format!("{}, {}", complex.x, complex.y));
     unsafe { sb.leak_cstr() }
 }
 

--- a/pgrx-version-updater/src/main.rs
+++ b/pgrx-version-updater/src/main.rs
@@ -116,10 +116,10 @@ fn query_toml(query_args: &QueryCargoVersionArgs) {
 
     // Open the Cargo.toml via toml_edit and parse it out.
     let data = fs::read_to_string(&filepath)
-        .expect(format!("Unable to open file at {}", &filepath.display()).as_str());
+        .expect(format!("Unable to open file at {}", filepath.display()).as_str());
 
     let doc = data.parse::<Document>().expect(
-        format!("File at location {} is an invalid Cargo.toml file", &filepath.display()).as_str(),
+        format!("File at location {} is an invalid Cargo.toml file", filepath.display()).as_str(),
     );
 
     if let Some(package_version) = doc.get("package").and_then(|p| p.get("version")) {
@@ -168,7 +168,7 @@ fn update_files(args: &UpdateFilesArgs) {
             let mut output = format!(
                 "{} Cargo.toml file at {}",
                 "Discovered".bold().green(),
-                &filepath.display().cyan()
+                filepath.display().cyan()
             );
 
             // Extract the package name if possible
@@ -204,7 +204,7 @@ fn update_files(args: &UpdateFilesArgs) {
         let mut output = format!(
             "{} Cargo.toml file at {} for processing",
             " Including".bold().green(),
-            &filepath.display().cyan()
+            filepath.display().cyan()
         );
 
         // Extract the package name if possible
@@ -248,14 +248,14 @@ fn update_files(args: &UpdateFilesArgs) {
         let mut output = format!(
             "{} Cargo.toml file at {}",
             "Processing".bold().green(),
-            &filepath.display().cyan()
+            filepath.display().cyan()
         );
 
         let data = fs::read_to_string(&filepath)
-            .expect(format!("Unable to open file at {}", &filepath.display()).as_str());
+            .expect(format!("Unable to open file at {}", filepath.display()).as_str());
 
         let mut doc = data.parse::<Document>().expect(
-            format!("File at location {} is an invalid Cargo.toml file", &filepath.display())
+            format!("File at location {} is an invalid Cargo.toml file", filepath.display())
                 .as_str(),
         );
 
@@ -458,10 +458,10 @@ fn extract_package_name<P: AsRef<Path>>(filepath: P) -> Option<String> {
     let filepath = filepath.as_ref();
 
     let data = fs::read_to_string(filepath)
-        .expect(format!("Unable to open file at {}", &filepath.display()).as_str());
+        .expect(format!("Unable to open file at {}", filepath.display()).as_str());
 
     let doc = data.parse::<Document>().expect(
-        format!("File at location {} is an invalid Cargo.toml file", &filepath.display()).as_str(),
+        format!("File at location {} is an invalid Cargo.toml file", filepath.display()).as_str(),
     );
 
     doc.get("package")?.as_table()?.get("name")?.as_str().map(|s| s.to_string())

--- a/pgrx/src/pg_catalog/pg_proc.rs
+++ b/pgrx/src/pg_catalog/pg_proc.rs
@@ -151,7 +151,7 @@ impl PgProc {
         self.get_attr(pg_sys::Anum_pg_proc_procost).unwrap()
     }
 
-    /// Estimated number of result rows (zero if not [`proretset()`][PgProc::proretset],)
+    /// Estimated number of result rows (zero if not [`proretset()`][PgProc::proretset])
     pub fn prorows(&self) -> f32 {
         // won't panic because `prorows` has a NOT NULL constraint, so `.unwrap()` wont panic
         self.get_attr(pg_sys::Anum_pg_proc_prorows).unwrap()


### PR DESCRIPTION
Format args should almost never be passed as references to the `format!` because that causes some performance (boxing) degradation due to how Rust handles it internally (unable to optimize).

In this PR I also removed a few trailing commas where they seemed to be incorrect.

Lastly, in `pgrx-sql-entity-graph/src/pg_extern/mod.rs` I removed `to_string()` as it seemed redundant (and also perf cost)