### PR TITLE
`cargo pgrx test --runas`

### DIFF
--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Report version
         run: cargo --version
 
-      - name: Test pronto-as-a-library
+      - name: Test cargo pgrx test --runas
         run: cd pgrx-examples/arrays && cargo pgrx test --runas postgres --pgdata=/tmp/pgdata

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Report version
         run: cargo --version
 
+      - name: Install cargo pgrx
+        run: cd cargo-pgrx && cargo install --path . --debug
+
       - name: Test cargo pgrx test --runas
         run: cd pgrx-examples/arrays && cargo pgrx test --runas postgres --pgdata=/tmp/pgdata

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -1,4 +1,4 @@
-name: Test cargo pgrx test --runas
+name: cargo pgrx test --runas
 
 on:
   push:

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -1,0 +1,28 @@
+name: Test cargo pgrx test --runas
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: "-C link-args=-Wl,-undefined,dynamic_lookup"   # we don't want target-cpu=native from `.cargo/config` b/c we're caching binaries but we want the other stuff
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
+
+      - name: Report version
+        run: cargo --version
+
+      - name: Test pronto-as-a-library
+        run: cd pgrx-examples/arrays && cargo pgrx test --runas postgres --pgdata=/tmp/pgdata

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install Postgres deps
         run: |
-          apt-get update -y -qq --fix-missing
-          apt-get install -y postgresql-server-dev-14
+          sudo apt-get update -y -qq --fix-missing
+          sudo apt-get install -y postgresql-server-dev-14
 
       - name: Report version
         run: cargo --version

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -9,7 +9,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUSTFLAGS: "-C link-args=-Wl,-undefined,dynamic_lookup"   # we don't want target-cpu=native from `.cargo/config` b/c we're caching binaries but we want the other stuff
 
 jobs:
   ubuntu:

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Install cargo pgrx
         run: cd cargo-pgrx && cargo install --path . --debug
 
+      - name: cargo pgrx init
+        run: cargo pgrx init --pg14=$(which pg_config)
+
       - name: Test cargo pgrx test --runas
-        run: cd pgrx-examples/arrays && cargo pgrx test --runas postgres --pgdata=/tmp/pgdata
+        run: cd pgrx-examples/arrays && cargo pgrx test pg14 --runas postgres --pgdata=/tmp/pgdata

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -19,7 +19,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-rust"
+          prefix-key: "v1-cargo-pgrx-test--runas"
+
+      - name: Install Postgres deps
+        run: |
+          apt-get update -y -qq --fix-missing
+          apt-get install -y postgresql-server-dev-14
 
       - name: Report version
         run: cargo --version

--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -494,8 +494,8 @@ make to the database are not preserved.
 
 An administrative note is that the `--runas` and `--pgdata` options can be used to control the operating-system user used
 to run the separate `postmaster` process for test execution.  Likely, if `--runas` is used, then `--pgdata` will also need
-to be set to a base directory that is readable and writable by that user -- the default PGDATA directory of `./target/` may
-not be permissive enough.
+to be set to a base directory that is readable and writable by that user -- the default PGDATA directory at `./target/pgrx-test-pgdata` 
+will have the permissions of the user running `cargo pgrx test` and won't be chown-able to the `--runas` user.
 
 ```console
 $ cargo pgrx test --help

--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -514,8 +514,8 @@ Options:
   -r, --release                        compile for release mode (default is debug)
       --profile <PROFILE>              Specific profile to use (conflicts with `--release`)
   -n, --no-schema                      Don't regenerate the schema
-      --runas <RUNAS>                  Use `sudo` to initialize and run the Postgres test instance as this system user
-      --pgdata <PGDATA>                Initialize the test database cluster here, instead of the default location.  If used with `--runas`, then it must be writable by the user
+      --runas <USER>                   Use `sudo` to initialize and run the Postgres test instance as this system user
+      --pgdata <DIR>                   Initialize the test database cluster here, instead of the default location.  If used with `--runas`, then it must be writable by the user
       --all-features                   Activate all available features
       --no-default-features            Do not activate the `default` feature
   -F, --features <FEATURES>            Space-separated list of features to activate

--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -492,6 +492,11 @@ Rust `#[test]` functions behave normally, while `#[pg_test]` functions are run *
 Additionally, a `#[pg_test]` function runs in a transaction that is aborted when the test is finished. As such, any changes it might
 make to the database are not preserved.
 
