### PR TITLE
Update 2 syn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1507,7 +1507,7 @@ dependencies = [
  "serde",
  "shlex",
  "sptr",
- "syn 1.0.109",
+ "syn 2.0.48",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -218,7 +218,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -471,7 +471,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -661,17 +661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,7 +700,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -874,7 +863,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1297,9 +1286,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
- "flate2",
  "memchr",
- "ruzstd",
 ]
 
 [[package]]
@@ -1331,7 +1318,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1470,7 +1457,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1507,7 +1494,7 @@ dependencies = [
  "serde",
  "shlex",
  "sptr",
- "syn 2.0.48",
+ "syn",
  "walkdir",
 ]
 
@@ -1521,7 +1508,7 @@ dependencies = [
  "petgraph",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "syntect",
  "thiserror",
  "unescape",
@@ -1967,17 +1954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
-dependencies = [
- "byteorder",
- "derive_more",
- "twox-hash",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,7 +2109,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2267,12 +2243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "stringprep"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,17 +2272,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2427,7 +2386,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2592,7 +2551,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2666,16 +2625,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
 ]
 
 [[package]]
@@ -2859,7 +2808,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2881,7 +2830,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3142,5 +3091,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
  "petgraph",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
  "syntect",
  "thiserror",
  "unescape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ owo-colors = "3.5" # for output highlighting
 proc-macro2 = { version = "1.0.78" }
 quote = "1.0.33"
 regex = "1.1" # used for build/test
-syn = { version = "2", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "2", features = [ "extra-traits", "full", "parsing" ] }
 thiserror = "1"
 unescape = "0.1.0" # for escaped-character-handling
 url = "2.4.1" # the non-existent std::web

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,10 @@ cargo_toml = "0.16" # used for building projects
 eyre = "0.6.9" # simplifies error-handling
 libc = "0.2" # FFI compat
 owo-colors = "3.5" # for output highlighting
+proc-macro2 = { version = "1.0.78" }
+quote = "1.0.33"
 regex = "1.1" # used for build/test
+syn = { version = "2", features = [ "extra-traits", "full", "fold", "parsing" ] }
 thiserror = "1"
 unescape = "0.1.0" # for escaped-character-handling
 url = "2.4.1" # the non-existent std::web

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ cargo_toml = "0.16" # used for building projects
 eyre = "0.6.9" # simplifies error-handling
 libc = "0.2" # FFI compat
 owo-colors = "3.5" # for output highlighting
-proc-macro2 = { version = "1.0.78" }
+proc-macro2 = { version = "1.0.78", features = [ "span-locations" ] }
 quote = "1.0.33"
 regex = "1.1" # used for build/test
 syn = { version = "2", features = [ "extra-traits", "full", "parsing" ] }

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -29,7 +29,6 @@ pgrx-sql-entity-graph.workspace = true
 
 cargo_toml.workspace = true
 libc.workspace = true
-
 regex.workspace = true
 
 cargo_metadata = "0.17.0"

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -29,6 +29,7 @@ pgrx-sql-entity-graph.workspace = true
 
 cargo_toml.workspace = true
 libc.workspace = true
+
 regex.workspace = true
 
 cargo_metadata = "0.17.0"
@@ -40,9 +41,9 @@ tempfile = "3.8.0"
 toml = "0.8.2" # our config files
 
 # SQL schema generation
-object = "0.32.1"
-proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
-quote = "1.0.33"
+object = { version = "0.32.1", default-features = false, features = [ "std" ] }
+proc-macro2.workspace = true
+quote.workspace = true
 
 # emit better diagnostics
 color-eyre = "0.6.2"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -34,9 +34,9 @@ no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 [dependencies]
 pgrx-sql-entity-graph.workspace = true
 
-proc-macro2 = "1.0.69"
-quote = "1.0.33"
-syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 
 
 [dev-dependencies]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -133,7 +133,7 @@ pub fn pg_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                 thing.span(),
                 "#[pg_test] can only be applied to top-level functions",
             )
-            .to_compile_error()
+            .into_compile_error()
             .into()
         }
     }
@@ -197,12 +197,7 @@ pub fn pg_cast(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(CodeEnrichment(pg_extern.as_cast(cast)).to_token_stream().into())
     }
 
-    wrapped(attr, item).unwrap_or_else(|e| {
-        let msg = e.to_string();
-        TokenStream::from(quote! {
-          compile_error!(#msg);
-        })
-    })
+    wrapped(attr, item).unwrap_or_else(|e: syn::Error| e.into_compile_error().into())
 }
 
 /// Declare a function as `#[pg_operator]` to indicate that it represents a Postgres operator
@@ -288,12 +283,7 @@ pub fn pg_schema(_attr: TokenStream, input: TokenStream) -> TokenStream {
         Ok(pgrx_schema.to_token_stream().into())
     }
 
