### PR TITLE
Give CI a makeover

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,9 +116,9 @@ jobs:
     - name: Clippy -Dwarnings sql-entity-graph
       run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
 
-    - name: Check doc-links
+    - name: Check doc-links in pgrx-macros
       run: |
-        cargo rustdoc -p pgrx --features pg$PG_VER -- \
+        cargo rustdoc -p pgrx-macros --features pg$PG_VER -- \
           --document-private-items \
           -Drustdoc::broken-intra-doc-links \
           -Drustdoc::invalid-html-tags
@@ -469,6 +469,14 @@ jobs:
     # We can't do this with other lints because we need $PGRX_HOME
     - name: Clippy -Awarnings
       run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
+
+    # This also requires $PGRX_HOME
+    - name: Check doc-links
+      run: |
+        cargo rustdoc -p pgrx --features pg$PG_VER -- \
+          --document-private-items \
+          -Drustdoc::broken-intra-doc-links \
+          -Drustdoc::invalid-html-tags
 
     - name: create new sample extension
       run: cd /tmp/ && cargo pgrx new sample

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   pgrx_tests:
     name: pgrx-tests & examples
+    needs: cargo_pgrx_init
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
@@ -397,6 +398,7 @@ jobs:
 
   build_mac:
     name: MacOS build & test
+    needs: cargo_pgrx_init
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -406,7 +406,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["macos-13"]
+        os: ["macos-13", "macos-14"] # macos-14 is M1
         # Since Postgres 16 on macOS the dynamic library extension is "dylib" (instead of "so" on older versions),
         # so it's important to test against both versions (with "old" and "new" extensions).
         #
@@ -473,14 +473,14 @@ jobs:
       continue-on-error: false
       with:
         path: /Users/runner/Library/Caches/Mozilla.sccache
-        key: pgrx-sccache-macos-11-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
+        key: pgrx-sccache-${{matrix.os}}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
 
     - name: Cache cargo directory
       uses: actions/cache@v3
       with:
         path: |
           ~/.cargo
-        key: pgrx-cargo-macos-11-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
+        key: pgrx-cargo-${{matrix.os}}-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
 
     - name: Start sccache server
       run: sccache --start-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,28 +54,6 @@ jobs:
         cat $GITHUB_ENV
         echo ""
 
-        echo "----- Set up PG_VER variable -----"
-        echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
-
-        echo "----- Remove old postgres -----"
-        sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
-        echo ""
-
-        echo "----- Install system dependencies -----"
-        sudo apt-get install -y \
-          build-essential \
-          llvm-14-dev libclang-14-dev clang-14 \
-          gcc \
-          libssl-dev \
-          libz-dev \
-          make \
-          pkg-config \
-          strace \
-          zlib1g-dev
-        echo ""
-
         echo "----- Output Cargo version -----"
         cargo --version
         echo ""

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,120 @@ env:
   # CARGO_LOG: cargo::core::compiler::fingerprint=info # Uncomment this to output compiler fingerprint info
 
 jobs:
