### PR TITLE
inline lib reqs for `cargo pgrx init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ Now install the `cargo-pgrx` sub-command.
 cargo install --locked cargo-pgrx
 ```
 
-**Important:** `cargo-pgrx` **must** be built using the same compiler as you'll use to build the rest of your project. Every time you update your Rust toolchain you have to also manually reinstall `cargo-pgrx`. See [Upgrading](#Upgrading), below.
-
 Once `cargo-pgrx` is ready you can initialize the "PGRX Home" directory:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ those remain untested. So far, some of PGRX's build tooling works on Windows, bu
    - RHEL: `yum install clang`
 - GCC 7 or newer
 - [PostgreSQL's build dependencies](https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code) ‡
+   - Debian-likes: `sudo apt-get install build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc ccache pkg-config`
+   - RHEL-likes: `sudo yum install -y bison-devel readline-devel zlib-devel openssl-devel wget ccache && sudo yum groupinstall -y 'Development Tools'`
 
  † PGRX has no MSRV policy, thus may require the latest stable version of Rust, available via Rustup
 
@@ -118,8 +120,9 @@ brew install git icu4c pkg-config
 
 ## Getting Started
 
+Before anything else, install the [system dependencies](#system-requirements).
 
-First install the `cargo-pgrx` sub-command.
+Now install the `cargo-pgrx` sub-command.
 
 ```bash
 cargo install --locked cargo-pgrx


### PR DESCRIPTION
include the required libs for `cargo pgrx init` so people don't miss checking the wiki and fail to install them. without e.g. `libreadline` installed, you get a long error from cmake:

```
  Configuring Postgres v14.11
Error: 
   0: cd "/home/jyn/.pgrx/14.11" && env -u DEBUG -u DYLD_FALLBACK_LIBRARY_PATH -u HOST -u LIBRARY_PATH -u MAKEFLAGS -u MAKELEVEL -u MFLAGS -u NUM_JOBS -u OPT_LEVEL -u OUT_DIR -u PROFILE -u TARGET CPPFLAGS=" -DMEMORY_CONTEXT_CHECKING=1 -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 " PATH="/home/jyn/.pgrx/14.11:/home/jyn/.local/bin:/home/jyn/.local/lib/cargo/bin:/home/jyn/src/dotfiles/bin:/home/jyn/.local/bin:/home/jyn/.vscode-server/bin/019f4d1419fbc8219a181fab7892ebccf7ee29a2/bin/remote-cli:/home/jyn/.local/bin:/home/jyn/.local/lib/cargo/bin:/home/jyn/src/dotfiles/bin:/home/jyn/.local/bin:/home/jyn/.local/bin:/home/jyn/.local/lib/cargo/bin:/home/jyn/src/dotfiles/bin:/home/jyn/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" "/home/jyn/.pgrx/14.11/configure" "--prefix=/home/jyn/.pgrx/14.11/pgrx-install" "--with-pgport=28814" "--enable-debug" "--enable-cassert"
```

with a bunch of configure output and then:
```
      checking for library containing readline... no
      configure: WARNING:
      *** Without Bison you will not be able to build PostgreSQL from Git nor
      *** change any of the parser definition files.  You can obtain Bison from
      *** a GNU mirror site.  (If you are using the official distribution of
      *** PostgreSQL then you do not need to worry about this, because the Bison
      *** output is pre-generated.)
      configure: WARNING:
      *** Without Flex you will not be able to build PostgreSQL from Git nor
      *** change any of the scanner definition files.  You can obtain Flex from
      *** a GNU mirror site.  (If you are using the official distribution of
      *** PostgreSQL then you do not need to worry about this because the Flex
      *** output is pre-generated.)
      configure: error: readline library not found
      If you have readline already installed, see config.log for details on the
      failure.  It is possible the compiler isn't looking in the proper directory.
      Use --without-readline to disable readline support.


Location:
   /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.3/src/command/init.rs:432

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ SPANTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

   0: cargo_pgrx::command::init::download_postgres with pg_version=14.11
      at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-pgrx-0.11.3/src/command/init.rs:210
```