-    wrapped(input).unwrap_or_else(|e| {
-        let msg = e.to_string();
-        TokenStream::from(quote! {
-          compile_error!(#msg);
-        })
-    })
+    wrapped(input).unwrap_or_else(|e: syn::Error| e.into_compile_error().into())
 }
 
 /**
@@ -428,12 +418,7 @@ pub fn extension_sql(input: TokenStream) -> TokenStream {
         Ok(ext_sql.to_token_stream().into())
     }
 
-    wrapped(input).unwrap_or_else(|e| {
-        let msg = e.to_string();
-        TokenStream::from(quote! {
-          compile_error!(#msg);
-        })
-    })
+    wrapped(input).unwrap_or_else(|e: syn::Error| e.into_compile_error().into())
 }
 
 /**
@@ -470,12 +455,7 @@ pub fn extension_sql_file(input: TokenStream) -> TokenStream {
         Ok(ext_sql.to_token_stream().into())
     }
 
-    wrapped(input).unwrap_or_else(|e| {
-        let msg = e.to_string();
-        TokenStream::from(quote! {
-          compile_error!(#msg);
-        })
-    })
+    wrapped(input).unwrap_or_else(|e: syn::Error| e.into_compile_error().into())
 }
 
 /// Associated macro for `#[pg_extern]` or `#[macro@pg_operator]`.  Used to set the `SEARCH_PATH` option
@@ -631,7 +611,7 @@ pub fn pg_extern(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(pg_extern_item.to_token_stream().into())
     }
 
-    wrapped(attr, item).unwrap_or_else(|e: syn::Error| e.to_compile_error().into())
+    wrapped(attr, item).unwrap_or_else(|e: syn::Error| e.into_compile_error().into())
 }
 
 /**
@@ -653,7 +633,7 @@ enum DogNames {
 pub fn postgres_enum(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as syn::DeriveInput);
 
-    impl_postgres_enum(ast).unwrap_or_else(|e| e.to_compile_error()).into()
+    impl_postgres_enum(ast).unwrap_or_else(|e| e.into_compile_error()).into()
 }
 
 fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
@@ -766,7 +746,7 @@ Optionally accepts the following attributes:
 pub fn postgres_type(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as syn::DeriveInput);
 
-    impl_postgres_type(ast).unwrap_or_else(|e| e.to_compile_error()).into()
+    impl_postgres_type(ast).unwrap_or_else(|e| e.into_compile_error()).into()
 }
 
 fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
@@ -958,7 +938,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 pub fn postgres_guc_enum(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as syn::DeriveInput);
 
-    impl_guc_enum(ast).unwrap_or_else(|e| e.to_compile_error()).into()
+    impl_guc_enum(ast).unwrap_or_else(|e| e.into_compile_error()).into()
 }
 
 fn impl_guc_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
@@ -1173,7 +1153,7 @@ pub fn pg_aggregate(_attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let parsed_base = parse_macro_input!(item as syn::ItemImpl);
-    wrapped(parsed_base).unwrap_or_else(|e| e.to_compile_error().into())
+    wrapped(parsed_base).unwrap_or_else(|e| e.into_compile_error().into())
 }
 
 /**
@@ -1224,5 +1204,5 @@ pub fn pg_trigger(attrs: TokenStream, input: TokenStream) -> TokenStream {
         Ok(trigger_tokens.into())
     }
 
-    wrapped(attrs, input).unwrap_or_else(|e| e.to_compile_error().into())
+    wrapped(attrs, input).unwrap_or_else(|e| e.into_compile_error().into())
 }

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -624,17 +624,15 @@ fn example_return() -> pg_sys::Oid {
 
 */
 #[proc_macro_attribute]
