### PR TITLE
feat(cargo-pgrx): add support for downloading specific pg versions

### DIFF
--- a/cargo-pgrx/src/command/mod.rs
+++ b/cargo-pgrx/src/command/mod.rs
@@ -39,4 +39,13 @@ fn build_agent_for_url(url: &str) -> eyre::Result<Agent> {
     }
 }
 
+/// Generate the FTP download for a Postgres tarball, given the major and minor versions
+fn generate_ftp_download_url(major: impl ToString, minor: impl ToString) -> String {
+    let major = major.to_string();
+    let minor = minor.to_string();
+    format!(
+        "https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2"
+    )
+}
+
 // TODO: Abstract over the repeated `fn perform`?

--- a/cargo-pgrx/src/command/version.rs
+++ b/cargo-pgrx/src/command/version.rs
@@ -27,7 +27,7 @@ mod rss {
     use std::collections::BTreeMap;
     use url::Url;
 
-    use crate::command::build_agent_for_url;
+    use crate::command::{build_agent_for_url, generate_ftp_download_url};
 
     pub(super) struct PostgreSQLVersionRss;
 
@@ -65,9 +65,8 @@ mod rss {
                     if matches!(known_pgver.minor, PgMinorVersion::Latest) {
                         // fill in the latest minor version number and its url
                         known_pgver.minor = PgMinorVersion::Release(minor);
-                        known_pgver.url = Some(Url::parse(
-                                &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2")
-                            )?);
+                        known_pgver.url =
+                            Some(Url::parse(&generate_ftp_download_url(major, minor))?);
                     }
                 }
             }


### PR DESCRIPTION
This commit adds support for downloading a specific version of Postgres when running `cargo pgrx init` via tarball.

Some example invocations would look like:
- `cargo pgx init --pg12=12.6`

Where as previously you could only provide a path to an existing `pg_config` from a Postgres installation (which you needed to place yourself), with this PR we can now specify either the version or a tarball.

This PR does not solve the problem of allowing *any* URL to be used as a download URL, but instead only uses https://ftp.postgresql.org derived URLs.

Resolves #149
