### PR TITLE
Cleanup List impl

### DIFF
--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -178,6 +178,28 @@ impl<'cx, T> List<'cx, T> {
     }
 }
 
+
+impl<'cx, T: Enlist> List<'cx, T> {
+    /// Attempt to push or Err if it would allocate
+    ///
+    /// This exists primarily to allow working with a list with maybe-zero capacity.
+    pub fn try_push(&mut self, value: T) -> Result<&mut ListHead<'cx, T>, &mut Self> {
+        match self {
+            List::Nil => Err(self),
+            list if list.capacity() - list.len() == 0 => Err(list),
+            List::Cons(head) => Ok(head.push(value)),
+        }
+    }
+
+    /// Try to reserve space for N more items
+    pub fn try_reserve(&mut self, items: usize) -> Result<&mut ListHead<'cx, T>, &mut Self> {
+        match self {
+            List::Nil => Err(self),
+            List::Cons(head) => Ok(head.reserve(items)),
+        }
+    }
+}
+
 impl<T: Enlist> ListHead<'_, T> {
     /// From a non-nullable pointer that points to a valid List, produce a ListHead of the correct type
     ///

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -220,6 +220,6 @@ impl<T: Enlist> ListHead<'_, T> {
 impl<T> ListHead<'_, T> {
     #[inline]
     pub fn len(&self) -> usize {
-        unsafe { self.list.as_ref().length as usize }
+        unsafe { (*self.list.as_ptr()).length as usize }
     }
 }

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -178,7 +178,6 @@ impl<'cx, T> List<'cx, T> {
     }
 }
 
-
 impl<'cx, T: Enlist> List<'cx, T> {
     /// Attempt to push or Err if it would allocate
     ///

--- a/pgrx/src/list/flat_list.rs
+++ b/pgrx/src/list/flat_list.rs
@@ -341,10 +341,9 @@ unsafe fn grow_list(list: &mut pg_sys::List, target: usize) {
             panic!("List allocation failure");
         }
         ptr::copy_nonoverlapping(list.elements, buf.cast(), list.length as _);
-        // If the old buffer is pointers, we would like everyone dereferencing them to segfault,
-        // if OIDs, Postgres will surface errors quickly on InvalidOid, etc.
-        // #[cfg(debug_assertions)]
-        // ptr::write_bytes(list.elements, 0x7F, list.length as _);
+        // This is the "clobber pattern" that Postgres uses.
+        #[cfg(debug_assertions)]
+        ptr::write_bytes(list.elements, 0x7F, list.length as _);
         list.elements = buf.cast();
     } else {
         // We already have a separate buf, making this easy.

--- a/pgrx/src/list/flat_list.rs
+++ b/pgrx/src/list/flat_list.rs
@@ -133,25 +133,6 @@ impl<'cx, T: Enlist> List<'cx, T> {
         }
     }
 
-    /// Attempt to push or Err if it would allocate
-    ///
-    /// This exists primarily to allow working with a list with maybe-zero capacity.
-    pub fn try_push(&mut self, value: T) -> Result<&mut ListHead<'cx, T>, &mut Self> {
-        match self {
-            List::Nil => Err(self),
-            list if list.capacity() - list.len() == 0 => Err(list),
-            List::Cons(head) => Ok(head.push(value)),
-        }
-    }
-
-    /// Try to reserve space for N more items
-    pub fn try_reserve(&mut self, items: usize) -> Result<&mut ListHead<'cx, T>, &mut Self> {
-        match self {
-            List::Nil => Err(self),
-            List::Cons(head) => Ok(head.reserve(items)),
-        }
-    }
-
     // Iterate over part of the List while removing elements from it
     //
     // Note that if this removes the last item, it deallocates the entire list.

--- a/pgrx/src/list/flat_list.rs
+++ b/pgrx/src/list/flat_list.rs
@@ -86,12 +86,12 @@ unsafe impl Enlist for pg_sys::TransactionId {
 }
 
 impl<'cx, T: Enlist> List<'cx, T> {
-    /// Borrow an item from the slice at the index
+    /// Borrow an item from the List at the index
     pub fn get(&self, index: usize) -> Option<&T> {
         self.as_cells().get(index).map(Deref::deref)
     }
 
-    /// Mutably borrow an item from the slice at the index
+    /// Mutably borrow an item from the List at the index
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
         self.as_cells_mut().get_mut(index).map(DerefMut::deref_mut)
     }

--- a/pgrx/src/list/linked_list.rs
+++ b/pgrx/src/list/linked_list.rs
@@ -143,25 +143,6 @@ impl<'cx, T: Enlist> List<'cx, T> {
         }
     }
 
-    /// Attempt to push or Err if it would allocate
-    ///
-    /// This exists primarily to allow working with a list with maybe-zero capacity.
-    pub fn try_push(&mut self, value: T) -> Result<&mut ListHead<'cx, T>, &mut Self> {
-        match self {
-            List::Nil => Err(self),
-            list if list.capacity() - list.len() == 0 => Err(list),
-            List::Cons(head) => Ok(head.push(value)),
-        }
-    }
-
-    /// Try to reserve space for N more items
-    pub fn try_reserve(&mut self, items: usize) -> Result<&mut ListHead<'cx, T>, &mut Self> {
-        match self {
-            List::Nil => Err(self),
-            List::Cons(head) => Ok(head.reserve(items)),
-        }
-    }
-
     // Iterate over part of the List while removing elements from it
     //
     // Note that if this removes the last item, it deallocates the entire list.

--- a/pgrx/src/list/linked_list.rs
+++ b/pgrx/src/list/linked_list.rs
@@ -100,12 +100,12 @@ unsafe impl Enlist for pg_sys::Oid {
 }
 
 impl<'cx, T: Enlist> List<'cx, T> {
-    /// Borrow an item from the slice at the index
+    /// Borrow an item from the List at the index
     pub fn get(&self, index: usize) -> Option<&T> {
         self.iter().nth(index)
     }
 
-    /// Mutably borrow an item from the slice at the index
+    /// Mutably borrow an item from the List at the index
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
         self.iter_mut().nth(index)
     }


### PR DESCRIPTION
I noticed there was some garbage floating around the List impl, like unnecessary `unsafe` code, so I cleaned that up. Also, adds some warnings because people sometimes do not think clearly about pointers.