### PR TITLE
Implement `RetAbi` and `BoxRet`

### DIFF
--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::callconv::{BoxRet, Ret};
 use pgrx::pg_sys::{Datum, Oid};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
@@ -90,6 +91,23 @@ impl IntoDatum for HexInt {
 
     fn type_oid() -> Oid {
         rust_regtypein::<Self>()
+    }
+}
+
+impl BoxRet for HexInt {
+    type CallRet = Self;
+    fn into_ret(self) -> Ret<Self>
+    where
+        Self: Sized,
+    {
+        Ret::Once(self)
+    }
+
+    fn box_return(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
+        match ret {
+            Ret::Once(inner) => Datum::from(inner.value),
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -94,7 +94,7 @@ impl IntoDatum for HexInt {
     }
 }
 
-impl BoxRet for HexInt {
+unsafe impl BoxRet for HexInt {
     type CallRet = Self;
     fn into_ret(self) -> Ret<Self>
     where
@@ -103,7 +103,7 @@ impl BoxRet for HexInt {
         Ret::Once(self)
     }
 
-    fn box_return(_fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
+    unsafe fn box_return(_fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
         match ret {
             Ret::Once(inner) => Datum::from(inner.value),
             _ => unreachable!(),

--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -103,7 +103,7 @@ impl BoxRet for HexInt {
         Ret::Once(self)
     }
 
-    fn box_return(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
+    fn box_return(_fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
         match ret {
             Ret::Once(inner) => Datum::from(inner.value),
             _ => unreachable!(),

--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -7,7 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use pgrx::callconv::{Ret, ReturnShipping};
+use pgrx::callconv::RetPackage;
 use pgrx::pg_sys::{Datum, Oid};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
@@ -94,20 +94,9 @@ impl IntoDatum for HexInt {
     }
 }
 
-unsafe impl ReturnShipping for HexInt {
-    type CallRet = Self;
-    fn label_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
-        Ret::Once(self)
-    }
-
-    unsafe fn box_return(_fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
-        match ret {
-            Ret::Once(inner) => Datum::from(inner.value),
-            _ => unreachable!(),
-        }
+unsafe impl RetPackage for HexInt {
+    unsafe fn package_ret(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+        Datum::from(self.value)
     }
 }
 

--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -7,7 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use pgrx::callconv::{BoxRet, Ret};
+use pgrx::callconv::{Ret, ReturnShipping};
 use pgrx::pg_sys::{Datum, Oid};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
@@ -94,9 +94,9 @@ impl IntoDatum for HexInt {
     }
 }
 
-unsafe impl BoxRet for HexInt {
+unsafe impl ReturnShipping for HexInt {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
+    fn label_ret(self) -> Ret<Self>
     where
         Self: Sized,
     {

--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -7,7 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use pgrx::callconv::RetPackage;
+use pgrx::callconv::BoxRet;
 use pgrx::pg_sys::{Datum, Oid};
 use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
@@ -94,8 +94,8 @@ impl IntoDatum for HexInt {
     }
 }
 
-unsafe impl RetPackage for HexInt {
-    unsafe fn package_ret(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl BoxRet for HexInt {
+    unsafe fn box_in_fcinfo(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         Datum::from(self.value)
     }
 }

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -38,9 +38,9 @@ fn calculate_human_years() -> Result<
     TableIterator<
         'static,
         (
-            name!(dog_name, Result<Option<String>, pgrx::spi::Error>),
+            name!(dog_name, Option<String>),
             name!(dog_age, i32),
-            name!(dog_breed, Result<Option<String>, pgrx::spi::Error>),
+            name!(dog_breed, Option<String>),
             name!(human_age, i32),
         ),
     >,
@@ -62,7 +62,7 @@ fn calculate_human_years() -> Result<
             let dog_age = row["dog_age"].value::<i32>()?.expect("dog_age was null");
             let dog_breed = row["dog_breed"].value::<String>();
             let human_age = dog_age * 7;
-            results.push((dog_name, dog_age, dog_breed, human_age));
+            results.push((dog_name?, dog_age, dog_breed?, human_age));
         }
 
         Ok(TableIterator::new(results))
@@ -76,9 +76,9 @@ fn filter_by_breed(
     TableIterator<
         'static,
         (
-            name!(dog_name, Result<Option<String>, pgrx::spi::Error>),
-            name!(dog_age, Result<Option<i32>, pgrx::spi::Error>),
-            name!(dog_breed, Result<Option<String>, pgrx::spi::Error>),
+            name!(dog_name, Option<String>),
+            name!(dog_age, Option<i32>),
+            name!(dog_breed, Option<String>),
         ),
     >,
     spi::Error,
@@ -95,9 +95,11 @@ fn filter_by_breed(
         let tup_table = client.select(query, None, Some(args))?;
 
         let filtered = tup_table
-            .map(|row| (row["dog_name"].value(), row["dog_age"].value(), row["dog_breed"].value()))
-            .collect::<Vec<_>>();
-        Ok(TableIterator::new(filtered))
+            .map(|row| {
+                Ok((row["dog_name"].value()?, row["dog_age"].value()?, row["dog_breed"].value()?))
+            })
+            .collect::<Result<Vec<_>, _>>();
+        filtered.map(|v| TableIterator::new(v))
     })
 }
 
@@ -110,16 +112,16 @@ mod tests {
     #[rustfmt::skip]
     #[pg_test]
     fn test_calculate_human_years() -> Result<(), pgrx::spi::Error> {
-        let mut results: Vec<(Result<Option<String>, _>, i32, Result<Option<String>, _>, i32)> =
+        let mut results =
             Vec::new();
 
-        results.push((Ok(Some("Fido".to_string())), 3, Ok(Some("Labrador".to_string())), 21));
-        results.push((Ok(Some("Spot".to_string())), 5, Ok(Some("Poodle".to_string())), 35));
-        results.push((Ok(Some("Rover".to_string())), 7, Ok(Some("Golden Retriever".to_string())), 49));
-        results.push((Ok(Some("Snoopy".to_string())), 9, Ok(Some("Beagle".to_string())), 63));
-        results.push((Ok(Some("Lassie".to_string())), 11, Ok(Some("Collie".to_string())), 77));
-        results.push((Ok(Some("Scooby".to_string())), 13, Ok(Some("Great Dane".to_string())), 91));
-        results.push((Ok(Some("Moomba".to_string())), 15, Ok(Some("Labrador".to_string())), 105));
+        results.push((Some("Fido".to_string()), 3, Some("Labrador".to_string()), 21));
+        results.push((Some("Spot".to_string()), 5, Some("Poodle".to_string()), 35));
+        results.push((Some("Rover".to_string()), 7, Some("Golden Retriever".to_string()), 49));
+        results.push((Some("Snoopy".to_string()), 9, Some("Beagle".to_string()), 63));
+        results.push((Some("Lassie".to_string()), 11, Some("Collie".to_string()), 77));
+        results.push((Some("Scooby".to_string()), 13, Some("Great Dane".to_string()), 91));
+        results.push((Some("Moomba".to_string()), 15, Some("Labrador".to_string()), 105));
         let func_results = calculate_human_years()?;
 
         for (expected, actual) in results.iter().zip(func_results) {

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -109,11 +109,9 @@ mod tests {
     use crate::calculate_human_years;
     use pgrx::prelude::*;
 
-    #[rustfmt::skip]
     #[pg_test]
     fn test_calculate_human_years() -> Result<(), pgrx::spi::Error> {
-        let mut results =
-            Vec::new();
+        let mut results = Vec::new();
 
         results.push((Some("Fido".to_string()), 3, Some("Labrador".to_string()), 21));
         results.push((Some("Spot".to_string()), 5, Some("Poodle".to_string()), 35));

--- a/pgrx-examples/srf/src/lib.rs
+++ b/pgrx-examples/srf/src/lib.rs
@@ -34,10 +34,10 @@ fn random_values(num_rows: i32) -> TableIterator<'static, (name!(index, i32), na
 
 #[pg_extern]
 fn result_table() -> Result<
-    Option<::pgrx::iter::TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+    ::pgrx::iter::TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
-    Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
+    Ok(TableIterator::new(vec![(Some(1), Some(2))]))
 }
 
 #[pg_extern]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -705,7 +705,7 @@ fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
         }
 
-        impl ::pgrx::callconv::BoxRet for #enum_ident {
+        unsafe impl ::pgrx::callconv::BoxRet for #enum_ident {
             type CallRet = Self;
             fn into_ret(self) -> ::pgrx::callconv::Ret<Self>
             where
@@ -714,7 +714,7 @@ fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 ::pgrx::callconv::Ret::Once(self)
             }
 
-            fn box_return(fcinfo: ::pgrx::pg_sys::FunctionCallInfo, ret: ::pgrx::callconv::Ret<Self>) -> ::pgrx::pg_sys::Datum {
+            unsafe fn box_return(fcinfo: ::pgrx::pg_sys::FunctionCallInfo, ret: ::pgrx::callconv::Ret<Self>) -> ::pgrx::pg_sys::Datum {
                 match ret {
                     ::pgrx::callconv::Ret::Zero => unsafe { ::pgrx::pg_return_null(fcinfo) },
                     ::pgrx::callconv::Ret::Once(value) => value.into_datum().unwrap(),
@@ -826,12 +826,12 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                     }
                 }
 
-                impl #generics ::pgrx::callconv::BoxRet for #name #generics {
+                unsafe impl #generics ::pgrx::callconv::BoxRet for #name #generics {
                     type CallRet = Self;
                     fn into_ret(self) -> ::pgrx::callconv::Ret<Self> {
                         ::pgrx::callconv::Ret::Once(self)
                     }
-                    fn box_return(fcinfo: ::pgrx::pg_sys::FunctionCallInfo, ret: ::pgrx::callconv::Ret<Self>) -> ::pgrx::pg_sys::Datum {
+                    unsafe fn box_return(fcinfo: ::pgrx::pg_sys::FunctionCallInfo, ret: ::pgrx::callconv::Ret<Self>) -> ::pgrx::pg_sys::Datum {
                         unsafe {
                             match ret {
                                 ::pgrx::callconv::Ret::Zero => ::pgrx::fcinfo::pg_return_null(fcinfo),

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -705,8 +705,8 @@ fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
         }
 
-        unsafe impl ::pgrx::callconv::RetPackage for #enum_ident {
-            unsafe fn package_ret(self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
+        unsafe impl ::pgrx::callconv::BoxRet for #enum_ident {
+            unsafe fn box_in_fcinfo(self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
                 ::pgrx::datum::IntoDatum::into_datum(self).unwrap()
             }
         }
@@ -814,8 +814,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                     }
                 }
 
-                unsafe impl #generics ::pgrx::callconv::RetPackage for #name #generics {
-                    unsafe fn package_ret(self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
+                unsafe impl #generics ::pgrx::callconv::BoxRet for #name #generics {
+                    unsafe fn box_in_fcinfo(self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
                         match ::pgrx::datum::IntoDatum::into_datum(self) {
                             None => ::pgrx::fcinfo::pg_return_null(fcinfo),
                             Some(datum) => datum,

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -705,15 +705,11 @@ fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
         }
 
-        unsafe impl ::pgrx::callconv::BoxRet for #enum_ident {
+        unsafe impl ::pgrx::callconv::ReturnShipping for #enum_ident {
             type CallRet = Self;
-            fn into_ret(self) -> ::pgrx::callconv::Ret<Self>
-            where
-                Self: Sized,
-            {
+            fn label_ret(self) -> ::pgrx::callconv::Ret<Self> {
                 ::pgrx::callconv::Ret::Once(self)
             }
-
             unsafe fn box_return(fcinfo: ::pgrx::pg_sys::FunctionCallInfo, ret: ::pgrx::callconv::Ret<Self>) -> ::pgrx::pg_sys::Datum {
                 match ret {
                     ::pgrx::callconv::Ret::Zero => unsafe { ::pgrx::pg_return_null(fcinfo) },
@@ -826,9 +822,9 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                     }
                 }
 
-                unsafe impl #generics ::pgrx::callconv::BoxRet for #name #generics {
+                unsafe impl #generics ::pgrx::callconv::ReturnShipping for #name #generics {
                     type CallRet = Self;
-                    fn into_ret(self) -> ::pgrx::callconv::Ret<Self> {
+                    fn label_ret(self) -> ::pgrx::callconv::Ret<Self> {
                         ::pgrx::callconv::Ret::Once(self)
                     }
                     unsafe fn box_return(fcinfo: ::pgrx::pg_sys::FunctionCallInfo, ret: ::pgrx::callconv::Ret<Self>) -> ::pgrx::pg_sys::Datum {

--- a/pgrx-pg-sys/src/lib.rs
+++ b/pgrx-pg-sys/src/lib.rs
@@ -17,7 +17,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(improper_ctypes)]
 #![allow(clippy::unneeded_field_pattern)]
-#![cfg_attr(nightly, feature(strict_provenance))]
 
 #[cfg(
     // no features at all will cause problems

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/returning.rs
@@ -20,19 +20,9 @@ use crate::UsedTypeEntity;
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PgExternReturnEntity {
     None,
-    Type {
-        ty: UsedTypeEntity,
-    },
-    SetOf {
-        ty: UsedTypeEntity,
-        is_option: bool, /* Eg `Option<SetOfIterator<T>>` */
-        is_result: bool, /* Eg `Result<SetOfIterator<T>, E>` */
-    },
-    Iterated {
-        tys: Vec<PgExternReturnEntityIteratedItem>,
-        is_option: bool, /* Eg `Option<TableIterator<T>>` */
-        is_result: bool, /* Eg `Result<TableIterator<T>, E>` */
-    },
+    Type { ty: UsedTypeEntity },
+    SetOf { ty: UsedTypeEntity },
+    Iterated { tys: Vec<PgExternReturnEntityIteratedItem> },
     Trigger,
 }
 

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -425,34 +425,6 @@ impl PgExtern {
         };
 
         match &self.returns {
-            Returning::Iterated { tys: retval_tys, is_option, is_result }
-                if retval_tys.len() == 1 =>
-            {
-                let result_handler =
-                    emit_result_handler(self.func.sig.span(), *is_option, *is_result);
-
-                // Postgres considers functions returning a 1-field table (`RETURNS TABLE (T)`) to be
-                // a function that `RETURNS SETOF T`.  So we write a different wrapper implementation
-                // that transparently transforms the `TableIterator` returned by the user into a `SetOfIterator`
-                let iter_closure = quote! {
-                    #[allow(unused_unsafe)]
-                    unsafe {
-                        // SAFETY: the caller has asserted that `fcinfo` is a valid FunctionCallInfo pointer, allocated by Postgres
-                        // with all its fields properly setup.  Unless the user is calling this wrapper function directly, this
-                        // will always be the case
-                        ::pgrx::iter::SetOfIterator::srf_next(#fcinfo_ident, || {
-                            #( #arg_fetches )*
-                            let table_iterator = { #result_handler };
-
-                            // we need to convert the 1-field `TableIterator` provided by the user
-                            // into a SetOfIterator in order to properly handle the case of `RETURNS TABLE (T)`,
-                            // which is a table that returns only 1 field.
-                            table_iterator.map(|i| ::pgrx::iter::SetOfIterator::new(i.into_iter().map(|(v,)| v)))
-                        })
-                    }
-                };
-                finfo_v1_extern_c(&self.func, fcinfo_ident, iter_closure)
-            }
             Returning::None
             | Returning::Type(_)
             | Returning::SetOf { .. }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -435,56 +435,56 @@ impl PgExtern {
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, fn_contents)
             }
-            Returning::Type(retval_ty) => {
-                let result_ident = syn::Ident::new("result", self.func.sig.span());
-                let retval_transform = if retval_ty.resolved_ty == syn::parse_quote!(()) {
-                    quote_spanned! { self.func.sig.output.span() =>
-                       unsafe { ::pgrx::fcinfo::pg_return_void() }
-                    }
-                } else if retval_ty.result && retval_ty.optional.is_some() {
-                    // returning `Result<Option<T>>`
-                    quote_spanned! { self.func.sig.output.span() =>
-                        match ::pgrx::datum::IntoDatum::into_datum(#result_ident) {
-                            Some(datum) => datum,
-                            None => unsafe { ::pgrx::fcinfo::pg_return_null(#fcinfo_ident) },
-                        }
-                    }
-                } else if retval_ty.result {
-                    // returning Result<T>
-                    quote_spanned! { self.func.sig.output.span() =>
-                        ::pgrx::datum::IntoDatum::into_datum(#result_ident).unwrap_or_else(|| panic!("returned Datum was NULL"))
-                    }
-                } else if retval_ty.resolved_ty.last_ident_is("Datum") {
-                    // As before, we can just throw this in because it must typecheck
-                    quote_spanned! { self.func.sig.output.span() =>
-                       #result_ident
-                    }
-                } else if retval_ty.optional.is_some() {
-                    quote_spanned! { self.func.sig.output.span() =>
-                        match #result_ident {
-                            Some(result) => {
-                                ::pgrx::datum::IntoDatum::into_datum(result).unwrap_or_else(|| panic!("returned Option<T> was NULL"))
-                            },
-                            None => unsafe { ::pgrx::fcinfo::pg_return_null(#fcinfo_ident) }
-                        }
-                    }
-                } else {
-                    quote_spanned! { self.func.sig.output.span() =>
-                        ::pgrx::datum::IntoDatum::into_datum(#result_ident).unwrap_or_else(|| panic!("returned Datum was NULL"))
-                    }
-                };
+            // Returning::Type(retval_ty) => {
+            //     let result_ident = syn::Ident::new("result", self.func.sig.span());
+            //     let retval_transform = if retval_ty.resolved_ty == syn::parse_quote!(()) {
+            //         quote_spanned! { self.func.sig.output.span() =>
+            //            unsafe { ::pgrx::fcinfo::pg_return_void() }
+            //         }
+            //     } else if retval_ty.result && retval_ty.optional.is_some() {
+            //         // returning `Result<Option<T>>`
+            //         quote_spanned! { self.func.sig.output.span() =>
+            //             match ::pgrx::datum::IntoDatum::into_datum(#result_ident) {
+            //                 Some(datum) => datum,
+            //                 None => unsafe { ::pgrx::fcinfo::pg_return_null(#fcinfo_ident) },
+            //             }
+            //         }
+            //     } else if retval_ty.result {
+            //         // returning Result<T>
+            //         quote_spanned! { self.func.sig.output.span() =>
+            //             ::pgrx::datum::IntoDatum::into_datum(#result_ident).unwrap_or_else(|| panic!("returned Datum was NULL"))
+            //         }
+            //     } else if retval_ty.resolved_ty.last_ident_is("Datum") {
+            //         // As before, we can just throw this in because it must typecheck
+            //         quote_spanned! { self.func.sig.output.span() =>
+            //            #result_ident
+            //         }
+            //     } else if retval_ty.optional.is_some() {
+            //         quote_spanned! { self.func.sig.output.span() =>
+            //             match #result_ident {
+            //                 Some(result) => {
+            //                     ::pgrx::datum::IntoDatum::into_datum(result).unwrap_or_else(|| panic!("returned Option<T> was NULL"))
+            //                 },
+            //                 None => unsafe { ::pgrx::fcinfo::pg_return_null(#fcinfo_ident) }
+            //             }
+            //         }
+            //     } else {
+            //         quote_spanned! { self.func.sig.output.span() =>
+            //             ::pgrx::datum::IntoDatum::into_datum(#result_ident).unwrap_or_else(|| panic!("returned Datum was NULL"))
+            //         }
+            //     };
 
-                let fn_contents = quote! {
-                    #(#arg_fetches)*
+            //     let fn_contents = quote! {
+            //         #(#arg_fetches)*
 
-                    #[allow(unused_unsafe)] // unwrapped fn might be unsafe
-                    let #result_ident = unsafe { #func_name(#(#arg_pats),*) };
+            //         #[allow(unused_unsafe)] // unwrapped fn might be unsafe
+            //         let #result_ident = unsafe { #func_name(#(#arg_pats),*) };
 
-                    #retval_transform
-                };
-                finfo_v1_extern_c(&self.func, fcinfo_ident, fn_contents)
-            }
-            Returning::SetOf { ty: _retval_ty, .. } => {
+            //         #retval_transform
+            //     };
+            //     finfo_v1_extern_c(&self.func, fcinfo_ident, fn_contents)
+            // }
+            Returning::Type(_) | Returning::SetOf { .. } => {
                 let syn::ReturnType::Type(_, ret_ty) = &self.func.sig.output else {
                     unreachable!()
                 };

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -484,7 +484,7 @@ impl PgExtern {
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, fn_contents)
             }
-            Returning::SetOf { ty: _retval_ty, is_option, is_result } => {
+            Returning::SetOf { ty: _retval_ty, .. } => {
                 let syn::ReturnType::Type(_, ret_ty) = &self.func.sig.output else {
                     unreachable!()
                 };

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -430,7 +430,7 @@ impl PgExtern {
                     syn::ReturnType::Default => syn::parse_quote! { () },
                     syn::ReturnType::Type(_, ret_ty) => ret_ty.clone(),
                 };
-                let setof_closure = quote_spanned! { self.func.block.span() =>
+                let wrapper_code = quote_spanned! { self.func.block.span() =>
                     #[allow(unused_unsafe)]
                     unsafe {
                         let fcinfo = #fcinfo_ident;
@@ -448,7 +448,7 @@ impl PgExtern {
                         unsafe { ::pgrx::callconv::BoxRet::box_return(fcinfo, result) }
                     }
                 };
-                finfo_v1_extern_c(&self.func, fcinfo_ident, setof_closure)
+                finfo_v1_extern_c(&self.func, fcinfo_ident, wrapper_code)
             }
             Returning::Iterated { tys: retval_tys, is_option, is_result } => {
                 let result_handler =

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -38,7 +38,7 @@ use crate::ToSqlConfig;
 use operator::{PgrxOperatorAttributeWithIdent, PgrxOperatorOpName};
 use search_path::SearchPathList;
 
-use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
+use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{format_ident, quote, quote_spanned};
 use syn::parse::{Parse, ParseStream, Parser};
 use syn::punctuated::Punctuated;
@@ -405,24 +405,6 @@ impl PgExtern {
                 }
             }
         });
-
-        // Iterators require fancy handling for their retvals
-        let emit_result_handler = |span: Span, optional: bool, result: bool| {
-            let mut ret_expr = quote! { #func_name(#(#arg_pats),*) };
-            if result {
-                // If it's a result, we need to report it.
-                ret_expr = quote! { #ret_expr.unwrap_or_report() };
-            }
-            if !optional {
-                // If it's not already an option, we need to wrap it.
-                ret_expr = quote! { Some(#ret_expr) };
-            }
-            let import = result.then(|| quote! { use ::pgrx::pg_sys::panic::ErrorReportable; });
-            quote_spanned! { span =>
-                    #import
-                    #ret_expr
-            }
-        };
 
         match &self.returns {
             Returning::None

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -419,18 +419,18 @@ impl PgExtern {
                     #[allow(unused_unsafe)]
                     unsafe {
                         let fcinfo = #fcinfo_ident;
-                        let result: ::pgrx::callconv::Ret<#ret_ty> = match <#ret_ty as ::pgrx::callconv::ReturnShipping>::prepare_call(fcinfo) {
+                        let result: ::pgrx::callconv::Ret<#ret_ty> = match <#ret_ty as ::pgrx::callconv::RetAbi>::check_fcinfo_and_prepare(fcinfo) {
                             ::pgrx::callconv::CallCx::WrappedFn(mcx) => {
                                 let mut mcx = ::pgrx::PgMemoryContexts::For(mcx);
                                 let call_result: #ret_ty = mcx.switch_to(|_| {
                                     #(#arg_fetches)*
                                     #func_name( #(#arg_pats),* )
                                 });
-                                ::pgrx::callconv::ReturnShipping::label_ret(call_result)
+                                ::pgrx::callconv::RetAbi::label_ret(call_result)
                             }
-                            ::pgrx::callconv::CallCx::RestoreCx => ::pgrx::callconv::ReturnShipping::ret_from_context(fcinfo),
+                            ::pgrx::callconv::CallCx::RestoreCx => ::pgrx::callconv::RetAbi::ret_from_fcinfo_fcx(fcinfo),
                         };
-                        unsafe { ::pgrx::callconv::ReturnShipping::box_return(fcinfo, result) }
+                        unsafe { ::pgrx::callconv::RetAbi::box_ret_in_fcinfo(fcinfo, result) }
                     }
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, wrapper_code)

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -419,18 +419,17 @@ impl PgExtern {
                     #[allow(unused_unsafe)]
                     unsafe {
                         let fcinfo = #fcinfo_ident;
-                        let result: ::pgrx::callconv::Ret<#ret_ty> = match <#ret_ty as ::pgrx::callconv::RetAbi>::check_fcinfo_and_prepare(fcinfo) {
+                        let result = match <#ret_ty as ::pgrx::callconv::RetAbi>::check_fcinfo_and_prepare(fcinfo) {
                             ::pgrx::callconv::CallCx::WrappedFn(mcx) => {
                                 let mut mcx = ::pgrx::PgMemoryContexts::For(mcx);
-                                let call_result: #ret_ty = mcx.switch_to(|_| {
+                                ::pgrx::callconv::RetAbi::to_ret(mcx.switch_to(|_| {
                                     #(#arg_fetches)*
                                     #func_name( #(#arg_pats),* )
-                                });
-                                ::pgrx::callconv::RetAbi::label_ret(call_result)
+                                }))
                             }
-                            ::pgrx::callconv::CallCx::RestoreCx => ::pgrx::callconv::RetAbi::ret_from_fcinfo_fcx(fcinfo),
+                            ::pgrx::callconv::CallCx::RestoreCx => <#ret_ty as ::pgrx::callconv::RetAbi>::ret_from_fcinfo_fcx(fcinfo),
                         };
-                        unsafe { ::pgrx::callconv::RetAbi::box_ret_in_fcinfo(fcinfo, result) }
+                        unsafe { <#ret_ty as ::pgrx::callconv::RetAbi>::box_ret_in_fcinfo(fcinfo, result) }
                     }
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, wrapper_code)

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -419,18 +419,18 @@ impl PgExtern {
                     #[allow(unused_unsafe)]
                     unsafe {
                         let fcinfo = #fcinfo_ident;
-                        let result: ::pgrx::callconv::Ret<#ret_ty> = match <#ret_ty as ::pgrx::callconv::BoxRet>::prepare_call(fcinfo) {
+                        let result: ::pgrx::callconv::Ret<#ret_ty> = match <#ret_ty as ::pgrx::callconv::ReturnShipping>::prepare_call(fcinfo) {
                             ::pgrx::callconv::CallCx::WrappedFn(mcx) => {
                                 let mut mcx = ::pgrx::PgMemoryContexts::For(mcx);
                                 let call_result: #ret_ty = mcx.switch_to(|_| {
                                     #(#arg_fetches)*
                                     #func_name( #(#arg_pats),* )
                                 });
-                                ::pgrx::callconv::BoxRet::into_ret(call_result)
+                                ::pgrx::callconv::ReturnShipping::label_ret(call_result)
                             }
-                            ::pgrx::callconv::CallCx::RestoreCx => ::pgrx::callconv::BoxRet::ret_from_context(fcinfo),
+                            ::pgrx::callconv::CallCx::RestoreCx => ::pgrx::callconv::ReturnShipping::ret_from_context(fcinfo),
                         };
-                        unsafe { ::pgrx::callconv::BoxRet::box_return(fcinfo, result) }
+                        unsafe { ::pgrx::callconv::ReturnShipping::box_return(fcinfo, result) }
                     }
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, wrapper_code)

--- a/pgrx-tests/src/tests/srf_tests.rs
+++ b/pgrx-tests/src/tests/srf_tests.rs
@@ -298,12 +298,15 @@ mod tests {
     }
 
     #[pg_test(error = "column \"cause_an_error\" does not exist")]
-    pub fn spi_in_setof() -> SetOfIterator<'static, Result<Option<String>, spi::Error>> {
+    pub fn spi_in_setof() -> Result<SetOfIterator<'static, Option<String>>, spi::Error> {
         let oids = vec![1213, 1214, 1232, 1233, 1247, 1249, 1255];
-
-        SetOfIterator::new(oids.into_iter().map(|oid| {
-            Spi::get_one(&format!("SELECT CAUSE_AN_ERROR FROM pg_class WHERE oid = {oid}"))
-        }))
+        let result = oids
+            .into_iter()
+            .map(|oid| {
+                Spi::get_one(&format!("SELECT CAUSE_AN_ERROR FROM pg_class WHERE oid = {oid}"))
+            })
+            .collect::<Result<Vec<Option<_>>, _>>();
+        result.map(SetOfIterator::new)
     }
 
     #[pg_test]

--- a/pgrx-tests/src/tests/srf_tests.rs
+++ b/pgrx-tests/src/tests/srf_tests.rs
@@ -27,33 +27,33 @@ fn example_composite_set() -> TableIterator<'static, (name!(idx, i32), name!(val
 }
 
 #[pg_extern]
-fn return_some_iterator(
-) -> Option<TableIterator<'static, (name!(idx, i32), name!(some_value, &'static str))>> {
-    Some(TableIterator::new(
+fn return_table_iterator(
+) -> TableIterator<'static, (name!(idx, i32), name!(some_value, &'static str))> {
+    TableIterator::new(
         vec!["a", "b", "c"].into_iter().enumerate().map(|(idx, value)| ((idx + 1) as i32, value)),
-    ))
+    )
 }
 
 #[pg_extern]
-fn return_none_iterator(
-) -> Option<TableIterator<'static, (name!(idx, i32), name!(some_value, &'static str))>> {
-    None
+fn return_empty_iterator(
+) -> TableIterator<'static, (name!(idx, i32), name!(some_value, &'static str))> {
+    TableIterator::empty()
 }
 
 #[pg_extern]
-fn return_some_setof_iterator() -> Option<SetOfIterator<'static, i32>> {
-    Some(SetOfIterator::new(vec![1, 2, 3].into_iter()))
+fn return_setof_iterator() -> SetOfIterator<'static, i32> {
+    SetOfIterator::new(vec![1, 2, 3].into_iter())
 }
 
 #[pg_extern]
-fn return_none_setof_iterator() -> Option<SetOfIterator<'static, i32>> {
-    None
+fn return_empty_setof_iterator() -> SetOfIterator<'static, i32> {
+    SetOfIterator::empty()
 }
 
 #[pg_extern]
-fn return_none_result_setof_iterator(
-) -> Result<Option<SetOfIterator<'static, String>>, Box<dyn std::error::Error>> {
-    Ok(None)
+fn return_empty_result_setof_iterator(
+) -> Result<SetOfIterator<'static, String>, Box<dyn std::error::Error>> {
+    Ok(SetOfIterator::empty())
 }
 
 // TODO:  We don't yet support returning Result<Option<TableIterator>> because the code generator
@@ -82,31 +82,31 @@ fn split_table_with_borrow<'a>(
 
 #[pg_extern]
 fn result_table_1() -> Result<
-    Option<::pgrx::iter::TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+    ::pgrx::iter::TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
-    Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
+    Ok(TableIterator::new(vec![(Some(1), Some(2))]))
 }
 
 #[pg_extern]
 fn result_table_2() -> Result<
-    Option<TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+    TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
-    Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
+    Ok(TableIterator::new(vec![(Some(1), Some(2))]))
 }
 
 #[pg_extern]
 fn result_table_3() -> Result<
-    Option<TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+    TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
-    Ok(Some(TableIterator::new(vec![(Some(1), Some(2))])))
+    Ok(TableIterator::new(vec![(Some(1), Some(2))]))
 }
 
 #[pg_extern]
 fn result_table_4_err() -> Result<
-    Option<TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+    TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
     Err("oh no")?
@@ -114,10 +114,10 @@ fn result_table_4_err() -> Result<
 
 #[pg_extern]
 fn result_table_5_none() -> Result<
-    Option<TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>>,
+    TableIterator<'static, (name!(a, Option<i32>), name!(b, Option<i32>))>,
     Box<dyn std::error::Error + Send + Sync + 'static>,
 > {
-    Ok(None)
+    Ok(TableIterator::empty())
 }
 
 #[pg_extern]
@@ -126,8 +126,8 @@ fn one_col() -> TableIterator<'static, (name!(a, i32),)> {
 }
 
 #[pg_extern]
-fn one_col_option() -> Option<TableIterator<'static, (name!(a, i32),)>> {
-    Some(TableIterator::once((42,)))
+fn one_col_option() -> TableIterator<'static, (name!(a, i32),)> {
+    TableIterator::once((42,))
 }
 
 #[pg_extern]
@@ -138,8 +138,8 @@ fn one_col_result() -> Result<TableIterator<'static, (name!(a, i32),)>, Box<dyn 
 
 #[pg_extern]
 fn one_col_result_option(
-) -> Result<Option<TableIterator<'static, (name!(a, i32),)>>, Box<dyn std::error::Error>> {
-    Ok(Some(TableIterator::once((42,))))
+) -> Result<TableIterator<'static, (name!(a, i32),)>, Box<dyn std::error::Error>> {
+    Ok(TableIterator::once((42,)))
 }
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -198,9 +198,9 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_return_some_iterator() {
+    fn test_return_table_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_some_iterator();", None, None)?;
+            let table = client.select("SELECT * from return_table_iterator();", None, None)?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });
@@ -209,9 +209,9 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_return_none_iterator() {
+    fn test_return_empty_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_none_iterator();", None, None)?;
+            let table = client.select("SELECT * from return_empty_iterator();", None, None)?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });
@@ -220,9 +220,9 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_return_some_setof_iterator() {
+    fn test_return_setof_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_some_setof_iterator();", None, None)?;
+            let table = client.select("SELECT * from return_setof_iterator();", None, None)?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });
@@ -231,9 +231,10 @@ mod tests {
     }
 
     #[pg_test]
-    fn test_return_none_setof_iterator() {
+    fn test_return_empty_setof_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_none_setof_iterator();", None, None)?;
+            let table =
+                client.select("SELECT * from return_empty_setof_iterator();", None, None)?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });

--- a/pgrx-tests/tests/compile-fail/eq-for-postgres_hash.stderr
+++ b/pgrx-tests/tests/compile-fail/eq-for-postgres_hash.stderr
@@ -39,7 +39,7 @@ note: required by a bound in `brokentype_hash`
   |                                                ^^^^^^^^^^^^ required by this bound in `brokentype_hash`
 5 | pub struct BrokenType {
   |            ---------- required by a bound in this function
-  = note: this error originates in the attribute macro `::pgrx::pgrx_macros::pg_extern` which comes from the expansion of the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Hash)]`
   |
 5 + #[derive(Hash)]
@@ -59,7 +59,7 @@ note: required by a bound in `brokentype_hash`
   |                                                ^^^^^^^^^^^^ required by this bound in `brokentype_hash`
 5 | pub struct BrokenType {
   |            ---------- required by a bound in this function
-  = note: this error originates in the attribute macro `::pgrx::pgrx_macros::pg_extern` which comes from the expansion of the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Eq)]`
   |
 5 + #[derive(Eq)]

