### PR TITLE
Remove seq-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,6 @@ dependencies = [
  "pgrx-pg-sys",
  "pgrx-sql-entity-graph",
  "seahash",
- "seq-macro",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -2097,12 +2096,6 @@ checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "seq-macro"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -52,7 +52,6 @@ thiserror.workspace = true # error handling and logging
 
 # used to internally impl things
 once_cell = "1.18.0" # polyfill until std::lazy::OnceCell stabilizes
-seq-macro = "0.3" # impls loops in macros
 uuid = { version = "1.4.1", features = [ "v4" ] } # PgLwLock and shmem
 enum-map = "2.6.3"
 

--- a/pgrx/src/htup.rs
+++ b/pgrx/src/htup.rs
@@ -9,7 +9,6 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Utility functions for working with [`pg_sys::HeapTuple`] and [`pg_sys::HeapTupleHeader`] structs
 use crate::*;
-use seq_macro::seq;
 use std::num::NonZeroUsize;
 
 /// Given a `pg_sys::Datum` representing a composite row type, return a boxed `HeapTupleData`,
@@ -187,30 +186,3 @@ pub trait IntoHeapTuple {
         tupdesc: *mut pg_sys::TupleDescData,
     ) -> *mut pg_sys::HeapTupleData;
 }
-
-seq!(I in 0..32 {
-    #(
-        seq!(N in 0..I {
-            impl<#(T~N: IntoDatum,)*> IntoHeapTuple for (#(T~N,)*) {
-                unsafe fn into_heap_tuple(self, tupdesc: pg_sys::TupleDesc) -> *mut pg_sys::HeapTupleData {
-                    let mut datums = [pg_sys::Datum::from(0); I];
-                    let mut nulls = [false; I];
-
-                    #(
-                        match self.N.into_datum() {
-                            Some(datum) => datums[N] = datum,
-                            None => nulls[N] = true,
-                        }
-                    )*
-
-                    unsafe {
-                        // SAFETY:  Caller has asserted that `tupdesc` is valid, and we just went
-                        // through a little bit of effort to setup properly sized arrays for
-                        // `datums` and `nulls`
-                        pg_sys::heap_form_tuple(tupdesc, datums.as_mut_ptr(), nulls.as_mut_ptr())
-                    }
-                }
-            }
-        });
-    )*
-});


### PR DESCRIPTION
This adds some local boilerplate but removes an external proc-macro from our build.