### PR TITLE
Remove the `pg_sql_graph_magic!()` macro.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -332,7 +332,7 @@ jobs:
         run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
 
       - name: Run `cargo pgrx schema` against the versioned_custom_libname_so example
-        run: cargo pgrx schema pg{$PG_VER} --package versioned_custom_libname_so
+        run: cargo pgrx schema pg$PG_VER --package versioned_custom_libname_so
 
       # Attempt to make the cache payload slightly smaller.
       - name: Clean up built PGRX files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,82 +27,82 @@ jobs:
 
     strategy:
       matrix:
-        version: ["postgres-15"]
+        version: [ "postgres-15" ]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up prerequisites and environment
-      run: |
-        sudo apt-get update -y -qq --fix-missing
+      - name: Set up prerequisites and environment
+        run: |
+          sudo apt-get update -y -qq --fix-missing
+          
+          echo ""
+          
+          echo "----- Install / Set up sccache -----"
+          mkdir -p $HOME/.local/bin
+          curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+          mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          mkdir -p /home/runner/.cache/sccache
+          echo ""
+          
+          # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+          
+          echo "----- Set up MAKEFLAGS -----"
+          echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+          echo ""
+          
+          echo "----- Output Cargo version -----"
+          cargo --version
+          echo ""
+          
+          echo "----- Outputting env -----"
+          env
+          echo ""
 
-        echo ""
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: pgrx-lintck-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-        echo "----- Install / Set up sccache -----"
-        mkdir -p $HOME/.local/bin
-        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-        chmod +x $HOME/.local/bin/sccache
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        mkdir -p /home/runner/.cache/sccache
-        echo ""
+      - name: Cache sccache directory
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: pgrx-lintck-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+      - name: Start sccache server
+        run: sccache --start-server
 
-        echo "----- Set up MAKEFLAGS -----"
-        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
+      - name: Print sccache stats (before)
+        run: sccache --show-stats
 
-        echo "----- Output Cargo version -----"
-        cargo --version
-        echo ""
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
 
-        echo "----- Outputting env -----"
-        env
-        echo ""
+      - name: Run license check
+        run: cargo install cargo-deny --locked && ./ci/license-check.sh
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: pgrx-lintck-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+      # We can't lint most crates because they require "cargo pgrx init" to build
+      - name: Clippy -Dwarnings sql-entity-graph
+        run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
 
-    - name: Cache sccache directory
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        path: /home/runner/.cache/sccache
-        key: pgrx-lintck-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+      - name: Check doc-links in pgrx-macros
+        run: |
+          cargo rustdoc -p pgrx-macros -- \
+            --document-private-items \
+            -Drustdoc::broken-intra-doc-links \
+            -Drustdoc::invalid-html-tags
 
-    - name: Start sccache server
-      run: sccache --start-server
-
-    - name: Print sccache stats (before)
-      run: sccache --show-stats
-
-    - name: Run rustfmt
-      run: cargo fmt --all -- --check
-
-    - name: Run license check
-      run: cargo install cargo-deny --locked && ./ci/license-check.sh
-
-    # We can't lint most crates because they require "cargo pgrx init" to build
-    - name: Clippy -Dwarnings sql-entity-graph
-      run: cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings
-
-    - name: Check doc-links in pgrx-macros
-      run: |
-        cargo rustdoc -p pgrx-macros -- \
-          --document-private-items \
-          -Drustdoc::broken-intra-doc-links \
-          -Drustdoc::invalid-html-tags
-
-    - name: Stop sccache server
-      run: sccache --stop-server || true
+      - name: Stop sccache server
+        run: sccache --stop-server || true
 
   pgrx_tests:
     name: pgrx-tests & examples
@@ -115,239 +115,242 @@ jobs:
 
     strategy:
       matrix:
-        version: ["postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16"]
+        version: [ "postgres-12", "postgres-13", "postgres-14", "postgres-15", "postgres-16" ]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up prerequisites and environment
-      run: |
-        sudo apt-get update -y -qq --fix-missing
+      - name: Set up prerequisites and environment
+        run: |
+          sudo apt-get update -y -qq --fix-missing
+          
+          echo ""
+          echo "----- Install sccache -----"
+          mkdir -p $HOME/.local/bin
+          curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+          mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          mkdir -p /home/runner/.cache/sccache
+          echo ""
+          
+          echo "----- Set up dynamic variables -----"
+          export PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)
+          echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+          echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+          echo ""
+          
+          echo "----- Remove old postgres -----"
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
+          echo ""
+          
+          echo "----- Install system dependencies -----"
+          sudo apt-get install -y \
+            build-essential \
+            llvm-14-dev libclang-14-dev clang-14 \
+            gcc \
+            libssl-dev \
+            libz-dev \
+            make \
+            pkg-config \
+            strace \
+            zlib1g-dev
+          echo ""
+          
+          echo "----- Set up cross compilation -----"
+          sudo apt-get install -y --fix-missing crossbuild-essential-arm64
+          rustup target add aarch64-unknown-linux-gnu
+          
+          echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
+          # TODO: not all of these should be needed, but for now it's likely fine.
+          echo 'BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu=-target aarch64-unknown-linux-gnu -isystem /usr/aarch64-linux-gnu/include/ -ccc-gcc-name aarch64-linux-gnu-gcc' >> $GITHUB_ENV
+          
+          echo "----- Print env -----"
+          env
+          echo ""
+          
+          echo "----- Get cargo version -----"
+          cargo --version
+          echo ""
 
