### PR TITLE
Lock the install of cargo-deny

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Run license check
-      run: cargo install cargo-deny && ./ci/license-check.sh
+      run: cargo install cargo-deny --locked && ./ci/license-check.sh
 
     # We can't lint most crates because they require "cargo pgrx init" to build
     - name: Clippy -Dwarnings sql-entity-graph


### PR DESCRIPTION
For the same reasons that we normally recommend it: because it guarantees there's no breaking changes in the dependencies when the binary is installed.