--- a/pgrx-tests/tests/compile-fail/total-eq-for-postgres_eq.stderr
+++ b/pgrx-tests/tests/compile-fail/total-eq-for-postgres_eq.stderr
@@ -25,7 +25,7 @@ note: required by a bound in `brokentype_eq`
   |                                                           ^^^^^^^^^^ required by this bound in `brokentype_eq`
 5 | pub struct BrokenType {
   |            ---------- required by a bound in this function
-  = note: this error originates in the attribute macro `::pgrx::pgrx_macros::pg_operator` which comes from the expansion of the derive macro `PostgresEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `PostgresEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Eq)]`
   |
 5 + #[derive(Eq)]

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -16,6 +16,7 @@ use std::mem::{self, ManuallyDrop};
 
 use crate::heap_tuple::PgHeapTuple;
 use crate::iter::{SetOfIterator, TableIterator};
+use crate::ptr::PointerExt;
 use crate::{
     nonstatic_typeid, pg_return_null, pg_sys, srf_is_first_call, srf_return_done, srf_return_next,
     AnyNumeric, Date, Inet, Internal, Interval, IntoDatum, IntoHeapTuple, Json, PgBox,
@@ -298,7 +299,9 @@ where
                 let mut tupdesc = ptr::null_mut();
                 let mut oid = pg_sys::Oid::default();
                 let ty_class = pg_sys::get_call_result_type(fcinfo, &mut oid, &mut tupdesc);
-                pg_sys::BlessTupleDesc(tupdesc);
+                if tupdesc.is_non_null() {
+                    pg_sys::BlessTupleDesc(tupdesc);
+                }
                 (*fcx).tuple_desc = tupdesc;
                 mcx.leak_and_drop_on_delete(self)
             });

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -117,26 +117,6 @@ pub unsafe trait BoxRet: Sized {
     unsafe fn finish_call(_fcinfo: pg_sys::FunctionCallInfo) {}
 }
 
-// pub unsafe fn handle_ret<T: BoxRet>(
-//     fcinfo: pg_sys::FunctionCallInfo,
-//     ret: Ret<T>,
-// ) -> pg_sys::Datum {
-//     match ret {
-//         // Single-call fn or value-per-call iteration
-//         Ret::Once(value) => <T as BoxRet>::box_return(fcinfo, value),
-//         // Value-per-call first-time
-//         Ret::Many(iter, value) => {
-//             iter.into_context(fcinfo);
-//             <T as BoxRet>::box_return(fcinfo, value)
-//         }
-//         // Value-per-call last-time
-//         Ret::Zero => {
-//             <T as BoxRet>::finish_call(fcinfo);
-//             unsafe { pg_return_null(fcinfo) }
-//         }
-//     }
-// }
-
 pub enum CallCx {
     RestoreCx,
     WrappedFn(pg_sys::MemoryContext),

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -139,6 +139,9 @@ pub enum Ret<T: BoxRet> {
 // struct ValuePerCall?
 // struct MaterializeTable?
 
+fn wrapper_fn(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+    unsafe { pg_return_null(fcinfo) }
+}
 impl<'a, T: IntoDatum> SetOfIterator<'a, T> {
     #[doc(hidden)]
     pub unsafe fn srf_next(

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -606,10 +606,11 @@ unsafe impl BoxRet for f64 {
     }
 }
 
-fn boxret_via_into_datum<T: BoxRet<CallRet: IntoDatum>>(
-    fcinfo: pg_sys::FunctionCallInfo,
-    ret: Ret<T>,
-) -> pg_sys::Datum {
+fn boxret_via_into_datum<T>(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<T>) -> pg_sys::Datum
+where
+    T: BoxRet,
+    <T as BoxRet>::CallRet: IntoDatum,
+{
     match ret {
         Ret::Zero => unsafe { pg_return_null(fcinfo) },
         Ret::Once(value) => match value.into_datum() {

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -16,9 +16,8 @@ use std::mem::{self, ManuallyDrop};
 use crate::heap_tuple::PgHeapTuple;
 use crate::iter::{SetOfIterator, TableIterator};
 use crate::{
-    nonstatic_typeid, pg_return_null, pg_sys, srf_first_call_init, srf_is_first_call,
-    srf_per_call_setup, srf_return_done, srf_return_next, IntoDatum, IntoHeapTuple,
-    PgMemoryContexts,
+    nonstatic_typeid, pg_return_null, pg_sys, srf_is_first_call, srf_return_done, srf_return_next,
+    IntoDatum, IntoHeapTuple, PgMemoryContexts,
 };
 use core::ops::ControlFlow;
 use core::ptr;

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -70,9 +70,8 @@ pub unsafe trait BoxRet: Sized {
     /// answer what kind and how many returns happen from this type
     ///
     /// must be overridden if `Self != Self::CallRet`
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized;
+    fn into_ret(self) -> Ret<Self>;
+
     // morally I should be allowed to supply a default impl >:(
     /* this default impl would work, but at what cost?
     {
@@ -142,10 +141,7 @@ where
         prepare_value_per_call_srf(fcinfo)
     }
 
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         let mut iter = self;
         let ret = iter.next();
         match ret {
@@ -213,10 +209,7 @@ where
         prepare_value_per_call_srf(fcinfo)
     }
 
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         let mut iter = self;
         let ret = iter.next();
         match ret {
@@ -333,10 +326,7 @@ where
         T::prepare_call(fcinfo)
     }
 
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         match self {
             None => Ret::Zero,
             Some(value) => match value.into_ret() {
@@ -390,10 +380,7 @@ where
         T::prepare_call(fcinfo)
     }
 
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         let value = pg_sys::panic::ErrorReportable::unwrap_or_report(self);
         match T::into_ret(value) {
             Ret::Zero => Ret::Zero,
@@ -440,10 +427,7 @@ macro_rules! impl_boxret_for_primitives {
         $(
         unsafe impl BoxRet for $scalar {
             type CallRet = Self;
-            fn into_ret(self) -> Ret<Self>
-            where
-                Self: Sized,
-            {
+            fn into_ret(self) -> Ret<Self> {
                 Ret::Once(self)
             }
 
@@ -465,10 +449,7 @@ impl_boxret_for_primitives! {
 
 unsafe impl BoxRet for () {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Zero
     }
 
@@ -479,10 +460,7 @@ unsafe impl BoxRet for () {
 
 unsafe impl BoxRet for f32 {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -497,10 +475,7 @@ unsafe impl BoxRet for f32 {
 
 unsafe impl BoxRet for f64 {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -530,10 +505,7 @@ where
 
 unsafe impl<'a> BoxRet for &'a [u8] {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -544,10 +516,7 @@ unsafe impl<'a> BoxRet for &'a [u8] {
 
 unsafe impl<'a> BoxRet for &'a str {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -558,10 +527,7 @@ unsafe impl<'a> BoxRet for &'a str {
 
 unsafe impl<'a> BoxRet for &'a CStr {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -575,10 +541,7 @@ macro_rules! impl_boxret_via_intodatum {
         $(
         unsafe impl BoxRet for $boxable {
             type CallRet = Self;
-            fn into_ret(self) -> Ret<Self>
-            where
-                Self: Sized,
-            {
+            fn into_ret(self) -> Ret<Self> {
                 Ret::Once(self)
             }
 
@@ -598,10 +561,7 @@ impl_boxret_via_intodatum! {
 
 unsafe impl<const P: u32, const S: u32> BoxRet for crate::Numeric<P, S> {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -615,10 +575,7 @@ where
     T: IntoDatum + crate::RangeSubType,
 {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -632,10 +589,7 @@ where
     T: IntoDatum,
 {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -646,10 +600,7 @@ where
 
 unsafe impl<T: Copy> BoxRet for PgVarlena<T> {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -663,10 +614,7 @@ where
     A: crate::WhoAllocated,
 {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -680,10 +628,7 @@ where
     A: crate::WhoAllocated,
 {
     type CallRet = Self;
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -192,7 +192,7 @@ where
     unsafe fn ret_from_context(fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
         let fcx = deref_fcx(fcinfo);
         // SAFETY: fcx.user_fctx was set earlier, immediately before or in a prior call
-        let iter = &mut *(*fcx).user_fctx.cast::<TableIterator<T>>();
+        let iter = &mut *(*fcx).user_fctx.cast::<SetOfIterator<'_, T>>();
         match iter.next() {
             None => Ret::Zero,
             Some(value) => Ret::Once(value),

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -408,7 +408,7 @@ where
     }
 }
 
-macro_rules! impl_boxret_for_primitives {
+macro_rules! return_packaging_for_primitives {
     ($($scalar:ty),*) => {
         $(
         unsafe impl RetPackage for $scalar {
@@ -420,7 +420,7 @@ macro_rules! impl_boxret_for_primitives {
     }
 }
 
-impl_boxret_for_primitives! {
+return_packaging_for_primitives! {
     i8, i16, i32, i64, bool
 }
 
@@ -470,7 +470,7 @@ unsafe impl<'a> RetPackage for &'a CStr {
     }
 }
 
-macro_rules! impl_boxret_via_intodatum {
+macro_rules! impl_repackage_into_datum {
     ($($boxable:ty),*) => {
         $(
         unsafe impl RetPackage for $boxable {
@@ -481,7 +481,7 @@ macro_rules! impl_boxret_via_intodatum {
     };
 }
 
-impl_boxret_via_intodatum! {
+impl_repackage_into_datum! {
     String, CString, Json, Inet, Uuid, AnyNumeric, Vec<u8>,
     Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone,
     pg_sys::Oid, pg_sys::BOX, pg_sys::Point, char,

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -105,6 +105,7 @@ where
     unsafe fn finish_call_fcinfo(_fcinfo: pg_sys::FunctionCallInfo) {}
 }
 
+/// Control flow for RetAbi
 pub enum CallCx {
     RestoreCx,
     WrappedFn(pg_sys::MemoryContext),

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -44,7 +44,7 @@ pub trait UnboxArg: Sized {
 /// This bound is not accurately described by IntoDatum or similar traits, as value conversions are
 /// handled in a special way at function return boundaries, and may require mutating multiple fields
 /// behind the FunctionCallInfo. The most exceptional case are set-returning functions.
-pub unsafe trait ReturnShipping: Sized {
+pub unsafe trait RetAbi: Sized {
     /// The actual type returned from the call
     type Item: Sized;
 
@@ -53,7 +53,7 @@ pub unsafe trait ReturnShipping: Sized {
     /// the implementer must pick the correct memory context for the wrapped fn's allocations
     /// # safety
     /// must be called with a valid fcinfo
-    unsafe fn prepare_call(_fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
+    unsafe fn check_fcinfo_and_prepare(_fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
         CallCx::WrappedFn(unsafe { pg_sys::CurrentMemoryContext })
     }
 
@@ -63,14 +63,14 @@ pub unsafe trait ReturnShipping: Sized {
     /// box the return value
     /// # Safety
     /// must be called with a valid fcinfo
-    unsafe fn box_return(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum;
+    unsafe fn box_ret_in_fcinfo(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum;
 
     /// for multi-call types, how to init them in the multi-call context, for all others: panic
     ///
     /// for all others: panic
     /// # Safety
     /// must be called with a valid fcinfo
-    unsafe fn into_context(self, _fcinfo: pg_sys::FunctionCallInfo) {
+    unsafe fn fill_fcinfo_fcx(self, _fcinfo: pg_sys::FunctionCallInfo) {
         unimplemented!()
     }
 
@@ -79,21 +79,21 @@ pub unsafe trait ReturnShipping: Sized {
     /// for all others: panic
     /// # Safety
     /// must be called with a valid fcinfo
-    unsafe fn ret_from_context(_fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
+    unsafe fn ret_from_fcinfo_fcx(_fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
         unimplemented!()
     }
 
     /// must be called with a valid fcinfo
-    unsafe fn finish_call(_fcinfo: pg_sys::FunctionCallInfo) {}
+    unsafe fn finish_call_fcinfo(_fcinfo: pg_sys::FunctionCallInfo) {}
 }
 
-pub unsafe trait RetPackage: Sized {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+pub unsafe trait BoxRet: Sized {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
 }
 
-unsafe impl<T> ReturnShipping for T
+unsafe impl<T> RetAbi for T
 where
-    T: RetPackage,
+    T: BoxRet,
 {
     type Item = Self;
 
@@ -101,25 +101,25 @@ where
         Ret::Once(self)
     }
 
-    unsafe fn box_return(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
+    unsafe fn box_ret_in_fcinfo(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
         match ret {
             Ret::Zero => unsafe { pg_return_null(fcinfo) },
-            Ret::Once(ret) => ret.package_ret(fcinfo),
+            Ret::Once(ret) => ret.box_in_fcinfo(fcinfo),
             Ret::Many(_, _) => unreachable!(),
         }
     }
 
-    unsafe fn prepare_call(_fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
+    unsafe fn check_fcinfo_and_prepare(_fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
         CallCx::WrappedFn(unsafe { pg_sys::CurrentMemoryContext })
     }
 
-    unsafe fn into_context(self, _fcinfo: pg_sys::FunctionCallInfo) {
+    unsafe fn fill_fcinfo_fcx(self, _fcinfo: pg_sys::FunctionCallInfo) {
         unimplemented!()
     }
-    unsafe fn ret_from_context(_fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
+    unsafe fn ret_from_fcinfo_fcx(_fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
         unimplemented!()
     }
-    unsafe fn finish_call(_fcinfo: pg_sys::FunctionCallInfo) {}
+    unsafe fn finish_call_fcinfo(_fcinfo: pg_sys::FunctionCallInfo) {}
 }
 
 pub enum CallCx {
@@ -127,34 +127,34 @@ pub enum CallCx {
     WrappedFn(pg_sys::MemoryContext),
 }
 
-pub enum Ret<T: ReturnShipping> {
+pub enum Ret<T: RetAbi> {
     Zero,
     Once(T::Item),
     Many(T, T::Item),
 }
 
-unsafe impl<T> RetPackage for Option<T>
+unsafe impl<T> BoxRet for Option<T>
 where
-    T: RetPackage,
+    T: BoxRet,
 {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         match self {
             None => unsafe { pg_return_null(fcinfo) },
-            Some(value) => value.package_ret(fcinfo),
+            Some(value) => value.box_in_fcinfo(fcinfo),
         }
     }
 }
 
-unsafe impl<T, E> ReturnShipping for Result<T, E>
+unsafe impl<T, E> RetAbi for Result<T, E>
 where
-    T: ReturnShipping,
-    T::Item: ReturnShipping,
+    T: RetAbi,
+    T::Item: RetAbi,
     E: core::any::Any + core::fmt::Display,
 {
     type Item = T::Item;
 
-    unsafe fn prepare_call(fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
-        T::prepare_call(fcinfo)
+    unsafe fn check_fcinfo_and_prepare(fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
+        T::check_fcinfo_and_prepare(fcinfo)
     }
 
     fn label_ret(self) -> Ret<Self> {
@@ -166,7 +166,7 @@ where
         }
     }
 
-    unsafe fn box_return(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
+    unsafe fn box_ret_in_fcinfo(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
         let ret = match ret {
             Ret::Zero => Ret::Zero,
             Ret::Once(value) => Ret::Once(value),
@@ -176,33 +176,33 @@ where
             }
         };
 
-        T::box_return(fcinfo, ret)
+        T::box_ret_in_fcinfo(fcinfo, ret)
     }
 
-    unsafe fn into_context(self, fcinfo: pg_sys::FunctionCallInfo) {
+    unsafe fn fill_fcinfo_fcx(self, fcinfo: pg_sys::FunctionCallInfo) {
         match self {
             Err(_) => (),
-            Ok(value) => value.into_context(fcinfo),
+            Ok(value) => value.fill_fcinfo_fcx(fcinfo),
         }
     }
 
-    unsafe fn ret_from_context(fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
-        match T::ret_from_context(fcinfo) {
+    unsafe fn ret_from_fcinfo_fcx(fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
+        match T::ret_from_fcinfo_fcx(fcinfo) {
             Ret::Many(iter, value) => Ret::Many(Ok(iter), value),
             Ret::Once(value) => Ret::Once(value),
             Ret::Zero => Ret::Zero,
         }
     }
 
-    unsafe fn finish_call(fcinfo: pg_sys::FunctionCallInfo) {
-        T::finish_call(fcinfo)
+    unsafe fn finish_call_fcinfo(fcinfo: pg_sys::FunctionCallInfo) {
+        T::finish_call_fcinfo(fcinfo)
     }
 }
 
 macro_rules! return_packaging_for_primitives {
     ($($scalar:ty),*) => {
-        $(unsafe impl RetPackage for $scalar {
-              unsafe fn package_ret(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+        $(unsafe impl BoxRet for $scalar {
+              unsafe fn box_in_fcinfo(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
                   $crate::pg_sys::Datum::from(self)
               }
         })*
@@ -211,46 +211,46 @@ macro_rules! return_packaging_for_primitives {
 
 return_packaging_for_primitives!(i8, i16, i32, i64, bool);
 
-unsafe impl RetPackage for () {
-    unsafe fn package_ret(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl BoxRet for () {
+    unsafe fn box_in_fcinfo(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         pg_sys::Datum::from(0)
     }
 }
 
-unsafe impl RetPackage for f32 {
-    unsafe fn package_ret(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl BoxRet for f32 {
+    unsafe fn box_in_fcinfo(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         pg_sys::Datum::from(self.to_bits())
     }
 }
 
-unsafe impl RetPackage for f64 {
-    unsafe fn package_ret(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl BoxRet for f64 {
+    unsafe fn box_in_fcinfo(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         pg_sys::Datum::from(self.to_bits())
     }
 }
 
-unsafe impl<'a> RetPackage for &'a [u8] {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl<'a> BoxRet for &'a [u8] {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
-unsafe impl<'a> RetPackage for &'a str {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl<'a> BoxRet for &'a str {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
-unsafe impl<'a> RetPackage for &'a CStr {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl<'a> BoxRet for &'a CStr {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
 macro_rules! impl_repackage_into_datum {
     ($($boxable:ty),*) => {
-        $(unsafe impl RetPackage for $boxable {
-              unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+        $(unsafe impl BoxRet for $boxable {
+              unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
                   self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
               }
           })*
@@ -264,50 +264,50 @@ impl_repackage_into_datum! {
     pg_sys::Oid, pg_sys::BOX, pg_sys::Point
 }
 
-unsafe impl<const P: u32, const S: u32> RetPackage for crate::Numeric<P, S> {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl<const P: u32, const S: u32> BoxRet for crate::Numeric<P, S> {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
-unsafe impl<T> RetPackage for crate::Range<T>
+unsafe impl<T> BoxRet for crate::Range<T>
 where
     T: IntoDatum + crate::RangeSubType,
 {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
-unsafe impl<T> RetPackage for Vec<T>
+unsafe impl<T> BoxRet for Vec<T>
 where
     T: IntoDatum,
 {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
-unsafe impl<T: Copy> RetPackage for PgVarlena<T> {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+unsafe impl<T: Copy> BoxRet for PgVarlena<T> {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
-unsafe impl<'mcx, A> RetPackage for PgHeapTuple<'mcx, A>
+unsafe impl<'mcx, A> BoxRet for PgHeapTuple<'mcx, A>
 where
     A: crate::WhoAllocated,
 {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }
 
-unsafe impl<T, A> RetPackage for PgBox<T, A>
+unsafe impl<T, A> BoxRet for PgBox<T, A>
 where
     A: crate::WhoAllocated,
 {
-    unsafe fn package_ret(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
+    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         self.into_datum().unwrap_or_else(|| unsafe { pg_return_null(fcinfo) })
     }
 }

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -16,27 +16,6 @@ use crate::{
     pg_return_null, pg_sys, AnyNumeric, Date, Inet, Internal, Interval, IntoDatum, Json, PgBox,
     PgVarlena, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone, Uuid,
 };
-use core::ops::ControlFlow;
-
-/// Unboxing for arguments
-///
-/// This bound is necessary to distinguish things which can be passed into `#[pg_extern] fn`.
-/// It is strictly a mistake to use the BorrowDatum/UnboxDatum/DetoastDatum traits for this bound!
-/// PGRX allows "phantom arguments" which are not actually present in the C function, and are also
-/// omitted in the SQL, but are passed to the Rust function anyways.
-pub trait UnboxArg: Sized {
-    /// indicates min/max number of args that may be consumed if statically known
-    fn arg_width(_fcinfo: pg_sys::FunctionCallInfo) -> Option<(usize, usize)> {
-        todo!()
-    }
-
-    /// try to unbox the next argument
-    ///
-    /// should play into a quasi-iterator somehow?
-    fn try_unbox(_fcinfo: pg_sys::FunctionCallInfo, _current: usize) -> ControlFlow<Self, ()> {
-        todo!()
-    }
-}
 
 /// How to return a value from Rust to Postgres
 ///

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -12,15 +12,11 @@
 use std::ffi::{CStr, CString};
 
 use crate::heap_tuple::PgHeapTuple;