+An administrative note is that the `--runas` and `--pgdata` options can be used to control the operating-system user used
+to run the separate `postmaster` process for test execution.  Likely, if `--runas` is used, then `--pgdata` will also need
+to be set to a base directory that is readable and writable by that user -- the default PGDATA directory of `./target/` may
+not be permissive enough.
+
 ```console
 $ cargo pgrx test --help
 Run the test suite for this crate
@@ -509,6 +514,8 @@ Options:
   -r, --release                        compile for release mode (default is debug)
       --profile <PROFILE>              Specific profile to use (conflicts with `--release`)
   -n, --no-schema                      Don't regenerate the schema
+      --runas <RUNAS>                  Use `sudo` to initialize and run the Postgres test instance as this system user
+      --pgdata <PGDATA>                Initialize the test database cluster here, instead of the default location.  If used with `--runas`, then it must be writable by the user
       --all-features                   Activate all available features
       --no-default-features            Do not activate the `default` feature
   -F, --features <FEATURES>            Space-separated list of features to activate

--- a/cargo-pgrx/src/command/connect.rs
+++ b/cargo-pgrx/src/command/connect.rs
@@ -92,7 +92,7 @@ pub(crate) fn connect_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> e
     start_postgres(pg_config)?;
 
     // create the named database
-    if !createdb(pg_config, dbname, false, true)? {
+    if !createdb(pg_config, dbname, false, true, None)? {
         println!("{} existing database {}", "    Re-using".bold().cyan(), dbname);
     }
 

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -124,7 +124,7 @@ pub(crate) fn run(
     start_postgres(pg_config)?;
 
     // create the named database
-    if !createdb(pg_config, dbname, false, true)? {
+    if !createdb(pg_config, dbname, false, true, None)? {
         println!("{} existing database {}", "    Re-using".bold().cyan(), dbname);
     }
 

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -41,10 +41,10 @@ pub(crate) struct Test {
     #[clap(long, short)]
     no_schema: bool,
     /// Use `sudo` to initialize and run the Postgres test instance as this system user
-    #[clap(long)]
+    #[clap(long, value_name = "USER")]
     runas: Option<String>,
     /// Initialize the test database cluster here, instead of the default location.  If used with `--runas`, then it must be writable by the user
-    #[clap(long)]
+    #[clap(long, value_name = "DIR")]
     pgdata: Option<PathBuf>,
     #[clap(flatten)]
     features: clap_cargo::Features,

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -40,6 +40,12 @@ pub(crate) struct Test {
     /// Don't regenerate the schema
     #[clap(long, short)]
     no_schema: bool,
+    /// Use `sudo` to initialize and run the Postgres test instance as this system user
+    #[clap(long)]
+    runas: Option<String>,
+    /// Initialize the test database cluster here, instead of the default location.  If used with `--runas`, then it must be writable by the user
+    #[clap(long)]
+    pgdata: Option<PathBuf>,
     #[clap(flatten)]
     features: clap_cargo::Features,
     #[clap(from_global, action = clap::ArgAction::Count)]
@@ -75,6 +81,8 @@ impl CommandExecute for Test {
                 me.no_schema,
                 &features,
                 me.testname,
+                me.runas,
+                me.pgdata,
             )?;
 
             Ok(())
@@ -115,6 +123,8 @@ pub fn test_extension(
     no_schema: bool,
     features: &clap_cargo::Features,
     testname: Option<impl AsRef<str>>,
+    runas: Option<String>,
+    pgdata: Option<PathBuf>,
 ) -> eyre::Result<()> {
     if let Some(ref testname) = testname {
         tracing::Span::current().record("testname", &tracing::field::display(&testname.as_ref()));
@@ -139,6 +149,14 @@ pub fn test_extension(
         .env("PGRX_ALL_FEATURES", if features.all_features { "true" } else { "false" })
         .env("PGRX_BUILD_PROFILE", profile.name())
         .env("PGRX_NO_SCHEMA", if no_schema { "true" } else { "false" });
+
+    if let Some(runas) = runas {
+        command.env("CARGO_PGRX_TEST_RUNAS", runas);
+    }
+
+    if let Some(pgdata) = pgdata {
+        command.env("CARGO_PGRX_TEST_PGDATA", pgdata);
+    }
 
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
         command.env("RUST_LOG", rust_log);

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -675,13 +675,21 @@ pub fn createdb(
     dbname: &str,
     is_test: bool,
     if_not_exists: bool,
+    runas: Option<String>,
 ) -> eyre::Result<bool> {
     if if_not_exists && does_db_exist(pg_config, dbname)? {
         return Ok(false);
     }
 
     println!("{} database {}", "     Creating".bold().green(), dbname);
-    let mut command = Command::new(pg_config.createdb_path()?);
+    let createdb_path = pg_config.createdb_path()?;
+    let mut command = if let Some(runas) = runas {
+        let mut cmd = Command::new("sudo");
+        cmd.arg("-u").arg(runas).arg(createdb_path);
+        cmd
+    } else {
+        Command::new(createdb_path)
+    };
     command
         .env_remove("PGDATABASE")
         .env_remove("PGHOST")

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -18,6 +18,7 @@ use pgrx_pg_config::{
 };
 use postgres::error::DbError;
 use std::collections::HashMap;
+use std::env::VarError;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -786,7 +787,13 @@ pub(crate) fn get_pg_user() -> String {
 
 #[inline]
 fn get_runas() -> Option<String> {
-    std::env::var("CARGO_PGRX_TEST_RUNAS").ok()
+    match std::env::var("CARGO_PGRX_TEST_RUNAS") {
+        Ok(s) => Some(s),
+        Err(e) => match e {
+            VarError::NotPresent => None,
+            VarError::NotUnicode(e) => panic!("`CARGO_PGRX_TEST_RUNAS` envar value is not unicode"),
+        },
+    }
 }
 
 #[inline]

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -393,7 +393,10 @@ fn initdb(postgresql_conf: Vec<&'static str>) -> eyre::Result<()> {
         }
 
         if let Some(runas) = get_runas() {
-            // NB:  This command has to be run as root to change the permissions from us to the `runas` user
+            // we've been asked to run as a different user.  As such, the PGDATA directory we just created
+            // needs to be owned by that user.
+            //
+            // In order to do that, we have to become "root" to change its ownership.
             let mut chown = Command::new("sudo");
             chown
                 .args(&["-u", "root", "chown", &runas])

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -315,7 +315,7 @@ fn install_extension() -> eyre::Result<()> {
         .env("CARGO_TARGET_DIR", get_target_dir()?);
 
     if requires_runas() {
-        // if we're running tests as a different operating-system user we actually need to
+        // if we're running tests as a different operating-system user we, then actually need to
         // install the extension artifacts as "root", as it's the user that'll definitely
         // be able to write to Postgres' various artifact directories.  "root" is also the default
         // owner of these directories for distro-managed Postgres extensions
@@ -792,7 +792,10 @@ fn get_runas() -> Option<String> {
         Err(e) => match e {
             VarError::NotPresent => None,
             VarError::NotUnicode(e) => {
-                panic!("`CARGO_PGRX_TEST_RUNAS` environment var value is not unicode")
+                panic!(
+                    "`CARGO_PGRX_TEST_RUNAS` environment var value is not unicode:  `{}`",
+                    e.to_string_lossy()
+                )
             }
         },
     }

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -398,12 +398,8 @@ fn maybe_make_pgdata<P: AsRef<Path>>(pgdata: P) -> eyre::Result<bool> {
         //
         // In order to do that, we must become that user to create it
 
-        let mut mkdir = sudo_command(&runas)
-            .arg("mkdir")
-            .arg("-p")
-            .arg(pgdata)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        let mut mkdir = sudo_command(&runas);
+        mkdir.arg("mkdir").arg("-p").arg(pgdata).stdout(Stdio::piped()).stderr(Stdio::piped());
         let command_str = format!("{:?}", mkdir);
         println!("{} {}", "     Running".bold().green(), command_str);
         let child = mkdir.spawn()?;

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -430,7 +430,7 @@ fn initdb(postgresql_conf: Vec<&'static str>) -> eyre::Result<()> {
         };
 
         command
-            // .current_dir(pgdata.parent().unwrap())
+            .current_dir(pgdata.parent().unwrap())
             .args(get_c_locale_flags())
             .arg("-D")
             .arg(&pgdata)
@@ -772,6 +772,7 @@ fn get_pid_file() -> eyre::Result<PathBuf> {
     Ok(pgdata)
 }
 
+#[inline]
 pub(crate) fn get_pg_dbname() -> &'static str {
     "pgrx_tests"
 }
@@ -783,10 +784,12 @@ pub(crate) fn get_pg_user() -> String {
     })
 }
 
+#[inline]
 fn get_runas() -> Option<String> {
     std::env::var("CARGO_PGRX_TEST_RUNAS").ok()
 }
 
+#[inline]
 fn requires_runas() -> bool {
     get_runas().is_some()
 }

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -680,7 +680,6 @@ fn monitor_pg(mut command: Command, cmd_string: String, loglines: LogLines) -> S
 
 fn dropdb() -> eyre::Result<()> {
     let pg_config = get_pg_config()?;
-
     let dropdb_path = pg_config.dropdb_path().expect("unable to determine dropdb path");
     let mut command = if let Some(runas) = get_runas() {
         let mut cmd = Command::new("sudo");

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -791,7 +791,9 @@ fn get_runas() -> Option<String> {
         Ok(s) => Some(s),
         Err(e) => match e {
             VarError::NotPresent => None,
-            VarError::NotUnicode(e) => panic!("`CARGO_PGRX_TEST_RUNAS` envar value is not unicode"),
+            VarError::NotUnicode(e) => {
+                panic!("`CARGO_PGRX_TEST_RUNAS` environment var value is not unicode")
+            }
         },
     }
 }


### PR DESCRIPTION
```shell
$ cargo pgrx test pg14 --runas testuser --pgdata=/tmp/pgrxtest
```

This adds two new arguments to `cargo pgrx test`: `--runas <username>` and `--pgdata </writable/path>`

Together, these will initdb, createdb, dropdb, and run postgres as the "runas" user.

Extension artifacts are copied with `cargo pgrx install --sudo`, which will also require the current user be able to become root.

In general, these options are designed for the unusual situation where one needs to be "root" in order to run extension tests, but, of course, Postgres is not allowed to be root.