### PR TITLE
pfree toasted Arrays on drop

### DIFF
--- a/pgrx/src/toast.rs
+++ b/pgrx/src/toast.rs
@@ -27,18 +27,7 @@ impl<T: Toasty> Drop for Toast<T> {
     fn drop(&mut self) {
         match self {
             Toast::Stale(_) => {}
-            Toast::Fresh(_t) => {
-                //
-                // issue #971 (https://github.com/pgcentralfoundation/pgrx/issues/971) points out a UAF with Arrays
-                // of `&str`s.  This happens because ultimately we free the detoasted array.  Rather
-                // than allowing outstanding borrows to become freed, we'll just not drop the detoasted
-                // Datum pointer, which will leak that Postgres-allocated memory.
-                //
-                // In general tho, this will be happening within the confines of a #[pg_extern] call
-                // and Postgres will just free the CurrentMemoryContext when the function is finished
-                //
-                // unsafe { t.drop_toast() }
-            }
+            Toast::Fresh(t) => unsafe { t.drop_toast() },
         }
     }
 }


### PR DESCRIPTION
For tables with many rows, or that include enough large arrays, being unable to pfree the entire array can cause needless memory pressure. As pgrx used to not bind objects to the lifetime of backing arrays, the assigned lifetime of any 'obj could exceed `&'arr Array<'_, T>`. This rendered any Drop implementation for Array or any of its parts unsound. The references, expecting to be valid for the underlying 'mcx or even longer, would yield clobbered memory when actually examined.

This has finally become untrue with the introduction of UnboxDatum. It has an `unsafe trait` obligation that the implementation not allow lifetimes to exceed the Datum's lifetime except if the data is always inherently 'static or Copy. This allows deallocating detoasted items, as Arrays now only yield an object of an appropriate lifetime. It is possible for us to get this wrong, but only by implementing UnboxDatum in an incorrect, unsound way, so the fix would be to that code instead.