-use crate::iter::{SetOfIterator, TableIterator};
-use crate::ptr::PointerExt;
 use crate::{
-    pg_return_null, pg_sys, srf_is_first_call, srf_return_done, srf_return_next, AnyNumeric, Date,
-    Inet, Internal, Interval, IntoDatum, Json, PgBox, PgMemoryContexts, PgVarlena, Time,
-    TimeWithTimeZone, Timestamp, TimestampWithTimeZone, Uuid,
+    pg_return_null, pg_sys, AnyNumeric, Date, Inet, Internal, Interval, IntoDatum, Json, PgBox,
+    PgVarlena, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone, Uuid,
 };
 use core::ops::ControlFlow;
-use core::ptr;
 
 /// Unboxing for arguments
 ///
@@ -134,169 +130,10 @@ pub enum CallCx {
     WrappedFn(pg_sys::MemoryContext),
 }
 
-fn prepare_value_per_call_srf(fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
-    unsafe {
-        if srf_is_first_call(fcinfo) {
-            let fn_call_cx = pg_sys::init_MultiFuncCall(fcinfo);
-            CallCx::WrappedFn((*fn_call_cx).multi_call_memory_ctx)
-        } else {
-            CallCx::RestoreCx
-        }
-    }
-}
-
-unsafe impl<'a, T> ReturnShipping for SetOfIterator<'a, T>
-where
-    T: ReturnShipping,
-{
-    type Item = <Self as Iterator>::Item;
-    unsafe fn prepare_call(fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
-        prepare_value_per_call_srf(fcinfo)
-    }
-
-    fn label_ret(self) -> Ret<Self> {
-        let mut iter = self;
-        let ret = iter.next();
-        match ret {
-            None => Ret::Zero,
-            Some(value) => Ret::Many(iter, value),
-        }
-    }
-
-    unsafe fn box_return(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
-        let value = match ret {
-            Ret::Zero => return empty_srf(fcinfo),
-            Ret::Once(value) => value,
-            Ret::Many(iter, value) => {
-                iter.into_context(fcinfo);
-                value
-            }
-        };
-
-        unsafe {
-            let fcx = deref_fcx(fcinfo);
-            srf_return_next(fcinfo, fcx);
-            T::box_return(fcinfo, value.label_ret())
-        }
-    }
-
-    unsafe fn into_context(self, fcinfo: pg_sys::FunctionCallInfo) {
-        let fcx = deref_fcx(fcinfo);
-        unsafe {
-            let ptr = srf_memcx(fcx).leak_and_drop_on_delete(self);
-            // it's the first call so we need to finish setting up fcx
-            (*fcx).user_fctx = ptr.cast();
-        }
-    }
-
-    unsafe fn ret_from_context(fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
-        let fcx = deref_fcx(fcinfo);
-        // SAFETY: fcx.user_fctx was set earlier, immediately before or in a prior call
-        let iter = &mut *(*fcx).user_fctx.cast::<SetOfIterator<'_, T>>();
-        match iter.next() {
-            None => Ret::Zero,
-            Some(value) => Ret::Once(value),
-        }
-    }
-
-    unsafe fn finish_call(fcinfo: pg_sys::FunctionCallInfo) {
-        let fcx = deref_fcx(fcinfo);
-        unsafe { srf_return_done(fcinfo, fcx) }
-    }
-}
-
 pub enum Ret<T: ReturnShipping> {
     Zero,
     Once(T::Item),
     Many(T, T::Item),
-}
-
-unsafe impl<'a, T> ReturnShipping for TableIterator<'a, T>
-where
-    T: ReturnShipping,
-{
-    type Item = <Self as Iterator>::Item;
-
-    unsafe fn prepare_call(fcinfo: pg_sys::FunctionCallInfo) -> CallCx {
-        prepare_value_per_call_srf(fcinfo)
-    }
-
-    fn label_ret(self) -> Ret<Self> {
-        let mut iter = self;
-        let ret = iter.next();
-        match ret {
-            None => Ret::Zero,
-            Some(value) => Ret::Many(iter, value),
-        }
-    }
-
-    unsafe fn box_return(fcinfo: pg_sys::FunctionCallInfo, ret: Ret<Self>) -> pg_sys::Datum {
-        let value = match ret {
-            Ret::Zero => return empty_srf(fcinfo),
-            Ret::Once(value) => value,
-            Ret::Many(iter, value) => {
-                iter.into_context(fcinfo);
-                value
-            }
-        };
-
-        unsafe {
-            let fcx = deref_fcx(fcinfo);
-            srf_return_next(fcinfo, fcx);
-            T::box_return(fcinfo, value.label_ret())
-        }
-    }
-
-    unsafe fn into_context(self, fcinfo: pg_sys::FunctionCallInfo) {
-        // FIXME: this is assigned here but used in the tuple impl?
-        let fcx = deref_fcx(fcinfo);
-        unsafe {
-            let ptr = srf_memcx(fcx).switch_to(move |mcx| {
-                let mut tupdesc = ptr::null_mut();
-                let mut oid = pg_sys::Oid::default();
-                let ty_class = pg_sys::get_call_result_type(fcinfo, &mut oid, &mut tupdesc);
-                if tupdesc.is_non_null() {
-                    pg_sys::BlessTupleDesc(tupdesc);
-                }
-                (*fcx).tuple_desc = tupdesc;
-                mcx.leak_and_drop_on_delete(self)
-            });
-            // it's the first call so we need to finish setting up fcx
-            (*fcx).user_fctx = ptr.cast();
-        }
-    }
-
-    unsafe fn ret_from_context(fcinfo: pg_sys::FunctionCallInfo) -> Ret<Self> {
-        let fcx = deref_fcx(fcinfo);
-        // SAFETY: fcx.user_fctx was set earlier, immediately before or in a prior call
-        let iter = &mut *(*fcx).user_fctx.cast::<TableIterator<T>>();
-        match iter.next() {
-            None => Ret::Zero,
-            Some(value) => Ret::Once(value),
-        }
-    }
-
-    unsafe fn finish_call(fcinfo: pg_sys::FunctionCallInfo) {
-        let fcx = deref_fcx(fcinfo);
-        unsafe { srf_return_done(fcinfo, fcx) }
-    }
-}
-
-pub(crate) fn empty_srf(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
-    unsafe {
-        let fcx = deref_fcx(fcinfo);
-        srf_return_done(fcinfo, fcx);
-        pg_return_null(fcinfo)
-    }
-}
-
-/// "per_MultiFuncCall" but no FFI cost
-pub(crate) fn deref_fcx(fcinfo: pg_sys::FunctionCallInfo) -> *mut pg_sys::FuncCallContext {
-    unsafe { (*(*fcinfo).flinfo).fn_extra.cast() }
-}
-
-pub(crate) fn srf_memcx(fcx: *mut pg_sys::FuncCallContext) -> PgMemoryContexts {
-    unsafe { PgMemoryContexts::For((*fcx).multi_call_memory_ctx) }
 }
 
 unsafe impl<T> RetPackage for Option<T>

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -302,8 +302,10 @@ where
     }
 }
 
