### PR TITLE
Partially clean up `pg_extern/returning.rs`

### DIFF
--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -202,7 +202,7 @@ impl ToSql for PgExternEntity {
                     full_path = ty.full_path
                 )
             }
-            PgExternReturnEntity::SetOf { ty, optional: _, result: _ } => {
+            PgExternReturnEntity::SetOf { ty, .. } => {
                 let graph_index = context
                     .graph
                     .neighbors_undirected(self_index)
@@ -226,7 +226,7 @@ impl ToSql for PgExternEntity {
                     full_path = ty.full_path
                 )
             }
-            PgExternReturnEntity::Iterated { tys: table_items, optional: _, result: _ } => {
+            PgExternReturnEntity::Iterated { tys: table_items, .. } => {
                 let mut items = String::new();
                 let metadata_retval = self.metadata.retval.clone();
                 let metadata_retval_sqls: Vec<String> = match metadata_retval.return_sql {

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/returning.rs
@@ -25,13 +25,13 @@ pub enum PgExternReturnEntity {
     },
     SetOf {
         ty: UsedTypeEntity,
-        optional: bool, /* Eg `Option<SetOfIterator<T>>` */
-        result: bool,   /* Eg `Result<SetOfIterator<T>, E>` */
+        is_option: bool, /* Eg `Option<SetOfIterator<T>>` */
+        is_result: bool, /* Eg `Result<SetOfIterator<T>, E>` */
     },
     Iterated {
         tys: Vec<PgExternReturnEntityIteratedItem>,
-        optional: bool, /* Eg `Option<TableIterator<T>>` */
-        result: bool,   /* Eg `Result<TableIterator<T>, E>` */
+        is_option: bool, /* Eg `Option<TableIterator<T>>` */
+        is_result: bool, /* Eg `Result<TableIterator<T>, E>` */
     },
     Trigger,
 }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -484,8 +484,9 @@ impl PgExtern {
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, fn_contents)
             }
-            Returning::SetOf { ty: _retval_ty, optional, result } => {
-                let result_handler = emit_result_handler(self.func.sig.span(), *optional, *result);
+            Returning::SetOf { ty: _retval_ty, is_option, is_result } => {
+                let result_handler =
+                    emit_result_handler(self.func.sig.span(), *is_option, *is_result);
                 let setof_closure = quote! {
                     #[allow(unused_unsafe)]
                     unsafe {
@@ -500,8 +501,9 @@ impl PgExtern {
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, setof_closure)
             }
-            Returning::Iterated { tys: retval_tys, optional, result } => {
-                let result_handler = emit_result_handler(self.func.sig.span(), *optional, *result);
+            Returning::Iterated { tys: retval_tys, is_option, is_result } => {
+                let result_handler =
+                    emit_result_handler(self.func.sig.span(), *is_option, *is_result);
 
                 let iter_closure = if retval_tys.len() == 1 {
                     // Postgres considers functions returning a 1-field table (`RETURNS TABLE (T)`) to be

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -545,31 +545,31 @@ impl PgExtern {
 }
 
 trait LastIdent {
-    fn last_ident_is(&self, id: &str) -> bool;
+    fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment>;
+    fn last_ident_is(&self, id: &str) -> bool {
+        self.filter_last_ident(id).is_some()
+    }
 }
 
 impl LastIdent for syn::Type {
-    fn last_ident_is(&self, id: &str) -> bool {
-        let syn::Type::Path(syn::TypePath { path, .. }) = self else { return false };
-        path.last_ident_is(id)
+    fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
+        let syn::Type::Path(syn::TypePath { path, .. }) = self else { return None };
+        path.filter_last_ident(id)
     }
 }
-
 impl LastIdent for syn::TypePath {
-    fn last_ident_is(&self, id: &str) -> bool {
-        let syn::TypePath { path, .. } = self;
-        path.last_ident_is(id)
+    fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
+        self.path.filter_last_ident(id)
     }
 }
 impl LastIdent for syn::Path {
-    fn last_ident_is(&self, id: &str) -> bool {
-        self.segments.last_ident_is(id)
+    fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
+        self.segments.filter_last_ident(id)
     }
 }
-
 impl<P> LastIdent for Punctuated<syn::PathSegment, P> {
-    fn last_ident_is(&self, id: &str) -> bool {
-        self.last().is_some_and(|segment| segment.ident == id)
+    fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
+        self.last().filter(|segment| segment.ident == id)
     }
 }
 

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -548,28 +548,33 @@ impl PgExtern {
 
 trait LastIdent {
     fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment>;
+    #[inline]
     fn last_ident_is(&self, id: &str) -> bool {
         self.filter_last_ident(id).is_some()
     }
 }
 
 impl LastIdent for syn::Type {
+    #[inline]
     fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
         let syn::Type::Path(syn::TypePath { path, .. }) = self else { return None };
         path.filter_last_ident(id)
     }
 }
 impl LastIdent for syn::TypePath {
+    #[inline]
     fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
         self.path.filter_last_ident(id)
     }
 }
 impl LastIdent for syn::Path {
+    #[inline]
     fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
         self.segments.filter_last_ident(id)
     }
 }
 impl<P> LastIdent for Punctuated<syn::PathSegment, P> {
+    #[inline]
     fn filter_last_ident(&self, id: &str) -> Option<&syn::PathSegment> {
         self.last().filter(|segment| segment.ident == id)
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/returning.rs
@@ -123,13 +123,15 @@ impl Returning {
                             continue 'outer;
                         } else if segments.last_ident_is("SetOfIterator") {
                             is_setof_iter = true;
+                            break;
                         } else if let Some(segment) = segments.filter_last_ident("TableIterator") {
                             if found_option {
-                                segments = Punctuated::from_iter(Some(segment.clone()));
+                                segments = Punctuated::from_iter(std::iter::once(segment.clone()));
                                 found_option = false;
                                 continue 'outer;
                             }
                             is_table_iter = true;
+                            break;
                         } else {
                             break;
                         }

--- a/pgrx-sql-entity-graph/src/pg_extern/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/returning.rs
@@ -130,20 +130,12 @@ impl Returning {
 
                     if is_setof_iter {
                         let last_path_segment = option_inner_path.segments.last();
-                        let (used_ty, optional) = match &last_path_segment.map(|ps| &ps.arguments) {
+                        let used_ty = match &last_path_segment.map(|ps| &ps.arguments) {
                             Some(syn::PathArguments::AngleBracketed(args)) => {
                                 match args.args.last().expect("should have one arg?") {
                                     syn::GenericArgument::Type(ty) => {
-                                        match &ty {
-                                            syn::Type::Path(path) => {
-                                                (UsedType::new(syn::Type::Path(path.clone()))?, is_option)
-                                            }
-                                            syn::Type::Macro(type_macro) => {
-                                                (UsedType::new(syn::Type::Macro(type_macro.clone()), )?, is_option)
-                                            },
-                                            reference @ syn::Type::Reference(_) => {
-                                                (UsedType::new((*reference).clone(), )?, is_option)
-                                            },
+                                        match ty {
+                                            Type::Path(_) | Type::Macro(_) | Type::Reference(_) => UsedType::new(ty.clone())?,
                                             ty => return Err(syn::Error::new(
                                                 ty.span(),
                                                 "SetOf Iterator must have an item",
@@ -171,7 +163,7 @@ impl Returning {
                                 ))
                             }
                         };
-                        Ok(Returning::SetOf { ty: used_ty, optional, result: is_result })
+                        Ok(Returning::SetOf { ty: used_ty, optional: is_option, result: is_result })
                     } else if is_table_iter {
                         let last_path_segment = segments.last_mut().unwrap();
                         let mut iterated_items = vec![];

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -758,7 +758,7 @@ fn initialize_externs(
                     });
                 }
             }
-            PgExternReturnEntity::Iterated { tys: iterated_returns, optional: _, result: _ } => {
+            PgExternReturnEntity::Iterated { tys: iterated_returns, .. } => {
                 for PgExternReturnEntityIteratedItem { ty, .. } in iterated_returns {
                     let found = mapped_types.keys().any(|ty_item| ty_item.id_matches(&ty.ty_id))
                         || mapped_enums.keys().any(|ty_item| ty_item.id_matches(&ty.ty_id));
@@ -929,7 +929,7 @@ fn connect_externs(
                     }
                 }
             }
-            PgExternReturnEntity::Iterated { tys: iterated_returns, optional: _, result: _ } => {
+            PgExternReturnEntity::Iterated { tys: iterated_returns, .. } => {
                 for PgExternReturnEntityIteratedItem { ty: type_entity, .. } in iterated_returns {
                     let found_ty =
                         types.iter().find(|(ty_item, _)| ty_item.id_matches(&type_entity.ty_id));


### PR DESCRIPTION
There's the entire `is_table_iter` branch that I haven't touched yet that needs much more powerful weapons than this PR has readily-available. But also I think I have seen enough: this scheme's inner workings have begun to suggest a way to replace it entirely.