### PR TITLE
Accept `#[pg_test(expected = "string")]`

### DIFF
--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -58,7 +58,7 @@ pub fn pg_test(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut expected_error = None;
     args.into_iter().for_each(|v| {
-        if let ExternArgs::Error(message) = v {
+        if let ExternArgs::ShouldPanic(message) = v {
             expected_error = Some(message)
         }
     });

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -51,6 +51,10 @@ pub fn pg_guard(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// `#[pg_test]` functions are test functions (akin to `#[test]`), but they run in-process inside
 /// Postgres during `cargo pgrx test`.
+///
+/// This can be combined with test attributes like [`#[should_panic(expected = "..")]`][expected].
+///
+/// [expected]: https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute
 #[proc_macro_attribute]
 pub fn pg_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut stream = proc_macro2::TokenStream::new();

--- a/pgrx-sql-entity-graph/src/extern_args.rs
+++ b/pgrx-sql-entity-graph/src/extern_args.rs
@@ -26,7 +26,7 @@ pub enum ExternArgs {
     ParallelSafe,
     ParallelUnsafe,
     ParallelRestricted,
-    Error(String),
+    ShouldPanic(String),
     Schema(String),
     Name(String),
     Cost(String),
@@ -47,7 +47,7 @@ impl core::fmt::Display for ExternArgs {
             ExternArgs::SecurityDefiner => write!(f, "SECURITY DEFINER"),
             ExternArgs::SecurityInvoker => write!(f, "SECURITY INVOKER"),
             ExternArgs::ParallelRestricted => write!(f, "PARALLEL RESTRICTED"),
-            ExternArgs::Error(_) => Ok(()),
+            ExternArgs::ShouldPanic(_) => Ok(()),
             ExternArgs::NoGuard => Ok(()),
             ExternArgs::Schema(_) => Ok(()),
             ExternArgs::Name(_) => Ok(()),
@@ -72,7 +72,7 @@ impl ToTokens for ExternArgs {
             ExternArgs::ParallelSafe => tokens.append(format_ident!("ParallelSafe")),
             ExternArgs::ParallelUnsafe => tokens.append(format_ident!("ParallelUnsafe")),
             ExternArgs::ParallelRestricted => tokens.append(format_ident!("ParallelRestricted")),
-            ExternArgs::Error(_s) => {
+            ExternArgs::ShouldPanic(_s) => {
                 tokens.append_all(
                     quote! {
                         Error(String::from("#_s"))
@@ -143,7 +143,7 @@ pub fn parse_extern_attributes(attr: TokenStream) -> HashSet<ExternArgs> {
                     "parallel_safe" => args.insert(ExternArgs::ParallelSafe),
                     "parallel_unsafe" => args.insert(ExternArgs::ParallelUnsafe),
                     "parallel_restricted" => args.insert(ExternArgs::ParallelRestricted),
-                    "error" => {
+                    "error" | "expected" => {
                         let _punc = itr.next().unwrap();
                         let literal = itr.next().unwrap();
                         let message = literal.to_string();
@@ -151,7 +151,7 @@ pub fn parse_extern_attributes(attr: TokenStream) -> HashSet<ExternArgs> {
 
                         // trim leading/trailing quotes around the literal
                         let message = message[1..message.len() - 1].to_string();
-                        args.insert(ExternArgs::Error(message.to_string()))
+                        args.insert(ExternArgs::ShouldPanic(message.to_string()))
                     }
                     "schema" => {
                         let _punc = itr.next().unwrap();
@@ -201,6 +201,6 @@ mod tests {
         let ts = proc_macro2::TokenStream::from_str(s).unwrap();
 
         let args = parse_extern_attributes(ts);
-        assert!(args.contains(&ExternArgs::Error("syntax error at or near \"THIS\"".to_string())));
+        assert!(args.contains(&ExternArgs::ShouldPanic("syntax error at or near \"THIS\"".to_string())));
     }
 }

--- a/pgrx-sql-entity-graph/src/extern_args.rs
+++ b/pgrx-sql-entity-graph/src/extern_args.rs
@@ -201,6 +201,8 @@ mod tests {
         let ts = proc_macro2::TokenStream::from_str(s).unwrap();
 
         let args = parse_extern_attributes(ts);
-        assert!(args.contains(&ExternArgs::ShouldPanic("syntax error at or near \"THIS\"".to_string())));
+        assert!(
+            args.contains(&ExternArgs::ShouldPanic("syntax error at or near \"THIS\"".to_string()))
+        );
     }
 }

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -37,7 +37,7 @@ pub enum Attribute {
     ParallelSafe,
     ParallelUnsafe,
     ParallelRestricted,
-    Error(syn::LitStr),
+    ShouldPanic(syn::LitStr),
     Schema(syn::LitStr),
     Name(syn::LitStr),
     Cost(syn::Expr),
@@ -76,7 +76,7 @@ impl Attribute {
             Attribute::ParallelRestricted => {
                 quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::ParallelRestricted }
             }
-            Attribute::Error(s) => {
+            Attribute::ShouldPanic(s) => {
                 quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::ShouldPanic(String::from(#s)) }
             }
             Attribute::Schema(s) => {
@@ -125,8 +125,8 @@ impl ToTokens for Attribute {
             Attribute::ParallelRestricted => {
                 quote! { parallel_restricted }
             }
-            Attribute::Error(s) => {
-                quote! { error = #s }
+            Attribute::ShouldPanic(s) => {
+                quote! { expected = #s }
             }
             Attribute::Schema(s) => {
                 quote! { schema = #s }
@@ -166,10 +166,10 @@ impl Parse for Attribute {
             "parallel_safe" => Self::ParallelSafe,
             "parallel_unsafe" => Self::ParallelUnsafe,
             "parallel_restricted" => Self::ParallelRestricted,
-            "error" => {
+            "error" | "expected" => {
                 let _eq: Token![=] = input.parse()?;
                 let literal: syn::LitStr = input.parse()?;
-                Self::Error(literal)
+                Attribute::ShouldPanic(literal)
             }
             "schema" => {
                 let _eq: Token![=] = input.parse()?;

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -77,7 +77,7 @@ impl Attribute {
                 quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::ParallelRestricted }
             }
             Attribute::Error(s) => {
-                quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::Error(String::from(#s)) }
+                quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::ShouldPanic(String::from(#s)) }
             }
             Attribute::Schema(s) => {
                 quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::Schema(String::from(#s)) }

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(sum, Ok(Some(6)));
     }
 
-    #[pg_test(error = "attempt to add with overflow")]
+    #[pg_test(expected = "attempt to add with overflow")]
     fn test_sum_array_i32_overflow() -> Result<Option<i64>, pgrx::spi::Error> {
         Spi::get_one::<i64>(
             "SELECT sum_array(a) FROM (SELECT array_agg(s) a FROM generate_series(1, 1000000) s) x;",
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(sum, Ok(Some(6f32)));
     }
 
-    #[pg_test(error = "array contains NULL")]
+    #[pg_test(expected = "array contains NULL")]
     fn test_array_deny_nulls() -> Result<(), spi::Error> {
         Spi::run("SELECT iterate_array_with_deny_null(ARRAY[1,2,3, NULL]::int[])")
     }
@@ -273,7 +273,7 @@ mod tests {
         Ok(())
     }
 
-    #[pg_test(error = "array contains NULL")]
+    #[pg_test(expected = "array contains NULL")]
     fn test_serde_serialize_array_i32_deny_null() -> Result<Option<Json>, pgrx::spi::Error> {
         Spi::get_one::<Json>(
             "SELECT serde_serialize_array_i32_deny_null(ARRAY[1, 2, 3, null, 4, 5])",

--- a/pgrx-tests/src/tests/fn_call_tests.rs
+++ b/pgrx-tests/src/tests/fn_call_tests.rs
@@ -216,7 +216,8 @@ mod tests {
         assert_eq!(Err(FnCallError::InvalidIdentifier(String::from(stupid_name))), result)
     }
 
-    #[pg_test(error = "it worked")]
+    #[pg_test]
+    #[should_panic(expected = "it worked")]
     fn fn_raises_error() {
         use std::sync::atomic::AtomicBool;
 


### PR DESCRIPTION
It's not obvious why we accept the form we currently do, but we can at least accept the other string people might be motivated to try. We already accept this, too:
```rust
#[pg_test]
#[should_panic(expected = "string")]
fn test() {
```

- changes `{Attribute,ExternArgs}::Error` to `::ShouldPanic`
- adds docs to `#[pg_test]` regarding composing attributes
- accepts `expected` as well as `error` for the relevant attribute