+/// How iterators are returned
 pub struct IterRet<T: RetAbi>(Step<T>);
 
+/// ValuePerCall SRF steps
 enum Step<T: RetAbi> {
     Done,
     Once(T::Item),

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -11,7 +11,7 @@
 use std::iter;
 
 use crate::{
-    callconv::{BoxRet, Ret, *},
+    callconv::{Ret, ReturnShipping, *},
     pg_sys, IntoDatum, IntoHeapTuple,
 };
 use pgrx_sql_entity_graph::metadata::{
@@ -188,14 +188,14 @@ impl<C: IntoDatum> IntoHeapTuple for (C,) {
     }
 }
 
-unsafe impl<C> BoxRet for (C,)
+unsafe impl<C> ReturnShipping for (C,)
 where
-    C: BoxRet,
+    C: ReturnShipping,
     Self: IntoHeapTuple,
 {
     type CallRet = Self;
 
-    fn into_ret(self) -> Ret<Self> {
+    fn label_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -209,7 +209,7 @@ where
             }
         };
 
-        unsafe { C::box_return(fcinfo, value.0.into_ret()) }
+        unsafe { C::box_return(fcinfo, value.0.label_ret()) }
     }
 }
 
@@ -256,14 +256,14 @@ macro_rules! impl_table_iter {
             }
         }
 
