### PR TITLE
Allow relocatable extensions

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -135,13 +135,6 @@ pub(crate) fn install_extension(
     let manifest = Manifest::from_path(&package_manifest_path)?;
     let (control_file, extname) = find_control_file(&package_manifest_path)?;
 
-    if get_property(&package_manifest_path, "relocatable")? != Some("false".into()) {
-        return Err(eyre!(
-            "{}:  The `relocatable` property MUST be `false`.  Please update your .control file.",
-            control_file.display()
-        ));
-    }
-
     let versioned_so = get_property(&package_manifest_path, "module_pathname")?.is_none();
 
     let build_command_output =

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -12,7 +12,7 @@ use crate::manifest::{get_package_manifest, pg_config_and_version};
 use crate::profile::CargoProfile;
 use crate::CommandExecute;
 use cargo_toml::Manifest;
-use eyre::{eyre, WrapErr};
+use eyre::WrapErr;
 use owo_colors::OwoColorize;
 use pgrx_pg_config::cargo::PgrxManifestExt;
 use pgrx_pg_config::{get_target_dir, PgConfig, Pgrx};
@@ -133,13 +133,6 @@ pub(crate) fn generate_schema(
 ) -> eyre::Result<()> {
     let manifest = Manifest::from_path(&package_manifest_path)?;
     let (control_file, _extname) = find_control_file(&package_manifest_path)?;
-
-    if get_property(&package_manifest_path, "relocatable")? != Some("false".into()) {
-        return Err(eyre!(
-            "{}:  The `relocatable` property MUST be `false`.  Please update your .control file.",
-            control_file.display()
-        ));
-    }
 
     let flags = std::env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
   - [Testing Extensions with PGRX](./extension/test.md)
     - [Memory Checking](./extension/test/memory-checking.md)
   - [Installing a PGRX Extension](./extension/install.md)
+  - [Schema Configuration](./extension/schema.md)
 - [Basics of Postgres Internals](./pg-internal.md)
   - [Pass-By-Datum](./pg-internal/datum.md)
   - [Memory Contexts](./pg-internal/memory-context.md)

--- a/docs/src/extension.md
+++ b/docs/src/extension.md
@@ -7,3 +7,4 @@
 - [Testing Extensions with PGRX](./extension/test.md)
 - [Memory Checking](./extension/test/memory-checking.md)
 - [Installing a PGRX Extension](./extension/install.md)
+- [Schema configuration](./extension/schema.md)

--- a/docs/src/extension/schema.md
+++ b/docs/src/extension/schema.md
@@ -1,0 +1,3 @@
+# Schema Configuration
+
+{{#include ./../../../pgrx-examples/schemas/README.md}}

--- a/pgrx-examples/datetime/datetime.control
+++ b/pgrx-examples/datetime/datetime.control
@@ -1,5 +1,5 @@
 comment = 'arrays:  Created by pgrx'
 default_version = '0.1.0'
 module_pathname = '$libdir/datetime'
-relocatable = false
+relocatable = true
 superuser = false

--- a/pgrx-examples/schemas/README.md
+++ b/pgrx-examples/schemas/README.md
@@ -54,6 +54,7 @@ In general this is only necessary when returning a `Vec<T: PostgresType>`.  In t
 function's `search_path`.
 
 ### Relocatable extensions
+
 Previously, PGRX would schema-qualify all of the output of `cargo pgrx schema` if there was a `schema = foo` attribute in your
 extension `.control` file, including items outside of a `#[pg_scema]` macro. However, this meant that pgrx could not support [relocatable extensions](https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-RELOCATION).
 This is because relocatable extensions' defining characteristic is that they can be moved from one schema to another, and that

--- a/pgrx-examples/schemas/README.md
+++ b/pgrx-examples/schemas/README.md
@@ -56,7 +56,7 @@ function's `search_path`.
 ### Relocatable extensions
 
 Previously, PGRX would schema-qualify all of the output of `cargo pgrx schema` if there was a `schema = foo` attribute in your
-extension `.control` file, including items outside of a `#[pg_scema]` macro. However, this meant that pgrx could not support [relocatable extensions](https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-RELOCATION).
+extension `.control` file, including items outside of a `#[pg_schema]` macro. However, this meant that pgrx could not support [relocatable extensions](https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-RELOCATION).
 This is because relocatable extensions' defining characteristic is that they can be moved from one schema to another, and that
 means you absolutely cannot statically determine the schema the extension lives in by reading the control file alone.
 Since this change was implemented, you can now set `relocatable = true` in your control file without issue, and relocatable

--- a/pgrx-examples/schemas/README.md
+++ b/pgrx-examples/schemas/README.md
@@ -7,7 +7,7 @@ it is the schema argument to `CREATE EXTENSION`.
 In general, any `pgrx` object (a function, operator, type, etc), regardless of the Rust source
 file it is defined in, is created in that schema unless that object appears in a 
 `#[pg_schema] mod modname { ... }` block.  In this case, `pgrx` generates a top-level schema named the
-same as the module, and creates the contained objects within that schema.    
+same as the module, and creates the contained objects within that schema.
 
 Unlike Rust, which supports nested modules, Postgres only supports one-level of schemas,
 although a Postgres session can have many schemas in its `search_path`.  As such, any
@@ -15,17 +15,10 @@ although a Postgres session can have many schemas in its `search_path`.  As such
 
 ### `#[pg_extern]/#[pg_operator]` Functions and their Postgres `search_path`
 
-When `pgrx` generates the DDL for a function (`CREATE FUNCTION ...`), it uses uses the schema
-it understands the function to belong in two different ways.
-
-First off, if there's a `schema = foo` attribute in your extension `.control` file, the
-function is created in that schema.  If there is no `schema = foo` attribute, then the
-function is *not* schema-qualified, which indicates it'll be created in the schema
-determined by the `CREATE EXTENSION` function.
-
-Secondly, `pgrx` can apply `search_path` to that function that limits that function's
-search_path to whatever you specify.  This is done via the `#[search_path(...)]` attribute macro
-applied to the function with `#[pg_extern]` or `#[pg_operator]` or `#[pg_test]`.
+When `pgrx` generates the DDL for a function (`CREATE FUNCTION ...`), it can apply `search_path` to
+that function that limits that function's search_path to whatever you specify.
+This is done via the `#[search_path(...)]` attribute macro applied to the function
+with `#[pg_extern]` or `#[pg_operator]` or `#[pg_test]`.
 
 For example:
  
@@ -60,3 +53,10 @@ In general this is only necessary when returning a `Vec<T: PostgresType>`.  In t
 `oid` (from the `pg_catalog.pg_type` system catalog) and as such, the schema in which that type lives must be on that 
 function's `search_path`.
 
+### Relocatable extensions
+Previously, PGRX would schema-qualify all of the output of `cargo pgrx schema` if there was a `schema = foo` attribute in your
+extension `.control` file, including items outside of a `#[pg_scema]` macro. However, this meant that pgrx could not support [relocatable extensions](https://www.postgresql.org/docs/current/extend-extensions.html#EXTEND-EXTENSIONS-RELOCATION).
+This is because relocatable extensions' defining characteristic is that they can be moved from one schema to another, and that
+means you absolutely cannot statically determine the schema the extension lives in by reading the control file alone.
+Since this change was implemented, you can now set `relocatable = true` in your control file without issue, and relocatable
+extensions can be moved with a `ALTER EXTENSION your_extension SET SCHEMA new_schema;` query.

--- a/pgrx-examples/schemas/README.md
+++ b/pgrx-examples/schemas/README.md
@@ -5,7 +5,7 @@ If unspecified, that schema is whatever the first schema in the user's `search_p
 it is the schema argument to `CREATE EXTENSION`.
 
 In general, any `pgrx` object (a function, operator, type, etc), regardless of the Rust source
-file it is defined in, is created in that schema unless that object appears in a 
+file it is defined in, is created in that schema unless that object appears in a
 `#[pg_schema] mod modname { ... }` block.  In this case, `pgrx` generates a top-level schema named the
 same as the module, and creates the contained objects within that schema.
 
@@ -21,7 +21,7 @@ This is done via the `#[search_path(...)]` attribute macro applied to the functi
 with `#[pg_extern]` or `#[pg_operator]` or `#[pg_test]`.
 
 For example:
- 
+
 ```rust
 #[derive(PostgresType, Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct SomeStruct {}
@@ -50,7 +50,7 @@ fn return_vec_of_customtype() -> Vec<SomeStruct> {
 ```
 
 In general this is only necessary when returning a `Vec<T: PostgresType>`.  In this situation, pgrx needs to know that type's
-`oid` (from the `pg_catalog.pg_type` system catalog) and as such, the schema in which that type lives must be on that 
+`oid` (from the `pg_catalog.pg_type` system catalog) and as such, the schema in which that type lives must be on that
 function's `search_path`.
 
 ### Relocatable extensions

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -390,9 +390,7 @@ impl PgrxSql {
             .neighbors_undirected(*item_index)
             .flat_map(|neighbor_index| match &self.graph[neighbor_index] {
                 SqlGraphEntity::Schema(s) => Some(String::from(s.name)),
-                SqlGraphEntity::ExtensionRoot(_control) => {
-                    None
-                }
+                SqlGraphEntity::ExtensionRoot(_control) => None,
                 _ => None,
             })
             .next()

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -390,12 +390,8 @@ impl PgrxSql {
             .neighbors_undirected(*item_index)
             .flat_map(|neighbor_index| match &self.graph[neighbor_index] {
                 SqlGraphEntity::Schema(s) => Some(String::from(s.name)),
-                SqlGraphEntity::ExtensionRoot(control) => {
-                    if !control.relocatable {
-                        control.schema.clone()
-                    } else {
-                        Some(String::from("@extname@"))
-                    }
+                SqlGraphEntity::ExtensionRoot(_control) => {
+                    None
                 }
                 _ => None,
             })


### PR DESCRIPTION
Previously, relocatable extensions were disallowed by a check in the code for the install command. This pull request removes the check, and, more importantly, changes the behavior in ``PgrxSql::schema_alias_of()`` so that it simply never schema-qualifies based on the control file. This prevents relocatable extensions from trying to schema-qualify with `@extname@`, which did not get substituted out by Postgres.

This resolves #1626