+  lintck:
+  name: rustfmt && clippy
+  runs-on: ubuntu-latest
+  if: "!contains(github.event.head_commit.message, 'nogha')"
+  env:
+    RUSTC_WRAPPER: sccache
+    SCCACHE_DIR: /home/runner/.cache/sccache
+
+  strategy:
+    matrix:
+      version: ["postgres-15"]
+
+  steps:
+  - uses: actions/checkout@v3
+
+  - name: Set up prerequisites and environment
+    run: |
+      sudo apt-get update -y -qq --fix-missing
+
+      echo ""
+
+      echo "----- Install / Set up sccache -----"
+      mkdir -p $HOME/.local/bin
+      curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+      mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+      chmod +x $HOME/.local/bin/sccache
+      echo "$HOME/.local/bin" >> $GITHUB_PATH
+      mkdir -p /home/runner/.cache/sccache
+      echo ""
+
+      # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+
+      echo "----- Set up MAKEFLAGS -----"
+      echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+      cat $GITHUB_ENV
+      echo ""
+
+      echo "----- Set up PG_VER variable -----"
+      echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
+      cat $GITHUB_ENV
+      echo ""
+
+      echo "----- Remove old postgres -----"
+      sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
+      echo ""
+
+      echo "----- Install system dependencies -----"
+      sudo apt-get install -y \
+        build-essential \
+        llvm-14-dev libclang-14-dev clang-14 \
+        gcc \
+        libssl-dev \
+        libz-dev \
+        make \
+        pkg-config \
+        strace \
+        zlib1g-dev
+      echo ""
+
+      echo "----- Output Cargo version -----"
+      cargo --version
+      echo ""
+
+      echo "----- Outputting env -----"
+      env
+      echo ""
+
+  - name: Cache cargo registry
+    uses: actions/cache@v3
+    continue-on-error: false
+    with:
+      path: |
+        ~/.cargo/registry
+        ~/.cargo/git
+      key: pgrx-lintck-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  - name: Cache sccache directory
+    uses: actions/cache@v3
+    continue-on-error: false
+    with:
+      path: /home/runner/.cache/sccache
+      key: pgrx-lintck-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+
+  - name: Start sccache server
+    run: sccache --start-server
+
+  - name: Print sccache stats (before)
+    run: sccache --show-stats
+
+  - name: Run rustfmt
+    run: cargo fmt --all -- --check
+
+  - name: Run license check
+    run: cargo install cargo-deny && ./ci/license-check.sh
+
+  - name: Clippy -Awarnings
+    run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
+
+  - name: Clippy -Dwarnings sql-entity-graph
+    run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
+
+  - name: Check doc-links
+    run: |
+      cargo rustdoc -p pgrx --features pg$PG_VER -- \
+        --document-private-items \
+        -Drustdoc::broken-intra-doc-links \
+        -Drustdoc::invalid-html-tags
+
+  - name: Stop sccache server
+    run: sccache --stop-server || true
+
   pgrx_tests:
     name: pgrx-tests & examples
-    needs: cargo_pgrx_init
+    needs: lintck
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
@@ -351,30 +462,11 @@ jobs:
     - name: Print sccache stats (before)
       run: sccache --show-stats
 
-    - name: Run rustfmt
-      run: cargo fmt --all -- --check
-
-    - name: Run license check
-      run: cargo install cargo-deny --force && ./ci/license-check.sh
-
     - name: Install cargo-pgrx
       run: cargo install --path cargo-pgrx/ --debug --force
 
     - name: Run 'cargo pgrx init' for ${{ matrix.version }}
       run: cargo pgrx init --pg$PG_VER download
-
-    - name: Clippy -Awarnings
-      run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
-
-    - name: Clippy -Dwarnings sql-entity-graph
-      run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
-
-    - name: Check doc-links
-      run: |
-        cargo rustdoc -p pgrx --features pg$PG_VER -- \
-          --document-private-items \
-          -Drustdoc::broken-intra-doc-links \
-          -Drustdoc::invalid-html-tags
 
     - name: create new sample extension
       run: cd /tmp/ && cargo pgrx new sample
@@ -398,7 +490,7 @@ jobs:
 
   build_mac:
     name: MacOS build & test
-    needs: cargo_pgrx_init
+    needs: lintck
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
 
     - name: Check doc-links in pgrx-macros
       run: |
-        cargo rustdoc -p pgrx-macros --features pg$PG_VER -- \
+        cargo rustdoc -p pgrx-macros -- \
           --document-private-items \
           -Drustdoc::broken-intra-doc-links \
           -Drustdoc::invalid-html-tags

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,49 +84,49 @@ jobs:
         env
         echo ""
 
-  - name: Cache cargo registry
-    uses: actions/cache@v3
-    continue-on-error: false
-    with:
-      path: |
-        ~/.cargo/registry
-        ~/.cargo/git
-      key: pgrx-lintck-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+    - name: Cache cargo registry
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: pgrx-lintck-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-  - name: Cache sccache directory
-    uses: actions/cache@v3
-    continue-on-error: false
-    with:
-      path: /home/runner/.cache/sccache
-      key: pgrx-lintck-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+    - name: Cache sccache directory
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: /home/runner/.cache/sccache
+        key: pgrx-lintck-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-  - name: Start sccache server
-    run: sccache --start-server
+    - name: Start sccache server
+      run: sccache --start-server
 
-  - name: Print sccache stats (before)
-    run: sccache --show-stats
+    - name: Print sccache stats (before)
+      run: sccache --show-stats
 
-  - name: Run rustfmt
-    run: cargo fmt --all -- --check
+    - name: Run rustfmt
+      run: cargo fmt --all -- --check
 
-  - name: Run license check
-    run: cargo install cargo-deny && ./ci/license-check.sh
+    - name: Run license check
+      run: cargo install cargo-deny && ./ci/license-check.sh
 
