### PR TITLE
Factor out `extern_c_wrapper`

### DIFF
--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
 use syn::{self, spanned::Spanned, ItemFn};
 
@@ -19,7 +19,11 @@ pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
     syn::parse2(tokens)
 }
 
-pub fn finfo_v1_extern_c(original: &syn::ItemFn, contents: TokenStream) -> syn::Result<ItemFn> {
+pub fn finfo_v1_extern_c(
+    original: &syn::ItemFn,
+    fcinfo: Ident,
+    contents: TokenStream,
+) -> syn::Result<ItemFn> {
     let original_name = &original.sig.ident;
     let wrapper_symbol = format_ident!("{}_wrapper", original_name);
     let lifetimes = &original.sig.generics;
@@ -37,7 +41,7 @@ pub fn finfo_v1_extern_c(original: &syn::ItemFn, contents: TokenStream) -> syn::
         #[doc(hidden)]
         #unused_lifetimes
         #[::pgrx::pgrx_macros::pg_guard]
-        pub unsafe extern "C" fn #wrapper_symbol #lifetimes(_fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
+        pub unsafe extern "C" fn #wrapper_symbol #lifetimes(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
             #contents
         }
     };

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned};
 use syn::{self, spanned::Spanned, ItemFn};
 

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -1,5 +1,6 @@
-use quote::{format_ident, quote};
-use syn::{self, ItemFn};
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote, quote_spanned};
+use syn::{self, spanned::Spanned, ItemFn};
 
 /// Generate the Postgres fn info record
 ///
@@ -15,5 +16,31 @@ pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
             &V1_API
         }
     };
+    syn::parse2(tokens)
+}
+
+pub fn finfo_v1_extern_c(original: &syn::ItemFn, contents: TokenStream) -> syn::Result<ItemFn> {
+    let original_name = &original.sig.ident;
+    let wrapper_symbol = format_ident!("{}_wrapper", original_name);
+    let lifetimes = &original.sig.generics;
+    // the wrapper function declaration may contain lifetimes that are not used, since
+    // our input type is FunctionCallInfo and our return type is Datum
+    let unused_lifetimes = match lifetimes.lifetimes().next() {
+        Some(_) => quote! {
+            #[allow(unused_lifetimes, clippy::extra_unused_lifetimes)]
+        },
+        None => quote! {},
+    };
+
+    let tokens = quote_spanned! { original.sig.span() =>
+        #[no_mangle]
+        #[doc(hidden)]
+        #unused_lifetimes
+        #[::pgrx::pgrx_macros::pg_guard]
+        pub unsafe extern "C" fn #wrapper_symbol #lifetimes(_fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
+            #contents
+        }
+    };
+
     syn::parse2(tokens)
 }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -432,11 +432,6 @@ impl PgExtern {
             }
         };
 
-        // This is the generic wrapper fn that everything needs
-        let extern_c_wrapper = |_span, wrapped_contents: proc_macro2::TokenStream| {
-            finfo_v1_extern_c(&self.func, wrapped_contents)
-        };
-
         match &self.returns {
             Returning::None => {
                 let fn_contents = quote! {
@@ -445,7 +440,7 @@ impl PgExtern {
                     unsafe { #func_name(#(#arg_pats),*) };
                     ::pgrx::pg_sys::Datum::from(0)
                 };
-                extern_c_wrapper(self.func.sig.span(), fn_contents)
+                finfo_v1_extern_c(&self.func, fn_contents)
             }
             Returning::Type(retval_ty) => {
                 let result_ident = syn::Ident::new("result", self.func.sig.span());
@@ -500,7 +495,7 @@ impl PgExtern {
 
                     #retval_transform
                 };
-                extern_c_wrapper(self.func.sig.span(), fn_contents)
+                finfo_v1_extern_c(&self.func, fn_contents)
             }
             Returning::SetOf { ty: _retval_ty, optional, result } => {
                 let result_handler = emit_result_handler(self.func.sig.span(), *optional, *result);
@@ -516,7 +511,7 @@ impl PgExtern {
                         })
                     }
                 };
-                extern_c_wrapper(self.func.sig.span(), setof_closure)
+                finfo_v1_extern_c(&self.func, setof_closure)
             }
             Returning::Iterated { tys: retval_tys, optional, result } => {
                 let result_handler = emit_result_handler(self.func.sig.span(), *optional, *result);
@@ -556,7 +551,7 @@ impl PgExtern {
                         }
                     }
                 };
-                extern_c_wrapper(self.func.sig.span(), iter_closure)
+                finfo_v1_extern_c(&self.func, iter_closure)
             }
         }
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -438,6 +438,7 @@ impl PgExtern {
                     #(#arg_fetches)*
                     #[allow(unused_unsafe)]
                     unsafe { #func_name(#(#arg_pats),*) };
+                    // -> () means always returning the zero Datum
                     ::pgrx::pg_sys::Datum::from(0)
                 };
                 finfo_v1_extern_c(&self.func, fn_contents)

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -441,7 +441,7 @@ impl PgExtern {
                     // -> () means always returning the zero Datum
                     ::pgrx::pg_sys::Datum::from(0)
                 };
-                finfo_v1_extern_c(&self.func, fn_contents)
+                finfo_v1_extern_c(&self.func, fcinfo_ident, fn_contents)
             }
             Returning::Type(retval_ty) => {
                 let result_ident = syn::Ident::new("result", self.func.sig.span());
@@ -496,7 +496,7 @@ impl PgExtern {
 
                     #retval_transform
                 };
-                finfo_v1_extern_c(&self.func, fn_contents)
+                finfo_v1_extern_c(&self.func, fcinfo_ident, fn_contents)
             }
             Returning::SetOf { ty: _retval_ty, optional, result } => {
                 let result_handler = emit_result_handler(self.func.sig.span(), *optional, *result);
@@ -512,7 +512,7 @@ impl PgExtern {
                         })
                     }
                 };
