### PR TITLE
Rename `ErrorReportable::report()` to `unwrap_or_report()`

### DIFF
--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -28,7 +28,7 @@ pub trait ErrorReportable {
     type Inner;
 
     /// Raise a Postgres ERROR if appropriate, otherwise return a value
-    fn report(self) -> Self::Inner;
+    fn unwrap_or_report(self) -> Self::Inner;
 }
 
 impl<T, E> ErrorReportable for Result<T, E>
@@ -42,7 +42,7 @@ where
     /// If this [`Result`] represents the `Err` variant, raise it as an error.  If it happens to
     /// be an [`ErrorReport`], then that is specifically raised.  Otherwise it's just a general
     /// [`ereport!`] as a [`PgLogLevel::ERROR`].
-    fn report(self) -> Self::Inner {
+    fn unwrap_or_report(self) -> Self::Inner {
         self.unwrap_or_else(|e| {
             let any: Box<&dyn Any> = Box::new(&e);
             if any.downcast_ref::<ErrorReport>().is_some() {
@@ -235,7 +235,7 @@ impl ErrorReportWithLevel {
 
 impl ErrorReport {
     /// Create an [ErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
-    /// a specific Postgres "ereport()` level via [ErrorReport::report(self, PgLogLevel)]
+    /// a specific Postgres "ereport()` level via [ErrorReport::unwrap_or_report(self, PgLogLevel)]
     ///
     /// Embedded "file:line:col" location information is taken from the caller's location
     #[track_caller]
@@ -251,7 +251,7 @@ impl ErrorReport {
     }
 
     /// Create an [ErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
-    /// a specific Postgres "ereport()` level via [ErrorReport::report(self, PgLogLevel)].
+    /// a specific Postgres "ereport()` level via [ErrorReport::unwrap_or_report(self, PgLogLevel)].
     ///
     /// For internal use only
     fn with_location<S: Into<String>>(

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -439,7 +439,7 @@ impl PgExtern {
             let mut ret_expr = quote! { #func_name(#(#arg_pats),*) };
             if result {
                 // If it's a result, we need to report it.
-                ret_expr = quote! { #ret_expr.report() };
+                ret_expr = quote! { #ret_expr.unwrap_or_report() };
             }
             if !optional {
                 // If it's not already an option, we need to wrap it.

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -107,7 +107,7 @@ where
     /// [`ERRCODE_DATA_EXCEPTION`]: pg_sys::errcodes::PgSqlErrorCode::ERRCODE_DATA_EXCEPTION
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        self.report().into_datum()
+        self.unwrap_or_report().into_datum()
     }
 
     #[inline]

--- a/pgrx/src/spi/tuple.rs
+++ b/pgrx/src/spi/tuple.rs
@@ -288,7 +288,7 @@ impl<'conn> Iterator for SpiTupleTable<'conn> {
             None
         } else {
             assert!(self.current >= 0);
-            self.get_heap_tuple().report()
+            self.get_heap_tuple().unwrap_or_report()
         }
     }
 


### PR DESCRIPTION
As noted in #1561, `pgrx::pg_sys::panics::ErrorReportable::report()` is named identically to `std::process::Termination::report()`, and they are both traits that are implemented on `Result<T, E>` so if you import both traits you'll have a name collision. Aside from the name collision, it's very easy to see `.report()` called on a `Result` type and make the incorrect assumption this is the `Termination` trait when one is unfamiliar with PGRX's codebase.

To avoid ambiguity, this set of changes renames that method to `unwrap_or_report()`, and is intended to be included in the set of breaking changes for 0.12.