### PR TITLE
Fix off-by-one error in fastgetattr docs

### DIFF
--- a/pgrx-pg-sys/src/submodules/htup.rs
+++ b/pgrx-pg-sys/src/submodules/htup.rs
@@ -335,7 +335,7 @@ pub unsafe fn heap_getattr(
 ///
 /// # Panics
 ///
-/// Will panic if `attnum` is less than zero
+/// Will panic if `attnum` is less than one
 #[inline(always)]
 unsafe fn fastgetattr(
     tup: *mut HeapTupleData,


### PR DESCRIPTION
The code is correct. Fix the off-by-zero error in the documentation.

Resolves https://github.com/pgcentralfoundation/pgrx/issues/1613