### PR TITLE
Do everything more eagerly in `srf_next`

### DIFF
--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -49,8 +49,7 @@ impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
 
         // SAFETY: we created `funcctx.user_fctx` on the first call into this function so
         // we know it's valid
-        let setof_iterator =
-            (*funcctx).user_fctx.cast::<SetOfIterator<T>>().as_mut().unwrap_unchecked();
+        let setof_iterator = &mut *(*funcctx).user_fctx.cast::<SetOfIterator<T>>();
 
         match setof_iterator.next() {
             Some(datum) => {
@@ -117,8 +116,7 @@ impl<'a, T: IntoHeapTuple> TableIterator<'a, T> {
 
         // SAFETY: we created `funcctx.user_fctx` on the first call into this function so
         // we know it's valid
-        let table_iterator =
-            (*funcctx).user_fctx.cast::<TableIterator<T>>().as_mut().unwrap_unchecked();
+        let table_iterator = &mut *(*funcctx).user_fctx.cast::<TableIterator<T>>();
 
         match table_iterator.next() {
             Some(tuple) => {

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -35,7 +35,7 @@ impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
                     return pg_return_null(fcinfo);
                 }
 
-                // user's function returned Some(TableIterator), so we need to leak it into the
+                // user's function returned Some(SetOfIterator), so we need to leak it into the
                 // memory context Postgres has decided is to be used for multi-call SRF functions
                 Some(iter) => PgMemoryContexts::For((*funcctx).multi_call_memory_ctx)
                     .leak_and_drop_on_delete(iter),

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -78,9 +78,7 @@ impl<'a, T: IntoHeapTuple> TableIterator<'a, T> {
                     // first off, ask the user's function to do the needful and return Option<TableIterator<T>>
                     let table_iterator = first_call_func();
 
-                    //
                     // and if we're here, it worked, so carry on with the initial SRF setup dance
-                    //
 
                     // Build a tuple descriptor for our result type
                     let mut tupdesc = std::ptr::null_mut();

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -24,18 +24,9 @@ impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
         if srf_is_first_call(fcinfo) {
             let funcctx = pg_sys::init_MultiFuncCall(fcinfo);
 
-            let (setof_iterator, memcxt) = PgMemoryContexts::For((*funcctx).multi_call_memory_ctx)
-                .switch_to(|_| {
-                    // first off, ask the user's function to do the needful and return Option<SetOfIterator<T>>
-                    let setof_iterator = first_call_func();
-
-                    //
-                    // and if we're here, it worked, so carry on with the initial SRF setup dance
-                    //
-
-                    // allocate and return a Context for holding our SrfIterator which is used on every call
-                    (setof_iterator, (*funcctx).multi_call_memory_ctx)
-                });
+            // first off, ask the user's function to do the needful and return Option<SetOfIterator<T>>
+            let setof_iterator = PgMemoryContexts::For((*funcctx).multi_call_memory_ctx)
+                .switch_to(|_| first_call_func());
 
             let setof_iterator = match setof_iterator {
                 // user's function returned None, so there's nothing for us to later iterate

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -46,7 +46,8 @@ impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
 
                 // user's function returned Some(TableIterator), so we need to leak it into the
                 // memory context Postgres has decided is to be used for multi-call SRF functions
-                Some(iter) => PgMemoryContexts::For(memcxt).leak_and_drop_on_delete(iter),
+                Some(iter) => PgMemoryContexts::For((*funcctx).multi_call_memory_ctx)
+                    .leak_and_drop_on_delete(iter),
             };
 
             // it's the first call so we need to finish setting up `funcctx`
@@ -113,7 +114,8 @@ impl<'a, T: IntoHeapTuple> TableIterator<'a, T> {
 
                 // user's function returned Some(TableIterator), so we need to leak it into the
                 // memory context Postgres has decided is to be used for multi-call SRF functions
-                Some(iter) => PgMemoryContexts::For(memcxt).leak_and_drop_on_delete(iter),
+                Some(iter) => PgMemoryContexts::For((*funcctx).multi_call_memory_ctx)
+                    .leak_and_drop_on_delete(iter),
             };
 
             // it's the first call so we need to finish setting up `funcctx`

--- a/pgrx/src/fcinfo.rs
+++ b/pgrx/src/fcinfo.rs
@@ -386,6 +386,7 @@ pub unsafe fn srf_is_first_call(fcinfo: pg_sys::FunctionCallInfo) -> bool {
 }
 
 #[inline]
+#[deprecated(since = "0.12.0", note = "you want pg_sys::init_MultiFuncCall")]
 pub unsafe fn srf_first_call_init(
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> *mut pg_sys::FuncCallContext {
@@ -393,6 +394,7 @@ pub unsafe fn srf_first_call_init(
 }
 
 #[inline]
+#[deprecated(since = "0.12.0", note = "you want pg_sys::per_MultiFuncCall")]
 pub unsafe fn srf_per_call_setup(fcinfo: pg_sys::FunctionCallInfo) -> *mut pg_sys::FuncCallContext {
     pg_sys::per_MultiFuncCall(fcinfo)
 }


### PR DESCRIPTION
Simplify these mazy functions by doing things at the first opportunity.

Remove functions that are mere aliases and deprecate them.

I intend to factor these parts out even further but I found the current code confounding enough, that I felt it would be difficult to review such greater changes if they were based on a foundation of wrong comments and misleading control flow.