-        echo ""
-        echo "----- Install sccache -----"
-        mkdir -p $HOME/.local/bin
-        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-        chmod +x $HOME/.local/bin/sccache
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        mkdir -p /home/runner/.cache/sccache
-        echo ""
-
-        echo "----- Set up dynamic variables -----"
-        export PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)
-        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
-
-        echo "----- Remove old postgres -----"
-        sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
-        echo ""
-
-        echo "----- Install system dependencies -----"
-        sudo apt-get install -y \
-          build-essential \
-          llvm-14-dev libclang-14-dev clang-14 \
-          gcc \
-          libssl-dev \
-          libz-dev \
-          make \
-          pkg-config \
-          strace \
-          zlib1g-dev
-        echo ""
-
-        echo "----- Set up cross compilation -----"
-        sudo apt-get install -y --fix-missing crossbuild-essential-arm64
-        rustup target add aarch64-unknown-linux-gnu
-
-        echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
-        # TODO: not all of these should be needed, but for now it's likely fine.
-        echo 'BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu=-target aarch64-unknown-linux-gnu -isystem /usr/aarch64-linux-gnu/include/ -ccc-gcc-name aarch64-linux-gnu-gcc' >> $GITHUB_ENV
-
-        echo "----- Print env -----"
-        env
-        echo ""
-
-        echo "----- Get cargo version -----"
-        cargo --version
-        echo ""
-
-    - name: Install release version of PostgreSQL
-      run: |
-        echo "----- Set up PostgreSQL Apt repository -----"
-        sudo apt-get install -y wget gnupg
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo apt-get update -y -qq --fix-missing
-        echo ""
-
-        sudo apt-get install -y \
-          postgresql-$PG_VER \
-          postgresql-server-dev-$PG_VER
-
-        echo ""
-        echo "----- pg_config -----"
-        pg_config
-        echo ""
+      - name: Install release version of PostgreSQL
+        run: |
+          echo "----- Set up PostgreSQL Apt repository -----"
+          sudo apt-get install -y wget gnupg
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update -y -qq --fix-missing
+          echo ""
+          
+          sudo apt-get install -y \
+            postgresql-$PG_VER \
+            postgresql-server-dev-$PG_VER
+          
+          echo ""
+          echo "----- pg_config -----"
+          pg_config
+          echo ""
 
 
-    - name: Set up PostgreSQL permissions
-      run: sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
+      - name: Set up PostgreSQL permissions
+        run: sudo chmod a+rwx `/usr/lib/postgresql/$PG_VER/bin/pg_config --pkglibdir` `/usr/lib/postgresql/$PG_VER/bin/pg_config --sharedir`/extension /var/run/postgresql/
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: pgrx-tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: pgrx-tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-    - name: Cache sccache directory
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        path: /home/runner/.cache/sccache
-        key: pgrx-tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+      - name: Cache sccache directory
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: pgrx-tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-    - name: Start sccache server
-      run: sccache --start-server
+      - name: Start sccache server
+        run: sccache --start-server
 
-    - name: Print sccache stats (before run)
-      run: sccache --show-stats
+      - name: Print sccache stats (before run)
+        run: sccache --show-stats
 
-    - name: Install cargo-pgrx
-      run: cargo install --path cargo-pgrx/ --debug --force
+      - name: Install cargo-pgrx
+        run: cargo install --path cargo-pgrx/ --debug --force
 
-    - name: Run 'cargo pgrx init' against system-level ${{ matrix.version }}
-      run: cargo pgrx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
+      - name: Run 'cargo pgrx init' against system-level ${{ matrix.version }}
+        run: cargo pgrx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
 
-    - name: Run base-level tests
-      run: |
-        cargo test \
-          --features "pg$PG_VER" \
-          --package cargo-pgrx \
-          --package pgrx \
-          --package pgrx-macros \
-          --package pgrx-pg-sys \
-          --package pgrx-sql-entity-graph
+      - name: Run base-level tests
+        run: |
+          cargo test \
+            --features "pg$PG_VER" \
+            --package cargo-pgrx \
+            --package pgrx \
+            --package pgrx-macros \
+            --package pgrx-pg-sys \
+            --package pgrx-sql-entity-graph
 
-    - name: Check that cross-compiled pgrx-tests can build
-      run: |
-        cargo build --tests \
-          --features "pg$PG_VER" \
-          --package pgrx-tests \
-          --target aarch64-unknown-linux-gnu
+      - name: Check that cross-compiled pgrx-tests can build
+        run: |
+          cargo build --tests \
+            --features "pg$PG_VER" \
+            --package pgrx-tests \
+            --target aarch64-unknown-linux-gnu
 
-    - name: Run pgrx-tests with cshim enabled
-      run: |
-        cargo test \
-          --features "pg$PG_VER cshim proptest" \
-          --package pgrx-tests
+      - name: Run pgrx-tests with cshim enabled
+        run: |
+          cargo test \
+            --features "pg$PG_VER cshim proptest" \
+            --package pgrx-tests
 
-    - name: Run pgrx-tests with cshim disabled
-      run: |
-        cargo test \
-          --features "pg$PG_VER proptest" \
-          --package pgrx-tests
+      - name: Run pgrx-tests with cshim disabled
+        run: |
+          cargo test \
+            --features "pg$PG_VER proptest" \
+            --package pgrx-tests
 
-    - name: Run aggregate example tests
-      run: cargo test --package aggregate --features "pg$PG_VER" --no-default-features
+      - name: Run aggregate example tests
+        run: cargo test --package aggregate --features "pg$PG_VER" --no-default-features
 