-  - name: Clippy -Awarnings
-    run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
+    - name: Clippy -Awarnings
+      run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
 
-  - name: Clippy -Dwarnings sql-entity-graph
-    run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
+    - name: Clippy -Dwarnings sql-entity-graph
+      run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
 
-  - name: Check doc-links
-    run: |
-      cargo rustdoc -p pgrx --features pg$PG_VER -- \
-        --document-private-items \
-        -Drustdoc::broken-intra-doc-links \
-        -Drustdoc::invalid-html-tags
+    - name: Check doc-links
+      run: |
+        cargo rustdoc -p pgrx --features pg$PG_VER -- \
+          --document-private-items \
+          -Drustdoc::broken-intra-doc-links \
+          -Drustdoc::invalid-html-tags
 
-  - name: Stop sccache server
-    run: sccache --stop-server || true
+    - name: Stop sccache server
+      run: sccache --stop-server || true
 
   pgrx_tests:
     name: pgrx-tests & examples

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   lintck:
-    name: rustfmt and clippy
+    name: rustfmt, clippy, et al.
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
@@ -111,6 +111,9 @@ jobs:
 
     - name: Run license check
       run: cargo install cargo-deny && ./ci/license-check.sh
+
+    - name: Install cargo-pgrx # Needed for clippy
+      run: cargo install --path cargo-pgrx
 
     - name: Clippy -Awarnings
       run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,71 +18,71 @@ env:
 
 jobs:
   lintck:
-  name: rustfmt and clippy
-  runs-on: ubuntu-latest
-  if: "!contains(github.event.head_commit.message, 'nogha')"
-  env:
-    RUSTC_WRAPPER: sccache
-    SCCACHE_DIR: /home/runner/.cache/sccache
+    name: rustfmt and clippy
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'nogha')"
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
 
-  strategy:
-    matrix:
-      version: ["postgres-15"]
+    strategy:
+      matrix:
+        version: ["postgres-15"]
 
-  steps:
-  - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  - name: Set up prerequisites and environment
-    run: |
-      sudo apt-get update -y -qq --fix-missing
+    - name: Set up prerequisites and environment
+      run: |
+        sudo apt-get update -y -qq --fix-missing
 
-      echo ""
+        echo ""
 
-      echo "----- Install / Set up sccache -----"
-      mkdir -p $HOME/.local/bin
-      curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-      mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-      chmod +x $HOME/.local/bin/sccache
-      echo "$HOME/.local/bin" >> $GITHUB_PATH
-      mkdir -p /home/runner/.cache/sccache
-      echo ""
+        echo "----- Install / Set up sccache -----"
+        mkdir -p $HOME/.local/bin
+        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+        chmod +x $HOME/.local/bin/sccache
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        mkdir -p /home/runner/.cache/sccache
+        echo ""
 
-      # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
 
-      echo "----- Set up MAKEFLAGS -----"
-      echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-      cat $GITHUB_ENV
-      echo ""
+        echo "----- Set up MAKEFLAGS -----"
+        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+        echo ""
 
-      echo "----- Set up PG_VER variable -----"
-      echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
-      cat $GITHUB_ENV
-      echo ""
+        echo "----- Set up PG_VER variable -----"
+        echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+        echo ""
 
-      echo "----- Remove old postgres -----"
-      sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
-      echo ""
+        echo "----- Remove old postgres -----"
+        sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
+        echo ""
 
-      echo "----- Install system dependencies -----"
-      sudo apt-get install -y \
-        build-essential \
-        llvm-14-dev libclang-14-dev clang-14 \
-        gcc \
-        libssl-dev \
-        libz-dev \
-        make \
-        pkg-config \
-        strace \
-        zlib1g-dev
-      echo ""
+        echo "----- Install system dependencies -----"
+        sudo apt-get install -y \
+          build-essential \
+          llvm-14-dev libclang-14-dev clang-14 \
+          gcc \
+          libssl-dev \
+          libz-dev \
+          make \
+          pkg-config \
+          strace \
+          zlib1g-dev
+        echo ""
 
-      echo "----- Output Cargo version -----"
-      cargo --version
-      echo ""
+        echo "----- Output Cargo version -----"
+        cargo --version
+        echo ""
 
-      echo "----- Outputting env -----"
-      env
-      echo ""
+        echo "----- Outputting env -----"
+        env
+        echo ""
 
   - name: Cache cargo registry
     uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   lintck:
