### PR TITLE
Allow pgrx to be slightly messy

### DIFF
--- a/cargo-pgrx/src/templates/bgworker_lib_rs
+++ b/cargo-pgrx/src/templates/bgworker_lib_rs
@@ -2,7 +2,7 @@ use pgrx::bgworkers::*;
 use pgrx::prelude::*;
 use std::time::Duration;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 /*
 In order to use this bgworker with a cargo-pgrx managed database, you'll need to add this line to

--- a/cargo-pgrx/src/templates/lib_rs
+++ b/cargo-pgrx/src/templates/lib_rs
@@ -1,6 +1,6 @@
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn hello_{name}() -> &'static str {{

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -14,7 +14,9 @@ which is the one you will be opening pull requests against in most cases.
 
 After cloning the repository, mostly you can use similar flows as in the README.
 However, if there are any differences in `cargo pgrx` since the last release, then
-the first and most drastic difference in the developer environment vs. the user environment is that you will have to run
+the first and most drastic difference in the developer environment vs. the
+user environment is that you will have to run
+
 ```bash
 cargo install cargo-pgrx --path ./cargo-pgrx \
     --force \

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -33,6 +33,17 @@ cargo pgrx init # This might take a while. Consider getting a drink.
 - Diffs in Cargo.lock should be checked in
 - HOWEVER, diffs in the bindgen in `pgrx-pg-sys/src/pg*.rs` should **not** be checked in (this is a release task)
 
+### Small Diffs? Big PRs?
+
+In general, it is better to land smaller diffs in pull requests, for making them easy to review.
+However, the pgrx repo is no stranger to "big PRs". This is often because a smaller PR may be
+unjustified or nonfunctional on its own.
+
+Further, large cleanup diffs that merely move around code, format it, or apply lints should be
+landed independently, to allow use of `.git-blame-ignore-revs`. Even these, however, are best if
+they are restrained to a single crate, or a logically-connected set, if they involve altering
+anything that could conceivably affect the code's functionality.
+
 ### Adding Dependencies
 
 If a new crate dependency is required for a pull request, and it can't or should not be marked optional and behind some kind of feature flag, then it should have its reason for being used stated in the Cargo.toml it is added to. This can be "as a member of a category", in the case of e.g. error handling:

--- a/nix/templates/default/src/lib.rs
+++ b/nix/templates/default/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn hello() -> &'static str {

--- a/pgrx-examples/aggregate/src/lib.rs
+++ b/pgrx-examples/aggregate/src/lib.rs
@@ -14,7 +14,7 @@ use pgrx::{pgrx, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -11,7 +11,7 @@ use pgrx::prelude::*;
 use pgrx::Array;
 use serde::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn sq_euclid_pgrx(a: Array<f32>, b: Array<f32>) -> f32 {

--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::panic::catch_unwind;
 use std::process::Command;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn panic(s: &str) -> bool {

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
     this background worker
 */
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_guard]
 pub extern "C" fn _PG_init() {

--- a/pgrx-examples/bytea/src/lib.rs
+++ b/pgrx-examples/bytea/src/lib.rs
@@ -11,7 +11,7 @@ use libflate::gzip::{Decoder, Encoder};
 use pgrx::prelude::*;
 use std::io::{Read, Write};
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 /// gzip bytes.  Postgres will automatically convert `text`/`varchar` data into `bytea`
 #[pg_extern]

--- a/pgrx-examples/composite_type/src/lib.rs
+++ b/pgrx-examples/composite_type/src/lib.rs
@@ -23,7 +23,7 @@ using composite types.
 use pgrx::{opname, pg_operator, prelude::*, Aggregate};
 
 // All `pgrx` extensions will do this:
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 /* Composite types must be defined either before they are used.
 

--- a/pgrx-examples/custom_libname/src/lib.rs
+++ b/pgrx-examples/custom_libname/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn hello_custom_libname() -> &'static str {

--- a/pgrx-examples/custom_sql/src/lib.rs
+++ b/pgrx-examples/custom_sql/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_schema]
 mod home {

--- a/pgrx-examples/custom_types/src/lib.rs
+++ b/pgrx-examples/custom_types/src/lib.rs
@@ -15,7 +15,7 @@ mod hstore_clone;
 mod ordered;
 mod rust_enum;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[cfg(test)]
 pub mod pg_test {

--- a/pgrx-examples/datetime/src/lib.rs
+++ b/pgrx-examples/datetime/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use rand::Rng;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern(name = "to_iso_string", immutable, parallel_safe)]
 fn to_iso_string(tsz: TimestampWithTimeZone) -> String {

--- a/pgrx-examples/errors/src/lib.rs
+++ b/pgrx-examples/errors/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::{error, info, warning, PgRelation, FATAL, PANIC};
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn array_with_null_and_panic(input: Vec<Option<i32>>) -> i64 {

--- a/pgrx-examples/nostd/src/lib.rs
+++ b/pgrx-examples/nostd/src/lib.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use alloc::string::String;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 /// standard Rust equality/comparison derives
 #[derive(Eq, PartialEq, Ord, Hash, PartialOrd)]

--- a/pgrx-examples/operators/src/lib.rs
+++ b/pgrx-examples/operators/src/lib.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 mod derived;
 mod pgvarlena;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[derive(PostgresType, Serialize, Deserialize, Eq, PartialEq)]
 pub struct MyType {

--- a/pgrx-examples/pgtrybuilder/src/lib.rs
+++ b/pgrx-examples/pgtrybuilder/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::pg_sys::panic::CaughtError;
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn is_valid_number(i: i32) -> i32 {

--- a/pgrx-examples/range/src/lib.rs
+++ b/pgrx-examples/range/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn range(s: i32, e: i32) -> pgrx::Range<i32> {

--- a/pgrx-examples/schemas/src/lib.rs
+++ b/pgrx-examples/schemas/src/lib.rs
@@ -13,7 +13,7 @@
 use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[derive(PostgresType, Serialize, Deserialize)]
 pub struct MyType(pub(crate) String);

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -16,7 +16,7 @@ use serde::*;
 use std::iter::Iterator;
 use std::sync::atomic::Ordering;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 // types behind a `LwLock` must derive/implement `Copy` and `Clone`
 #[derive(Copy, Clone)]

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::{info, spi, IntoDatum};
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 extension_sql!(
     r#"

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::IntoDatum;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 extension_sql!(
     r#"

--- a/pgrx-examples/srf/src/lib.rs
+++ b/pgrx-examples/srf/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn generate_series(start: i64, finish: i64, step: default!(i64, 1)) -> SetOfIterator<'static, i64> {

--- a/pgrx-examples/strings/src/lib.rs
+++ b/pgrx-examples/strings/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn return_static() -> &'static str {

--- a/pgrx-examples/triggers/src/lib.rs
+++ b/pgrx-examples/triggers/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::WhoAllocated;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[derive(thiserror::Error, Debug)]
 enum TriggerError {

--- a/pgrx-examples/versioned_custom_libname_so/src/lib.rs
+++ b/pgrx-examples/versioned_custom_libname_so/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn hello_versioned_custom_libname_so() -> &'static str {

--- a/pgrx-examples/versioned_so/src/lib.rs
+++ b/pgrx-examples/versioned_so/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!();
+::pgrx::pg_module_magic!();
 
 #[pg_extern]
 fn hello_versioned_so() -> &'static str {

--- a/pgrx-tests/src/tests/list_tests.rs
+++ b/pgrx-tests/src/tests/list_tests.rs
@@ -7,6 +7,7 @@
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
+    #[allow(unused)] // I can never tell when this is actually needed.
     use crate as pgrx_tests;
     use pgrx::list::List;
     use pgrx::memcx;

--- a/pgrx-tests/src/tests/proptests.rs
+++ b/pgrx-tests/src/tests/proptests.rs
@@ -11,6 +11,7 @@ pub fn nop_date(date: Date) -> Date {
 #[pgrx::pg_schema]
 mod tests {
     use super::*;
+    #[allow(unused)] // I can never tell when this is actually needed.
     use crate as pgrx_tests;
 
     // Property tests consist of 1:

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -10,6 +10,7 @@
 //! Safely create Postgres Background Workers, including with full SPI support
 //!
 //! See: [https://www.postgresql.org/docs/current/bgworker.html](https://www.postgresql.org/docs/current/bgworker.html)
+#![allow(clippy::assign_op_pattern)]
 #![allow(clippy::useless_transmute)]
 use crate::pg_sys;
 use pgrx_pg_sys::PgTryBuilder;

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -911,6 +911,7 @@ where
         unsafe { pg_sys::get_array_type(T::type_oid()) }
     }
 
+    #[allow(clippy::get_first)] // https://github.com/pgcentralfoundation/pgrx/issues/1363
     fn composite_type_oid(&self) -> Option<pg_sys::Oid> {
         // the composite type oid for a vec of composite types is the array type of the base composite type
         self.get(0)

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -9,7 +9,10 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Handing for easily converting Postgres Datum types into their corresponding Rust types
 //! and converting Rust types into their corresponding Postgres types
+#![allow(clippy::borrow_interior_mutable_const, clippy::declare_interior_mutable_const)] // https://github.com/pgcentralfoundation/pgrx/issues/1526
+#![allow(clippy::needless_lifetimes)] // https://github.com/pgcentralfoundation/pgrx/issues?q=is%3Aissue+is%3Aopen+label%3Alifetime
 #![allow(clippy::unused_unit)]
+#![allow(clippy::unnecessary_fallible_conversions)] // https://github.com/pgcentralfoundation/pgrx/issues/1525
 mod anyarray;
 mod anyelement;
 mod array;

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -167,7 +167,7 @@ pub fn nonstatic_typeid<T: ?Sized>() -> core::any::TypeId {
     unsafe { core::mem::transmute::<&dyn NonStaticAny, &'static dyn NonStaticAny>(&it).type_id() }
 }
 
-/// A type which can have it's [`core::any::TypeId`]s registered for Rust to SQL mapping.
+/// A type which can have its [`core::any::TypeId`]s registered for Rust to SQL mapping.
 ///
 /// An example use of this trait:
 ///

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -11,6 +11,7 @@
 //!
 //! It functions similarly to a Rust [`Vec`], including iterator support, but provides separate
 //! understandings of [`List`][crate::pg_sys::List]s of [`pg_sys::Oid`]s, Integers, and Pointers.
+#![allow(clippy::into_iter_on_ref)] // https://github.com/rust-lang/rust-clippy/issues/12230
 
 use crate::memcx::MemCx;
 use crate::pg_sys;

--- a/pgrx/src/list/flat_list.rs
+++ b/pgrx/src/list/flat_list.rs
@@ -216,7 +216,7 @@ impl<'cx, T: Enlist> List<'cx, T> {
         }
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a T> {
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.as_cells().into_iter().map(Deref::deref)
     }
 


### PR DESCRIPTION
As noted in #1517 there are many distractions in this repo due to some people using cargo clippy or other lints. For some of them, I do not intend to fix them, or intentionally am deferring fixing the lint (because the lint is triggering due to a genuine problem, and the genuine problem should be fixed, instead of the smaller change for "fixing the lint").