### PR TITLE
chore: inline non-core formatting args

### DIFF
--- a/articles/forging-sql-from-rust.md
+++ b/articles/forging-sql-from-rust.md
@@ -792,7 +792,7 @@ With a graph built, we can topologically sort the graph and transform them to SQ
 pub fn to_sql(&self) -> eyre::Result<String> {
     let mut full_sql = String::new();
     for step_id in petgraph::algo::toposort(&self.graph, None)
-        .map_err(|e| eyre_err!("Failed to toposort SQL entities: {:?}", e))?
+        .map_err(|e| eyre_err!("Failed to toposort SQL entities: {e:?}"))?
     {
         let step = &self.graph[step_id];
 

--- a/articles/postgresql-aggregates-with-rust.md
+++ b/articles/postgresql-aggregates-with-rust.md
@@ -774,7 +774,7 @@ impl Aggregate for DemoSum {
         arg: Self::Args,
         _fcinfo: pg_sys::FunctionCallInfo,
     ) -> Self::State {
-        pgrx::log!("state({}, {})", current, arg);
+        pgrx::log!("state({current}, {arg})");
         current += arg;
         current
     }
@@ -784,7 +784,7 @@ impl Aggregate for DemoSum {
         arg: Self::Args,
         _fcinfo: pg_sys::FunctionCallInfo,
     ) -> Self::MovingState {
-        pgrx::log!("moving_state({}, {})", current, arg);
+        pgrx::log!("moving_state({current}, {arg})");
         current += arg;
         current
     }
@@ -794,7 +794,7 @@ impl Aggregate for DemoSum {
         arg: Self::Args,
         _fcinfo: pg_sys::FunctionCallInfo,
     ) -> Self::MovingState {
-        pgrx::log!("moving_state_inverse({}, {})", current, arg);
+        pgrx::log!("moving_state_inverse({current}, {arg})");
         current -= arg;
         current
     }
@@ -804,7 +804,7 @@ impl Aggregate for DemoSum {
         second: Self::State,
         _fcinfo: pg_sys::FunctionCallInfo,
     ) -> Self::State {
-        pgrx::log!("combine({}, {})", first, second);
+        pgrx::log!("combine({first}, {second})");
         first += second;
         first
     }

--- a/cargo-pgrx/src/command/cross/pgrx_target.rs
+++ b/cargo-pgrx/src/command/cross/pgrx_target.rs
@@ -126,7 +126,7 @@ fn run(c: &mut Command) -> Result<()> {
     c.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     let status = c.status().wrap_err("Unable to create temporary crate")?;
     if !status.success() {
-        Err(eyre!("{:?} failed with exit code: {}", c, status))
+        Err(eyre!("{c:?} failed with exit code: {status}"))
     } else {
         Ok(())
     }

--- a/cargo-pgrx/src/command/get.rs
+++ b/cargo-pgrx/src/command/get.rs
@@ -124,8 +124,7 @@ fn determine_git_hash() -> eyre::Result<Option<String>> {
                 let stderr = String::from_utf8(output.stderr)
                     .expect("`git rev-parse head` did not return valid utf8");
                 return Err(eyre!(
-                    "problem running `git` to determine the current revision hash: {}",
-                    stderr
+                    "problem running `git` to determine the current revision hash: {stderr}"
                 ));
             }
 

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -614,7 +614,7 @@ pub(crate) fn initdb(bindir: &PathBuf, datadir: &PathBuf) -> eyre::Result<()> {
     let command_str = format!("{:?}", command);
     tracing::debug!(command = %command_str, "Running");
 
-    let output = command.output().wrap_err_with(|| eyre!("unable to execute: {}", command_str))?;
+    let output = command.output().wrap_err_with(|| eyre!("unable to execute: {command_str}"))?;
     tracing::trace!(command = %command_str, status_code = %output.status, "Finished");
 
     if !output.status.success() {

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -550,7 +550,7 @@ fn create_stub(
     let code = output.status.code().ok_or(eyre!("could not get status code of build"))?;
     tracing::trace!(status_code = %code, command = %so_rustc_invocation_str, "Finished");
     if code != 0 {
-        return Err(eyre!("rustc exited with code {}", code));
+        return Err(eyre!("rustc exited with code {code}"));
     }
 
     std::fs::write(&postmaster_hash_file, postmaster_bin_hash)

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -54,7 +54,7 @@ pub(crate) fn manifest_path(
             .packages
             .iter()
             .find(|v| v.name == *package_name)
-            .ok_or_else(|| eyre!("Could not find package `{}`", package_name))?;
+            .ok_or_else(|| eyre!("Could not find package `{package_name}`"))?;
         tracing::debug!(manifest_path = %found.manifest_path, "Found workspace package");
         found.manifest_path.clone().into_std_path_buf()
     } else {

--- a/cargo-pgrx/src/templates/bgworker_lib_rs
+++ b/cargo-pgrx/src/templates/bgworker_lib_rs
@@ -66,7 +66,7 @@ pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {{
                     let a = tuple.get_datum_by_ordinal(1).unwrap().value::<String>().unwrap();
                     let b = tuple.get_datum_by_ordinal(2).unwrap().value::<i32>().unwrap();
                     let c = tuple.get_datum_by_ordinal(3).unwrap().value::<String>().unwrap();
-                    log!("from bgworker: ({{:?}}, {{:?}}, {{:?}})", a, b, c);
+                    log!("from bgworker: ({{a:?}}, {{b:?}}, {{c:?}})");
                 }});
             }});
         }});

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -24,7 +24,7 @@ fn approx_distance_pgrx(compressed: Array<i64>, distances: Array<f64>) -> f64 {
         .iter_deny_null()
         .map(|cc| {
             let d = distances.get(cc as usize).unwrap().unwrap();
-            pgrx::info!("cc={}, d={}", cc, d);
+            pgrx::info!("cc={cc}, d={d}");
             d
         })
         .sum()

--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -19,7 +19,7 @@ pgrx::pg_module_magic!();
 #[pg_extern]
 fn panic(s: &str) -> bool {
     catch_unwind(|| {
-        PANIC!("{}", s);
+        PANIC!("{s}");
     })
     .ok();
     true
@@ -28,7 +28,7 @@ fn panic(s: &str) -> bool {
 #[pg_extern]
 fn fatal(s: &str) -> bool {
     catch_unwind(|| {
-        FATAL!("{}", s);
+        FATAL!("{s}");
     })
     .ok();
     true
@@ -37,7 +37,7 @@ fn fatal(s: &str) -> bool {
 #[pg_extern]
 fn error(s: &str) -> bool {
     catch_unwind(|| {
-        error!("{}", s);
+        error!("{s}");
     })
     .ok();
     true
@@ -46,7 +46,7 @@ fn error(s: &str) -> bool {
 #[pg_extern]
 fn warning(s: &str) -> bool {
     catch_unwind(|| {
-        warning!("{}", s);
+        warning!("{s}");
     })
     .ok();
     true
@@ -113,7 +113,7 @@ fn random_abort() {
 pub unsafe extern "C" fn _PG_init() {
     #[pg_guard]
     extern "C" fn random_abort_callback(event: pg_sys::XactEvent, _arg: *mut std::os::raw::c_void) {
-        // info!("in global xact callback: event={}", event);
+        // info!("in global xact callback: event={event}");
 
         if event == pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT && rand::random::<bool>() {
             // panic!("aborting transaction");

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -76,7 +76,7 @@ pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {
                     let a = tuple.get_datum_by_ordinal(1)?.value::<String>()?;
                     let b = tuple.get_datum_by_ordinal(2)?.value::<i32>()?;
                     let c = tuple.get_datum_by_ordinal(3)?.value::<String>()?;
-                    log!("from bgworker: ({:?}, {:?}, {:?})", a, b, c);
+                    log!("from bgworker: ({a:?}, {b:?}, {c:?})");
                 }
                 Ok(())
             })

--- a/pgrx-examples/errors/src/lib.rs
+++ b/pgrx-examples/errors/src/lib.rs
@@ -43,27 +43,27 @@ fn throw_rust_panic(message: &str) {
 
 #[pg_extern]
 fn raise_pg_info(message: &str) {
-    info!("{}", message);
+    info!("{message}");
 }
 
 #[pg_extern]
 fn raise_pg_warning(message: &str) {
-    warning!("{}", message);
+    warning!("{message}");
 }
 
 #[pg_extern]
 fn throw_pg_error(message: &str) {
-    error!("{}", message);
+    error!("{message}");
 }
 
 #[pg_extern]
 fn throw_pg_panic(message: &str) {
-    PANIC!("{}", message);
+    PANIC!("{message}");
 }
 
 #[pg_extern]
 fn throw_pg_fatal(message: &str) {
-    FATAL!("{}", message);
+    FATAL!("{message}");
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pgrx-examples/pgtrybuilder/src/lib.rs
+++ b/pgrx-examples/pgtrybuilder/src/lib.rs
@@ -65,10 +65,10 @@ fn maybe_panic(panic: bool, trap_it: bool, message: &str) {
         // enum variant with the payload from the originating panic
         if trap_it {
             if let CaughtError::RustPanic { ereport, payload } = &cause {
-                warning!("{:#?}", ereport);
+                warning!("{ereport:#?}");
                 if let Some(s) = payload.downcast_ref::<String>() {
                     // we have access to the panic!() message
-                    warning!("{}", s);
+                    warning!("{s}");
                     return;
                 } else {
                     // this won't happen with this example, but say the `panic_any(42)` was used

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -87,7 +87,7 @@ fn spi_query_by_id(id: i64) -> Result<Option<String>, spi::Error> {
         tuptable.get_two::<i64, String>()
     })?;
 
-    info!("id={:?}", returned_id);
+    info!("id={returned_id:?}");
     Ok(title)
 }
 

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -905,7 +905,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<#name #generics> {
                 input.map_or_else(|| {
                     for m in <#name as ::pgrx::inoutfuncs::JsonInOutFuncs>::NULL_ERROR_MESSAGE {
-                        ::pgrx::pg_sys::error!("{}", m);
+                        ::pgrx::pg_sys::error!("{m}");
                     }
                     None
                 }, |i| Some(<#name as ::pgrx::inoutfuncs::JsonInOutFuncs>::input(i)))
@@ -929,7 +929,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<#name #generics> {
                 input.map_or_else(|| {
                     for m in <#name as ::pgrx::inoutfuncs::InOutFuncs>::NULL_ERROR_MESSAGE {
-                        ::pgrx::pg_sys::error!("{}", m);
+                        ::pgrx::pg_sys::error!("{m}");
                     }
                     None
                 }, |i| Some(<#name as ::pgrx::inoutfuncs::InOutFuncs>::input(i)))
@@ -952,7 +952,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<::pgrx::datum::PgVarlena<#name #generics>> {
                 input.map_or_else(|| {
                     for m in <#name as ::pgrx::inoutfuncs::PgVarlenaInOutFuncs>::NULL_ERROR_MESSAGE {
-                        ::pgrx::pg_sys::error!("{}", m);
+                        ::pgrx::pg_sys::error!("{m}");
                     }
                     None
                 }, |i| Some(<#name as ::pgrx::inoutfuncs::PgVarlenaInOutFuncs>::input(i)))

--- a/pgrx-pg-config/src/cargo.rs
+++ b/pgrx-pg-config/src/cargo.rs
@@ -96,5 +96,5 @@ impl PgrxManifestExt for Manifest {
 
 /// Helper functions to read `Cargo.toml` and remap error to `eyre::Result`.
 pub fn read_manifest<T: AsRef<Path>>(path: T) -> eyre::Result<Manifest> {
-    Manifest::from_path(path).map_err(|err| eyre!("Couldn't parse manifest: {}", err))
+    Manifest::from_path(path).map_err(|err| eyre!("Couldn't parse manifest: {err}"))
 }

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -224,7 +224,7 @@ impl PgConfig {
         let version_parts = version_str.split_whitespace().collect::<Vec<&str>>();
         let mut version = version_parts
             .get(1)
-            .ok_or_else(|| eyre!("invalid version string: {}", version_str))?
+            .ok_or_else(|| eyre!("invalid version string: {version_str}"))?
             .split('.')
             .collect::<Vec<&str>>();
 
@@ -242,7 +242,7 @@ impl PgConfig {
                 rc = true;
                 version = first.split("rc").collect();
             } else {
-                return Err(eyre!("invalid version string: {}", version_str));
+                return Err(eyre!("invalid version string: {version_str}"));
             }
         }
 
@@ -258,7 +258,7 @@ impl PgConfig {
         }
         minor = &minor[0..end_index];
         let minor = u16::from_str(minor)
-            .map_err(|e| eyre!("invalid minor version number `{}`: {:?}", minor, e))?;
+            .map_err(|e| eyre!("invalid minor version number `{minor}`: {e:?}"))?;
         let minor = if beta {
             PgMinorVersion::Beta(minor)
         } else if rc {
@@ -616,7 +616,7 @@ impl Pgrx {
                 return Ok(pg_config.clone());
             }
         }
-        Err(eyre!("Postgres `{}` is not managed by pgrx", label))
+        Err(eyre!("Postgres `{label}` is not managed by pgrx"))
     }
 
     /// Returns true if the specified `label` represents a Postgres version number feature flag,

--- a/pgrx-pg-config/src/path_methods.rs
+++ b/pgrx-pg-config/src/path_methods.rs
@@ -40,6 +40,6 @@ pub fn get_target_dir() -> eyre::Result<PathBuf> {
     let target_dir = json.get("target_directory");
     match target_dir {
         Some(JsonValue::String(target_dir)) => Ok(target_dir.into()),
-        v => Err(eyre!("could not read target dir from `cargo metadata` got: {:?}", v,)),
+        v => Err(eyre!("could not read target dir from `cargo metadata` got: {v:?}")),
     }
 }

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -887,7 +887,7 @@ fn build_shim_for_version(
     )?;
 
     if rc.status.code().unwrap() != 0 {
-        return Err(eyre!("failed to make pgrx-cshim for v{}", major_version));
+        return Err(eyre!("failed to make pgrx-cshim for v{major_version}"));
     }
 
     Ok(())

--- a/pgrx-sql-entity-graph/src/aggregate/aggregate_type.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/aggregate_type.rs
@@ -150,14 +150,14 @@ mod tests {
         let first = &list.found[0];
         let first_string = match &first.used_ty.resolved_ty {
             syn::Type::Path(ty_path) => ty_path.path.segments.last().unwrap().ident.to_string(),
-            _ => return Err(eyre_err!("Wrong first.used_ty.resolved_ty: {:?}", first)),
+            _ => return Err(eyre_err!("Wrong first.used_ty.resolved_ty: {first:?}")),
         };
         assert_eq!(first_string, "i32");
 
         let second = &list.found[1];
         let second_string = match &second.used_ty.resolved_ty {
             syn::Type::Path(ty_path) => ty_path.path.segments.last().unwrap().ident.to_string(),
-            _ => return Err(eyre_err!("Wrong second.used_ty.resolved_ty: {:?}", second)),
+            _ => return Err(eyre_err!("Wrong second.used_ty.resolved_ty: {second:?}")),
         };
         assert_eq!(second_string, "i8");
         Ok(())
@@ -175,14 +175,14 @@ mod tests {
         let first = &list.found[0];
         let first_string = match &first.used_ty.resolved_ty {
             syn::Type::Path(ty_path) => ty_path.path.segments.last().unwrap().ident.to_string(),
-            _ => return Err(eyre_err!("Wrong first.used_ty.resolved_ty: {:?}", first)),
+            _ => return Err(eyre_err!("Wrong first.used_ty.resolved_ty: {first:?}")),
         };
         assert_eq!(first_string, "i32");
 
         let second = &list.found[1];
         let second_string = match &second.used_ty.resolved_ty {
             syn::Type::Path(ty_path) => ty_path.path.segments.last().unwrap().ident.to_string(),
-            _ => return Err(eyre_err!("Wrong second.used_ty.resolved_ty: {:?}", second)),
+            _ => return Err(eyre_err!("Wrong second.used_ty.resolved_ty: {second:?}")),
         };
         assert_eq!(second_string, "VariadicArray");
         Ok(())
@@ -200,14 +200,14 @@ mod tests {
         let first = &list.found[0];
         let first_string = match &first.used_ty.resolved_ty {
             syn::Type::Path(ty_path) => ty_path.path.segments.last().unwrap().ident.to_string(),
-            _ => return Err(eyre_err!("Wrong first.ty: {:?}", first)),
+            _ => return Err(eyre_err!("Wrong first.ty: {first:?}")),
         };
         assert_eq!(first_string, "i32");
 
         let second = &list.found[1];
         let second_string = match &second.used_ty.resolved_ty {
             syn::Type::Path(ty_path) => ty_path.path.segments.last().unwrap().ident.to_string(),
-            _ => return Err(eyre_err!("Wrong second.used_ty.resolved_ty: {:?}", second)),
+            _ => return Err(eyre_err!("Wrong second.used_ty.resolved_ty: {second:?}")),
         };
         assert_eq!(second_string, "VariadicArray");
         Ok(())

--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -378,7 +378,7 @@ impl ToSql for PgAggregateEntity {
                         SqlGraphEntity::BuiltinType(defined) => defined == arg.used_ty.full_path,
                         _ => false,
                     })
-                    .ok_or_else(|| eyre!("Could not find arg type in graph. Got: {:?}", arg))?;
+                    .ok_or_else(|| eyre!("Could not find arg type in graph. Got: {arg:?}"))?;
                 let needs_comma = idx < (direct_args.len() - 1);
                 let buf = format!(
                     "\

--- a/pgrx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/entity.rs
@@ -153,7 +153,7 @@ impl SqlDeclaredEntity {
             sql: name
                 .split("::")
                 .last()
-                .ok_or_else(|| eyre::eyre!("Did not get SQL for `{}`", name))?
+                .ok_or_else(|| eyre::eyre!("Did not get SQL for `{name}`"))?
                 .to_string(),
             name: name.to_string(),
             option: format!("Option<{}>", name),

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -124,7 +124,7 @@ impl ToSql for PgExternEntity {
                         SqlGraphEntity::BuiltinType(defined) => defined == arg.used_ty.full_path,
                         _ => false,
                     })
-                    .ok_or_else(|| eyre!("Could not find arg type in graph. Got: {:?}", arg))?;
+                    .ok_or_else(|| eyre!("Could not find arg type in graph. Got: {arg:?}"))?;
                 let needs_comma = idx < (metadata_without_arg_skips.len().saturating_sub(1));
                 let metadata_argument = &self.metadata.arguments[idx];
                 match metadata_argument.argument_sql {
@@ -387,9 +387,7 @@ impl ToSql for PgExternEntity {
                     SqlGraphEntity::BuiltinType(defined) => defined == left_arg.type_name,
                     _ => false,
                 })
-                .ok_or_else(|| {
-                    eyre!("Could not find left arg type in graph. Got: {:?}", left_arg)
-                })?;
+                .ok_or_else(|| eyre!("Could not find left arg type in graph. Got: {left_arg:?}"))?;
             let left_arg_sql = match left_arg.argument_sql {
                 Ok(SqlMapping::As(ref sql)) => sql.clone(),
                 Ok(SqlMapping::Composite { array_brackets }) => {
@@ -428,7 +426,7 @@ impl ToSql for PgExternEntity {
                     _ => false,
                 })
                 .ok_or_else(|| {
-                    eyre!("Could not find right arg type in graph. Got: {:?}", right_arg)
+                    eyre!("Could not find right arg type in graph. Got: {right_arg:?}")
                 })?;
             let right_arg_sql = match right_arg.argument_sql {
                 Ok(SqlMapping::As(ref sql)) => sql.clone(),
@@ -491,9 +489,7 @@ impl ToSql for PgExternEntity {
                     (SqlGraphEntity::BuiltinType(defined), _) => defined == target_arg.type_name,
                     _ => false,
                 })
-                .ok_or_else(|| {
-                    eyre!("Could not find source type in graph. Got: {:?}", target_arg)
-                })?;
+                .ok_or_else(|| eyre!("Could not find source type in graph. Got: {target_arg:?}"))?;
             let target_arg_sql = match target_arg.argument_sql {
                 Ok(SqlMapping::As(ref sql)) => sql.clone(),
                 Ok(SqlMapping::Composite { array_brackets }) => {
@@ -543,9 +539,7 @@ impl ToSql for PgExternEntity {
                     SqlGraphEntity::BuiltinType(defined) => defined == source_arg.type_name,
                     _ => false,
                 })
-                .ok_or_else(|| {
-                    eyre!("Could not find source type in graph. Got: {:?}", source_arg)
-                })?;
+                .ok_or_else(|| eyre!("Could not find source type in graph. Got: {source_arg:?}"))?;
             let source_arg_sql = match source_arg.argument_sql {
                 Ok(SqlMapping::As(ref sql)) => sql.clone(),
                 Ok(SqlMapping::Composite { array_brackets }) => {

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -806,7 +806,7 @@ fn connect_externs(
                             graph.add_edge(*target, index, SqlGraphRequires::By);
                             has_explicit_requires = true;
                         } else {
-                            return Err(eyre!("Could not find `requires` target: {:?}", requires));
+                            return Err(eyre!("Could not find `requires` target: {requires:?}"));
                         }
                     }
                 }

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -85,7 +85,7 @@ impl ToSql for PostgresTypeEntity {
             ..
         }) = item_node
         else {
-            return Err(eyre!("Was not called on a Type. Got: {:?}", item_node));
+            return Err(eyre!("Was not called on a Type. Got: {item_node:?}"));
         };
 
         // The `in_fn`/`out_fn` need to be present in a certain order:
@@ -107,7 +107,7 @@ impl ToSql for PostgresTypeEntity {
             .externs
             .iter()
             .find(|(k, _v)| k.full_path == in_fn_path)
-            .ok_or_else(|| eyre::eyre!("Did not find `in_fn: {}`.", in_fn_path))?;
+            .ok_or_else(|| eyre::eyre!("Did not find `in_fn: {in_fn_path}`."))?;
         let (in_fn_graph_index, in_fn_entity) = context
             .graph
             .neighbors_undirected(self_index)
@@ -133,7 +133,7 @@ impl ToSql for PostgresTypeEntity {
             .externs
             .iter()
             .find(|(k, _v)| k.full_path == out_fn_path)
-            .ok_or_else(|| eyre::eyre!("Did not find `out_fn: {}`.", out_fn_path))?;
+            .ok_or_else(|| eyre::eyre!("Did not find `out_fn: {out_fn_path}`."))?;
         let (out_fn_graph_index, out_fn_entity) = context
             .graph
             .neighbors_undirected(self_index)

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -709,8 +709,7 @@ fn get_cargo_test_features() -> eyre::Result<clap_cargo::Features> {
             "--no-default-features" => features.no_default_features = true,
             "--features" => {
                 let configured_features = iter.next().ok_or(eyre!(
-                    "no `--features` specified in the cargo argument list: {:?}",
-                    cargo_user_args
+                    "no `--features` specified in the cargo argument list: {cargo_user_args:?}"
                 ))?;
                 features.features = configured_features
                     .split(|c: char| c.is_ascii_whitespace() || c == ',')

--- a/pgrx/src/callbacks.rs
+++ b/pgrx/src/callbacks.rs
@@ -278,7 +278,7 @@ impl SubXactCallbackReceipt {
     /// ```rust,no_run
     /// use pgrx::*;
     ///
-    /// let receipt = register_subxact_callback(PgSubXactCallbackEvent::CommitSub, |my_subid, parent_subid| info!("called after commit-sub: {} {}", my_subid, parent_subid));
+    /// let receipt = register_subxact_callback(PgSubXactCallbackEvent::CommitSub, |my_subid, parent_subid| info!("called after commit-sub: {my_subid} {parent_subid}"));
     ///
     /// let no_longer_necessary = true;
     ///


### PR DESCRIPTION
Manually inlining format args to make the code more a bit more readable and shorter -- all these args are calling non-core formatting functions like logging, so extra care must be taken to check - just in case the macros were incorrectly implemented (e.g. if a macro has a special case for a literal string without params -- the way `panic!` was implemented in edition 2018)