### PR TITLE
Make `RawArray::from_ptr` a simple cast

### DIFF
--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -192,10 +192,14 @@ impl RawArray {
         // Calculating the product with i32 mirrors the Postgres implementation,
         // except we can use checked_mul instead of trying to cast to 64 bits and
         // hoping that doesn't also overflow on multiplication.
-        self.dims()
-            .into_iter()
-            .fold(Some(1i32), |prod, &d| prod.and_then(|m| m.checked_mul(d)))
-            .unwrap() as usize
+        let dims = self.dims();
+        if dims.len() == 0 {
+            0
+        } else {
+            dims.into_iter()
+                .fold(Some(1i32), |prod, &d| prod.and_then(|m| m.checked_mul(d)))
+                .expect("Product of array dimensions should be <= i32::MAX") as usize
+        }
     }
 
     /// Accessor for ArrayType's elemtype.

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -187,6 +187,9 @@ impl RawArray {
 
     /// The flattened length of the array over every single element.
     /// Includes all items, even the ones that might be null.
+    ///
+    /// # Panics
+    /// Panics if the Array's dimensions, multiplied together, exceed sizes Postgres can handle.
     #[inline]
     pub fn len(&self) -> usize {
         // Calculating the product with i32 mirrors the Postgres implementation,

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -395,13 +395,6 @@ impl RawArray {
     pub fn nulls(&mut self) -> Option<NonNull<[u8]>> {
         let len = self.len + 7 >> 3; // Obtains 0 if len was 0.
 
-        /*
-        SAFETY: This obtains the nulls pointer, which is valid to obtain because
-        the len was asserted on construction. However, unlike the other cases,
-        it isn't correct to trust it. Instead, this gets null-checked.
-        This is because, while the initial pointer is NonNull,
-        ARR_NULLBITMAP can return a nullptr!
-        */
         NonNull::new(ptr::slice_from_raw_parts_mut(self.nulls_mut_ptr(), len))
     }
 
@@ -418,13 +411,6 @@ impl RawArray {
     [ARR_NULLBITMAP]: <https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/utils/array.h;h=4ae6c3be2f8b57afa38c19af2779f67c782e4efc;hb=278273ccbad27a8834dfdf11895da9cd91de4114#l293>
     */
     pub fn nulls_bitslice(&mut self) -> Option<NonNull<BitSlice<u8>>> {
-        /*
-        SAFETY: This obtains the nulls pointer, which is valid to obtain because
-        the len was asserted on construction. However, unlike the other cases,
-        it isn't correct to trust it. Instead, this gets null-checked.
-        This is because, while the initial pointer is NonNull,
-        ARR_NULLBITMAP can return a nullptr!
-        */
         NonNull::new(bitptr::bitslice_from_raw_parts_mut(self.nulls_bitptr()?, self.len))
     }
 

--- a/pgrx/src/array/port.rs
+++ b/pgrx/src/array/port.rs
@@ -1,0 +1,133 @@
+/*! Ported array macros and functions.
+*/
+#![allow(non_snake_case)]
+use crate::pg_sys;
+use core::{mem, ptr};
+
+#[inline(always)]
+pub(super) const fn TYPEALIGN(alignval: usize, len: usize) -> usize {
+    // #define TYPEALIGN(ALIGNVAL,LEN)  \
+    // (((uintptr_t) (LEN) + ((ALIGNVAL) - 1)) & ~((uintptr_t) ((ALIGNVAL) - 1)))
+    (len + (alignval - 1)) & !(alignval - 1)
+}
+
+#[inline(always)]
+pub(super) const fn MAXALIGN(len: usize) -> usize {
+    // #define MAXALIGN(LEN) TYPEALIGN(MAXIMUM_ALIGNOF, (LEN))
+    TYPEALIGN(pg_sys::MAXIMUM_ALIGNOF as _, len)
+}
+
+/// # Safety
+/// Does a field access, but doesn't deref out of bounds of ArrayType
+#[inline(always)]
+pub(super) unsafe fn ARR_NDIM(a: *mut pg_sys::ArrayType) -> usize {
+    // #define ARR_NDIM(a)				((a)->ndim)
+
+    // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
+    unsafe { (*a).ndim as usize }
+}
+
+/// # Safety
+/// Does a field access, but doesn't deref out of bounds of ArrayType
+#[inline(always)]
+pub(super) unsafe fn ARR_HASNULL(a: *mut pg_sys::ArrayType) -> bool {
+    // #define ARR_HASNULL(a)			((a)->dataoffset != 0)
+
+    // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
+    unsafe { (*a).dataoffset != 0 }
+}
+
+/// # Safety
+/// Does a field access, but doesn't deref out of bounds of ArrayType
+///
+/// [`pg_sys::ArrayType`] is typically allocated past its size, and its somewhere in that region
+/// that the returned pointer points, so don't attempt to `pfree` it.
+#[inline(always)]
+pub(super) const unsafe fn ARR_DIMS(a: *mut pg_sys::ArrayType) -> *mut i32 {
+    // #define ARR_DIMS(a) \
+    // ((int *) (((char *) (a)) + sizeof(ArrayType)))
+
+    // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
+    unsafe { a.cast::<u8>().add(mem::size_of::<pg_sys::ArrayType>()).cast::<i32>() }
+}
+
+/// # Safety
+/// Does a field access and deref but not out of bounds of ArrayType.  The caller asserts that
+/// `a` is a properly allocated [`pg_sys::ArrayType`]
+#[inline(always)]
+pub(super) unsafe fn ARR_NELEMS(a: *mut pg_sys::ArrayType) -> usize {
+    // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
+    unsafe { pg_sys::ArrayGetNItems((*a).ndim, ARR_DIMS(a)) as usize }
+}
+
+/// Returns the "null bitmap" of the specified array.  If there isn't one (the array contains no nulls)
+/// then the null pointer is returned.
+///
+/// # Safety
+/// Does a field access, but doesn't deref out of bounds of ArrayType.  The caller asserts that
+/// `a` is a properly allocated [`pg_sys::ArrayType`]
+///
+/// [`pg_sys::ArrayType`] is typically allocated past its size, and its somewhere in that region
+/// that the returned pointer points, so don't attempt to `pfree` it.
+#[inline(always)]
+pub(super) unsafe fn ARR_NULLBITMAP(a: *mut pg_sys::ArrayType) -> *mut pg_sys::bits8 {
+    // #define ARR_NULLBITMAP(a) \
+    // (ARR_HASNULL(a) ? \
+    // (bits8 *) (((char *) (a)) + sizeof(ArrayType) + 2 * sizeof(int) * ARR_NDIM(a)) \
+    // : (bits8 *) NULL)
+    //
+
+    // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
+    unsafe {
+        if ARR_HASNULL(a) {
+            a.cast::<u8>()
+                .add(mem::size_of::<pg_sys::ArrayType>() + 2 * mem::size_of::<i32>() * ARR_NDIM(a))
+        } else {
+            ptr::null_mut()
+        }
+    }
+}
+
+/// The total array header size (in bytes) for an array with the specified
+/// number of dimensions and total number of items.
+#[inline(always)]
+pub(super) const fn ARR_OVERHEAD_NONULLS(ndims: usize) -> usize {
+    // #define ARR_OVERHEAD_NONULLS(ndims) \
+    // MAXALIGN(sizeof(ArrayType) + 2 * sizeof(int) * (ndims))
+
+    MAXALIGN(mem::size_of::<pg_sys::ArrayType>() + 2 * mem::size_of::<i32>() * ndims)
+}
+
+/// # Safety
+/// Does a field access, but doesn't deref out of bounds of ArrayType.  The caller asserts that
+/// `a` is a properly allocated [`pg_sys::ArrayType`]
+#[inline(always)]
+pub(super) unsafe fn ARR_DATA_OFFSET(a: *mut pg_sys::ArrayType) -> usize {
+    // #define ARR_DATA_OFFSET(a) \
+    // (ARR_HASNULL(a) ? (a)->dataoffset : ARR_OVERHEAD_NONULLS(ARR_NDIM(a)))
+
+    // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
+    unsafe {
+        if ARR_HASNULL(a) {
+            (*a).dataoffset as _
+        } else {
+            ARR_OVERHEAD_NONULLS(ARR_NDIM(a))
+        }
+    }
+}
+
+/// Returns a pointer to the actual array data.
+///
+/// # Safety
+/// Does a field access, but doesn't deref out of bounds of ArrayType.  The caller asserts that
+/// `a` is a properly allocated [`pg_sys::ArrayType`]
+///
+/// [`pg_sys::ArrayType`] is typically allocated past its size, and its somewhere in that region
+/// that the returned pointer points, so don't attempt to `pfree` it.
+#[inline(always)]
+pub(super) unsafe fn ARR_DATA_PTR(a: *mut pg_sys::ArrayType) -> *mut u8 {
+    // #define ARR_DATA_PTR(a) \
+    // (((char *) (a)) + ARR_DATA_OFFSET(a))
+
+    unsafe { a.cast::<u8>().add(ARR_DATA_OFFSET(a)) }
+}

--- a/pgrx/src/array/port.rs
+++ b/pgrx/src/array/port.rs
@@ -27,8 +27,12 @@ pub(super) unsafe fn ARR_NDIM(a: *mut pg_sys::ArrayType) -> usize {
     unsafe { (*a).ndim as usize }
 }
 
+/// True if [the array *may* have nulls][array.h]
+///
 /// # Safety
 /// Does a field access, but doesn't deref out of bounds of ArrayType
+///
+/// [array.h]: https://github.com/postgres/postgres/blob/c4bd6ff57c9a7b188cbd93855755f1029d7a5662/src/include/utils/array.h#L9
 #[inline(always)]
 pub(super) unsafe fn ARR_HASNULL(a: *mut pg_sys::ArrayType) -> bool {
     // #define ARR_HASNULL(a)			((a)->dataoffset != 0)

--- a/pgrx/src/array/port.rs
+++ b/pgrx/src/array/port.rs
@@ -51,15 +51,6 @@ pub(super) const unsafe fn ARR_DIMS(a: *mut pg_sys::ArrayType) -> *mut i32 {
     unsafe { a.cast::<u8>().add(mem::size_of::<pg_sys::ArrayType>()).cast::<i32>() }
 }
 
-/// # Safety
-/// Does a field access and deref but not out of bounds of ArrayType.  The caller asserts that
-/// `a` is a properly allocated [`pg_sys::ArrayType`]
-#[inline(always)]
-pub(super) unsafe fn ARR_NELEMS(a: *mut pg_sys::ArrayType) -> usize {
-    // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
-    unsafe { pg_sys::ArrayGetNItems((*a).ndim, ARR_DIMS(a)) as usize }
-}
-
 /// Returns the "null bitmap" of the specified array.  If there isn't one (the array contains no nulls)
 /// then the null pointer is returned.
 ///


### PR DESCRIPTION
I have been working on the DetoastDatum implementation, and because our ArrayType wrappers happen to exercise a lot of parts of pgrx while being something I understand very well, I am aiming to ship its MVP with Yet Another improvement on `pgrx::datum::Array` that will be a model for future safe abstractions of Datum-derived types. This will involve quite a lot of work with RawArray and the code that is currently living next to RawArray, so I decided to factor that out, modularize the ported code, and overall just spruce things up a bit.

As part of that, this ports [`pg_sys::ArrayGetNItems`] to simply live inside the implementation of `RawArray::len`. This allows us to perform the calculation entirely in Rust, so there is now no more FFI overhead for creating a RawArray, and we can delete the `ARR_NELEMS` port. This also means we can simply stop caching the total element count, as we aren't saving enough math to be worth it. Now casting to RawArray from a simple reference or other raw pointer is a zero-overhead pointer cast, allowing reusing its already-defined accessors without incurring needless math or calls to Postgres.

[`pg_sys::ArrayGetNItems`]: https://github.com/postgres/postgres/blob/6979ea2638a51c40acf6d04b816550b2c35b3e55/src/backend/utils/adt/arrayutils.c#L46-L102