### PR TITLE
Ad hoc span fixups

### DIFF
--- a/pgrx-sql-entity-graph/src/pg_extern/argument.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/argument.rs
@@ -16,9 +16,9 @@ to the `pgrx` framework and very subject to change between versions. While you m
 
 */
 use crate::UsedType;
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{FnArg, Pat};
+use syn::{spanned::Spanned, FnArg, Pat};
 
 /// A parsed `#[pg_extern]` argument.
 ///
@@ -35,7 +35,7 @@ impl PgExternArgument {
         match &fn_arg {
             syn::FnArg::Typed(pat) => Self::build_from_pat_type(fn_arg.clone(), pat.clone()),
             syn::FnArg::Receiver(_) => {
-                Err(syn::Error::new(Span::call_site(), "Unable to parse FnArg that is Self"))
+                Err(syn::Error::new(fn_arg.span(), "Unable to parse FnArg that is Self"))
             }
         }
     }
@@ -48,9 +48,9 @@ impl PgExternArgument {
             Pat::Ident(ref p) => p.ident.clone(),
             Pat::Reference(ref p_ref) => match *p_ref.pat {
                 Pat::Ident(ref inner_ident) => inner_ident.ident.clone(),
-                _ => return Err(syn::Error::new(Span::call_site(), "Unable to parse FnArg")),
+                _ => return Err(syn::Error::new(value.span(), "Unable to parse FnArg")),
             },
-            _ => return Err(syn::Error::new(Span::call_site(), "Unable to parse FnArg")),
+            _ => return Err(syn::Error::new(value.span(), "Unable to parse FnArg")),
         };
 
         let used_ty = UsedType::new(*value.ty)?;

