### PR TITLE
Composite type result

### DIFF
--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -698,8 +698,10 @@ fn resolve_result_inner(
                             let ty = type_for_args(without_type_args, comp_ty, err_ty);
                             Ok((ty, sql))
                         },
-                        // Option<default!(composite_type!(..))> isn't valid. If the user wanted the default to be `NULL` they just don't need a default.
-                        "default" => Err(syn::Error::new(mac.span(), "`Result<default!(T, \"my_default\"), E>` not supported, choose `Result<T, E>` for a default of `NULL`, or `default!(T, default)` for a non-NULL default")),
+                        // Result<default!(composite_type!(..)), E> 
+                        "default" => {
+                            Err(syn::Error::new(mac.span(), "`Result<default!(T, default), E>` not supported, choose `default!(Result<T, E>, ident)` instead"))
+                        },
                         _ => Ok((syn::Type::Path(original), None)),
                     }
                 }
@@ -737,8 +739,7 @@ fn resolve_result_inner(
                             let wrapped_ty = type_for_args(without_type_args, inner_ty, err_ty);
                             Ok((wrapped_ty, expr))
                         }
-                        // Result<..>
-                        // TODO - evaluate, should this error rather than proceeding?
+                        // Result<T> where T is plain-old-data and not a (supported) container type.
                         _ => Ok((syn::Type::Path(original), None)),
                     }
                 }

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -623,7 +623,6 @@ fn resolve_result_inner(
         .ok_or(syn::Error::new(original.span(), "Could not read last segment of path"))?;
 
     // Get the path of our Result type, to handle crate::module::Result pattern
-    // TODO - more robust / idiomatic way of handling this?
     let mut without_type_args = original.path.clone();
     without_type_args.segments.last_mut().unwrap().arguments = syn::PathArguments::None;
 


### PR DESCRIPTION
This set of changes allows `#[pg-extern]` functions to return `Result<composite_type!(..), E>`. To get it working, I've added another type-specific case to match statements in `UsedType::new()`. That case then calls `fn resolve_result_inner()`, which I wrote for this purpose.

This is intended to resolve #1470.

### Future work 

* Although I've tested this behavior by hand and confirmed it's working correctly, I haven't yet written a test case for this code path. If you'd prefer me to put that in *this* PR, request changes and I'll take care of it. Otherwise, I'll open an issue for it shortly.
* #1561 : While working on this implementation, I ran into a naming ambiguity. Specifically, `pgrx::pg_sys::panics::ErrorReportable::report()` looks an awful lot like `std::process::Termination::report()`, and they are both traits that are implemented on `Result<T, E>` so if  you import both traits you'll have a name collision. I spoke to @workingjubilee about this and she agreed it should be renamed to `unwrap_or_report()` as part of the breaking changes in `0.12`. 

### A note on something esoteric
A note on something that was difficult to dig up answers to: Some concerns surrounding correctness jumped out at me while I was looking at macro expansions for this pull request. In the generated `UsedTypeEntity`, `ty_source` and `full_path` were definitely correct, but for a `Result<T, E>` the ty_id is `core::any::TypeId::of<T>`, whereas for `Option<T>` the macro expands to `core::any::TypeId::of<Option<T>>`.  I asked around, and after some thinking on the part of our senior engineers it looks like this is actually correct. This type information is used to communicate to Postgres, and while `Option<T>` is used as the Rust equivalent to translate to and from nullable Postgres types, so the Option behavior is special, whereas Postgres doesn't have a concept of a Result type and so translating `Result<T>` will either give Postgres an instance of `T` or an exit code and an error message. 

I just thought I'd clarify that to make sure my reasoning on the correctness of this code is written down. 