### PR TITLE
Consistently test on latest rustc stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,10 +54,6 @@ jobs:
           cat $GITHUB_ENV
           echo ""
           
-          echo "----- Output Cargo version -----"
-          cargo --version
-          echo ""
-          
           echo "----- Outputting env -----"
           env
           echo ""
@@ -157,10 +153,11 @@ jobs:
             strace \
             zlib1g-dev
           echo ""
-          
+
+          ./ci/rustup.sh
+
           echo "----- Set up cross compilation -----"
           sudo apt-get install -y --fix-missing crossbuild-essential-arm64
-          rustup target add aarch64-unknown-linux-gnu
           
           echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
           # TODO: not all of these should be needed, but for now it's likely fine.
@@ -170,10 +167,6 @@ jobs:
           env
           echo ""
           
-          echo "----- Get cargo version -----"
-          cargo --version
-          echo ""
-
       - name: Install release version of PostgreSQL
         run: |
           echo "----- Set up PostgreSQL Apt repository -----"
@@ -410,11 +403,9 @@ jobs:
             strace \
             zlib1g-dev
           echo ""
-          
-          echo "----- Output Cargo version -----"
-          cargo --version
-          echo ""
-          
+
+          ./ci/rustup.sh
+
           echo "----- Outputting env -----"
           env
           echo ""
@@ -540,14 +531,9 @@ jobs:
           sudo chmod a+rwx `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
           # ls -lath `$(which pg_config) --pkglibdir` `$(which pg_config) --sharedir`/extension
           echo ""
-          
-          echo "----- Stable Rust ----"
-          rustup update stable
-          rustup default stable
-          rustc -vV
-          cargo -vV
-          echo ""
-          
+
+          ./ci/rustup.sh
+
           echo "----- Outputting env -----"
           env
           echo ""

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,9 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           mkdir -p /home/runner/.cache/sccache
           echo ""
-          
+
+          ./ci/rustup.sh
+
           # https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions/57969570#57969570
           
           echo "----- Set up MAKEFLAGS -----"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,15 +1174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,7 +1479,6 @@ dependencies = [
  "clang-sys",
  "eyre",
  "libc",
- "memoffset",
  "pgrx-macros",
  "pgrx-pg-config",
  "pgrx-sql-entity-graph",

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -1,0 +1,10 @@
+echo "---- setup rustc ----"
+# setting default to a release channel syncs to that
+rustup default stable
+
+# only needed for cross-compile tests but we want consistent rust configuration
+rustup target add aarch64-unknown-linux-gnu
+
+# output full rustc version data
+rustc --version --verbose
+# that this determines what our cargo version is, so don't ask

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -1,5 +1,5 @@
 echo "---- setup rustc ----"
-# setting default to a release channel syncs to that
+rustup update stable
 rustup default stable
 
 # only needed for cross-compile tests but we want consistent rust configuration

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -7,4 +7,4 @@ rustup target add aarch64-unknown-linux-gnu
 
 # output full rustc version data
 rustc --version --verbose
-# that this determines what our cargo version is, so don't ask
+# this determines what our cargo version is, so don't ask

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -43,7 +43,6 @@ pgrx-sql-entity-graph.workspace = true
 
 libc.workspace = true
 
-memoffset = "0.9.0"
 serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -1,7 +1,6 @@
 use crate as pg_sys;
-
-use memoffset::*;
-use std::str::FromStr;
+use core::mem::offset_of;
+use core::str::FromStr;
 
 /// this comes from `postgres_ext.h`
 pub const InvalidOid: crate::Oid = crate::Oid::INVALID;

--- a/pgrx-tests/tests/todo/roundtrip-tests.stderr
+++ b/pgrx-tests/tests/todo/roundtrip-tests.stderr
@@ -55,7 +55,11 @@ error[E0277]: the trait bound `Vec<Option<&[u8]>>: FromDatum` is not satisfied
   --> tests/todo/roundtrip-tests.rs:36:38
    |
 36 |                   let result: $rtype = Spi::get_one_with_args(
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `FromDatum` is not implemented for `Vec<Option<&[u8]>>`
+   |  ______________________________________^
+37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
+38 | |                     vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+39 | |                 )?
+   | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&[u8]>>`
 ...
 52 | /     roundtrip!(
 53 | |         rt_array_bytea,
@@ -97,7 +101,11 @@ error[E0277]: the trait bound `Vec<Option<&str>>: FromDatum` is not satisfied
   --> tests/todo/roundtrip-tests.rs:36:38
    |
 36 |                   let result: $rtype = Spi::get_one_with_args(
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `FromDatum` is not implemented for `Vec<Option<&str>>`
+   |  ______________________________________^
+37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
+38 | |                     vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+39 | |                 )?
+   | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&str>>`
 ...
 66 | /     roundtrip!(
 67 | |         rt_array_refstr,
@@ -138,7 +146,11 @@ error[E0277]: the trait bound `Vec<Option<&CStr>>: FromDatum` is not satisfied
   --> tests/todo/roundtrip-tests.rs:36:38
    |
 36 |                   let result: $rtype = Spi::get_one_with_args(
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `FromDatum` is not implemented for `Vec<Option<&CStr>>`
+   |  ______________________________________^
+37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
+38 | |                     vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+39 | |                 )?
+   | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&CStr>>`
 ...
 73 | /     roundtrip!(
 74 | |         rt_array_cstr,


### PR DESCRIPTION
Consistently use latest rustc stable for the test infrastructure by replacing a number of ad hoc lines of bash-in-YAML with a single script. This allows us to use rustc 1.77, for which:
- `offset_of!` in stdlib lets us drop the `memoffset` crate
- some compile-fail tests require blessing, as diagnostics changed