### PR TITLE
Pass i64 and f64 by reference on 32-bit systems

### DIFF
--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -291,7 +291,13 @@ impl FromDatum for i64 {
         if is_null {
             None
         } else {
-            Some(datum.value() as _)
+            if std::mem::size_of::<usize>() >= 8 {
+              Some(datum.value() as _)
+            } else {
+              unsafe {
+                Some(*datum.cast_mut_ptr::<i64>())
+              }
+            }
         }
     }
 }
@@ -323,7 +329,14 @@ impl FromDatum for f64 {
         if is_null {
             None
         } else {
-            Some(f64::from_bits(datum.value() as _))
+            let value: u64 = if std::mem::size_of::<usize>() >= 8 {
+              datum.value() as _
+            } else {
+              unsafe {
+                *datum.cast_mut_ptr::<u64>()
+              }
+            };
+            Some(f64::from_bits(value))
         }
     }
 }


### PR DESCRIPTION
Fixes #1685.

This determines whether to pass by value or by reference based on the size of `usize`, this should replicate the behavior of the `USE_FLOAT8_BYVAL` macro defined in [pg_config_manual.h](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/pg_config_manual.h;h=f941ee2faf86b84a9d76b74269bec88d421fcbb7;hb=HEAD#l76).