### PR TITLE
reserve exact one blank line between two sql entities

### DIFF
--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -413,9 +413,14 @@ impl PgrxSql {
         })? {
             let step = &self.graph[step_id];
 
-            let sql = step.to_sql(self).map(|s| s + "\n")?;
-            full_sql.push_str(&sql);
+            let sql = step.to_sql(self)?;
+            full_sql.push_str(sql.trim_matches('\n'));
+
+            if !full_sql.is_empty() && !full_sql.ends_with("\n\n") {
+                full_sql.push_str("\n\n");
+            }
         }
+        let _ = full_sql.pop();
         Ok(full_sql)
     }
 


### PR DESCRIPTION
`cargo pgrx schema` emits 27 blank lines before any characters since there are 25 `SqlGraphEntity::BuiltinType`s. It's strange.