### PR TITLE
feat: reintroduce nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cmake*/
 .direnv
 pgrx-examples/*/target
 /bin
+result

--- a/ci/nix-update-rust-toolchain.sh
+++ b/ci/nix-update-rust-toolchain.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+echo "---- update nix rust dependency ----"
+nix flake update fenix --commit-lock-file

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,144 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713979152,
+        "narHash": "sha256-apdecPuh8SOQnkEET/kW/UcfjCRb8JbV5BKjoH+DcP4=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "a5eca68a2cf11adb32787fc141cddd29ac8eb79c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1714199028,
+        "narHash": "sha256-QO3Yv3UfJRfhZE1wsHOartg+k8/Kf1BiDyfl8eEpqcE=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "055f6db376eaf544d84aa55bd5a7c70634af41ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1714076141,
+        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714150666,
+        "narHash": "sha256-S8AsTyJvT6Q3pRFeo8QepWF/husnJh61cOhRt18Xmyc=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "1ed7e2de05ee76f6ae83cc9c72eb0b33ad6903f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
         pkgs,
         inputs',
         system,
+        self',
         ...
       }: let
         rustToolchain = inputs'.fenix.packages.stable.toolchain;
@@ -44,8 +45,26 @@
             cargoTestExtraArgs = "-- --skip=command::schema::tests::test_parse_managed_postmasters";
           };
         };
+        devShells.default = with pkgs; mkShell {
+          inputsFrom = [
+            self'.packages.cargo-pgrx
+          ];
+          nativeBuildInputs = with pkgs; [
+            rustToolchain
+            pkg-config
+          ];
+          buildInputs = with pkgs; [
+            openssl
+          ] ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.Security
+            libiconv
+          ];
+          
+          shellHook = ''
+            export PGRX_HOME=$(mktemp -d)
+          '';
+        };
       };
-
       flake.lib.buildPgrxExtension = {
         rustToolchain,
         system,

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
             inherit (craneLib.crateNameFromCargoToml {cargoToml = ./cargo-pgrx/Cargo.toml;}) pname version;
             cargoExtraArgs = "--package cargo-pgrx";
             nativeBuildInputs = [pkgs.pkg-config];
-            buildInputs = [pkgs.openssl] ++ lib.optionals pkgs.stdenv.isDarwin [pkgs.Security];
+            buildInputs = [pkgs.openssl] ++ lib.optionals pkgs.stdenv.isDarwin [pkgs.darwin.apple_sdk.frameworks.Security pkgs.libiconv];
             # fixes to enable running pgrx tests
             preCheck = ''
               export PGRX_HOME=$(mktemp -d)

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  inputs = {
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    gitignore = {
+      url = "github:hercules-ci/gitignore";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
+      perSystem = {
+        lib,
+        pkgs,
+        inputs',
+        system,
+        ...
+      }: let
+        rustToolchain = inputs'.fenix.packages.stable.toolchain;
+        craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
+      in {
+        packages = {
+          cargo-pgrx = craneLib.buildPackage {
+            src = inputs.gitignore.lib.gitignoreSource ./.;
+            inherit (craneLib.crateNameFromCargoToml {cargoToml = ./cargo-pgrx/Cargo.toml;}) pname version;
+            cargoExtraArgs = "--package cargo-pgrx";
+            nativeBuildInputs = [pkgs.pkg-config];
+            buildInputs = [pkgs.openssl] ++ lib.optionals pkgs.stdenv.isDarwin [pkgs.Security];
+            # fixes to enable running pgrx tests
+            preCheck = ''
+              export PGRX_HOME=$(mktemp -d)
+            '';
+            # skip tests that require pgrx to be initialized using `cargo pgrx init`
+            cargoTestExtraArgs = "-- --skip=command::schema::tests::test_parse_managed_postmasters";
+          };
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -45,5 +45,84 @@
           };
         };
       };
+
+      flake.lib.buildPgrxExtension = {
+        rustToolchain,
+        system,
+        src,
+        postgresql,
+        additionalFeatures ? [],
+      }: let
+        cargo-pgrx = inputs.self.packages.${system}.cargo-pgrx;
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+        craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
+
+        postgresMajor = inputs.nixpkgs.lib.versions.major postgresql.version;
+        cargoToml = builtins.fromTOML (builtins.readFile "${src}/Cargo.toml");
+        name = cargoToml.package.name;
+        pgrxFeatures = builtins.toString additionalFeatures;
+
+        preBuildAndTest = ''
+          export PGRX_HOME=$(mktemp -d)
+          mkdir -p $PGRX_HOME/${postgresMajor}
+
+          cp -r -L ${postgresql}/. $PGRX_HOME/${postgresMajor}/
+          chmod -R ugo+w $PGRX_HOME/${postgresMajor}
+          cp -r -L ${postgresql.lib}/lib/. $PGRX_HOME/${postgresMajor}/lib/
+
+          ${cargo-pgrx}/bin/cargo-pgrx pgrx init \
+            --pg${postgresMajor} $PGRX_HOME/${postgresMajor}/bin/pg_config \
+        '';
+
+        craneCommonBuildArgs = {
+          inherit src;
+          pname = "${name}-pg${postgresMajor}";
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.rustPlatform.bindgenHook
+            postgresql.lib
+            postgresql
+          ];
+          cargoExtraArgs = "--no-default-features --features \"pg${postgresMajor} ${pgrxFeatures}\"";
+          postPatch = "patchShebangs .";
+          preBuild = preBuildAndTest;
+          preCheck = preBuildAndTest;
+          postBuild = ''
+            if [ -f "${name}.control" ]; then
+              export NIX_PGLIBDIR=${postgresql.out}/share/postgresql/extension/
+              ${cargo-pgrx}/bin/cargo-pgrx pgrx package --pg-config ${postgresql}/bin/pg_config --features "${pgrxFeatures}" --out-dir $out
+              export NIX_PGLIBDIR=$PGRX_HOME/${postgresMajor}/lib
+            fi
+          '';
+
+          PGRX_PG_SYS_SKIP_BINDING_REWRITE = "1";
+          CARGO = "${rustToolchain}/bin/cargo";
+          CARGO_BUILD_INCREMENTAL = "false";
+          RUST_BACKTRACE = "full";
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly craneCommonBuildArgs;
+      in
+        craneLib.mkCargoDerivation ({
+            inherit cargoArtifacts;
+            buildPhaseCargoCommand = ''
+              ${cargo-pgrx}/bin/cargo-pgrx pgrx package --pg-config ${postgresql}/bin/pg_config --features "${pgrxFeatures}" --out-dir $out
+            '';
+            doCheck = false;
+            preFixup = ''
+              if [ -f "${name}.control" ]; then
+                ${cargo-pgrx}/bin/cargo-pgrx pgrx stop all
+                rm -rfv $out/target*
+              fi
+            '';
+
+            postInstall = ''
+              mkdir -p $out/lib
+              cp target/release/lib${name}.so $out/lib/${name}.so
+              mv -v $out/${postgresql.out}/* $out
+              rm -rfv $out/nix
+            '';
+          }
+          // craneCommonBuildArgs);
     };
 }


### PR DESCRIPTION
# overview

This reintroduces the nix code after it was removed in #1682. It has been refactored to live in a single file and many parts of it have been removed because they weren't necessary. I will attempt to provide an overview of everything that is taking place in this configuration and why I've chosen to write things the way I have. Additionally, my commit messages have context if you expand them.


The previous flake did the following things:
- built the `cargo-pgrx` binary
- exposed a function that can be called by consuming flakes to build their extension
- had checks that validated formatting for rust and nix code in the pgrx repository
- provided a template to get started building an extension with nix
- provides a devShell for developers who wish to work on pgrx to obtain their dependencies

I've chosen to focus on the first two options in the above list. There is no need to verify formatting using nix since this is done through GitHub Actions. I could feasibly make an example, but I'll only do that once I'm sure that this PR can be accepted (and if it is requested). For now, as part of my testing, I've taken the arrays example from the `pgrx-examples` directory and made a separate repo showcasing how to use this new flake https://github.com/justinrubek/pgrx-nix-example

## flake inputs

Here is what each input does and why we're using them:

- [crane](https://github.com/ipetkov/crane)
  - This is a wrapper around cargo that has some nice cache benefits for nix as well as simplifies the build
  - It is used to build the `cargo-pgrx` and also to call pgrx when building an extension
  - While nixpkgs has some rust tooling built in, I would suggest keeping this. It's a very mature library and the team behind it is very responsive when you need help
- [nixpkgs](https://github.com/NixOS/nixpkgs)
  - This is the base of all packaging with nix, we need it to do nearly anything
- [fenix](https://github.com/nix-community/fenix)
  - This is the rustup equivalent for nix. Having it as an input allows consuming flakes to override the rust toolchain used with whatever they need
- [flake-parts](https://github.com/hercules-ci/flake-parts)
  - This one is technically optional, but it well designed and provides a nice way to iterate over the many supported systems
  - See the `perSystem` function in `flake.nix`
- [gitignore](https://github.com/hercules-ci/gitignore.nix#comparison)
  - It's use is important to avoid the `.git` directory from being copied into builds
  - I would prefer to use [nix-filter](https://github.com/numtide/nix-filter) here, but it would require editing the list of directories/files to include in the build if more are added, so using this is a good compromise for maintenance


For the most part we should be fine to leave these dependencies locked to their current version in `flake.lock`. However, it isn't a bad idea to try to keep them up to date. I've provided a shell script that will update the `fenix` input to retrieve newer rust toolchains, although I could see that it may better suit the project to have the script update every input so I will change it if asked.


## flake outputs

This flake exposes two outputs: `packages.${system}.cargo-pgrx` and `lib.buildPgrxExtension`

### cargo-pgrx

This is the pgrx binary, built using the source code from this repo. It's build is a pretty standard cargo build, but there are a few extra things happening.

As part of the build step the tests are ran. However, pgrx's tests appear to have two requirements that won't be met by default:
1. The `PGRX_HOME` environment variable must be set
2. For `test_parse_managed_postmasters`, `cargo pgrx init` must have been ran

For 1. the solution is easy: the `preCheck` block is ran which sets the file to a temporary directory. However, 2. is not as simple because we don't have the pgrx binary available yet due to this being the build step for it. The compromise is to skip any tests that require this to be ran. The rest of the tests are still ran, so we can be fairly sure the nix build isn't broken. And since the pgrx test suite is not being ran through nix any issues with this test will be detected anyway.

This should require minimal maintenance as building a cargo package is fairly trivial. The only exceptions are:
1. If any of the above requirements change; either new tests are added that require an init, other environment variables, or similar
2. If any of the build/runtime dependencies are changed. This will require changing the `buildInputs` to contain the package corresponding to the new dependency. For a list of packages, see https://search.nixos.org/packages?channel=unstable


### buildPgrxExtension

This is the more complicated piece, but it is also the larger value-add for nix users. I've taken most of the logic from the previous configuration, distilling it down by removing extra code and simplifying the rest. I believe I've gotten it nearly as simple as it can be, but there may be some further room for improvement.

The function is responsible for setting up postgres in a way that stops `pgrx` from attempting to download it. This is because flake builds are executed in a sandbox without network access. Consuming flakes must provide the postgres package they wish to use in order for this to work. The function will determine the major version to set up the proper feature flags as well as put postgres in a subdirectory of `PGRX_HOME` according to its version (this is the `preBuildAndTest` block).

Apart from that, there is some file cleanup that takes place in the `preFixup` and `postInstall` steps, primarily to ensure that only the minimum things required end up in the final build (if I understanding right, the `--out-dir` flag from `pgrx` is placing things there that are not desired in the final build, so I chose to delete them).


# Testing performed

I have tested this all using `x86_64-linux`. I am unable to test `aarch64-linux`, although I may be able to try `aarch64-darwin`. I suspect that it will work on `aarch64-linux` anyway.

I've verified that I can build extensions and load them into postgres. See https://github.com/justinrubek/pgrx-nix-example/pull/1#issue-2267788423. I've also back-ported this change to pgrx v0.11 and tested using [pgx_ulid](https://github.com/pksunkara/pgx_ulid).


# further work

 I don't have a wide variety of extensions to test against. I can imagine the need for some tweaks depending on any issues encountered by people using this flake, but I'm not sure what those would be at this time. I am willing and able to look into this should any come up, so please route these to me so I can help.

Beyond that, I have a few small changes that may be good:
- add a nix formatter to GitHub Actions
- add the devShell again
- restore some of the previous options to `buildPgrxExtensions`
  - For example, debug/release build support, which I've not chosen to keep

# why this is important for nix users

There is a `cargo-pgrx` binary and `buildPgrxExtension` function in nixpkgs, but that is not sufficient due to the `pgrx` binary version needing to match the cargo dependency. If a consumer wishes to use a newer version of pgrx, they will have to wait for it to make it into nixpkgs. On the other side of things, if they wish to remain on an older version of pgrx they may have to pin an old nixpkgs. By keeping the flake in this repo consumers are able to easily use the latest version of pgrx without any difficulty. Here's an example of the supabase folks dealing with a glibc issue where they pray updating `cargo-pgrx` will resolve the issue https://github.com/supabase/nix-postgres/pull/28#issuecomment-1734529655, which is precisely the kind of thing I'd like to avoid.
