### PR TITLE
Redeclare additional *_walker fn

### DIFF
--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -741,7 +741,8 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
     bind.blocklist_type("Datum") // manually wrapping datum for correctness
         .blocklist_type("Oid") // "Oid" is not just any u32
         .blocklist_function("varsize_any") // pgrx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
-        .blocklist_function("(?:raw_)?(?:expression|planstate|query|query_or_expression)_tree_walker")
+        .blocklist_function("(?:raw_)?(?:expression|query|query_or_expression)_tree_walker")
+        .blocklist_function("planstate_tree_walker")
         .blocklist_function("range_table_(?:entry_)?walker")
         .blocklist_function(".*(?:set|long)jmp")
         .blocklist_function("pg_re_throw")

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -741,9 +741,7 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
     bind.blocklist_type("Datum") // manually wrapping datum for correctness
         .blocklist_type("Oid") // "Oid" is not just any u32
         .blocklist_function("varsize_any") // pgrx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
-        .blocklist_function("(?:raw_)?(?:query|expression)_tree_walker")
-        .blocklist_function("query_or_expression_tree_walker")
-        .blocklist_function("planstate_tree_walker")
+        .blocklist_function("(?:raw_)?(?:expression|planstate|query|query_or_expression)_tree_walker")
         .blocklist_function("range_table_(?:entry_)?walker")
         .blocklist_function(".*(?:set|long)jmp")
         .blocklist_function("pg_re_throw")

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -742,6 +742,9 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
         .blocklist_type("Oid") // "Oid" is not just any u32
         .blocklist_function("varsize_any") // pgrx converts the VARSIZE_ANY macro, so we don't want to also have this function, which is in heaptuple.c
         .blocklist_function("(?:raw_)?(?:query|expression)_tree_walker")
