### PR TITLE
docs: improve quotations

### DIFF
--- a/pgrx-macros/src/operators.rs
+++ b/pgrx-macros/src/operators.rs
@@ -80,11 +80,9 @@ pub(crate) fn deriving_postgres_hash(ast: DeriveInput) -> syn::Result<proc_macro
 ///
 /// Further, Postgres adds a disclaimer to these "optimization hints":
 ///
-/// ```text
-/// But if you provide them, you must be sure that they are right!
-/// Incorrect use of an optimization clause can result in
-/// slow queries, subtly wrong output, or other Bad Things.
-/// ```
+/// > But if you provide them, you must be sure that they are right!
+/// > Incorrect use of an optimization clause can result in
+/// > slow queries, subtly wrong output, or other Bad Things.
 ///
 /// In practice, most Eq impls are in fact correct, referentially transparent,
 /// and commutative. So this note could be for nothing. This signpost is left

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -426,10 +426,10 @@ pub(crate) fn downcast_panic_payload(e: Box<dyn Any + Send>) -> CaughtError {
         // caught a previously caught CaughtError that is being rethrown
         *e.downcast::<CaughtError>().unwrap()
     } else if e.downcast_ref::<ErrorReportWithLevel>().is_some() {
-        // someone called `panic_any(PgErrorReportWithLevel)`
+        // someone called `panic_any(ErrorReportWithLevel)`
         CaughtError::ErrorReport(*e.downcast().unwrap())
     } else if e.downcast_ref::<ErrorReport>().is_some() {
-        // someone called `panic_any(PgErrorReport)` so we convert it to be PgLogLevel::ERROR
+        // someone called `panic_any(ErrorReport)` so we convert it to be PgLogLevel::ERROR
         CaughtError::ErrorReport(ErrorReportWithLevel {
             level: PgLogLevel::ERROR,
             inner: *e.downcast().unwrap(),

--- a/pgrx/src/pg_catalog/pg_proc.rs
+++ b/pgrx/src/pg_catalog/pg_proc.rs
@@ -218,6 +218,7 @@ impl PgProc {
         self.get_attr(pg_sys::Anum_pg_proc_proconfig)
     }
 
+    /// From <https://www.postgresql.org/docs/current/catalog-pg-proc.html>:
     /// > An array of the modes of the function arguments, encoded as i for IN arguments, o for OUT
     /// > arguments, b for INOUT arguments, v for VARIADIC arguments, t for TABLE arguments. If all
     /// > the arguments are IN arguments, this field will be null. Note that subscripts correspond to

--- a/pgrx/src/pg_catalog/pg_proc.rs
+++ b/pgrx/src/pg_catalog/pg_proc.rs
@@ -218,12 +218,10 @@ impl PgProc {
         self.get_attr(pg_sys::Anum_pg_proc_proconfig)
     }
 
-    /// ```text
-    /// An array of the modes of the function arguments, encoded as i for IN arguments, o for OUT
-    /// arguments, b for INOUT arguments, v for VARIADIC arguments, t for TABLE arguments. If all
-    /// the arguments are IN arguments, this field will be null. Note that subscripts correspond to
-    /// positions of proallargtypes not proargtypes.
-    /// ```
+    /// > An array of the modes of the function arguments, encoded as i for IN arguments, o for OUT
+    /// > arguments, b for INOUT arguments, v for VARIADIC arguments, t for TABLE arguments. If all
+    /// > the arguments are IN arguments, this field will be null. Note that subscripts correspond to
+    /// > positions of proallargtypes not proargtypes.
     ///
     /// In our case, if all the arguments are `IN` arguments, the returned Vec will have the
     /// corresponding `ProArgModes::In` value in each element.

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -200,20 +200,18 @@ impl Spi {
     /// transaction `read_only = true`.  This is what we want as the user will expect an otherwise
     /// read-only statement like SELECT to see the results of prior statements.
     ///
-    /// Postgres docs say:
+    /// Postgres documentation says:
     ///
-    /// ```text
-    ///    It is generally unwise to mix read-only and read-write commands within a single function
-    ///    using SPI; that could result in very confusing behavior, since the read-only queries
-    ///    would not see the results of any database updates done by the read-write queries.
-    ///```
+    /// > It is generally unwise to mix read-only and read-write commands within a single function
+    /// > using SPI; that could result in very confusing behavior, since the read-only queries
+    /// > would not see the results of any database updates done by the read-write queries.
     ///
     /// pgrx interprets this to mean:
-    /// ```text
-    ///    Within a transaction, it's fine to execute Spi commands as `read_only = true` until the
-    ///    first mutable statement (DDL or DML).  From that point forward **all** statements
-    ///    must be executed as `read_only = false`.
-    /// ```
+    ///
+    /// > Within a transaction, it's fine to execute Spi commands as `read_only = true` until the
+    /// > first mutable statement (DDL or DML).  From that point forward **all** statements
+    /// > must be executed as `read_only = false`.
+    ///
     fn is_xact_still_immutable() -> bool {
         unsafe {
             // SAFETY:  `pg_sys::GetCurrentTransactionIdIfAny()` will always return a valid

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -206,12 +206,9 @@ impl Spi {
     /// > using SPI; that could result in very confusing behavior, since the read-only queries
     /// > would not see the results of any database updates done by the read-write queries.
     ///
-    /// pgrx interprets this to mean:
-    ///
-    /// > Within a transaction, it's fine to execute Spi commands as `read_only = true` until the
-    /// > first mutable statement (DDL or DML).  From that point forward **all** statements
-    /// > must be executed as `read_only = false`.
-    ///
+    /// PGRX interprets this to mean that within a transaction, it's fine to execute Spi commands
+    /// as `read_only = true` until the first mutable statement (DDL or DML).  From that point
+    /// forward **all** statements must be executed as `read_only = false`.
     fn is_xact_still_immutable() -> bool {
         unsafe {
             // SAFETY:  `pg_sys::GetCurrentTransactionIdIfAny()` will always return a valid

--- a/pgrx/src/trigger_support/mod.rs
+++ b/pgrx/src/trigger_support/mod.rs
@@ -178,7 +178,7 @@ Unsafe [`pgrx::pg_sys::FunctionCallInfo`][crate::pg_sys::FunctionCallInfo] and
 [`pgrx::pg_sys::Trigger`][crate::pg_sys::Trigger]) accessors are available..
 
 [`PgHeapTuple`]: crate::heap_tuple::PgHeapTuple
- */
+*/
 
 mod pg_trigger;
 mod pg_trigger_error;

--- a/pgrx/src/trigger_support/pg_trigger.rs
+++ b/pgrx/src/trigger_support/pg_trigger.rs
@@ -20,7 +20,7 @@ use std::ffi::c_char;
 /**
 The datatype accepted by a trigger
 
-A safe structure providing the an API similar to the constants provided in a PL/pgSQL function.
+A safe structure providing an API similar to the constants provided in a PL/pgSQL function.
 
 Usage examples exist in the module level docs.
 */


### PR DESCRIPTION
Several quotations needed improvement. One quote was not a quote. Another needed a citation. For the remainder, the `text` code block does not format very well for free-flow text. Quotes should use `> ...` instead.