-    - name: Run arrays example tests
-      run: cargo test --package arrays --features "pg$PG_VER" --no-default-features
+      - name: Run arrays example tests
+        run: cargo test --package arrays --features "pg$PG_VER" --no-default-features
 
-    - name: Run bad_ideas example tests
-      run: cargo test --package bad_ideas --features "pg$PG_VER" --no-default-features
+      - name: Run bad_ideas example tests
+        run: cargo test --package bad_ideas --features "pg$PG_VER" --no-default-features
 
-    - name: Run bgworker example tests
-      run: cargo test --package bgworker --features "pg$PG_VER" --no-default-features
+      - name: Run bgworker example tests
+        run: cargo test --package bgworker --features "pg$PG_VER" --no-default-features
 
-    - name: Run bytea example tests
-      run: cargo test --package bytea --features "pg$PG_VER" --no-default-features
+      - name: Run bytea example tests
+        run: cargo test --package bytea --features "pg$PG_VER" --no-default-features
 
-    - name: Run composite_type example tests
-      run: cargo test --package composite_type --features "pg$PG_VER" --no-default-features
+      - name: Run composite_type example tests
+        run: cargo test --package composite_type --features "pg$PG_VER" --no-default-features
 
-    - name: Run custom_libname example tests
-      run: cargo test --package custom_libname --features "pg$PG_VER" --no-default-features
+      - name: Run custom_libname example tests
+        run: cargo test --package custom_libname --features "pg$PG_VER" --no-default-features
 
-    - name: Run custom_types example tests
-      run: cargo test --package custom_types --features "pg$PG_VER" --no-default-features
+      - name: Run custom_types example tests
+        run: cargo test --package custom_types --features "pg$PG_VER" --no-default-features
 
-    - name: Run custom_types without schema generation example tests
-      run: cargo test --package custom_types --features "pg$PG_VER no-schema-generation" --no-default-features
+      - name: Run custom_types without schema generation example tests
+        run: cargo test --package custom_types --features "pg$PG_VER no-schema-generation" --no-default-features
 
-    - name: Run custom_sql example tests
-      run: cargo test --package custom_sql --features "pg$PG_VER" --no-default-features
+      - name: Run custom_sql example tests
+        run: cargo test --package custom_sql --features "pg$PG_VER" --no-default-features
 
-    - name: Run datetime example tests
-      run: cargo test --package datetime --features "pg$PG_VER" --no-default-features
+      - name: Run datetime example tests
+        run: cargo test --package datetime --features "pg$PG_VER" --no-default-features
 
-    - name: Run errors example tests
-      run: cargo test --package errors --features "pg$PG_VER" --no-default-features
+      - name: Run errors example tests
+        run: cargo test --package errors --features "pg$PG_VER" --no-default-features
 
-    - name: Run nostd example tests
-      run: cargo test --package nostd --features "pg$PG_VER" --no-default-features
+      - name: Run nostd example tests
+        run: cargo test --package nostd --features "pg$PG_VER" --no-default-features
 
-    - name: Run numeric example tests
-      run: cargo test --package numeric --features "pg$PG_VER" --no-default-features
+      - name: Run numeric example tests
+        run: cargo test --package numeric --features "pg$PG_VER" --no-default-features
 
-    - name: Run pgtrybuilder example tests
-      run: cargo test --package pgtrybuilder --features "pg$PG_VER" --no-default-features
+      - name: Run pgtrybuilder example tests
+        run: cargo test --package pgtrybuilder --features "pg$PG_VER" --no-default-features
 
-    - name: Run operators example tests
-      run: cargo test --package operators --features "pg$PG_VER" --no-default-features
+      - name: Run operators example tests
+        run: cargo test --package operators --features "pg$PG_VER" --no-default-features
 
-    - name: Run range example tests
-      run: cargo test --package range --features "pg$PG_VER" --no-default-features
+      - name: Run range example tests
+        run: cargo test --package range --features "pg$PG_VER" --no-default-features
 
-    - name: Run schemas example tests
-      run: cargo test --package schemas --features "pg$PG_VER" --no-default-features
+      - name: Run schemas example tests
+        run: cargo test --package schemas --features "pg$PG_VER" --no-default-features
 
-    - name: Run shmem example tests
-      run: cargo test --package shmem --features "pg$PG_VER" --no-default-features
+      - name: Run shmem example tests
+        run: cargo test --package shmem --features "pg$PG_VER" --no-default-features
 
-    - name: Run spi example tests
-      run: cargo test --package spi --features "pg$PG_VER" --no-default-features
+      - name: Run spi example tests
+        run: cargo test --package spi --features "pg$PG_VER" --no-default-features
 
-    - name: Run spi_srf example tests
-      run: cargo test --package spi_srf --features "pg$PG_VER" --no-default-features
+      - name: Run spi_srf example tests
+        run: cargo test --package spi_srf --features "pg$PG_VER" --no-default-features
 
-    - name: Run srf example tests
-      run: cargo test --package srf --features "pg$PG_VER" --no-default-features
+      - name: Run srf example tests
+        run: cargo test --package srf --features "pg$PG_VER" --no-default-features
 
-    - name: Run strings example tests
-      run: cargo test --package strings --features "pg$PG_VER" --no-default-features
+      - name: Run strings example tests
+        run: cargo test --package strings --features "pg$PG_VER" --no-default-features
 
-    - name: Run triggers example tests
-      run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
+      - name: Run triggers example tests
+        run: cargo test --package triggers --features "pg$PG_VER" --no-default-features
 