+#[track_caller]
 pub fn pg_extern(attr: TokenStream, item: TokenStream) -> TokenStream {
     fn wrapped(attr: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Error> {
         let pg_extern_item = PgExtern::new(attr.clone().into(), item.clone().into())?;
         Ok(pg_extern_item.to_token_stream().into())
     }
 
-    wrapped(attr, item).unwrap_or_else(|e| {
-        let msg = e.to_string();
-        TokenStream::from(quote! {
-          compile_error!(#msg);
-        })
+    wrapped(attr, item).unwrap_or_else(|e: syn::Error| {
+        e.to_compile_error().into()
     })
 }
 

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -631,9 +631,7 @@ pub fn pg_extern(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(pg_extern_item.to_token_stream().into())
     }
 
-    wrapped(attr, item).unwrap_or_else(|e: syn::Error| {
-        e.to_compile_error().into()
-    })
+    wrapped(attr, item).unwrap_or_else(|e: syn::Error| e.to_compile_error().into())
 }
 
 /**

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -627,7 +627,7 @@ fn example_return() -> pg_sys::Oid {
 #[track_caller]
 pub fn pg_extern(attr: TokenStream, item: TokenStream) -> TokenStream {
     fn wrapped(attr: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Error> {
-        let pg_extern_item = PgExtern::new(attr.clone().into(), item.clone().into())?;
+        let pg_extern_item = PgExtern::new(attr.into(), item.into())?;
         Ok(pg_extern_item.to_token_stream().into())
     }
 
@@ -1173,12 +1173,7 @@ pub fn pg_aggregate(_attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let parsed_base = parse_macro_input!(item as syn::ItemImpl);
-    wrapped(parsed_base).unwrap_or_else(|e| {
-        let msg = e.to_string();
-        TokenStream::from(quote! {
-          compile_error!(#msg);
-        })
-    })
+    wrapped(parsed_base).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 /**
@@ -1229,10 +1224,5 @@ pub fn pg_trigger(attrs: TokenStream, input: TokenStream) -> TokenStream {
         Ok(trigger_tokens.into())
     }
 
-    wrapped(attrs, input).unwrap_or_else(|e| {
-        let msg = e.to_string();
-        TokenStream::from(quote! {
-          compile_error!(#msg);
-        })
-    })
+    wrapped(attrs, input).unwrap_or_else(|e| e.to_compile_error().into())
 }

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -73,7 +73,7 @@ pub fn pg_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             let mut non_test_attributes = Vec::new();
 
             for attribute in func.attrs.iter() {
-                if let Some(ident) = attribute.path.get_ident() {
+                if let Some(ident) = attribute.path().get_ident() {
                     let ident_str = ident.to_string();
 
                     if ident_str == "ignore" || ident_str == "should_panic" {
@@ -105,7 +105,7 @@ pub fn pg_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             let mut att_stream = proc_macro2::TokenStream::new();
 
             for a in attributes.iter() {
-                let as_str = a.tokens.to_string();
+                let as_str = a.to_token_stream().to_string();
                 att_stream.extend(quote! {
                     options.push(#as_str);
                 });
@@ -1057,7 +1057,7 @@ fn parse_postgres_type_args(attributes: &[Attribute]) -> HashSet<PostgresTypeAtt
     let mut categorized_attributes = HashSet::new();
 
     for a in attributes {
-        let path = &a.path;
+        let path = &a.path();
         let path = quote! {#path}.to_string();
         match path.as_str() {
             "inoutfuncs" => {

--- a/pgrx-macros/src/operators.rs
+++ b/pgrx-macros/src/operators.rs
@@ -14,6 +14,7 @@ use proc_macro2::Ident;
 use quote::{quote, ToTokens};
 use syn::DeriveInput;
 
+#[track_caller]
 fn ident_and_path(ast: &DeriveInput) -> (&Ident, proc_macro2::TokenStream) {
     let ident = &ast.ident;
     let args = parse_postgres_type_args(&ast.attrs);
@@ -25,6 +26,7 @@ fn ident_and_path(ast: &DeriveInput) -> (&Ident, proc_macro2::TokenStream) {
     (ident, path)
 }
 
+#[track_caller]
 pub(crate) fn deriving_postgres_eq(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
     let (ident, path) = ident_and_path(&ast);
@@ -34,6 +36,7 @@ pub(crate) fn deriving_postgres_eq(ast: DeriveInput) -> syn::Result<proc_macro2:
     Ok(stream)
 }
 
+#[track_caller]
 pub(crate) fn deriving_postgres_ord(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let mut stream = proc_macro2::TokenStream::new();
     let (ident, path) = ident_and_path(&ast);
@@ -90,6 +93,7 @@ pub(crate) fn deriving_postgres_hash(ast: DeriveInput) -> syn::Result<proc_macro
 /// finally leads them here.
 ///
 /// ["optimization hints"]: https://www.postgresql.org/docs/current/xoper-optimization.html
+#[track_caller]
 pub fn derive_pg_eq(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_eq").to_lowercase(), name.span());
     quote! {
@@ -119,6 +123,7 @@ pub fn derive_pg_eq(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
 /// - PartialEq::ne is commutative
 ///
 /// See `derive_pg_eq` for the implications of this assumption.
+#[track_caller]
 pub fn derive_pg_ne(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_ne").to_lowercase(), name.span());
     quote! {
@@ -135,6 +140,7 @@ pub fn derive_pg_ne(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
     }
 }
 
+#[track_caller]
 pub fn derive_pg_lt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_lt").to_lowercase(), name.span());
     quote! {
@@ -152,6 +158,7 @@ pub fn derive_pg_lt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
     }
 }
 
+#[track_caller]
 pub fn derive_pg_gt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_gt").to_lowercase(), name.span());
     quote! {
@@ -168,6 +175,7 @@ pub fn derive_pg_gt(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
     }
 }
 
+#[track_caller]
 pub fn derive_pg_le(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_le").to_lowercase(), name.span());
     quote! {
@@ -184,6 +192,7 @@ pub fn derive_pg_le(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
     }
 }
 
+#[track_caller]
 pub fn derive_pg_ge(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_ge").to_lowercase(), name.span());
     quote! {
@@ -200,6 +209,7 @@ pub fn derive_pg_ge(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro
     }
 }
 
+#[track_caller]
 pub fn derive_pg_cmp(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_cmp").to_lowercase(), name.span());
     quote! {
@@ -225,6 +235,7 @@ pub fn derive_pg_cmp(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macr
 ///
 /// Postgres is no different: this hashing is for the explicit purpose of equality checks,
 /// and it also needs to be able to reason from hash equality to actual equality.
+#[track_caller]
 pub fn derive_pg_hash(name: &Ident, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     let pg_name = Ident::new(&format!("{name}_hash").to_lowercase(), name.span());
     quote! {

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -40,7 +40,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
 
     let generics = func.sig.generics.clone();
 
-    if attrs.iter().any(|attr| attr.path.is_ident("no_mangle"))
+    if attrs.iter().any(|attr| attr.path().is_ident("no_mangle"))
         && generics.params.iter().any(|p| match p {
             GenericParam::Type(_) => true,
             GenericParam::Lifetime(_) => false,

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -52,11 +52,11 @@ sptr = "0.3"
 pgrx-pg-config.workspace = true
 
 eyre.workspace = true
+proc-macro2.workspace = true
+syn.workspace = true
 walkdir.workspace = true
 
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
-proc-macro2 = "1.0.69"
 quote = "1.0.33"
-syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
 shlex = "1.3" # shell lexing, also used by many of our deps

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -32,7 +32,7 @@ convert_case = "0.6.0"
 petgraph = "0.6.4"
 proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
 quote = "1.0.33"
-syn = { version = "1.0.109", features = [ "extra-traits", "full", "fold", "parsing" ] }
+syn = { version = "2", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0" # for escaped-character-handling
 
 # colorized sql output

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -26,13 +26,13 @@ no-schema-generation = []
 
 [dependencies]
 eyre.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 thiserror.workspace = true
 
 convert_case = "0.6.0"
 petgraph = "0.6.4"
-proc-macro2 = { version = "1.0.69", features = [ "span-locations" ] }
-quote = "1.0.33"
-syn = { version = "2", features = [ "extra-traits", "full", "fold", "parsing" ] }
 unescape = "0.1.0" # for escaped-character-handling
 
 # colorized sql output

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -762,7 +762,7 @@ fn get_target_path(item_impl: &ItemImpl) -> Result<Path, syn::Error> {
 fn pg_extern_attr(item: &ImplItemFn) -> syn::Attribute {
     let mut found = None;
     for attr in item.attrs.iter() {
-        match attr.path.segments.last() {
+        match attr.path().segments.last() {
             Some(segment) if segment.ident == "pgrx" => {
                 found = Some(attr.tokens.clone());
                 break;

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -32,7 +32,7 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{
-    parse_quote, Expr, ImplItemConst, ImplItemMethod, ImplItemType, ItemFn, ItemImpl, Path, Type,
+    parse_quote, Expr, ImplItemConst, ImplItemFn, ImplItemType, ItemFn, ItemImpl, Path, Type,
 };
 
 use crate::ToSqlConfig;
@@ -759,7 +759,7 @@ fn get_target_path(item_impl: &ItemImpl) -> Result<Path, syn::Error> {
     Ok(target_ident)
 }
 
-fn pg_extern_attr(item: &ImplItemMethod) -> syn::Attribute {
+fn pg_extern_attr(item: &ImplItemFn) -> syn::Attribute {
     let mut found = None;
     for attr in item.attrs.iter() {
         match attr.path.segments.last() {
@@ -794,15 +794,15 @@ fn get_impl_type_by_name<'a>(item_impl: &'a ItemImpl, name: &str) -> Option<&'a 
     needle
 }
 
-fn get_impl_func_by_name<'a>(item_impl: &'a ItemImpl, name: &str) -> Option<&'a ImplItemMethod> {
+fn get_impl_func_by_name<'a>(item_impl: &'a ItemImpl, name: &str) -> Option<&'a ImplItemFn> {
     let mut needle = None;
-    for impl_item_method in item_impl.items.iter().filter_map(|impl_item| match impl_item {
-        syn::ImplItem::Method(iimethod) => Some(iimethod),
+    for impl_item_fn in item_impl.items.iter().filter_map(|impl_item| match impl_item {
+        syn::ImplItem::Fn(iifn) => Some(iifn),
         _ => None,
     }) {
-        let ident_string = impl_item_method.sig.ident.to_string();
+        let ident_string = impl_item_fn.sig.ident.to_string();
         if ident_string == name {
-            needle = Some(impl_item_method);
+            needle = Some(impl_item_fn);
         }
     }
     needle

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -764,7 +764,7 @@ fn pg_extern_attr(item: &ImplItemFn) -> syn::Attribute {
     for attr in item.attrs.iter() {
         match attr.path().segments.last() {
             Some(segment) if segment.ident == "pgrx" => {
-                found = Some(attr.tokens.clone());
+                found = Some(quote::ToTokens::to_token_stream(attr));
                 break;
             }
             _ => (),

--- a/pgrx-sql-entity-graph/src/extension_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/mod.rs
@@ -128,7 +128,7 @@ impl Parse for CodeEnrichment<ExtensionSqlFile> {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let path = input.parse()?;
         let _after_sql_comma: Option<Token![,]> = input.parse()?;
-        let attrs = input.parse_terminated(ExtensionSqlAttribute::parse)?;
+        let attrs = input.parse_terminated(ExtensionSqlAttribute::parse, Token![,])?;
         Ok(CodeEnrichment(ExtensionSqlFile { path, attrs }))
     }
 }
@@ -226,7 +226,7 @@ impl Parse for CodeEnrichment<ExtensionSql> {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let sql = input.parse()?;
         let _after_sql_comma: Option<Token![,]> = input.parse()?;
-        let attrs = input.parse_terminated(ExtensionSqlAttribute::parse)?;
+        let attrs = input.parse_terminated(ExtensionSqlAttribute::parse, Token![,])?;
         let name = attrs.iter().rev().find_map(|attr| match attr {
             ExtensionSqlAttribute::Name(found_name) => Some(found_name.clone()),
             _ => None,
@@ -260,13 +260,13 @@ impl Parse for ExtensionSqlAttribute {
                 let _eq: syn::token::Eq = input.parse()?;
                 let content;
                 let _bracket = syn::bracketed!(content in input);
-                Self::Creates(content.parse_terminated(SqlDeclared::parse)?)
+                Self::Creates(content.parse_terminated(SqlDeclared::parse, Token![,])?)
             }
             "requires" => {
                 let _eq: syn::token::Eq = input.parse()?;
                 let content;
                 let _bracket = syn::bracketed!(content in input);
-                Self::Requires(content.parse_terminated(PositioningRef::parse)?)
+                Self::Requires(content.parse_terminated(PositioningRef::parse, Token![,])?)
             }
             "bootstrap" => Self::Bootstrap,
             "finalize" => Self::Finalize,

--- a/pgrx-sql-entity-graph/src/extern_args.rs
+++ b/pgrx-sql-entity-graph/src/extern_args.rs
@@ -116,6 +116,8 @@ impl ToTokens for ExternArgs {
     }
 }
 
+// This horror-story should be returning result
+#[track_caller]
 pub fn parse_extern_attributes(attr: TokenStream) -> HashSet<ExternArgs> {
     let mut args = HashSet::<ExternArgs>::new();
     let mut itr = attr.into_iter();

--- a/pgrx-sql-entity-graph/src/fmt.rs
+++ b/pgrx-sql-entity-graph/src/fmt.rs
@@ -1,3 +1,33 @@
+macro_rules! lazy_err {
+    ($span_expr:expr, $lit:literal $(, $tokens:tt),*) => {
+        {
+            let spanning = $span_expr;
+            || ::syn::Error::new_spanned(spanning, format!($lit, $($tokens)*))
+        }
+    }
+}
+
 pub fn with_array_brackets(s: String, brackets: bool) -> String {
     s + if brackets { "[]" } else { "" }
+}
+
+pub(crate) trait ErrHarder {
+    fn more_error(self, closerr: impl FnOnce() -> syn::Error) -> Self;
+}
+
+impl<T> ErrHarder for syn::Result<T> {
+    fn more_error(self, closerr: impl FnOnce() -> syn::Error) -> Self {
+        self.map_err(|inner| {
+            let mut e = inner.clone();
+            e.combine(closerr());
+            e
+        })
+    }
+}
+
+impl ErrHarder for syn::Error {
+    fn more_error(mut self, closerr: impl FnOnce() -> syn::Error) -> Self {
+        self.combine(closerr());
+        self
+    }
 }

--- a/pgrx-sql-entity-graph/src/fmt.rs
+++ b/pgrx-sql-entity-graph/src/fmt.rs
@@ -1,3 +1,5 @@
+/// Evaluate an expression that resolves to any `impl ToTokens`, then produce a closure
+/// for lazily combining errors only on the unhappy path of `syn::Result`
 macro_rules! lazy_err {
     ($span_expr:expr, $lit:literal $(, $tokens:tt),*) => {
         {

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -56,6 +56,7 @@ pub(crate) mod control_file;
 pub(crate) mod enrich;
 pub(crate) mod extension_sql;
 pub(crate) mod extern_args;
+#[macro_use]
 pub(crate) mod fmt;
 pub mod lifetimes;
 pub(crate) mod mapping;

--- a/pgrx-sql-entity-graph/src/lifetimes.rs
+++ b/pgrx-sql-entity-graph/src/lifetimes.rs
@@ -35,7 +35,7 @@ pub fn anonymize_lifetimes(value: &mut syn::Type) {
                 }
                 // recurse
                 syn::GenericArgument::Type(ty) => anonymize_lifetimes(ty),
-                syn::GenericArgument::Binding(binding) => anonymize_lifetimes(&mut binding.ty),
+                syn::GenericArgument::AssocType(binding) => anonymize_lifetimes(&mut binding.ty),
                 syn::GenericArgument::Constraint(constraint) => {
                     constraint.bounds.iter_mut().for_each(|bound| {
                         if let syn::TypeParamBound::Lifetime(lifetime) = bound {

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -190,7 +190,7 @@ impl Parse for Attribute {
                 let _eq: syn::token::Eq = input.parse()?;
                 let content;
                 let _bracket = syn::bracketed!(content in input);
-                Self::Requires(content.parse_terminated(PositioningRef::parse)?)
+                Self::Requires(content.parse_terminated(PositioningRef::parse, Token![,])?)
             }
             "sql" => {
                 use crate::pgrx_attribute::ArgValue;

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -183,7 +183,7 @@ impl PgExtern {
             Ok(meta) if meta.path().is_ident("doc") => Some(meta),
             _ => None,
         }) {
-            let Meta::NameValue(syn::MetaNameValue { lit, .. }) = meta else { continue };
+            let Meta::NameValue(syn::MetaNameValue { value, .. }) = meta else { continue };
             let syn::Lit::Str(ref inner) = lit else { continue };
             span.get_or_insert(lit.span());
             if !in_commented_sql_block && inner.value().trim() == "```pgrxsql" {

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -29,7 +29,7 @@ pub use operator::PgOperator;
 pub use returning::NameMacro;
 
 use crate::ToSqlConfig;
-use attribute::Attribute;
+pub(crate) use attribute::Attribute;
 use operator::{PgrxOperatorAttributeWithIdent, PgrxOperatorOpName};
 use search_path::SearchPathList;
 
@@ -214,6 +214,7 @@ impl PgExtern {
         retval.map(|s| syn::LitStr::new(s.as_ref(), span.unwrap()))
     }
 
+    #[track_caller]
     fn operator(func: &syn::ItemFn) -> syn::Result<Option<PgOperator>> {
         let mut skel = Option::<PgOperator>::default();
         for attr in &func.attrs {

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -213,23 +213,23 @@ impl PgExtern {
             let last_segment = attr.path().segments.last().unwrap();
             match last_segment.ident.to_string().as_str() {
                 "opname" => {
-                    let attr: PgrxOperatorOpName = syn::parse2(attr.tokens.clone())?;
+                    let attr: PgrxOperatorOpName = syn::parse2(attr.to_token_stream())?;
                     skel.get_or_insert_with(Default::default).opname.get_or_insert(attr);
                 }
                 "commutator" => {
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.tokens.clone())?;
+                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.to_token_stream())?;
                     skel.get_or_insert_with(Default::default).commutator.get_or_insert(attr);
                 }
                 "negator" => {
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.tokens.clone())?;
+                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.to_token_stream())?;
                     skel.get_or_insert_with(Default::default).negator.get_or_insert(attr);
                 }
                 "join" => {
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.tokens.clone())?;
+                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.to_token_stream())?;
                     skel.get_or_insert_with(Default::default).join.get_or_insert(attr);
                 }
                 "restrict" => {
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.tokens.clone())?;
+                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.to_token_stream())?;
                     skel.get_or_insert_with(Default::default).restrict.get_or_insert(attr);
                 }
                 "hashes" => {

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -210,7 +210,7 @@ impl PgExtern {
     fn operator(func: &syn::ItemFn) -> syn::Result<Option<PgOperator>> {
         let mut skel = Option::<PgOperator>::default();
         for attr in &func.attrs {
-            let last_segment = attr.path.segments.last().unwrap();
+            let last_segment = attr.path().segments.last().unwrap();
             match last_segment.ident.to_string().as_str() {
                 "opname" => {
                     let attr: PgrxOperatorOpName = syn::parse2(attr.tokens.clone())?;
@@ -248,7 +248,7 @@ impl PgExtern {
         func.attrs
             .iter()
             .find(|f| {
-                f.path
+                f.path()
                     .segments
                     .first()
                     .map(|f| f.ident == Ident::new("search_path", Span::call_site()))

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -91,8 +91,9 @@ impl PgExtern {
 
         let parser = Punctuated::<Attribute, Token![,]>::parse_terminated;
         let attr_ts = attr.clone();
-        let punctuated_attrs =
-            parser.parse2(attr).more_error(lazy_err!(attr_ts, "failed parsing pg_extern arguments"))?;
+        let punctuated_attrs = parser
+            .parse2(attr)
+            .more_error(lazy_err!(attr_ts, "failed parsing pg_extern arguments"))?;
         for pair in punctuated_attrs.into_pairs() {
             match pair.into_value() {
                 Attribute::Sql(config) => to_sql_config = to_sql_config.or(Some(config)),

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -232,26 +232,40 @@ impl PgExtern {
                     })?;
                     skel.get_or_insert_with(Default::default).opname.get_or_insert(attr);
                 }
-                "commutator" => {
+                s @ "commutator" => {
                     let attr_ts = attr.to_token_stream();
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr_ts.clone())
-                        .map_err(|e| {
-                            let mut e = e.clone();
-                            e.combine(syn::Error::new_spanned(attr_ts, "bad parse of commutator?"));
-                            e
-                        })?;
+                    let attr: PgrxOperatorAttributeWithIdent = attr.parse_args().map_err(|e| {
+                        let mut e = e.clone();
+                        e.combine(syn::Error::new_spanned(attr_ts, format!("bad parse of {s}?")));
+                        e
+                    })?;
                     skel.get_or_insert_with(Default::default).commutator.get_or_insert(attr);
                 }
-                "negator" => {
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.to_token_stream())?;
+                s @ "negator" => {
+                    let attr_ts = attr.to_token_stream();
+                    let attr: PgrxOperatorAttributeWithIdent = attr.parse_args().map_err(|e| {
+                        let mut e = e.clone();
+                        e.combine(syn::Error::new_spanned(attr_ts, format!("bad parse of {s}?")));
+                        e
+                    })?;
                     skel.get_or_insert_with(Default::default).negator.get_or_insert(attr);
                 }
-                "join" => {
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.to_token_stream())?;
+                s @ "join" => {
+                    let attr_ts = attr.to_token_stream();
+                    let attr: PgrxOperatorAttributeWithIdent = attr.parse_args().map_err(|e| {
+                        let mut e = e.clone();
+                        e.combine(syn::Error::new_spanned(attr_ts, format!("bad parse of {s}?")));
+                        e
+                    })?;
                     skel.get_or_insert_with(Default::default).join.get_or_insert(attr);
                 }
-                "restrict" => {
-                    let attr: PgrxOperatorAttributeWithIdent = syn::parse2(attr.to_token_stream())?;
+                s @ "restrict" => {
+                    let attr_ts = attr.to_token_stream();
+                    let attr: PgrxOperatorAttributeWithIdent = attr.parse_args().map_err(|e| {
+                        let mut e = e.clone();
+                        e.combine(syn::Error::new_spanned(attr_ts, format!("bad parse of {s}?")));
+                        e
+                    })?;
                     skel.get_or_insert_with(Default::default).restrict.get_or_insert(attr);
                 }
                 "hashes" => {

--- a/pgrx-sql-entity-graph/src/pg_extern/operator.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/operator.rs
@@ -17,9 +17,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 */
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::parenthesized;
 use syn::parse::{Parse, ParseBuffer};
-use syn::token::Paren;
 
 /// A parsed `#[pg_operator]` operator.
 ///
@@ -61,17 +59,12 @@ impl ToTokens for PgOperator {
 
 #[derive(Debug, Clone)]
 pub struct PgrxOperatorAttributeWithIdent {
-    pub paren_token: Paren,
     pub fn_name: TokenStream2,
 }
 
 impl Parse for PgrxOperatorAttributeWithIdent {
     fn parse(input: &ParseBuffer) -> Result<Self, syn::Error> {
-        let inner;
-        Ok(PgrxOperatorAttributeWithIdent {
-            paren_token: parenthesized!(inner in input),
-            fn_name: inner.parse()?,
-        })
+        Ok(PgrxOperatorAttributeWithIdent { fn_name: input.parse()? })
     }
 }
 
@@ -88,17 +81,12 @@ impl ToTokens for PgrxOperatorAttributeWithIdent {
 
 #[derive(Debug, Clone)]
 pub struct PgrxOperatorOpName {
-    pub paren_token: Paren,
     pub op_name: TokenStream2,
 }
 
 impl Parse for PgrxOperatorOpName {
     fn parse(input: &ParseBuffer) -> Result<Self, syn::Error> {
-        let inner;
-        Ok(PgrxOperatorOpName {
-            paren_token: parenthesized!(inner in input),
-            op_name: inner.parse()?,
-        })
+        Ok(PgrxOperatorOpName { op_name: input.parse()? })
     }
 }
 

--- a/pgrx-sql-entity-graph/src/pg_extern/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/returning.rs
@@ -119,7 +119,12 @@ impl Returning {
                             match ident_string.as_str() {
                                 "Option" => match &segment.arguments {
                                     PathArguments::AngleBracketed(bracketed) => {
-                                        match bracketed.args.first().unwrap() {
+                                        match bracketed.args.first().ok_or_else(|| {
+                                            syn::Error::new_spanned(
+                                                bracketed,
+                                                "where's the generic args?",
+                                            )
+                                        })? {
                                             GenericArgument::Type(Type::Path(this_path)) => {
                                                 segments = this_path.path.segments.clone();
                                                 saw_option_ident = true;
@@ -151,7 +156,7 @@ impl Returning {
                         let last_path_segment = option_inner_path.segments.last();
                         let (used_ty, optional) = match &last_path_segment.map(|ps| &ps.arguments) {
                             Some(syn::PathArguments::AngleBracketed(args)) => {
-                                match args.args.last().unwrap() {
+                                match args.args.last().expect("should have one arg?") {
                                     syn::GenericArgument::Type(ty) => {
                                         match &ty {
                                             syn::Type::Path(path) => {

--- a/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
@@ -64,7 +64,7 @@ impl Parse for SearchPathList {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         Ok(Self {
             fields: input
-                .parse_terminated(SearchPath::parse)
+                .parse_terminated(SearchPath::parse, Token![,])
                 .unwrap_or_else(|_| panic!("Got {}", input)),
         })
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/search_path.rs
@@ -62,11 +62,7 @@ pub struct SearchPathList {
 
 impl Parse for SearchPathList {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
-        Ok(Self {
-            fields: input
-                .parse_terminated(SearchPath::parse, Token![,])
-                .unwrap_or_else(|_| panic!("Got {}", input)),
-        })
+        Ok(Self { fields: input.parse_terminated(SearchPath::parse, Token![,])? })
     }
 }
 

--- a/pgrx-sql-entity-graph/src/pgrx_attribute.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_attribute.rs
@@ -55,7 +55,7 @@ impl Parse for PgrxArg {
     /// #[pg_aggregate]
     /// impl Aggregate for Aggregated {
     ///     #[pgrx(immutable, parallel_safe)]
-    ///     fn state(current: _, args: _, fcinfo: _) -> Self::State {) {
+    ///     fn state(current: _, args: _, fcinfo: _) -> Self::State {
     ///         todo!()
     ///     }
     /// }

--- a/pgrx-sql-entity-graph/src/pgrx_attribute.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_attribute.rs
@@ -15,6 +15,7 @@
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */
+use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::Token;

--- a/pgrx-sql-entity-graph/src/pgrx_attribute.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_attribute.rs
@@ -15,7 +15,6 @@
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */
-use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::Token;

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -21,7 +21,7 @@ use crate::enrich::{ToEntityGraphTokens, ToRustCodeTokens};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
-use syn::{DeriveInput, Generics, ItemStruct, Lifetime, LifetimeDef};
+use syn::{DeriveInput, Generics, ItemStruct, Lifetime, LifetimeParam};
 
 use crate::{CodeEnrichment, ToSqlConfig};
 
@@ -116,7 +116,7 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
                     Some(item)
                 }
                 syn::GenericParam::Lifetime(lt_def) => Some(syn::GenericParam::Lifetime(
-                    LifetimeDef::new(Lifetime::new("'_", lt_def.lifetime.span())),
+                    LifetimeParam::new(Lifetime::new("'_", lt_def.lifetime.span())),
                 )),
             })
             .collect();

--- a/pgrx-sql-entity-graph/src/to_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/mod.rs
@@ -122,7 +122,7 @@ impl ToSqlConfig {
 
     /// Used to parse a generator config from a set of item attributes
     pub fn from_attributes(attrs: &[Attribute]) -> Result<Option<Self>, syn::Error> {
-        if let Some(attr) = attrs.iter().find(|attr| attr.path.is_ident("pgrx")) {
+        if let Some(attr) = attrs.iter().find(|attr| attr.path().is_ident("pgrx")) {
             Self::from_attribute(attr)
         } else {
             Ok(None)

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -640,27 +640,6 @@ fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<Stri
                 format!("Unrecognized UnaryExpr in `default!()` macro, got: {:?}", out.expr),
             )),
         },
-        syn::Expr::Type(syn::ExprType { ref ty, .. }) => match ty.deref() {
-            syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. }) => {
-                let last = segments.last().expect("No last segment");
-                let last_string = last.ident.to_string();
-                if last_string == "NULL" {
-                    Ok((true_ty, Some(last_string)))
-                } else {
-                    Err(syn::Error::new(
-                        Span::call_site(),
-                        format!(
-                            "Unable to parse default value of `default!()` macro, got: {:?}",
-                            out.expr
-                        ),
-                    ))
-                }
-            }
-            _ => Err(syn::Error::new(
-                Span::call_site(),
-                format!("Unable to parse default value of `default!()` macro, got: {:?}", out.expr),
-            )),
-        },
         syn::Expr::Path(syn::ExprPath { path: syn::Path { ref segments, .. }, .. }) => {
             let last = segments.last().expect("No last segment");
             let last_string = last.ident.to_string();

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -15,8 +15,6 @@ Type level metadata for Rust to SQL generation.
 to the `pgrx` framework and very subject to change between versions. While you may use this, please do it with caution.
 
 */
-use std::ops::Deref;
-
 use crate::composite_type::{handle_composite_type_macro, CompositeTypeMacro};
 use crate::lifetimes::anonymize_lifetimes;
 use proc_macro2::Span;


### PR DESCRIPTION
We have not been receiving updates to syn for a while, because we are on syn 1 still. Update to syn 2 and lift it into the workspace, which requires revamping how several `proc_macro_attribute`s are parsed. In the process, sprinkle pgrx-sql-entity-graph with paranoid amounts of `track_caller`, expects, and compound errors on the unhappy path, to try to make the code start producing useful error spans.

Then also drop unused features from some of our dependencies to completely erase syn 1 from the dependency tree. We don't meddle with any compressible sections, because we just look at exported symbols, not debuginfo, so I believe this is inconsequential. It's acceptable to revert that part of this change, however, if it doesn't actually work out.

Removes 4 crates from the dependency tree

The syn changes include:
- `syn::LifetimeDef` is now `LifetimeParam`
- `syn::ImplItem::Method` is now `syn::ImplItem::Fn`
- `syn::ImplItemMethod` is now `syn::ImplItemFn`
- Type ascription && `syn::Expr::Type` no longer exist
- `syn::MetaNameValue` replaces its `lit` field with `value`, as it accepts non-literals
- `syn::GenericArgument::Binding` is now `GenericArgument::AssocType`
- `syn::Attribute` hid its `path` field as `.path()`
- `syn::Attribute` hid its `token` field, so there is only `ToTokens`
- `syn::Attribute` changed how it structures access to its args. We now parse inner args of a `syn::Attribute` for our proc-macro attributes like `#[pg_operator]`, without considering parentheses.