### PR TITLE
Clean up library with `is_non_null`

### DIFF
--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -88,6 +88,7 @@ pub use once_cell;
 
 /// Not ready for public exposure.
 mod layout;
+mod ptr;
 mod slice;
 mod toast;
 

--- a/pgrx/src/pg_sys.rs
+++ b/pgrx/src/pg_sys.rs
@@ -2,6 +2,7 @@
 
 // Flatten out the contents into here.
 use crate::memcx;
+use crate::ptr::PointerExt;
 pub use pgrx_pg_sys::*;
 
 // Interposing here can allow extensions like ZomboDB to skip the cshim,
@@ -39,7 +40,7 @@ pub unsafe fn rt_fetch(index: Index, range_table: *mut List) -> *mut RangeTblEnt
 #[inline]
 pub unsafe fn planner_rt_fetch(index: Index, root: *mut PlannerInfo) -> *mut RangeTblEntry {
     unsafe {
-        if (*root).simple_rte_array != core::ptr::null_mut() {
+        if (*root).simple_rte_array.is_non_null() {
             *(*root).simple_rte_array.add(index as _)
         } else {
             rt_fetch(index, (*(*root).parse).rtable).cast()

--- a/pgrx/src/ptr.rs
+++ b/pgrx/src/ptr.rs
@@ -1,0 +1,15 @@
+pub(crate) trait PointerExt {
+    fn is_non_null(&self) -> bool;
+}
+
+impl<T> PointerExt for *mut T {
+    fn is_non_null(&self) -> bool {
+        !self.is_null()
+    }
+}
+
+impl<T> PointerExt for *const T {
+    fn is_non_null(&self) -> bool {
+        !self.is_null()
+    }
+}


### PR DESCRIPTION
This adds `PointerExt::is_non_null` and cleans up some of the list code. I am told this is more readable?