### PR TITLE
Use Ceescape's `sigsetjmp()` wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cee-scape"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d67dfb052149f779f77e9ce089cea126e00657e8f0d11dafc7901fde4291101"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1486,7 @@ name = "pgrx-pg-sys"
 version = "0.12.0-alpha.1"
 dependencies = [
  "bindgen",
+ "cee-scape",
  "clang-sys",
  "eyre",
  "libc",

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -47,6 +47,9 @@ serde = { version = "1.0", features = [ "derive" ] } # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
 
+# Safer `sigsetjmp` and `siglongjmp`
+cee-scape = "0.2"
+
 [build-dependencies]
 pgrx-pg-config.workspace = true
 


### PR DESCRIPTION
The [cee-scape](https://crates.io/crates/cee-scape) crate uses a hand-rolled assembly wrapper around libc's `sigsetjmp()`. This has better correctness guarantees than calling `sigsetjmp()` directly, because LLVM is not allowed to reason about / attempt to optimize inside hand-written assembly. `sigsetjmp()` is used for `pg_guard_ffi_boundary_impl()`, which is our wrapper around Postgres' exception handling, since Postgres uses `sigsetjmp()` and `siglongjmp()` to handle multiple return points. Rust's paradigm doesn't understand this - in Rust, a a function call can only return to its caller at one point in time: when it has finished executing. Whereas, sigsetjmp can return to two places _chronologically_ - and so this needs to be handled carefully.

Fixes https://github.com/pgcentralfoundation/pgrx/issues/1144