### PR TITLE
Memory management for Datum to String conversion

### DIFF
--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -412,22 +412,20 @@ impl FromDatum for String {
         is_null: bool,
         typoid: pg_sys::Oid,
     ) -> Option<String> {
-        if varlena::varatt_is_1b_e(datum.cast_mut_ptr::<pg_sys::varlena>())
-            || varlena::varatt_is_4b_c(datum.cast_mut_ptr::<pg_sys::varlena>())
+        let varlena = pg_sys::pg_detoast_datum_packed(datum.cast_mut_ptr());
+        let converted_varlena = convert_varlena_to_str_memoized(varlena);
+        let ret_string = converted_varlena.to_owned();
+
+        // If the datum is EXTERNAL or COMPRESSED, then detoasting creates a pfree-able chunk
+        // that needs to be freed. We can free it because `to_owned` above creates a Rust copy
+        // of the string.
+        if varlena::varatt_is_1b_e(datum.cast_mut_ptr())
+            || varlena::varatt_is_4b_c(datum.cast_mut_ptr())
         {
-            let varlena = pg_sys::pg_detoast_datum_packed(datum.cast_mut_ptr());
-            let converted_varlena = convert_varlena_to_str_memoized(varlena);
-            let ret_string = converted_varlena.to_owned();
-
-            // If the datum is EXTERNAL or COMPRESSED, then detoasting creates a pfree-able chunk
-            // that needs to be freed. We can free it because `to_owned` above creates a Rust copy
-            // of the string.
             pg_sys::pfree(varlena.cast());
-
-            Some(ret_string)
-        } else {
-            FromDatum::from_polymorphic_datum(datum, is_null, typoid).map(|s: &str| s.to_owned())
         }
+
+        Some(ret_string)
     }
 }
 

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -424,7 +424,7 @@ impl FromDatum for String {
             // of the string.
             pg_sys::pfree(varlena.cast());
 
-            ret_string
+            Some(ret_string)
         } else {
             FromDatum::from_polymorphic_datum(datum, is_null, typoid).map(|s: &str| s.to_owned())
         }

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -412,7 +412,21 @@ impl FromDatum for String {
         is_null: bool,
         typoid: pg_sys::Oid,
     ) -> Option<String> {
-        FromDatum::from_polymorphic_datum(datum, is_null, typoid).map(|s: &str| s.to_owned())
+        if varlena::varatt_is_1b_e(datum.cast_mut_ptr::<pg_sys::varlena>())
+            || varlena::varatt_is_4b_c(datum.cast_mut_ptr::<pg_sys::varlena>()) {
+            let varlena = pg_sys::pg_detoast_datum_packed(datum.cast_mut_ptr());
+            let converted_varlena = convert_varlena_to_str_memoized(varlena);
+            let ret_string = converted_varlena.to_owned();
+
+            // If the datum is EXTERNAL or COMPRESSED, then detoasting creates a pfree-able chunk
+            // that needs to be freed. We can free it because `to_owned` above creates a Rust copy
+            // of the string.
+            pg_sys::pfree(varlena.cast());
+
+            ret_string
+        } else {
+            FromDatum::from_polymorphic_datum(datum, is_null, typoid).map(|s: &str| s.to_owned())
+        }
     }
 }
 

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -413,7 +413,8 @@ impl FromDatum for String {
         typoid: pg_sys::Oid,
     ) -> Option<String> {
         if varlena::varatt_is_1b_e(datum.cast_mut_ptr::<pg_sys::varlena>())
-            || varlena::varatt_is_4b_c(datum.cast_mut_ptr::<pg_sys::varlena>()) {
+            || varlena::varatt_is_4b_c(datum.cast_mut_ptr::<pg_sys::varlena>())
+        {
             let varlena = pg_sys::pg_detoast_datum_packed(datum.cast_mut_ptr());
             let converted_varlena = convert_varlena_to_str_memoized(varlena);
             let ret_string = converted_varlena.to_owned();

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -169,7 +169,7 @@ pub unsafe fn varatt_is_4b_u(ptr: *const pg_sys::varlena) -> bool {
 /// ((((varattrib_1b *) (PTR))->va_header & 0x03) == 0x02)
 /// ```
 #[inline]
-pub unsafe fn varatt_is_b8_c(ptr: *const pg_sys::varlena) -> bool {
+pub unsafe fn varatt_is_4b_c(ptr: *const pg_sys::varlena) -> bool {
     let va1b = ptr as *const pg_sys::varattrib_1b;
     (*va1b).va_header & 0x03 == 0x02
 }


### PR DESCRIPTION
Since `FromDatum` for `String` creates a Rust-allocated copy of the string data, it makes sense to free the palloc'ed varlena created when detoasting the Datum for string conversion. 

This PR also includes a function rename to match the function name in Postgres.