### PR TITLE
Factor out `finfo_tokens`

### DIFF
--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -1,11 +1,11 @@
 use quote::{format_ident, quote};
-use syn;
+use syn::{self, ItemFn};
 
 /// Generate the Postgres fn info record
 ///
 /// Equivalent to PG_FUNCTION_INFO_V1, Postgres will sprintf the fn ident, then `dlsym(so, expected_name)`,
 /// so it is important to pass exactly the ident that you want to have the record associated with!
-pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<syn::ItemFn> {
+pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
     let finfo_name = format_ident!("pg_finfo_{ident}");
     let tokens = quote! {
         #[no_mangle]

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -1,0 +1,19 @@
+use quote::{format_ident, quote};
+use syn;
+
+/// Generate the Postgres fn info record
+///
+/// Equivalent to PG_FUNCTION_INFO_V1, Postgres will call this fn for metadata
+/// so it has to match the relevant fn's name exactly.
+pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<syn::ItemFn> {
+    let finfo_name = format_ident!("pg_finfo_{ident}");
+    let tokens = quote! {
+        #[no_mangle]
+        #[doc(hidden)]
+        pub extern "C" fn #finfo_name() -> &'static ::pgrx::pg_sys::Pg_finfo_record {
+            const V1_API: ::pgrx::pg_sys::Pg_finfo_record = ::pgrx::pg_sys::Pg_finfo_record { api_version: 1 };
+            &V1_API
+        }
+    };
+    syn::parse2(tokens)
+}

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -3,8 +3,8 @@ use syn;
 
 /// Generate the Postgres fn info record
 ///
-/// Equivalent to PG_FUNCTION_INFO_V1, Postgres will call this fn for metadata
-/// so it has to match the relevant fn's name exactly.
+/// Equivalent to PG_FUNCTION_INFO_V1, Postgres will sprintf the fn ident, then `dlsym(so, expected_name)`,
+/// so it is important to pass exactly the ident that you want to have the record associated with!
 pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<syn::ItemFn> {
     let finfo_name = format_ident!("pg_finfo_{ident}");
     let tokens = quote! {

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -57,6 +57,7 @@ pub(crate) mod control_file;
 pub(crate) mod enrich;
 pub(crate) mod extension_sql;
 pub(crate) mod extern_args;
+pub(crate) mod finfo;
 #[macro_use]
 pub(crate) mod fmt;
 pub mod lifetimes;

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -19,6 +19,7 @@ pub mod attribute;
 pub mod entity;
 
 use crate::enrich::{ToEntityGraphTokens, ToRustCodeTokens};
+use crate::finfo::finfo_v1_tokens;
 use crate::{CodeEnrichment, ToSqlConfig};
 use attribute::PgTriggerAttribute;
 use proc_macro2::TokenStream as TokenStream2;
@@ -101,19 +102,6 @@ impl PgTrigger {
         };
         syn::parse2(tokens)
     }
-
-    pub fn finfo_tokens(&self) -> Result<ItemFn, syn::Error> {
-        let finfo_name = format_ident!("pg_finfo_{}_wrapper", self.func.sig.ident);
-        let tokens = quote! {
-            #[no_mangle]
-            #[doc(hidden)]
-            pub extern "C" fn #finfo_name() -> &'static ::pgrx::pg_sys::Pg_finfo_record {
-                const V1_API: ::pgrx::pg_sys::Pg_finfo_record = ::pgrx::pg_sys::Pg_finfo_record { api_version: 1 };
-                &V1_API
-            }
-        };
-        syn::parse2(tokens)
-    }
 }
 
 impl ToEntityGraphTokens for PgTrigger {
@@ -149,7 +137,7 @@ impl ToEntityGraphTokens for PgTrigger {
 impl ToRustCodeTokens for PgTrigger {
     fn to_rust_code_tokens(&self) -> TokenStream2 {
         let wrapper_func = self.wrapper_tokens().expect("Generating wrappper function for trigger");
-        let finfo_func = self.finfo_tokens().expect("Generating finfo function for trigger");
+        let finfo_func = finfo_v1_tokens(wrapper_func.sig.ident.clone()).unwrap();
         let func = &self.func;
 
         quote! {

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -136,7 +136,7 @@ impl ToEntityGraphTokens for PgTrigger {
 
 impl ToRustCodeTokens for PgTrigger {
     fn to_rust_code_tokens(&self) -> TokenStream2 {
-        let wrapper_func = self.wrapper_tokens().expect("Generating wrappper function for trigger");
+        let wrapper_func = self.wrapper_tokens().expect("Generating wrapper function for trigger");
         let finfo_func = finfo_v1_tokens(wrapper_func.sig.ident.clone()).unwrap();
         let func = &self.func;
 


### PR DESCRIPTION
An initial toehold on refactoring work to partially unify wrapper-fn expansions in their implementations, especially where it is correctness-relevant.