-    - name: Run versioned_custom_libname_so example tests
-      run: cargo test --package versioned_custom_libname_so --features "pg$PG_VER" --no-default-features
+      - name: Run versioned_custom_libname_so example tests
+        run: cargo test --package versioned_custom_libname_so --features "pg$PG_VER" --no-default-features
 
-    - name: Run versioned_so example tests
-      run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
+      - name: Run versioned_so example tests
+        run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
 
-    # Attempt to make the cache payload slightly smaller.
-    - name: Clean up built PGRX files
-      run: |
-        cd target/debug/deps/
-        for built_file in $(find * -type f -executable -print | grep -v "\.so$"); do
-          base_name=$(echo $built_file | cut -d- -f1);
-          for basefile in "$base_name".*; do
-            [ -f "$basefile" ] || continue;
-            echo "Removing $basefile"
-            rm $basefile
-          done;
-          echo "Removing $built_file"
-          rm $built_file
-        done
+      - name: Run `cargo pgrx schema` against the versioned_custom_libname_so example
+        run: cargo pgrx schema pg14 --features "pg$PG_VER" --no-default-features
 
-    - name: Stop sccache server
-      run: sccache --stop-server || true
+      # Attempt to make the cache payload slightly smaller.
+      - name: Clean up built PGRX files
+        run: |
+          cd target/debug/deps/
+          for built_file in $(find * -type f -executable -print | grep -v "\.so$"); do
+            base_name=$(echo $built_file | cut -d- -f1);
+            for basefile in "$base_name".*; do
+              [ -f "$basefile" ] || continue;
+              echo "Removing $basefile"
+              rm $basefile
+            done;
+            echo "Removing $built_file"
+            rm $built_file
+          done
+
+      - name: Stop sccache server
+        run: sccache --stop-server || true
 
   cargo_pgrx_init:
     name: cargo pgrx init
@@ -359,122 +362,122 @@ jobs:
 
     strategy:
       matrix:
-        version: ["postgres-15"]
+        version: [ "postgres-15" ]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up prerequisites and environment
-      run: |
-        sudo apt-get update -y -qq --fix-missing
+      - name: Set up prerequisites and environment
+        run: |
+          sudo apt-get update -y -qq --fix-missing
+          
+          echo ""
+          
+          echo "----- Install / Set up sccache -----"
+          mkdir -p $HOME/.local/bin
+          curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
+          mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
+          chmod +x $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          mkdir -p /home/runner/.cache/sccache
+          echo ""
+          
+          # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+          
+          echo "----- Set up MAKEFLAGS -----"
+          echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+          echo ""
+          
+          echo "----- Set up PG_VER variable -----"
+          echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+          echo ""
+          
+          echo "----- Remove old postgres -----"
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
+          echo ""
+          
+          echo "----- Install system dependencies -----"
+          sudo apt-get install -y \
+            build-essential \
+            llvm-14-dev libclang-14-dev clang-14 \
+            gcc \
+            libssl-dev \
+            libz-dev \
+            make \
+            pkg-config \
+            strace \
+            zlib1g-dev
+          echo ""
+          
+          echo "----- Output Cargo version -----"
+          cargo --version
+          echo ""
+          
+          echo "----- Outputting env -----"
+          env
+          echo ""
 
-        echo ""
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: pgrx-cargo_init_tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-        echo "----- Install / Set up sccache -----"
-        mkdir -p $HOME/.local/bin
-        curl -L https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz | tar xz
-        mv -f sccache-v0.2.15-x86_64-unknown-linux-musl/sccache $HOME/.local/bin/sccache
-        chmod +x $HOME/.local/bin/sccache
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        mkdir -p /home/runner/.cache/sccache
-        echo ""
+      - name: Cache sccache directory
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: /home/runner/.cache/sccache
+          key: pgrx-cargo_init_tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
-        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+      - name: Start sccache server
+        run: sccache --start-server
 
-        echo "----- Set up MAKEFLAGS -----"
-        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
+      - name: Print sccache stats (before)
+        run: sccache --show-stats
 
-        echo "----- Set up PG_VER variable -----"
-        echo "PG_VER=$(echo ${{ matrix.version }} | cut -d '-' -f2)" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-        echo ""
+      - name: Install cargo-pgrx
+        run: cargo install --path cargo-pgrx/ --debug --force
 
-        echo "----- Remove old postgres -----"
-        sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
-        echo ""
+      - name: Run 'cargo pgrx init' for ${{ matrix.version }}
+        run: cargo pgrx init --pg$PG_VER download
 
-        echo "----- Install system dependencies -----"
-        sudo apt-get install -y \
-          build-essential \
-          llvm-14-dev libclang-14-dev clang-14 \
-          gcc \
-          libssl-dev \
-          libz-dev \
-          make \
-          pkg-config \
-          strace \
-          zlib1g-dev
-        echo ""
+      # We can't do this with other lints because we need $PGRX_HOME
+      - name: Clippy -Awarnings
+        run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
 
-        echo "----- Output Cargo version -----"
-        cargo --version
-        echo ""
+      # This also requires $PGRX_HOME
+      - name: Check doc-links
+        run: |
+          cargo rustdoc -p pgrx --features pg$PG_VER -- \
+            --document-private-items \
+            -Drustdoc::broken-intra-doc-links \
+            -Drustdoc::invalid-html-tags
 
-        echo "----- Outputting env -----"
-        env
-        echo ""
+      - name: create new sample extension
+        run: cd /tmp/ && cargo pgrx new sample
 
