### PR TITLE
u32 has bad diagnostics with `#[pg_extern]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,15 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bgworker"
 version = "0.0.0"
 dependencies = [
@@ -2658,17 +2649,16 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.89"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9d3ba662913483d6722303f619e75ea10b7855b0f8e0d72799cf8621bb488f"
+checksum = "bfe21c256d6fba8499cf9d9b1c24971bec43a369d81c52e024adc7670cf112df"
 dependencies = [
- "basic-toml",
  "glob",
- "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
  "termcolor",
+ "toml",
 ]
 
 [[package]]

--- a/pgrx-tests/tests/compile-fail/u32_arg_diagnostics.rs
+++ b/pgrx-tests/tests/compile-fail/u32_arg_diagnostics.rs
@@ -1,0 +1,21 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+// u32 has bad diagnostic UX as an argument type
+#[pg_extern]
+fn hello_u32(value: u32) -> String {
+    format!("Hello {value}")
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_hello_u32() {
+        assert_eq!("Hello 10", crate::hello_u32(10));
+    }
+}
+

--- a/pgrx-tests/tests/compile-fail/u32_arg_diagnostics.stderr
+++ b/pgrx-tests/tests/compile-fail/u32_arg_diagnostics.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `fn(u32) -> String: FunctionMetadata<_>` is not satisfied
+ --> tests/compile-fail/u32_arg_diagnostics.rs:7:1
+  |
+7 | fn hello_u32(value: u32) -> String {
+  | ^^ the trait `FunctionMetadata<_>` is not implemented for `fn(u32) -> String`
+  |
+  = help: the following other types implement trait `FunctionMetadata<A>`:
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)>>
+          and $N others
+
+error[E0599]: the function or associated item `entity` exists for type `u32`, but its trait bounds were not satisfied
+ --> tests/compile-fail/u32_arg_diagnostics.rs:6:1
+  |
+6 | #[pg_extern]
+  | ^^^^^^^^^^^^ function or associated item cannot be called on `u32` due to unsatisfied trait bounds
+  |
+  = note: the following trait bounds were not satisfied:
+          `u32: SqlTranslatable`
+          which is required by `&u32: SqlTranslatable`
+  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/compile-fail/u32_ret_diagnostics.rs
+++ b/pgrx-tests/tests/compile-fail/u32_ret_diagnostics.rs
@@ -1,0 +1,21 @@
+use pgrx::prelude::*;
+
+fn main() {}
+
+// u32 has bad diagnostic UX as a return type
+#[pg_extern]
+fn u32_world(value: String) -> u32 {
+    value.parse().unwrap()
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_u32_world() {
+        assert_eq!(10, crate::u32_world("10".to_string()));
+    }
+}
+

--- a/pgrx-tests/tests/compile-fail/u32_ret_diagnostics.stderr
+++ b/pgrx-tests/tests/compile-fail/u32_ret_diagnostics.stderr
@@ -1,0 +1,43 @@
+error[E0277]: the trait bound `fn(String) -> u32: FunctionMetadata<_>` is not satisfied
+ --> tests/compile-fail/u32_ret_diagnostics.rs:7:1
+  |
+7 | fn u32_world(value: String) -> u32 {
+  | ^^ the trait `FunctionMetadata<_>` is not implemented for `fn(String) -> u32`
+  |
+  = help: the following other types implement trait `FunctionMetadata<A>`:
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)>>
+            <unsafe fn(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23) -> R as FunctionMetadata<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)>>
+          and $N others
+
+error[E0599]: the function or associated item `entity` exists for type `u32`, but its trait bounds were not satisfied
+ --> tests/compile-fail/u32_ret_diagnostics.rs:6:1
+  |
+6 | #[pg_extern]
+  | ^^^^^^^^^^^^ function or associated item cannot be called on `u32` due to unsatisfied trait bounds
+  |
+  = note: the following trait bounds were not satisfied:
+          `u32: SqlTranslatable`
+          which is required by `&u32: SqlTranslatable`
+  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `u32: IntoDatum` is not satisfied
+ --> tests/compile-fail/u32_ret_diagnostics.rs:7:1
+  |
+7 | fn u32_world(value: String) -> u32 {
+  | ^^                          - required by a bound introduced by this call
+  | |
+  | the trait `IntoDatum` is not implemented for `u32`
+  |
+  = help: the following other types implement trait `IntoDatum`:
+            i8
+            i16
+            i32
+            i64
+            f32
+            f64

--- a/pgrx-tests/tests/ui.rs
+++ b/pgrx-tests/tests/ui.rs
@@ -4,6 +4,7 @@ use trybuild::TestCases;
 
 /// These are tests which are intended to always fail.
 #[test]
+#[cfg(not(feature = "cshim"))]
 fn compile_fail() {
     let t = TestCases::new();
     t.compile_fail("tests/compile-fail/*.rs");

--- a/pgrx-tests/tests/ui.rs
+++ b/pgrx-tests/tests/ui.rs
@@ -4,7 +4,6 @@ use trybuild::TestCases;
 
 /// These are tests which are intended to always fail.
 #[test]
-#[cfg(not(feature = "cshim"))]
 fn compile_fail() {
     let t = TestCases::new();
     t.compile_fail("tests/compile-fail/*.rs");


### PR DESCRIPTION
Check in a test that demonstrates this so that we are aware of improvements, and to prevent any regressions, as they used to be significantly worse.

This is a step towards resolving these issues:
- https://github.com/pgcentralfoundation/pgrx/issues/951
- https://github.com/pgcentralfoundation/pgrx/issues/1536