### PR TITLE
VARHDRSZ `const`s are not `fn`

### DIFF
--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -134,15 +134,8 @@ pub unsafe fn MemoryContextIsValid(context: crate::MemoryContext) -> bool {
         }
 }
 
-#[inline]
-pub fn VARHDRSZ_EXTERNAL() -> usize {
-    offset_of!(super::varattrib_1b_e, va_data)
-}
-
-#[inline]
-pub fn VARHDRSZ_SHORT() -> usize {
-    offset_of!(super::varattrib_1b, va_data)
-}
+pub const VARHDRSZ_EXTERNAL: usize = offset_of!(super::varattrib_1b_e, va_data);
+pub const VARHDRSZ_SHORT: usize = offset_of!(super::varattrib_1b, va_data);
 
 #[inline]
 pub fn get_pg_major_version_string() -> &'static str {

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
-use crate::pg_sys::{VARATT_SHORT_MAX, VARHDRSZ_SHORT};
 use crate::{
     pg_sys, rust_regtypein, set_varsize, set_varsize_short, vardata_any, varsize_any,
     varsize_any_exhdr, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts, StringInfo,
@@ -135,9 +134,9 @@ where
 
         // safe: ptr will halready be allocated
         unsafe {
-            if size_of + VARHDRSZ_SHORT() <= VARATT_SHORT_MAX as usize {
+            if size_of + pg_sys::VARHDRSZ_SHORT <= pg_sys::VARATT_SHORT_MAX as usize {
                 // we can use the short header size
-                set_varsize_short(ptr, (size_of + VARHDRSZ_SHORT()) as i32);
+                set_varsize_short(ptr, (size_of + pg_sys::VARHDRSZ_SHORT) as i32);
             } else {
                 // gotta use the full 4-byte header
                 set_varsize(ptr, (size_of + pg_sys::VARHDRSZ) as i32);

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -62,7 +62,7 @@ pub unsafe fn set_varsize_short(ptr: *mut pg_sys::varlena, len: i32) {
 /// ```
 #[inline]
 pub unsafe fn varsize_external(ptr: *const pg_sys::varlena) -> usize {
-    pg_sys::VARHDRSZ_EXTERNAL() + vartag_size(vartag_external(ptr) as pg_sys::vartag_external)
+    pg_sys::VARHDRSZ_EXTERNAL + vartag_size(vartag_external(ptr) as pg_sys::vartag_external)
 }
 
 /// ```c
@@ -232,9 +232,9 @@ pub unsafe fn varsize_any(ptr: *const pg_sys::varlena) -> usize {
 #[inline]
 pub unsafe fn varsize_any_exhdr(ptr: *const pg_sys::varlena) -> usize {
     if varatt_is_1b_e(ptr) {
-        varsize_external(ptr) - pg_sys::VARHDRSZ_EXTERNAL()
+        varsize_external(ptr) - pg_sys::VARHDRSZ_EXTERNAL
     } else if varatt_is_1b(ptr) {
-        varsize_1b(ptr) - pg_sys::VARHDRSZ_SHORT()
+        varsize_1b(ptr) - pg_sys::VARHDRSZ_SHORT
     } else {
         varsize_4b(ptr) - pg_sys::VARHDRSZ
     }


### PR DESCRIPTION
These were defined as functions at a time, I presume, that the `offset_of!` macro we use was a bit less reliable at compile time? That's long since not been the case anymore, if ever. Redefine them as constants.