### PR TITLE
Remove redundant imports

### DIFF
--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -8,6 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::command::get::{find_control_file, get_property};
+use crate::manifest::{get_package_manifest, pg_config_and_version};
 use crate::profile::CargoProfile;
 use crate::CommandExecute;
 use cargo_toml::Manifest;
@@ -18,10 +19,6 @@ use pgrx_pg_config::{get_target_dir, PgConfig, Pgrx};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-// Since we support extensions with `#[no_std]`
-extern crate alloc;
-use crate::manifest::{get_package_manifest, pg_config_and_version};
-use alloc::vec::Vec;
 
 /// Generate extension schema files
 #[derive(clap::Args, Debug)]

--- a/pgrx-examples/aggregate/src/lib.rs
+++ b/pgrx-examples/aggregate/src/lib.rs
@@ -10,7 +10,7 @@
 use core::ffi::CStr;
 use pgrx::aggregate::*;
 use pgrx::prelude::*;
-use pgrx::{PgVarlena, PgVarlenaInOutFuncs, StringInfo};
+use pgrx::StringInfo;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
-use pgrx::Array;
 use serde::*;
 
 ::pgrx::pg_module_magic!();

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::bgworkers::*;
-use pgrx::datum::{FromDatum, IntoDatum};
 use pgrx::prelude::*;
 use std::time::Duration;
 

--- a/pgrx-examples/composite_type/src/lib.rs
+++ b/pgrx-examples/composite_type/src/lib.rs
@@ -20,7 +20,7 @@ A number of considerations are detailed in the [`pgrx::composite_type`][pgrx::co
 [`PgHeapTuple`][pgrx::PgHeapTuple] documentation which may assist in productionalizing extensions
 using composite types.
 */
-use pgrx::{opname, pg_operator, prelude::*, Aggregate};
+use pgrx::{opname, pg_operator, prelude::*};
 
 // All `pgrx` extensions will do this:
 ::pgrx::pg_module_magic!();

--- a/pgrx-examples/custom_types/src/complex.rs
+++ b/pgrx-examples/custom_types/src/complex.rs
@@ -9,7 +9,6 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use maplit::*;
 use pgrx::prelude::*;
-use pgrx::Array;
 use serde::*;
 use std::collections::HashMap;
 

--- a/pgrx-examples/custom_types/src/fixed_size.rs
+++ b/pgrx-examples/custom_types/src/fixed_size.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use core::ffi::CStr;
 use pgrx::prelude::*;
-use pgrx::{opname, pg_operator, PgVarlena, PgVarlenaInOutFuncs, StringInfo};
+use pgrx::{opname, pg_operator, StringInfo};
 use std::str::FromStr;
 
 #[derive(Copy, Clone, PostgresType)]

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -13,7 +13,6 @@ use pgrx::prelude::*;
 use pgrx::shmem::*;
 use pgrx::{pg_shmem_init, warning};
 use serde::*;
-use std::iter::Iterator;
 use std::sync::atomic::Ordering;
 
 ::pgrx::pg_module_magic!();

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
-use pgrx::{info, spi, IntoDatum};
 
 ::pgrx::pg_module_magic!();
 

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
-use pgrx::IntoDatum;
 
 ::pgrx::pg_module_magic!();
 

--- a/pgrx-examples/triggers/src/lib.rs
+++ b/pgrx-examples/triggers/src/lib.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
-use pgrx::WhoAllocated;
 
 ::pgrx::pg_module_magic!();
 

--- a/pgrx-sql-entity-graph/src/control_file.rs
+++ b/pgrx-sql-entity-graph/src/control_file.rs
@@ -16,7 +16,6 @@ to the `pgrx` framework and very subject to change between versions. While you m
 
 */
 use super::{SqlGraphEntity, SqlGraphIdentifier, ToSql};
-use core::convert::TryFrom;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/pgrx-sql-entity-graph/src/pg_extern/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/returning.rs
@@ -18,7 +18,6 @@ to the `pgrx` framework and very subject to change between versions. While you m
 use crate::UsedType;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
-use std::convert::TryFrom;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;

--- a/pgrx-tests/src/proptest.rs
+++ b/pgrx-tests/src/proptest.rs
@@ -1,8 +1,7 @@
 use pgrx::pg_sys::panic::CaughtError;
 use pgrx::prelude::*;
-use proptest::prelude::*;
 use proptest::strategy::Strategy;
-use proptest::test_runner::{TestCaseResult, TestError, TestRunner};
+use proptest::test_runner::{TestCaseError, TestCaseResult, TestError, TestRunner};
 use std::panic::AssertUnwindSafe;
 
 /** proptest's [`TestRunner`] adapted for `#[pg_test]`

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -11,8 +11,8 @@
 use crate::datum::Array;
 use crate::toast::{Toast, Toasty};
 use crate::{layout, pg_sys, varlena};
-use bitvec::prelude::*;
 use bitvec::ptr::{self as bitptr, BitPtr, BitPtrError, Mut};
+use bitvec::slice::BitSlice;
 use core::ptr::{self, NonNull};
 use core::slice;
 

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -14,7 +14,6 @@
 #![allow(clippy::useless_transmute)]
 use crate::pg_sys;
 use pgrx_pg_sys::PgTryBuilder;
-use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::ptr::null_mut;

--- a/pgrx/src/datum/time_stamp_with_timezone.rs
+++ b/pgrx/src/datum/time_stamp_with_timezone.rs
@@ -16,7 +16,6 @@ use pgrx_pg_sys::PgTryBuilder;
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
-use std::convert::TryFrom;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 // taken from /include/datatype/timestamp.h

--- a/pgrx/src/hooks.rs
+++ b/pgrx/src/hooks.rs
@@ -11,7 +11,7 @@
 #![allow(clippy::unit_arg)]
 use crate as pgrx; // for #[pg_guard] support from within ourself
 use crate::prelude::*;
-use crate::{void_mut_ptr, PgBox, PgList};
+use crate::{void_mut_ptr, PgList};
 use std::ops::Deref;
 
 #[cfg(any(feature = "pg12", feature = "pg13"))]

--- a/pgrx/src/spi/tuple.rs
+++ b/pgrx/src/spi/tuple.rs
@@ -6,7 +6,6 @@ use std::ptr::NonNull;
 
 use crate::memcxt::PgMemoryContexts;
 use crate::pg_sys::panic::ErrorReportable;
-use crate::pg_sys::{self, PgOid};
 use crate::prelude::*;
 
 use super::{SpiError, SpiErrorCodes, SpiOkCodes, SpiResult};


### PR DESCRIPTION
Silence warnings that Rust ~1.78 will mouth off about.