### PR TITLE
Remove unused `#[pgrx(..)]` support

### DIFF
--- a/pgrx-sql-entity-graph/src/pgrx_attribute.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_attribute.rs
@@ -17,7 +17,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 */
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{parenthesized, token, Token};
+use syn::Token;
 
 /// This struct is intended to represent the contents of the `#[pgrx]` attribute when parsed.
 ///
@@ -42,35 +42,29 @@ impl Parse for PgrxAttribute {
 
 /// This enum is akin to `syn::Meta`, but supports a custom `NameValue` variant which allows
 /// for bare paths in the value position.
+#[derive(Debug)]
 pub enum PgrxArg {
-    Path(syn::Path),
-    List(syn::MetaList),
     NameValue(NameValueArg),
 }
 
 impl Parse for PgrxArg {
+    #[track_caller]
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let path = input.parse::<syn::Path>()?;
-        if input.peek(token::Paren) {
-            let content;
-            Ok(Self::List(syn::MetaList {
-                path,
-                paren_token: parenthesized!(content in input),
-                nested: content.parse_terminated(syn::NestedMeta::parse)?,
-            }))
-        } else if input.peek(Token![=]) {
+        if input.peek(Token![=]) {
             Ok(Self::NameValue(NameValueArg {
                 path,
                 eq_token: input.parse()?,
                 value: input.parse()?,
             }))
         } else {
-            Ok(Self::Path(path))
+            Err(input.error("unsupported argument to #[pgrx] in this context"))
         }
     }
 }
 
-/// This struct is akin to `syn::NameValueMeta`, but allows for more than just `syn::Lit` as a value.
+/// This struct is akin to `syn::NameValueMeta`, but allows for more than just `syn::Lit` as a value.m
+#[derive(Debug)]
 pub struct NameValueArg {
     pub path: syn::Path,
     pub eq_token: syn::token::Eq,
@@ -78,6 +72,7 @@ pub struct NameValueArg {
 }
 
 /// This is the type of a value that can be used in the value position of a `name = value` attribute argument.
+#[derive(Debug)]
 pub enum ArgValue {
     Path(syn::Path),
     Lit(syn::Lit),

--- a/pgrx-sql-entity-graph/src/pgrx_attribute.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_attribute.rs
@@ -48,6 +48,20 @@ pub enum PgrxArg {
 }
 
 impl Parse for PgrxArg {
+    /// Parse `name = val` in `#[pgrx(name = val)]`
+    ///
+    /// It may seem like we leave this unhandled:
+    /// ```rust
+    /// #[pg_aggregate]
+    /// impl Aggregate for Aggregated {
+    ///     #[pgrx(immutable, parallel_safe)]
+    ///     fn state(current: _, args: _, fcinfo: _) -> Self::State {) {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    /// However, that actually never reaches this point!
+    /// This parser only handles the direct attributes.
     #[track_caller]
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let path = input.parse::<syn::Path>()?;
@@ -63,7 +77,7 @@ impl Parse for PgrxArg {
     }
 }
 
-/// This struct is akin to `syn::NameValueMeta`, but allows for more than just `syn::Lit` as a value.m
+/// This struct is akin to `syn::NameValueMeta`, but allows for more than just `syn::Lit` as a value.
 #[derive(Debug)]
 pub struct NameValueArg {
     pub path: syn::Path,
@@ -79,6 +93,7 @@ pub enum ArgValue {
 }
 
 impl Parse for ArgValue {
+    /// Parse `val` in `#[pgrx(name = val)]`
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         if input.peek(syn::Lit) {
             return Ok(Self::Lit(input.parse()?));

--- a/pgrx-sql-entity-graph/src/to_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/mod.rs
@@ -94,28 +94,27 @@ impl ToSqlConfig {
 
         let attr = attr.parse_args::<PgrxAttribute>()?;
         for arg in attr.args.iter() {
-            if let PgrxArg::NameValue(ref nv) = arg {
-                if !nv.path.is_ident("sql") {
-                    continue;
-                }
-
-                return match nv.value {
-                    ArgValue::Path(ref callback_path) => Ok(Some(Self {
-                        enabled: true,
-                        callback: Some(callback_path.clone()),
-                        content: None,
-                    })),
-                    ArgValue::Lit(Lit::Bool(ref b)) => {
-                        Ok(Some(Self { enabled: b.value, callback: None, content: None }))
-                    }
-                    ArgValue::Lit(Lit::Str(ref s)) => {
-                        Ok(Some(Self { enabled: true, callback: None, content: Some(s.clone()) }))
-                    }
-                    ArgValue::Lit(ref other) => {
-                        Err(syn::Error::new(other.span(), INVALID_ATTR_CONTENT))
-                    }
-                };
+            let PgrxArg::NameValue(ref nv) = arg;
+            if !nv.path.is_ident("sql") {
+                continue;
             }
+
+            return match nv.value {
+                ArgValue::Path(ref callback_path) => Ok(Some(Self {
+                    enabled: true,
+                    callback: Some(callback_path.clone()),
+                    content: None,
+                })),
+                ArgValue::Lit(Lit::Bool(ref b)) => {
+                    Ok(Some(Self { enabled: b.value, callback: None, content: None }))
+                }
+                ArgValue::Lit(Lit::Str(ref s)) => {
+                    Ok(Some(Self { enabled: true, callback: None, content: Some(s.clone()) }))
+                }
+                ArgValue::Lit(ref other) => {
+                    Err(syn::Error::new(other.span(), INVALID_ATTR_CONTENT))
+                }
+            };
         }
 
         Ok(None)


### PR DESCRIPTION
The support for this attribute in other cases, with other styles of arg, was never fully implemented. It seems `#[pg_aggregate]` handles the only case of this happening in the codebase on its own? The `#[pgrx(name = val)]` style is the only case actually handled by this code.

Remove unused code as it complicates debugging and updating the rest, especially with the lack of testing for its cases. Also touch everything with Debug implementations, so that will be easier in the future.