### PR TITLE
fix: use `memoffset` for `offset_of`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1499,7 @@ dependencies = [
  "clang-sys",
  "eyre",
  "libc",
+ "memoffset",
  "pgrx-macros",
  "pgrx-pg-config",
  "pgrx-sql-entity-graph",

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -49,6 +49,7 @@ sptr = "0.3"
 
 # Safer `sigsetjmp` and `siglongjmp`
 cee-scape = "0.2"
+memoffset = "0.9.1"
 
 [build-dependencies]
 pgrx-pg-config.workspace = true

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -1,6 +1,6 @@
 use crate as pg_sys;
-use core::mem::offset_of;
 use core::str::FromStr;
+use memoffset::offset_of;
 
 /// this comes from `postgres_ext.h`
 pub const InvalidOid: crate::Oid = crate::Oid::INVALID;


### PR DESCRIPTION
As of Rust 1.77.0, `offset_of` is still unstable, and compiling `pgrx` fails for us because of this. We can use `memoffset::offset_of` as a workaround.