### PR TITLE
Do not default `to_entity_graph_tokens`

### DIFF
--- a/pgrx-sql-entity-graph/src/enrich.rs
+++ b/pgrx-sql-entity-graph/src/enrich.rs
@@ -21,9 +21,7 @@ pub trait ToRustCodeTokens {
 
 /// Generates the rust code to tie one of pgrx' supported SQL interfaces into pgrx' schema generator
 pub trait ToEntityGraphTokens {
-    fn to_entity_graph_tokens(&self) -> TokenStream2 {
-        quote! {}
-    }
+    fn to_entity_graph_tokens(&self) -> TokenStream2;
 }
 
 impl<T> ToTokens for CodeEnrichment<T>


### PR DESCRIPTION
Not providing an impl for this fn would result in nonsensical behavior, and fortunately nothing does.

There are defaults for the other part of the CodeEnrichment scheme (`ToRustTokens`) but I am not going to address them right now. The items in question do expand to Rust tokens, just not under the "purview" of pgrx-sql-entity-graph.