### PR TITLE
Deprecate `set_varsize`

### DIFF
--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Wrapper for Postgres 'varlena' type, over Rust types of a fixed size (ie, `impl Copy`)
 use crate::{
-    pg_sys, rust_regtypein, set_varsize, set_varsize_short, vardata_any, varsize_any,
+    pg_sys, rust_regtypein, set_varsize_4b, set_varsize_short, vardata_any, varsize_any,
     varsize_any_exhdr, void_mut_ptr, FromDatum, IntoDatum, PgMemoryContexts, StringInfo,
 };
 use pgrx_sql_entity_graph::metadata::{
@@ -139,7 +139,7 @@ where
                 set_varsize_short(ptr, (size_of + pg_sys::VARHDRSZ_SHORT) as i32);
             } else {
                 // gotta use the full 4-byte header
-                set_varsize(ptr, (size_of + pg_sys::VARHDRSZ) as i32);
+                set_varsize_4b(ptr, (size_of + pg_sys::VARHDRSZ) as i32);
             }
         }
 
@@ -390,7 +390,7 @@ where
     let size = serialized.len();
     let varlena = serialized.into_char_ptr();
     unsafe {
-        set_varsize(varlena as *mut pg_sys::varlena, size as i32);
+        set_varsize_4b(varlena as *mut pg_sys::varlena, size as i32);
     }
 
     varlena as *const pg_sys::varlena

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -15,6 +15,7 @@ use core::{ops::DerefMut, slice, str};
 /// # Safety
 ///
 /// The caller asserts the specified `ptr` really is a non-null, palloc'd [`pg_sys::varlena`] pointer
+/// that is aligned to 4 bytes.
 #[inline(always)]
 pub unsafe fn set_varsize_4b(ptr: *mut pg_sys::varlena, len: i32) {
     // #define SET_VARSIZE_4B(PTR,len) \
@@ -30,7 +31,9 @@ pub unsafe fn set_varsize_4b(ptr: *mut pg_sys::varlena, len: i32) {
 /// # Safety
 ///
 /// The caller asserts the specified `ptr` really is a non-null, palloc'd [`pg_sys::varlena`] pointer
+/// that is aligned to 4 bytes.
 #[inline(always)]
+#[deprecated(since = "0.12.0", note = "you probably meant set_varsize_4b")]
 pub unsafe fn set_varsize(ptr: *mut pg_sys::varlena, len: i32) {
     // #define SET_VARSIZE(PTR, len)				SET_VARSIZE_4B(PTR, len)
     set_varsize_4b(ptr, len)


### PR DESCRIPTION
The `set_varsize` name is used by Postgres but is ambiguous and unlike the "read" variant, cannot be made fully interchangeable between the 1b and 4b version, even if one mitigated the difference slightly by using unaligned writes. Document both `set_varsize` and `set_varsize_4b`'s alignment precondition, and deprecate the ambiguous version.

Fixes https://github.com/pgcentralfoundation/pgrx/issues/1321