+        .blocklist_function("query_or_expression_tree_walker")
+        .blocklist_function("planstate_tree_walker")
+        .blocklist_function("range_table_(?:entry_)?walker")
         .blocklist_function(".*(?:set|long)jmp")
         .blocklist_function("pg_re_throw")
         .blocklist_function("err(start|code|msg|detail|context_msg|hint|finish)")

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -333,11 +333,11 @@ pub unsafe fn query_or_expression_tree_walker(
 
 #[cfg(feature = "pg16")]
 pub unsafe fn expression_tree_walker(
-    arg_node: *mut crate::Node,
-    arg_walker: Option<unsafe extern "C" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
-    arg_context: *mut ::core::ffi::c_void,
+    node: *mut crate::Node,
+    walker: Option<unsafe extern "C" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
+    context: *mut ::core::ffi::c_void,
 ) -> bool {
-    crate::expression_tree_walker_impl(arg_node, arg_walker, arg_context)
+    crate::expression_tree_walker_impl(node, walker, context)
 }
 
 #[cfg(feature = "pg16")]
@@ -366,11 +366,11 @@ pub unsafe fn range_table_walker(
 
 #[cfg(feature = "pg16")]
 pub unsafe fn raw_expression_tree_walker(
-    arg_node: *mut crate::Node,
-    arg_walker: Option<unsafe extern "C" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
-    arg_context: *mut ::core::ffi::c_void,
+    node: *mut crate::Node,
+    walker: Option<unsafe extern "C" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
+    context: *mut ::core::ffi::c_void,
 ) -> bool {
-    crate::raw_expression_tree_walker_impl(arg_node, arg_walker, arg_context)
+    crate::raw_expression_tree_walker_impl(node, walker, context)
 }
 
 #[inline(always)]

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -235,8 +235,43 @@ pub unsafe fn heap_tuple_get_struct<T>(htup: super::HeapTuple) -> *mut T {
 #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
 #[::pgrx_macros::pg_guard]
 extern "C" {
+    pub fn planstate_tree_walker(
+        planstate: *mut super::PlanState,
+        walker: ::core::option::Option<
+            unsafe extern "C" fn(*mut super::PlanState, *mut ::core::ffi::c_void) -> bool,
+        >,
+        context: *mut ::core::ffi::c_void,
+    ) -> bool;
+
     pub fn query_tree_walker(
         query: *mut super::Query,
+        walker: ::core::option::Option<
+            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+        >,
+        context: *mut ::core::ffi::c_void,
+        flags: ::core::ffi::c_int,
+    ) -> bool;
+
+    pub fn query_or_expression_tree_walker(
+        node: *mut super::Node,
+        walker: ::core::option::Option<
+            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+        >,
+        context: *mut ::core::ffi::c_void,
+        flags: ::core::ffi::c_int,
+    ) -> bool;
+
+    pub fn range_table_entry_walker(
+        rte: *mut super::RangeTblEntry,
+        walker: ::core::option::Option<
+            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+        >,
+        context: *mut ::core::ffi::c_void,
+        flags: ::core::ffi::c_int,
+    ) -> bool;
+
+    pub fn range_table_walker(
+        rtable: *mut super::List,
         walker: ::core::option::Option<
             unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
         >,
@@ -262,6 +297,17 @@ extern "C" {
 }
 
 #[cfg(feature = "pg16")]
+pub unsafe fn planstate_tree_walker(
+    planstate: *mut super::PlanState,
+    walker: ::core::option::Option<
+        unsafe extern "C" fn(*mut super::PlanState, *mut ::core::ffi::c_void) -> bool,
+    >,
+    context: *mut ::core::ffi::c_void,
+) -> bool {
+    crate::planstate_tree_walker_impl(planstate, walker, context)
+}
+
+#[cfg(feature = "pg16")]
 pub unsafe fn query_tree_walker(
     query: *mut super::Query,
     walker: ::core::option::Option<
@@ -274,12 +320,48 @@ pub unsafe fn query_tree_walker(
 }
 
 #[cfg(feature = "pg16")]
+pub unsafe fn query_or_expression_tree_walker(
+    node: *mut super::Node,
+    walker: ::core::option::Option<
+        unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+    >,
+    context: *mut ::core::ffi::c_void,
+    flags: ::core::ffi::c_int,
+) -> bool {
+    crate::query_or_expression_tree_walker_impl(node, walker, context, flags)
+}
+
+#[cfg(feature = "pg16")]
 pub unsafe fn expression_tree_walker(
     arg_node: *mut crate::Node,
     arg_walker: Option<unsafe extern "C" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
     arg_context: *mut ::core::ffi::c_void,
 ) -> bool {
     crate::expression_tree_walker_impl(arg_node, arg_walker, arg_context)
+}
+
+#[cfg(feature = "pg16")]
+pub unsafe fn range_table_entry_walker(
+    rte: *mut super::RangeTblEntry,
+    walker: ::core::option::Option<
+        unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+    >,
+    context: *mut ::core::ffi::c_void,
+    flags: ::core::ffi::c_int,
+) -> bool {
+    crate::range_table_entry_walker_impl(rte, walker, context, flags)
+}
+
+#[cfg(feature = "pg16")]
+pub unsafe fn range_table_walker(
+    rtable: *mut super::List,
+    walker: ::core::option::Option<
+        unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+    >,
+    context: *mut ::core::ffi::c_void,
+    flags: ::core::ffi::c_int,
+) -> bool {
+    crate::range_table_walker_impl(rtable, walker, context, flags)
 }
 
 #[cfg(feature = "pg16")]


### PR DESCRIPTION
As a follow up to the discussion here 
https://github.com/pgcentralfoundation/pgrx/issues/1583#issuecomment-2030105513

Here's a patch to declare correctly the following functions:

* query_or_expression_tree_walker
* range_table_entry_walker
* planstate_tree_walker
* range_table_walker

This is a shameless copy of PR #1596 , I'm not entirely sure what I am actually doing here :)

Quick questions regarding the format:

-  I see some arguments have the `arg_` prefix while others don't... Like  `arg_node` vs `node`  in the query_tree_walker function... Is there a naming rule regarding this ?

- I'm unsure how to sort the functions... alphabetical order ?