-    - name: Cache cargo registry
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: pgrx-cargo_init_tests-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+      # hack Cargo.toml to use this version of pgrx from github
+      - name: hack Cargo.toml
+        run: |
+          echo "[patch.crates-io]" >> /tmp/sample/Cargo.toml
+          echo "pgrx        = { path = \"${GITHUB_WORKSPACE}/pgrx\"        }" >> /tmp/sample/Cargo.toml
+          echo "pgrx-macros = { path = \"${GITHUB_WORKSPACE}/pgrx-macros\" }" >> /tmp/sample/Cargo.toml
+          echo "pgrx-tests  = { path = \"${GITHUB_WORKSPACE}/pgrx-tests\"  }" >> /tmp/sample/Cargo.toml
 
-    - name: Cache sccache directory
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        path: /home/runner/.cache/sccache
-        key: pgrx-cargo_init_tests-sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
+      - name: show Cargo.toml
+        run: cat /tmp/sample/Cargo.toml
 
-    - name: Start sccache server
-      run: sccache --start-server
+      - name: Test sample for ${{ matrix.version }}
+        run: cd /tmp/sample && cargo pgrx test pg$PG_VER
 
-    - name: Print sccache stats (before)
-      run: sccache --show-stats
-
-    - name: Install cargo-pgrx
-      run: cargo install --path cargo-pgrx/ --debug --force
-
-    - name: Run 'cargo pgrx init' for ${{ matrix.version }}
-      run: cargo pgrx init --pg$PG_VER download
-
-    # We can't do this with other lints because we need $PGRX_HOME
-    - name: Clippy -Awarnings
-      run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
-
-    # This also requires $PGRX_HOME
-    - name: Check doc-links
-      run: |
-        cargo rustdoc -p pgrx --features pg$PG_VER -- \
-          --document-private-items \
-          -Drustdoc::broken-intra-doc-links \
-          -Drustdoc::invalid-html-tags
-
-    - name: create new sample extension
-      run: cd /tmp/ && cargo pgrx new sample
-
-    # hack Cargo.toml to use this version of pgrx from github
-    - name: hack Cargo.toml
-      run: |
-       echo "[patch.crates-io]" >> /tmp/sample/Cargo.toml
-       echo "pgrx        = { path = \"${GITHUB_WORKSPACE}/pgrx\"        }" >> /tmp/sample/Cargo.toml
-       echo "pgrx-macros = { path = \"${GITHUB_WORKSPACE}/pgrx-macros\" }" >> /tmp/sample/Cargo.toml
-       echo "pgrx-tests  = { path = \"${GITHUB_WORKSPACE}/pgrx-tests\"  }" >> /tmp/sample/Cargo.toml
-
-    - name: show Cargo.toml
-      run: cat /tmp/sample/Cargo.toml
-
-    - name: Test sample for ${{ matrix.version }}
-      run: cd /tmp/sample && cargo pgrx test pg$PG_VER
-
-    - name: Stop sccache server
-      run: sccache --stop-server || true
+      - name: Stop sccache server
+        run: sccache --stop-server || true
 
   build_mac:
     name: MacOS build & test
@@ -488,7 +491,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["macos-13", "macos-14"] # macos-14 is M1
+        os: [ "macos-13", "macos-14" ] # macos-14 is M1
         # Since Postgres 16 on macOS the dynamic library extension is "dylib" (instead of "so" on older versions),
         # so it's important to test against both versions (with "old" and "new" extensions).
         #
@@ -496,96 +499,96 @@ jobs:
         postgresql: [ 15, 16 ]
 
     steps:
-    - uses: Homebrew/actions/setup-homebrew@master
+      - uses: Homebrew/actions/setup-homebrew@master
 
-    # Although we don't use Python per se, if Homebrew has an updated version of Python,
-    # the following steps could fail because GitHub Actions mixed up the linkage.
-    - name: Workaround GitHub Actions Python issues
-      run: brew unlink python && brew link --overwrite python
+      # Although we don't use Python per se, if Homebrew has an updated version of Python,
+      # the following steps could fail because GitHub Actions mixed up the linkage.
+      - name: Workaround GitHub Actions Python issues
+        run: brew unlink python && brew link --overwrite python
 
-    # install postgres with homebrew, but do't let homebrew do an update too.  The update
-    # process not only takes forever, but it tends to fail when the internet changes
-    #       https://github.com/Homebrew/brew/issues/1670#issuecomment-267096602
-    - name: brew install postgresql
-      run: |
-        HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install ${FORMULA}
+      # install postgres with homebrew, but do't let homebrew do an update too.  The update
+      # process not only takes forever, but it tends to fail when the internet changes
+      #       https://github.com/Homebrew/brew/issues/1670#issuecomment-267096602
+      - name: brew install postgresql
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install ${FORMULA}
+          
+          echo "$(brew --prefix ${FORMULA})/bin" >> $GITHUB_PATH
+        env:
+          FORMULA: postgresql@${{ matrix.postgresql }}
 
