### PR TITLE
Believe in the typechecker in `mod pg_extern`

### DIFF
--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -547,7 +547,7 @@ impl PgExtern {
 }
 
 fn last_ident_is(ty: &syn::Type, id: &str) -> bool {
-    let syn::Type::Path(ty_path) = ty else { unimplemented!("queried a non-path!") };
+    let syn::Type::Path(ty_path) = ty else { return false };
     let syn::TypePath { path, .. } = ty_path;
     path.segments.last().is_some_and(|segment| segment.ident == id)
 }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -547,8 +547,7 @@ impl PgExtern {
 }
 
 fn last_ident_is(ty: &syn::Type, id: &str) -> bool {
-    let syn::Type::Path(ty_path) = ty else { return false };
-    let syn::TypePath { path, .. } = ty_path;
+    let syn::Type::Path(syn::TypePath { path, .. }) = ty else { return false };
     path.segments.last().is_some_and(|segment| segment.ident == id)
 }
 

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -388,7 +388,7 @@ impl PgExtern {
                 ty @ Type::Path(_) if last_ident_is(ty, "FunctionCallInfo") => quote_spanned! {pat.span()=>
                     let #pat = #fcinfo_ident;
                 },
-                Type::Tuple(tup) if /* () */ tup.elems.is_empty() => quote_spanned! {pat.span()=>
+                Type::Tuple(tup) if tup.elems.is_empty() => quote_spanned! { pat.span() =>
                     debug_assert!(unsafe { ::pgrx::fcinfo::pg_getarg::<()>(#fcinfo_ident, #idx).is_none() }, "A `()` argument should always receive `NULL`");
                     let #pat = ();
                 },

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -384,8 +384,7 @@ impl PgExtern {
             let pat = &arg_pats[idx];
             let resolved_ty = &arg.used_ty.resolved_ty;
             match resolved_ty {
-                // There's no danger of us misinterpreting FunctionCallInfo's spelling, as the pointer coercion must typecheck:
-                // C might allow casting *mut T to *mut U implicitly, but Rust does not.
+                // There's no danger of misinterpreting the type, as pointer coercions must typecheck!
                 ty @ Type::Path(_) if last_ident_is(ty, "FunctionCallInfo") => quote_spanned! {pat.span()=>
                     let #pat = #fcinfo_ident;
                 },

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -388,8 +388,7 @@ impl PgExtern {
                 ty @ Type::Path(_) if last_ident_is(ty, "FunctionCallInfo") => quote_spanned! {pat.span()=>
                     let #pat = #fcinfo_ident;
                 },
-                // Unit
-                Type::Tuple(tup) if tup.elems.len() == 0 => quote_spanned! {pat.span()=>
+                Type::Tuple(tup) if /* () */ tup.elems.is_empty() => quote_spanned! {pat.span()=>
                     debug_assert!(unsafe { ::pgrx::fcinfo::pg_getarg::<()>(#fcinfo_ident, #idx).is_none() }, "A `()` argument should always receive `NULL`");
                     let #pat = ();
                 },

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -24,30 +24,26 @@ mod returning;
 mod search_path;
 
 pub use argument::PgExternArgument;
+pub(crate) use attribute::Attribute;
 pub use cast::PgCast;
 pub use operator::PgOperator;
 pub use returning::NameMacro;
 
+use self::returning::Returning;
+use super::UsedType;
+use crate::enrich::{CodeEnrichment, ToEntityGraphTokens, ToRustCodeTokens};
 use crate::finfo::{finfo_v1_extern_c, finfo_v1_tokens};
 use crate::fmt::ErrHarder;
 use crate::ToSqlConfig;
-pub(crate) use attribute::Attribute;
 use operator::{PgrxOperatorAttributeWithIdent, PgrxOperatorOpName};
 use search_path::SearchPathList;
 
-use crate::enrich::CodeEnrichment;
-use crate::enrich::ToEntityGraphTokens;
-use crate::enrich::ToRustCodeTokens;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, quote_spanned};
 use syn::parse::{Parse, ParseStream, Parser};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{Meta, Token, Type};
-
-use self::returning::Returning;
-
-use super::UsedType;
 
 /// A parsed `#[pg_extern]` item.
 ///


### PR DESCRIPTION
Do some assorted cleanup because Rust is a language with an actual typechecker, fairly limited coercion sites, and minimal coercions at those sites.