### PR TITLE
`cargo pgrx test --runas` envar passing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "shlex",
  "sysinfo",
  "thiserror 2.0.11",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ quote = "1.0.38"
 regex = "1.11" # used for build/test
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+shlex = "1.3" # shell lexing, also used by many of our deps
 syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 toml = "0.8" # our config files
 toml_edit = "0.22.24" # format-preserving edits to toml files, used with cargo-edit

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -61,6 +61,7 @@ owo-colors.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+shlex.workspace = true
 thiserror.workspace = true
 
 paste = "1"

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -561,8 +561,7 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
         // when running the `postmaster` process via `sudo`, we need to copy the cargo/rust-related
         // environment variables and pass as arguments to sudo, ahead of the `postmaster` command itself
         //
-        // This ensures that any in-processs #[pg_test]s that might otherwise expect some kind of
-        // `CARGO_xxx` envar to actually exist.
+        // This ensures that in-processs #[pg_test]s will see the `CARGO_xxx` envars they expect
         for (var, value) in std::env::vars() {
             if accept_envar(&var) {
                 let env_as_arg = format!("{var}={}", shlex::try_quote(&value)?);

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -561,7 +561,7 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
         // when running the `postmaster` process via `sudo`, we need to copy the cargo/rust-related
         // environment variables and pass as arguments to sudo, ahead of the `postmaster` command itself
         //
-        // This ensures that in-processs #[pg_test]s will see the `CARGO_xxx` envars they expect
+        // This ensures that in-process #[pg_test]s will see the `CARGO_xxx` envars they expect
         for (var, value) in std::env::vars() {
             if accept_envar(&var) {
                 let env_as_arg = format!("{var}={}", shlex::try_quote(&value)?);


### PR DESCRIPTION
This teaches the test `framework.rs` to pass through to `sudo` all the various cargo/rust environment variables.

Turns out this might be necessary for `#[pg_test]` tests that use `std::env::var(...)`.  When using `--runas` we spawn the postmaster with `sudo`, and its default policy is to reset the environment (`env_reset` flag in the sudoers file).