-  name: rustfmt && clippy
+  name: rustfmt and clippy
   runs-on: ubuntu-latest
   if: "!contains(github.event.head_commit.message, 'nogha')"
   env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,12 +112,7 @@ jobs:
     - name: Run license check
       run: cargo install cargo-deny && ./ci/license-check.sh
 
-    - name: Install cargo-pgrx # Needed for clippy
-      run: cargo install --path cargo-pgrx
-
-    - name: Clippy -Awarnings
-      run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
-
+    # We can't lint most crates because they require "cargo pgrx init" to build
     - name: Clippy -Dwarnings sql-entity-graph
       run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
 
@@ -470,6 +465,10 @@ jobs:
 
     - name: Run 'cargo pgrx init' for ${{ matrix.version }}
       run: cargo pgrx init --pg$PG_VER download
+
+    # We can't do this with other lints because we need $PGRX_HOME
+    - name: Clippy -Awarnings
+      run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
 
     - name: create new sample extension
       run: cd /tmp/ && cargo pgrx new sample

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         version: ["postgres-15"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up prerequisites and environment
       run: |
@@ -85,7 +85,7 @@ jobs:
         echo ""
 
     - name: Cache cargo registry
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       continue-on-error: false
       with:
         path: |
@@ -94,7 +94,7 @@ jobs:
         key: pgrx-lintck-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
     - name: Cache sccache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       continue-on-error: false
       with:
         path: /home/runner/.cache/sccache
@@ -140,7 +140,7 @@ jobs:
         version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up prerequisites and environment
       run: |
@@ -219,7 +219,7 @@ jobs:
       run: sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
     - name: Cache cargo registry
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       continue-on-error: false
       with:
         path: |
@@ -228,7 +228,7 @@ jobs:
         key: pgrx-tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
     - name: Cache sccache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       continue-on-error: false
       with:
         path: /home/runner/.cache/sccache
@@ -384,7 +384,7 @@ jobs:
         version: ["postgres-15"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up prerequisites and environment
       run: |
@@ -439,7 +439,7 @@ jobs:
         echo ""
 
     - name: Cache cargo registry
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       continue-on-error: false
       with:
         path: |
@@ -448,7 +448,7 @@ jobs:
         key: pgrx-cargo_init_tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
     - name: Cache sccache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       continue-on-error: false
       with:
         path: /home/runner/.cache/sccache
@@ -536,7 +536,7 @@ jobs:
       env:
         FORMULA: postgresql@${{ matrix.postgresql }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up prerequisites and environment
       run: |
@@ -573,14 +573,14 @@ jobs:
 
 
     - name: Cache sccache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       continue-on-error: false
       with:
         path: /Users/runner/Library/Caches/Mozilla.sccache
         key: pgrx-sccache-${{matrix.os}}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
 
     - name: Cache cargo directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   distro_tests:
     name: Distro tests
-    runs-on: PGRX
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:
@@ -36,7 +36,7 @@ jobs:
 
   cargo_unlocked_tests:
     name: Cargo unlocked tests
-    runs-on: PGRX
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -22,7 +22,7 @@ jobs:
         pg_version: ["pg12", "pg13", "pg14", "pg15", "pg16"]
         container: ["fedora", "debian_bullseye", "alpine_3.18"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up environment variables
         run: |
@@ -54,7 +54,7 @@ jobs:
             echo "NIGHTLY_BUILD_REF=$GITHUB_HEAD_REF" >> $GITHUB_ENV
           fi
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.NIGHTLY_BUILD_REF }}
 

--- a/nix/templates/default/.github/workflows/ci.yml
+++ b/nix/templates/default/.github/workflows/ci.yml
@@ -6,16 +6,18 @@ jobs:
       fail-fast: false
       matrix:
         pg_version:
-          - 11
           - 12
           - 13
           - 14
           - 15
+          - 16
         target:
           - os: ubuntu-latest
             platform: x86_64-linux
-          - os: macos-latest
+          - os: macos-13
             platform: x86_64-darwin
+          - os: macos-14
+            platform: aarch64-darwin
     runs-on: ${{ matrix.target.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Various fixups to our CI infra
- fix "Will It Blend?" to use the free CI
- enable the beta aarch64-darwin jobs
- split out lints that don't need `cargo pgrx init` into a lintck job
- make most jobs depend on lintck passing
- use `{checkout,cache}@v4` to avoid deprecation
- update the nix CI template