### PR TITLE
mark pgrx_pg_sys bindings inline

### DIFF
--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -128,6 +128,7 @@ fn foreign_item_fn(func: &ForeignItemFn, abi: &syn::Abi) -> syn::Result<proc_mac
     let return_type = func.sig.output.clone();
 
     Ok(quote! {
+        #[inline]
         #[track_caller]
         pub unsafe fn #func_name ( #arg_list_with_types ) #return_type {
             crate::ffi::pg_guard_ffi_boundary(move || {


### PR DESCRIPTION
> I did a little investigation in compilation time and found the most time-consuming part in pgrx is rustc codegen: most bindings of PostgreSQL are not used but rustc spends time in generating machine code of `pg_guard` wrappers. I just read https://kobzol.github.io/rust/rustc/2024/03/15/rustc-what-takes-so-long.html and it said, `Because if you just build an intermediate artifact (like an .rlib, which is what your crate dependencies compile into), that won’t compile #[inline]-d and generic functions, and also the linker won’t be involved`. So, I thought `#[inline]` should help compilation time.

Marking pgrx_pg_sys bindings inline reduces compilation time. It took 150 seconds to build `pgrx` before and it takes 36 seconds to build `pgrx` now.

```
cargo build --no-default-features --features pg13 --release --timings
```

Before this PR:

![Screenshot_20240318_184237](https://github.com/pgcentralfoundation/pgrx/assets/79277854/6507ea98-4e59-4881-8c2d-7465ff542f2a)

After this PR:

![Screenshot_20240318_183904](https://github.com/pgcentralfoundation/pgrx/assets/79277854/b8ba2ee2-1ba3-41ba-abe0-7172ae7e6065)

> The “codegen” times are highlighted in a lavender color.
> The “custom build” units are build.rs scripts, which when run are highlighted in orange.

Inlining prevents unused codegen in macros, so it's faster.