-                finfo_v1_extern_c(&self.func, setof_closure)
+                finfo_v1_extern_c(&self.func, fcinfo_ident, setof_closure)
             }
             Returning::Iterated { tys: retval_tys, optional, result } => {
                 let result_handler = emit_result_handler(self.func.sig.span(), *optional, *result);
@@ -552,7 +552,7 @@ impl PgExtern {
                         }
                     }
                 };
-                finfo_v1_extern_c(&self.func, iter_closure)
+                finfo_v1_extern_c(&self.func, fcinfo_ident, iter_closure)
             }
         }
     }

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -19,7 +19,7 @@ pub mod attribute;
 pub mod entity;
 
 use crate::enrich::{ToEntityGraphTokens, ToRustCodeTokens};
-use crate::finfo::finfo_v1_tokens;
+use crate::finfo::{finfo_v1_extern_c, finfo_v1_tokens};
 use crate::{CodeEnrichment, ToSqlConfig};
 use attribute::PgTriggerAttribute;
 use proc_macro2::TokenStream as TokenStream2;
@@ -69,38 +69,33 @@ impl PgTrigger {
     }
 
     pub fn wrapper_tokens(&self) -> Result<ItemFn, syn::Error> {
-        let function_ident = &self.func.sig.ident;
-        let extern_func_ident = format_ident!("{}_wrapper", self.func.sig.ident);
+        let function_ident = self.func.sig.ident.clone();
         let tokens = quote! {
-            #[no_mangle]
-            #[::pgrx::pgrx_macros::pg_guard]
-            unsafe extern "C" fn #extern_func_ident(fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
-                let fcinfo_ref = unsafe {
-                    // SAFETY:  The caller should be Postgres in this case and it will give us a valid "fcinfo" pointer
-                    fcinfo.as_ref().expect("fcinfo was NULL from Postgres")
-                };
-                let maybe_pg_trigger = unsafe { ::pgrx::trigger_support::PgTrigger::from_fcinfo(fcinfo_ref) };
-                let pg_trigger = maybe_pg_trigger.expect("PgTrigger::from_fcinfo failed");
-                let trigger_fn_result: Result<
-                    Option<::pgrx::heap_tuple::PgHeapTuple<'_, _>>,
-                    _,
-                > = #function_ident(&pg_trigger);
+            let fcinfo_ref = unsafe {
+                // SAFETY:  The caller should be Postgres in this case and it will give us a valid "fcinfo" pointer
+                fcinfo.as_ref().expect("fcinfo was NULL from Postgres")
+            };
+            let maybe_pg_trigger = unsafe { ::pgrx::trigger_support::PgTrigger::from_fcinfo(fcinfo_ref) };
+            let pg_trigger = maybe_pg_trigger.expect("PgTrigger::from_fcinfo failed");
+            let trigger_fn_result: Result<
+                Option<::pgrx::heap_tuple::PgHeapTuple<'_, _>>,
+                _,
+            > = #function_ident(&pg_trigger);
 
 
-                // The trigger "protocol" allows a function to return the null pointer, but NOT to
-                // set the isnull result flag.  This is why we return `Datum::from(0)` in the None cases
-                let trigger_retval = trigger_fn_result.expect("Trigger function panic");
-                match trigger_retval {
+            // The trigger "protocol" allows a function to return the null pointer, but NOT to
+            // set the isnull result flag.  This is why we return `Datum::from(0)` in the None cases
+            let trigger_retval = trigger_fn_result.expect("Trigger function panic");
+            match trigger_retval {
+                None => unsafe { ::pgrx::pg_sys::Datum::from(0) },
+                Some(trigger_retval) => match trigger_retval.into_trigger_datum() {
                     None => unsafe { ::pgrx::pg_sys::Datum::from(0) },
-                    Some(trigger_retval) => match trigger_retval.into_trigger_datum() {
-                        None => unsafe { ::pgrx::pg_sys::Datum::from(0) },
-                        Some(datum) => datum,
-                    }
+                    Some(datum) => datum,
                 }
             }
-
         };
-        syn::parse2(tokens)
+
+        finfo_v1_extern_c(&self.func, tokens)
     }
 }
 

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -73,7 +73,7 @@ impl PgTrigger {
         let tokens = quote! {
             let fcinfo_ref = unsafe {
                 // SAFETY:  The caller should be Postgres in this case and it will give us a valid "fcinfo" pointer
-                fcinfo.as_ref().expect("fcinfo was NULL from Postgres")
+                _fcinfo.as_ref().expect("fcinfo was NULL from Postgres")
             };
             let maybe_pg_trigger = unsafe { ::pgrx::trigger_support::PgTrigger::from_fcinfo(fcinfo_ref) };
             let pg_trigger = maybe_pg_trigger.expect("PgTrigger::from_fcinfo failed");


### PR DESCRIPTION
This briefly existed as a little closure inside `pg_extern/mod.rs`, but this is also more logic shared between `pg_extern` and `pg_trigger`. Handle them uniformly.

In so doing, notice an ABI violation for `void` returns and fix it!