### PR TITLE
Add a docker image for CI

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1
+
+ARG PGRX_VERSION=0.12.0-alpha.1
+
+RUN apt-get update && apt-get install -y \
+    gettext-base \
+    libclang-dev \
+    postgresql-server-dev-all
+
+USER postgres
+
+ENV USER=postgres
+
+ENV PATH="${PATH}:/usr/local/cargo/bin/:~postgres/.cargo/bin"
+
+RUN rustup component add clippy && \
+    cargo install --locked --version "${PGRX_VERSION}" cargo-pgrx && \
+    cargo pgrx init
+
+WORKDIR /pgrx
+
+VOLUME /pgrx


### PR DESCRIPTION
Following a discussion on the discord channel:

Here's a basic docker image with all the requirements to build a PGRX project in a CI job. This saves a lot of CI minutes, especially the `cargo pgrx init` step which is quite long.

By default, the image is based on the latest version available but it can be overriden with `--build-arg PGRX_VERSION=0.11.3`

This could be completed with a CI action to build and push the image automatically on dockerhub, like this

https://github.com/daamien/docker-pgrx/blob/latest/.github/workflows/build-push.yaml

This would require to add [secrets variables in the Github account] for `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`

[secrets variables in the Github account]: https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions

This would also provide an easy way to test against alpha/beta versions by simply pulling any version like this

docker pull pgcentralfoundation/pgrx:0.12.0-alpha.1