### PR TITLE
Remove unnecessary nightly hack

### DIFF
--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -31,21 +31,6 @@ mod build {
 #[derive(Debug)]
 struct PgrxOverrides(HashSet<String>);
 
-fn is_nightly() -> bool {
-    if env_tracked("CARGO_CFG_PLRUSTC").is_some() {
-        return false;
-    }
-    let rustc = env_tracked("RUSTC").map(PathBuf::from).unwrap_or_else(|| "rustc".into());
-    let output = match std::process::Command::new(rustc).arg("--version").output() {
-        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_owned(),
-        _ => return false,
-    };
-    // Output looks like:
-    // - for nightly: `"rustc 1.66.0-nightly (0ca356586 2022-10-06)"`
-    // - for dev (locally built rust toolchain): `"rustc 1.66.0-dev"`
-    output.starts_with("rustc ") && (output.contains("-nightly") || output.contains("-dev"))
-}
-
 impl PgrxOverrides {
     fn default() -> Self {
         // these cause duplicate definition problems on linux
@@ -122,11 +107,6 @@ fn main() -> eyre::Result<()> {
 
     let is_for_release =
         env_tracked("PGRX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE").as_deref() == Some("1");
-
-    // Do nightly detection to suppress silly warnings.
-    if is_nightly() {
-        println!("cargo:rustc-cfg=nightly")
-    };
 
     let build_paths = BuildPaths::from_env();
 

--- a/pgrx-pg-sys/src/submodules/datum.rs
+++ b/pgrx-pg-sys/src/submodules/datum.rs
@@ -9,8 +9,6 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 // Polyfill while #![feature(strict_provenance)] is unstable
 use crate::NullableDatum;
-#[cfg(not(nightly))]
-use sptr::Strict;
 use std::ptr::NonNull;
 
 /// Postgres defines the "Datum" type as uintptr_t, so bindgen decides it is usize.
@@ -64,8 +62,7 @@ impl Datum {
     /// the memory address, interpreting them as an integer.
     #[inline]
     pub fn value(self) -> usize {
-        #[allow(unstable_name_collisions)]
-        self.0.addr()
+        sptr::Strict::addr(self.0)
     }
 
     /// True if the datum is equal to the null pointer.
@@ -78,7 +75,6 @@ impl Datum {
     /// It is recommended to explicitly use `datum.cast_mut_ptr::<T>()`.
     #[inline]
     pub fn cast_mut_ptr<T>(self) -> *mut T {
-        #[allow(unstable_name_collisions)]
         self.0.cast()
     }
 }
@@ -86,16 +82,14 @@ impl Datum {
 impl From<usize> for Datum {
     #[inline]
     fn from(val: usize) -> Datum {
-        #[allow(unstable_name_collisions)]
-        Datum(NonNull::<DatumBlob>::dangling().as_ptr().with_addr(val))
+        Datum(sptr::Strict::with_addr(NonNull::<DatumBlob>::dangling().as_ptr(), val))
     }
 }
 
 impl From<Datum> for usize {
     #[inline]
     fn from(val: Datum) -> usize {
-        #[allow(unstable_name_collisions)]
-        val.0.addr()
+        sptr::Strict::addr(val.0)
     }
 }
 

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -671,6 +671,7 @@ fn wait_latch(timeout: libc::c_long, wakeup_flags: WLflags) -> i32 {
 ))]
 type RpgffiChar = RpgffiChar96;
 
+#[allow(dead_code)]
 struct RpgffiChar64([c_char; 64]);
 
 impl<'a> From<&'a str> for RpgffiChar64 {


### PR DESCRIPTION
cc @NotGyro

It was done to suppress the `unstable_name_collisions` lint, which was independently fixed in 69e9b5b and 3e4b188. Propagate Thom's fix to remove this foolishness once and for all.