-        unsafe impl<$($C),*> BoxRet for ($($C,)*)
+        unsafe impl<$($C),*> ReturnShipping for ($($C,)*)
         where
-             $($C: BoxRet,)*
+             $($C: ReturnShipping,)*
              Self: IntoHeapTuple,
         {
             type CallRet = Self;
 
-            fn into_ret(self) -> Ret<Self> {
+            fn label_ret(self) -> Ret<Self> {
                 Ret::Once(self)
             }
 

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -190,7 +190,7 @@ impl<C: IntoDatum> IntoHeapTuple for (C,) {
 
 unsafe impl<C> ReturnShipping for (C,)
 where
-    C: ReturnShipping, // so we support TableIterator<'a, (Option<T>,)> as well
+    C: RetPackage, // so we support TableIterator<'a, (Option<T>,)> as well
     Self: IntoHeapTuple,
 {
     type Item = Self;
@@ -259,7 +259,7 @@ macro_rules! impl_table_iter {
 
         unsafe impl<$($C),*> ReturnShipping for ($($C,)*)
         where
-             $($C: ReturnShipping,)*
+             $($C: RetPackage,)*
              Self: IntoHeapTuple,
         {
             type Item = Self;

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -193,7 +193,7 @@ where
     C: ReturnShipping, // so we support TableIterator<'a, (Option<T>,)> as well
     Self: IntoHeapTuple,
 {
-    type CallRet = Self;
+    type Item = Self;
 
     fn label_ret(self) -> Ret<Self> {
         Ret::Once(self)
@@ -262,7 +262,7 @@ macro_rules! impl_table_iter {
              $($C: ReturnShipping,)*
              Self: IntoHeapTuple,
         {
-            type CallRet = Self;
+            type Item = Self;
 
             fn label_ret(self) -> Ret<Self> {
                 Ret::Once(self)

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -218,8 +218,8 @@ where
 
     unsafe fn ret_from_fcinfo_fcx(fcinfo: pg_sys::FunctionCallInfo) -> Self::Ret {
         let step = match TableIterator::<(T,)>::ret_from_fcinfo_fcx(fcinfo).0 {
-            Step::Once((item,)) => Step::Once(item),
             Step::Done => Step::Done,
+            Step::Once((item,)) => Step::Once(item),
             Step::Init(iter, (value,)) => Step::Init(Self(iter), value),
         };
         IterRet(step)

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -401,7 +401,6 @@ macro_rules! impl_table_iter {
 
                 unsafe {
                     let fcx = deref_fcx(fcinfo);
-                    // FIXME: we only know this is here due to our clairvoyant powers
                     let heap_tuple = value.into_heap_tuple((*fcx).tuple_desc);
                     pg_sys::HeapTupleHeaderGetDatum((*heap_tuple).t_data)
                 }

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -7,7 +7,6 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-#![allow(clippy::vec_init_then_push)]
 use core::{iter, ptr};
 
 use crate::callconv::{CallCx, Ret, RetPackage, ReturnShipping};

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -195,10 +195,7 @@ where
 {
     type CallRet = Self;
 
-    fn into_ret(self) -> Ret<Self>
-    where
-        Self: Sized,
-    {
+    fn into_ret(self) -> Ret<Self> {
         Ret::Once(self)
     }
 
@@ -266,10 +263,7 @@ macro_rules! impl_table_iter {
         {
             type CallRet = Self;
 
-            fn into_ret(self) -> Ret<Self>
-            where
-                Self: Sized,
-            {
+            fn into_ret(self) -> Ret<Self> {
                 Ret::Once(self)
             }
 


### PR DESCRIPTION
This completely reworks the way we handle returning types from functions, so that we no longer have to rely on a macro expansion behavior that has to already know the types at expansion time (and thus has to parse them somehow, which it cannot realistically do because type aliases exist). Instead, we simply expand into code that asks the types themselves to modify the FunctionCallInfo appropriately and then return a raw Datum to Postgres.

This breaks support for certain returns because it was difficult to do this and also support arbitrary nesting, because Postgres does not support arbitrary nesting. For instance, you can no longer return:
- `SetOfIterator<'a, Result<T, E>>`
- `TableIterator<'a, (Result<T, E>, Result<U, D>)>`
- `Option<TableIterator<'a, Tuple>>`

It's expected that this will improve in the near-ish future.

This also breaks returning values from `#[pg_extern]` functions that were relying on `IntoDatum` implementations being enough. It is not expected this will improve, for the reasons described on the documentation of the new traits, which can be summarized as "`IntoDatum` should never have been used for that bound". This change blocks off several latent correctness problems from affecting pgrx going forward.

Fixes https://github.com/pgcentralfoundation/pgrx/issues/1484