-        echo "$(brew --prefix ${FORMULA})/bin" >> $GITHUB_PATH
-      env:
-        FORMULA: postgresql@${{ matrix.postgresql }}
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
-
-    - name: Set up prerequisites and environment
-      run: |
-        echo ""
-
-        echo "----- Install sccache -----"
-        curl -L https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-apple-darwin.tar.gz | tar xz
-        mv -f sccache-v0.5.4-x86_64-apple-darwin/sccache /usr/local/bin
-        chmod +x /usr/local/bin/sccache
-        mkdir -p $SCCACHE_DIR
-        sccache --version
-
-        # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
-        echo "----- Getting pre-installed Postgres major version -----"
-        PG_VER=$(pg_config --version | awk '{split($2,a,"."); print a[1]}')
-        echo "PG_VER=$PG_VER" >> $GITHUB_ENV
-        cat $GITHUB_ENV
-
-        echo "----- Set up Postgres permissions -----"
-        sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-        # ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
-        echo ""
-
-        echo "----- Stable Rust ----"
-        rustup update stable
-        rustup default stable
-        rustc -vV
-        cargo -vV
-        echo ""
-
-        echo "----- Outputting env -----"
-        env
-        echo ""
+      - name: Set up prerequisites and environment
+        run: |
+          echo ""
+          
+          echo "----- Install sccache -----"
+          curl -L https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-apple-darwin.tar.gz | tar xz
+          mv -f sccache-v0.5.4-x86_64-apple-darwin/sccache /usr/local/bin
+          chmod +x /usr/local/bin/sccache
+          mkdir -p $SCCACHE_DIR
+          sccache --version
+          
+          # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
+          echo "----- Getting pre-installed Postgres major version -----"
+          PG_VER=$(pg_config --version | awk '{split($2,a,"."); print a[1]}')
+          echo "PG_VER=$PG_VER" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+          
+          echo "----- Set up Postgres permissions -----"
+          sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+          # ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
+          echo ""
+          
+          echo "----- Stable Rust ----"
+          rustup update stable
+          rustup default stable
+          rustc -vV
+          cargo -vV
+          echo ""
+          
+          echo "----- Outputting env -----"
+          env
+          echo ""
 
 
-    - name: Cache sccache directory
-      uses: actions/cache@v4
-      continue-on-error: false
-      with:
-        path: /Users/runner/Library/Caches/Mozilla.sccache
-        key: pgrx-sccache-${{matrix.os}}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
+      - name: Cache sccache directory
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: /Users/runner/Library/Caches/Mozilla.sccache
+          key: pgrx-sccache-${{matrix.os}}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
 
-    - name: Cache cargo directory
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo
-        key: pgrx-cargo-${{matrix.os}}-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
+      - name: Cache cargo directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+          key: pgrx-cargo-${{matrix.os}}-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
 
-    - name: Start sccache server
-      run: sccache --start-server
+      - name: Start sccache server
+        run: sccache --start-server
 
-    - name: Print sccache stats
-      run: sccache --show-stats
+      - name: Print sccache stats
+        run: sccache --show-stats
 
-    - name: Install cargo-pgrx
-      run: cargo install --path cargo-pgrx/ --debug --force
+      - name: Install cargo-pgrx
+        run: cargo install --path cargo-pgrx/ --debug --force
 
-    - name: Print sccache stats
-      run: sccache --show-stats
+      - name: Print sccache stats
+        run: sccache --show-stats
 
-    - name: Run 'cargo pgrx init'
-      run: |
-        set -x
-        cargo pgrx init --pg$PG_VER $(which pg_config)
+      - name: Run 'cargo pgrx init'
+        run: |
+          set -x
+          cargo pgrx init --pg$PG_VER $(which pg_config)
 
-    - name: Run tests
-      run: cargo test --all --features "pg$PG_VER pg_test cshim proptest" --no-default-features
+      - name: Run tests
+        run: cargo test --all --features "pg$PG_VER pg_test cshim proptest" --no-default-features
 
-    - name: Print sccache stats
-      run: sccache --show-stats
+      - name: Print sccache stats
+        run: sccache --show-stats
 
-    - name: Stop sccache server
-      run: sccache --stop-server || true
+      - name: Stop sccache server
+        run: sccache --stop-server || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -332,7 +332,7 @@ jobs:
         run: cargo test --package versioned_so --features "pg$PG_VER" --no-default-features
 
       - name: Run `cargo pgrx schema` against the versioned_custom_libname_so example
