### PR TITLE
Remove `Interval::is_finite`

### DIFF
--- a/pgrx/src/datum/interval.rs
+++ b/pgrx/src/datum/interval.rs
@@ -170,13 +170,6 @@ impl Interval {
         self.0.month < 0 || self.0.day < 0 || self.0.time < 0
     }
 
-    /// Postgres defines intervals as bounded
-    #[deprecated(since = "0.10.0", note = "consider using `true`")]
-    pub fn is_finite(&self) -> bool {
-        // Yes, really.
-        true
-    }
-
     /// Truncate [`Interval`] to specified units
     pub fn truncate(self, units: DateTimeParts) -> Self {
         unsafe {


### PR DESCRIPTION
We do not need function calls to return `true`.