### PR TITLE
only build library in cargo-pgrx commands

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -299,6 +299,7 @@ pub(crate) fn build_extension(
 
     let mut command = crate::env::cargo();
     command.arg("build");
+    command.arg("--lib");
 
     if let Some(user_manifest_path) = user_manifest_path {
         command.arg("--manifest-path");

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -331,6 +331,7 @@ fn first_build(
         command.arg("--no-run");
     } else {
         command.arg("build");
+        command.arg("--lib");
     }
 
     command.arg("--package");


### PR DESCRIPTION
Only build the package’s library in `cargo-pgrx` commands since only `dylib` is needed.