-        run: cargo pgrx schema pg14 --features "pg$PG_VER" --no-default-features
+        run: cargo pgrx schema pg{$PG_VER} --package versioned_custom_libname_so
 
       # Attempt to make the cache payload slightly smaller.
       - name: Clean up built PGRX files

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -569,10 +569,10 @@ fn compute_sql(
     command.stderr(Stdio::inherit());
 
     // pass the package version through as an environment variable
-    command.env(
-        "PGRX_PKG_VERSION",
-        manifest.package_version().expect("`Cargo.toml` is missing the package version property"),
-    );
+    let cargo_pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| {
+        manifest.package_version().expect("`CARGO_PKG_VERSION` should be set, and barring that, `Cargo.toml` should have a package version property")
+    });
+    command.env("CARGO_PKG_VERSION", cargo_pkg_version);
 
     let command_str = format!("{:?}", command);
     tracing::debug!(command = %command_str, "Running");

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -400,8 +400,11 @@ fn compute_codegen(
 
     let inputs = {
         // read the .control file and do the required variable replacements
-        let control_file_contents = std::fs::read_to_string(control_file_path)?
-            .replace("@CARGO_VERSION@", env!("CARGO_PKG_VERSION"));
+        let control_file_contents = std::fs::read_to_string(control_file_path)?.replace(
+            "@CARGO_VERSION@",
+            &std::env::var("CARGO_PKG_VERSION")
+                .expect("`CARGO_PGK_VERSION` environment variable should be set"),
+        );
 
         let mut out = quote::quote! {
             // call the marker.  Primarily this ensures that rustc will actually link to the library

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -564,6 +564,9 @@ fn compute_sql(profile: &CargoProfile, package_name: &str) -> eyre::Result<()> {
     command.stdout(Stdio::inherit());
     command.stderr(Stdio::inherit());
 
+    // carry cargo's CARGO_PKG_VERSION value through to the pgrx_embed binary as our own
+    command.env("PGRX_CARGO_PKG_VERSION", env!("CARGO_PKG_VERSION"));
+
     let command_str = format!("{:?}", command);
     tracing::debug!(command = %command_str, "Running");
     let embed_output = command

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -399,20 +399,18 @@ fn compute_codegen(
     let lib_name_ident = Ident::new(&lib_name, Span::call_site());
 
     let inputs = {
-        // read the .control file and do the required variable replacements
-        let control_file_contents = std::fs::read_to_string(control_file_path)?.replace(
-            "@CARGO_VERSION@",
-            &std::env::var("CARGO_PKG_VERSION")
-                .expect("`CARGO_PGK_VERSION` environment variable should be set"),
-        );
-
+        let control_file_path = control_file_path
+            .as_ref()
+            .to_str()
+            .expect(".control file filename should be valid UTF8");
         let mut out = quote::quote! {
             // call the marker.  Primarily this ensures that rustc will actually link to the library
             // during the "pgrx_embed" build initiated by `cargo-pgrx schema` generation
             #lib_name_ident::__pgrx_marker();
 
             let mut entities = Vec::new();
-            let control_file = ::pgrx::pgrx_sql_entity_graph::ControlFile::try_from(#control_file_contents).expect(".control file should properly formatted");
+            let control_file_path = std::path::PathBuf::from(#control_file_path);
+            let control_file = ::pgrx::pgrx_sql_entity_graph::ControlFile::try_from(control_file_path).expect(".control file should properly formatted");
             let control_file_entity = ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity::ExtensionRoot(control_file);
 
             entities.push(control_file_entity);

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -48,7 +48,9 @@ impl ControlFile {
     ///
     /// # Supported Dynamic Variable Substitutions
     ///
-    /// `@CARGO_VERSION@`:  Replaced with the value of the environment variable `CARGO_PKG_VERSION`
+    /// `@CARGO_VERSION@`:  Replaced with the value of the environment variable `PGRX_PKG_VERSION`,
+    ///                     which is set by `cargo-pgrx` using the package version from the extension's
+    ///                     `Cargo.toml` file
     ///
     /// ```rust
     /// use pgrx_sql_entity_graph::ControlFile;
@@ -63,8 +65,8 @@ impl ControlFile {
         fn do_var_replacements(input: &str) -> String {
             input.replace(
                 "@CARGO_VERSION@",
-                &std::env::var("PGRX_CARGO_PKG_VERSION")
-                    .expect("`PGRX_CARGO_PKG_VERSION` environment variable should be set"),
+                &std::env::var("PGRX_PKG_VERSION")
+                    .expect("`PGRX_PKG_VERSION` environment variable should be set"),
             )
         }
 

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -63,8 +63,8 @@ impl ControlFile {
         fn do_var_replacements(input: &str) -> String {
             input.replace(
                 "@CARGO_VERSION@",
-                &std::env::var("CARGO_PKG_VERSION")
-                    .expect("`CARGO_PKG_VERSION` environment variable should be set"),
+                &std::env::var("PGRX_CARGO_PKG_VERSION")
+                    .expect("`PGRX_CARGO_PKG_VERSION` environment variable should be set"),
             )
         }
 

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -18,6 +18,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
 use core::convert::TryFrom;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use thiserror::Error;
 
 /// The parsed contents of a `.control` file.
@@ -43,7 +44,11 @@ pub struct ControlFile {
 }
 
 impl ControlFile {
-    /// Parse a `.control` file.
+    /// Parse a `.control` file, performing all known pgrx dynamic variable substitutions.
+    ///
+    /// # Supported Dynamic Variable Substitutions
+    ///
+    /// `@CARGO_VERSION@`:  Replaced with the value of the environment variable `CARGO_PKG_VERSION`
     ///
     /// ```rust
     /// use pgrx_sql_entity_graph::ControlFile;
@@ -55,6 +60,14 @@ impl ControlFile {
     /// ```
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(input: &str) -> Result<Self, ControlFileError> {
+        fn do_var_replacements(input: &str) -> String {
+            input.replace(
+                "@CARGO_VERSION@",
+                &std::env::var("CARGO_PKG_VERSION")
+                    .expect("`CARGO_PKG_VERSION` environment variable should be set"),
+            )
+        }
+
         let mut temp = HashMap::new();
         for line in input.lines() {
             let parts: Vec<&str> = line.split('=').collect();
@@ -68,7 +81,7 @@ impl ControlFile {
             let v = v.trim_start_matches('\'');
             let v = v.trim_end_matches('\'');
 
-            temp.insert(k, v);
+            temp.insert(k, do_var_replacements(v));
         }
         let control_file = ControlFile {
             comment: temp
@@ -108,12 +121,26 @@ impl From<ControlFile> for SqlGraphEntity {
 }
 
 /// An error met while parsing a `.control` file.
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Error)]
 pub enum ControlFileError {
+    #[error("Filesystem error reading control file")]
+    IOError {
+        #[from]
+        error: std::io::Error,
+    },
     #[error("Missing field in control file! Please add `{field}`.")]
     MissingField { field: &'static str },
     #[error("Redundant field in control file! Please remove `{field}`.")]
     RedundantField { field: &'static str },
+}
+
+impl TryFrom<PathBuf> for ControlFile {
+    type Error = ControlFileError;
+
+    fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
+        let contents = std::fs::read_to_string(value)?;
+        ControlFile::try_from(contents.as_str())
+    }
 }
 
 impl TryFrom<&str> for ControlFile {

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -96,13 +96,13 @@ impl ControlFile {
             relocatable: temp
                 .get("relocatable")
                 .ok_or(ControlFileError::MissingField { field: "relocatable" })?
-                == &"true",
+                == "true",
             superuser: temp
                 .get("superuser")
                 .ok_or(ControlFileError::MissingField { field: "superuser" })?
-                == &"true",
+                == "true",
             schema: temp.get("schema").map(|v| v.to_string()),
-            trusted: if let Some(v) = temp.get("trusted") { v == &"true" } else { false },
+            trusted: if let Some(v) = temp.get("trusted") { v == "true" } else { false },
         };
 
         if !control_file.superuser && control_file.trusted {

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -70,7 +70,7 @@ impl ControlFile {
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(input: &str) -> Result<Self, ControlFileError> {
         fn do_var_replacements(mut input: String) -> Result<String, ControlFileError> {
-            const CARGO_VERSION: &'static str = "@CARGO_VERSION@";
+            const CARGO_VERSION: &str = "@CARGO_VERSION@";
 
             // endeavor to not require external values if they're not used by the input
             if input.contains(CARGO_VERSION) {

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -312,7 +312,7 @@ fn install_extension() -> eyre::Result<()> {
         .arg("--pg-config")
         .arg(pg_config.path().ok_or(eyre!("No pg_config found"))?)
         .stdout(Stdio::inherit())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::inherit())
         .env("CARGO_TARGET_DIR", get_target_dir()?);
 
     if let Ok(manifest_path) = std::env::var("PGRX_MANIFEST_PATH") {

--- a/pgrx-tests/src/lib.rs
+++ b/pgrx-tests/src/lib.rs
@@ -16,7 +16,7 @@ pub use framework::*;
 pub mod proptest;
 
 #[cfg(any(test, feature = "pg_test"))]
-pgrx::pg_sql_graph_magic!();
+pgrx::pg_module_magic!();
 
 #[cfg(test)]
 pub mod pg_test {

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -61,5 +61,3 @@ mod variadic_tests;
 mod xact_callback_tests;
 mod xid64_tests;
 mod zero_datum_edge_cases;
-
-pgrx::pg_magic_func!();

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -177,7 +177,7 @@ const _: () = {
 ///
 /// </pre></div>
 ///
-/// This calls both [`pg_magic_func!()`](pg_magic_func) and [`pg_sql_graph_magic!()`](pg_sql_graph_magic).
+/// This calls [`pg_magic_func!()`](pg_magic_func).
 #[macro_export]
 macro_rules! pg_module_magic {
     () => {

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -185,6 +185,7 @@ macro_rules! pg_module_magic {
 
         // A marker function which must exist in the root of the extension for proper linking by the
         // "pgrx_embed" binary during `cargo-pgrx schema` generation.
+        #[inline(never)] /* we don't want DCE to remove this as it *could* cause the compiler to decide to not link to us */
         #[doc(hidden)]
         pub fn __pgrx_marker() {
             // noop

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -182,7 +182,13 @@ const _: () = {
 macro_rules! pg_module_magic {
     () => {
         $crate::pg_magic_func!();
-        $crate::pg_sql_graph_magic!();
+
+        // A marker function which must exist in the root of the extension for proper linking by the
+        // "pgrx_embed" binary during `cargo-pgrx schema` generation.
+        #[doc(hidden)]
+        pub fn __pgrx_marker() {
+            // noop
+        }
     };
 }
 
@@ -255,39 +261,6 @@ macro_rules! pg_magic_func {
 
             // return the magic
             &MY_MAGIC
-        }
-    };
-}
-
-/// Create necessary extension-local internal marker for use with SQL generation.
-///
-/// <div class="example-wrap" style="display:inline-block">
-/// <pre class="ignore" style="white-space:normal;font:inherit;">
-///
-/// **Note**: Generally [`pg_module_magic`] is preferred, and results in this macro being called.
-/// This macro should only be directly called in advanced use cases.
-///
-/// </pre></div>
-#[macro_export]
-macro_rules! pg_sql_graph_magic {
-    () => {
-        // A marker which must exist in the root of the extension.
-        #[doc(hidden)]
-        pub fn __pgrx_marker() -> $crate::pgrx_sql_entity_graph::ControlFile {
-            use ::core::convert::TryFrom;
-            let package_version = env!("CARGO_PKG_VERSION");
-            let context = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/",
-                env!("CARGO_CRATE_NAME"),
-                ".control"
-            ))
-            .replace("@CARGO_VERSION@", package_version);
-
-            let control_file =
-                $crate::pgrx_sql_entity_graph::ControlFile::try_from(context.as_str())
-                    .expect("Could not parse control file, is it valid?");
-            control_file
         }
     };
 }


### PR DESCRIPTION
The `pg_sql_graph_magic!()` did some shenanigans related to loading the extension ".control" file at compile-time and embedded it in the compiled artifact.  This was convoluted and actually unnecessary as the location where that information was used (in `schema.rs`) can easily access the ".control" file at runtime.

This PR removes that macro and its usages.

The `fn __pgrx__marker()` function is still required, however.  It's necessary to ensure that the `rustc` build we do for the `pgrx_embed` binary for schema generation properly links so that the other (dynamically referenced) `__pgrx_internals_XXX` symbols can be found.  The function, however, is now a noop.

This is related to #1546, but is not a solution.  It should just make solving that request easier.