--- a/pgrx-sql-entity-graph/src/pg_extern/argument.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/argument.rs
@@ -35,6 +35,7 @@ impl PgExternArgument {
         match &fn_arg {
             syn::FnArg::Typed(pat) => Self::build_from_pat_type(fn_arg.clone(), pat.clone()),
             syn::FnArg::Receiver(_) => {
+                // FIXME: Add a UI test for this
                 Err(syn::Error::new(fn_arg.span(), "Unable to parse FnArg that is Self"))
             }
         }
@@ -48,8 +49,10 @@ impl PgExternArgument {
             Pat::Ident(ref p) => p.ident.clone(),
             Pat::Reference(ref p_ref) => match *p_ref.pat {
                 Pat::Ident(ref inner_ident) => inner_ident.ident.clone(),
+                // FIXME: add a UI test for this
                 _ => return Err(syn::Error::new(value.span(), "Unable to parse FnArg")),
             },
+            // FIXME: add a UI test for this
             _ => return Err(syn::Error::new(value.span(), "Unable to parse FnArg")),
         };
 

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -211,7 +211,7 @@ impl Parse for Attribute {
             }
             e => {
                 return Err(syn::Error::new(
-                    Span::call_site(),
+                    ident.span(),
                     format!("Invalid option `{e}` inside `{ident} {input}`"),
                 ))
             }

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -206,15 +206,16 @@ impl Parse for Attribute {
                         return Err(syn::Error::new(
                             other.span(),
                             "expected boolean, path, or string literal",
-                        ))
+                        ));
                     }
                 }
             }
             e => {
+                // FIXME: add a UI test for this
                 return Err(syn::Error::new(
                     ident.span(),
                     format!("Invalid option `{e}` inside `{ident} {input}`"),
-                ))
+                ));
             }
         };
         Ok(found)

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -202,6 +202,7 @@ impl Parse for Attribute {
                     ArgValue::Lit(Lit::Bool(b)) => Self::Sql(ToSqlConfig::from(b.value)),
                     ArgValue::Lit(Lit::Str(s)) => Self::Sql(ToSqlConfig::from(s)),
                     ArgValue::Lit(other) => {
+                        // FIXME: add a ui test for this
                         return Err(syn::Error::new(
                             other.span(),
                             "expected boolean, path, or string literal",

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -17,7 +17,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 */
 use crate::positioning_ref::PositioningRef;
 use crate::to_sql::ToSqlConfig;
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -274,7 +274,7 @@ impl PgExtern {
                 f.path()
                     .segments
                     .first()
-                    .map(|f| f.ident == Ident::new("search_path", Span::call_site()))
+                    .map(|f| f.ident == Ident::new("search_path", func.span()))
                     .unwrap_or_default()
             })
             .map(|attr| attr.parse_args::<SearchPathList>())

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -107,6 +107,7 @@ impl PgExtern {
 
         if let Some(ref mut content) = to_sql_config.content {
             let value = content.value();
+            // FIXME: find out if we should be using synthetic spans, issue #1667
             let span = content.span();
             let updated_value =
                 value.replace("@FUNCTION_NAME@", &(func.sig.ident.to_string() + "_wrapper")) + "\n";
@@ -274,6 +275,7 @@ impl PgExtern {
                 f.path()
                     .segments
                     .first()
+                    // FIXME: find out if we should be using synthetic spans, issue #1667
                     .map(|f| f.ident == Ident::new("search_path", func.span()))
                     .unwrap_or_default()
             })

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -107,9 +107,10 @@ impl PgExtern {
 
         if let Some(ref mut content) = to_sql_config.content {
             let value = content.value();
+            let span = content.span();
             let updated_value =
                 value.replace("@FUNCTION_NAME@", &(func.sig.ident.to_string() + "_wrapper")) + "\n";
-            *content = syn::LitStr::new(&updated_value, Span::call_site());
+            *content = syn::LitStr::new(&updated_value, span);
         }
 
         if !to_sql_config.overrides_default() {

--- a/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
@@ -51,7 +51,7 @@ impl Parse for PgTriggerAttribute {
                     // FIXME: add a UI test for this
                     input.span(),
                     format!("Invalid option `{e}` inside `{ident} {input}`"),
-                ))
+                ));
             }
         };
         Ok(found)

--- a/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
@@ -48,6 +48,7 @@ impl Parse for PgTriggerAttribute {
             }
             e => {
                 return Err(syn::Error::new(
+                    // FIXME: add a UI test for this
                     input.span(),
                     format!("Invalid option `{e}` inside `{ident} {input}`"),
                 ))

--- a/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/attribute.rs
@@ -16,7 +16,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 
 */
 use crate::ToSqlConfig;
-use proc_macro2::Span;
+
 use syn::parse::{Parse, ParseStream};
 use syn::Token;
 
@@ -48,7 +48,7 @@ impl Parse for PgTriggerAttribute {
             }
             e => {
                 return Err(syn::Error::new(
-                    Span::call_site(),
+                    input.span(),
                     format!("Invalid option `{e}` inside `{ident} {input}`"),
                 ))
             }

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -48,10 +48,11 @@ impl PgTrigger {
             .map(|PgTriggerAttribute::Sql(mut config)| {
                 if let Some(ref mut content) = config.content {
                     let value = content.value();
+                    let span = content.span();
                     let updated_value = value
                         .replace("@FUNCTION_NAME@", &(func.sig.ident.to_string() + "_wrapper"))
                         + "\n";
-                    *content = syn::LitStr::new(&updated_value, Span::call_site());
+                    *content = syn::LitStr::new(&updated_value, span);
                 };
                 config
             })

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -23,7 +23,7 @@ use crate::{CodeEnrichment, ToSqlConfig};
 use attribute::PgTriggerAttribute;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
-use syn::{ItemFn, Token};
+use syn::{spanned::Spanned, ItemFn, Token};
 
 #[derive(Debug, Clone)]
 pub struct PgTrigger {
@@ -38,7 +38,7 @@ impl PgTrigger {
     ) -> Result<CodeEnrichment<Self>, syn::Error> {
         if attributes.len() > 1 {
             return Err(syn::Error::new(
-                Span::call_site(),
+                func.span(),
                 "Multiple `sql` arguments found, it must be unique",
             ));
         };

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -37,6 +37,7 @@ impl PgTrigger {
         attributes: syn::punctuated::Punctuated<PgTriggerAttribute, Token![,]>,
     ) -> Result<CodeEnrichment<Self>, syn::Error> {
         if attributes.len() > 1 {
+            // FIXME: add a UI test for this
             return Err(syn::Error::new(
                 func.span(),
                 "Multiple `sql` arguments found, it must be unique",

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -48,6 +48,7 @@ impl PgTrigger {
             .map(|PgTriggerAttribute::Sql(mut config)| {
                 if let Some(ref mut content) = config.content {
                     let value = content.value();
+                    // FIXME: find out if we should be using synthetic spans, issue #1667
                     let span = content.span();
                     let updated_value = value
                         .replace("@FUNCTION_NAME@", &(func.sig.ident.to_string() + "_wrapper"))

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -21,7 +21,7 @@ pub mod entity;
 use crate::enrich::{ToEntityGraphTokens, ToRustCodeTokens};
 use crate::{CodeEnrichment, ToSqlConfig};
 use attribute::PgTriggerAttribute;
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{spanned::Spanned, ItemFn, Token};
 

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -17,7 +17,7 @@ to the `pgrx` framework and very subject to change between versions. While you m
 */
 use crate::composite_type::{handle_composite_type_macro, CompositeTypeMacro};
 use crate::lifetimes::anonymize_lifetimes;
-use proc_macro2::Span;
+
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
@@ -771,7 +771,7 @@ fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<Stri
                 Ok((true_ty, Some("-".to_owned() + value)))
             }
             _ => Err(syn::Error::new(
-                Span::call_site(),
+                mac.span(),
                 format!("Unrecognized UnaryExpr in `default!()` macro, got: {:?}", out.expr),
             )),
         },
@@ -782,7 +782,7 @@ fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<Stri
                 Ok((true_ty, Some(last_string)))
             } else {
                 Err(syn::Error::new(
-                    Span::call_site(),
+                    mac.span(),
                     format!(
                         "Unable to parse default value of `default!()` macro, got: {:?}",
                         out.expr
@@ -791,7 +791,7 @@ fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<Stri
             }
         }
         _ => Err(syn::Error::new(
-            Span::call_site(),
+            mac.span(),
             format!("Unable to parse default value of `default!()` macro, got: {:?}", out.expr),
         )),
     }

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -770,6 +770,7 @@ fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<Stri
                 let value = def.base10_digits();
                 Ok((true_ty, Some("-".to_owned() + value)))
             }
+            // FIXME: add a UI test for this
             _ => Err(syn::Error::new(
                 mac.span(),
                 format!("Unrecognized UnaryExpr in `default!()` macro, got: {:?}", out.expr),
@@ -781,6 +782,7 @@ fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<Stri
             if last_string == "NULL" {
                 Ok((true_ty, Some(last_string)))
             } else {
+                // FIXME: add a UI test for this
                 Err(syn::Error::new(
                     mac.span(),
                     format!(
@@ -790,6 +792,7 @@ fn handle_default_macro(mac: &syn::Macro) -> syn::Result<(syn::Type, Option<Stri
                 ))
             }
         }
+        // FIXME: add a UI test for this
         _ => Err(syn::Error::new(
             mac.span(),
             format!("Unable to parse default value of `default!()` macro, got: {:?}", out.expr),


### PR DESCRIPTION
A suite of random cases where we drop spans on the floor will no longer do so. As with the `format_ident!` change in 5c719e5 the same caveat of "perhaps we should synthesize spans?" applies. A relevant FIXME applies to each case so we can find them later, in the absence of a more-unique string.

The error-reporting changes get needs-test FIXMEs, as none of them diffed any UI tests and that lack is preexisting. I am confident of the improvement due to seeing the improvement from similar changes, and we really must recover basic debuggability for this code.