### PR TITLE
perf: avoid mem alloc in formatting, minor bug fix

### DIFF
--- a/pgrx-examples/operators/src/pgvarlena.rs
+++ b/pgrx-examples/operators/src/pgvarlena.rs
@@ -88,7 +88,7 @@ impl PgVarlenaInOutFuncs for PgVarlenaThing {
     }
 
     fn output(&self, buffer: &mut StringInfo) {
-        buffer.write_fmt(format_args!("{}", self)).unwrap()
+        write!(buffer, "{self}").unwrap()
     }
 }
 

--- a/pgrx-pg-sys/src/submodules/errcodes.rs
+++ b/pgrx-pg-sys/src/submodules/errcodes.rs
@@ -387,7 +387,7 @@ pub enum PgSqlErrorCode {
 
 impl Display for PgSqlErrorCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&format!("{:?}", self))
+        write!(f, "{self:?}")
     }
 }
 

--- a/pgrx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/entity.rs
@@ -134,13 +134,13 @@ impl Display for SqlDeclaredEntity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SqlDeclaredEntity::Type(data) => {
-                f.write_str(&(String::from("Type(") + &data.name + ")"))
+                write!(f, "Type({})", data.name)
             }
             SqlDeclaredEntity::Enum(data) => {
-                f.write_str(&(String::from("Enum(") + &data.name + ")"))
+                write!(f, "Enum({})", data.name)
             }
             SqlDeclaredEntity::Function(data) => {
-                f.write_str(&(String::from("Function ") + &data.name + ")"))
+                write!(f, "Function({})", data.name)
             }
         }
     }

--- a/pgrx/src/datum/numeric_support/serde.rs
+++ b/pgrx/src/datum/numeric_support/serde.rs
@@ -20,7 +20,7 @@ impl Serialize for AnyNumeric {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&format!("{}", self))
+        serializer.collect_str(&format_args!("{self}"))
     }
 }
 

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -78,7 +78,7 @@ pub enum SpiErrorCodes {
 
 impl std::fmt::Display for SpiErrorCodes {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.write_fmt(format_args!("{:?}", self))
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
Optimize writing formatted string to Serde, bypassing string allocations when possible.

Note that `pgrx-sql-entity-graph/src/extension_sql/entity.rs` seemed to have a bug for Function printing - it was printing `Function name)` without the opening parenthesis.

Also, in a few spots, I replaced `buffer.write_fmt(format_args!(...))` with `write!(buffer, ...)` -- as that's exactly what `write!` macro is for.