### PR TITLE
Abstract over `id_matches` in sql-entity-graph

### DIFF
--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -22,7 +22,8 @@ use crate::metadata::SqlMapping;
 use crate::pgrx_sql::PgrxSql;
 use crate::to_sql::entity::ToSqlConfigEntity;
 use crate::to_sql::ToSql;
-use crate::{SqlGraphEntity, SqlGraphIdentifier, UsedTypeEntity};
+use crate::type_keyed;
+use crate::{SqlGraphEntity, SqlGraphIdentifier, TypeMatch, UsedTypeEntity};
 use core::any::TypeId;
 use eyre::{eyre, WrapErr};
 
@@ -277,21 +278,14 @@ impl ToSql for PgAggregateEntity {
         };
 
         let stype_sql = map_ty(&self.stype.used_ty).wrap_err("Mapping state type")?;
-        let mut stype_schema = String::from("");
-        for (ty_item, ty_index) in context.types.iter() {
-            if ty_item.id_matches(&self.stype.used_ty.ty_id) {
-                stype_schema = context.schema_prefix_for(ty_index);
-                break;
-            }
-        }
-        if String::is_empty(&stype_schema) {
-            for (ty_item, ty_index) in context.enums.iter() {
-                if ty_item.id_matches(&self.stype.used_ty.ty_id) {
-                    stype_schema = context.schema_prefix_for(ty_index);
-                    break;
-                }
-            }
-        }
+        let stype_schema = context
+            .types
+            .iter()
+            .map(type_keyed)
+            .chain(context.enums.iter().map(type_keyed))
+            .find(|(ty, _)| ty.id_matches(&self.stype.used_ty.ty_id))
+            .map(|(_, ty_index)| context.schema_prefix_for(ty_index))
+            .unwrap_or_default();
 
         if let Some(value) = &self.mstype {
             let mstype_sql = map_ty(value).wrap_err("Mapping moving state type")?;

--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -23,7 +23,7 @@ use crate::pgrx_sql::PgrxSql;
 use crate::to_sql::entity::ToSqlConfigEntity;
 use crate::to_sql::ToSql;
 use crate::type_keyed;
-use crate::{SqlGraphEntity, SqlGraphIdentifier, TypeMatch, UsedTypeEntity};
+use crate::{SqlGraphEntity, SqlGraphIdentifier, UsedTypeEntity};
 use core::any::TypeId;
 use eyre::{eyre, WrapErr};
 

--- a/pgrx-sql-entity-graph/src/aggregate/entity.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/entity.rs
@@ -319,12 +319,7 @@ impl ToSql for PgAggregateEntity {
                 let graph_index = context
                     .graph
                     .neighbors_undirected(self_index)
-                    .find(|neighbor| match &context.graph[*neighbor] {
-                        SqlGraphEntity::Type(ty) => ty.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::Enum(en) => en.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::BuiltinType(defined) => defined == arg.used_ty.full_path,
-                        _ => false,
-                    })
+                    .find(|neighbor| context.graph[*neighbor].type_matches(&arg.used_ty))
                     .ok_or_else(|| {
                         eyre!("Could not find arg type in graph. Got: {:?}", arg.used_ty)
                     })?;
@@ -372,12 +367,7 @@ impl ToSql for PgAggregateEntity {
                 let graph_index = context
                     .graph
                     .neighbors_undirected(self_index)
-                    .find(|neighbor| match &context.graph[*neighbor] {
-                        SqlGraphEntity::Type(ty) => ty.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::Enum(en) => en.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::BuiltinType(defined) => defined == arg.used_ty.full_path,
-                        _ => false,
-                    })
+                    .find(|neighbor| context.graph[*neighbor].type_matches(&arg.used_ty))
                     .ok_or_else(|| eyre!("Could not find arg type in graph. Got: {:?}", arg))?;
                 let needs_comma = idx < (direct_args.len() - 1);
                 let buf = format!(

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -142,6 +142,14 @@ impl SqlGraphEntity {
     }
 }
 
+pub trait TypeMatch {
+    fn id_matches(&self, arg: &core::any::TypeId) -> bool;
+}
+
+pub fn type_keyed<'a, 'b, A: TypeMatch, B>((a, b): (&'a A, &'b B)) -> (&'a dyn TypeMatch, &'b B) {
+    (a, b)
+}
+
 pub trait TypeIdentifiable {
     fn ty_id(&self) -> &core::any::TypeId;
     fn ty_name(&self) -> &str;

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -127,6 +127,24 @@ impl SqlGraphEntity {
             rust_identifier = self.rust_identifier(),
         )
     }
+
+    pub fn id_or_name_matches(&self, ty_id: &::core::any::TypeId, name: &str) -> bool {
+        match self {
+            SqlGraphEntity::Enum(entity) => entity.id_matches(ty_id),
+            SqlGraphEntity::Type(entity) => entity.id_matches(ty_id),
+            SqlGraphEntity::BuiltinType(string) => string == name,
+            _ => false,
+        }
+    }
+
+    pub fn type_matches(&self, arg: &dyn TypeIdentifiable) -> bool {
+        self.id_or_name_matches(arg.ty_id(), arg.ty_name())
+    }
+}
+
+pub trait TypeIdentifiable {
+    fn ty_id(&self) -> &core::any::TypeId;
+    fn ty_name(&self) -> &str;
 }
 
 impl SqlGraphIdentifier for SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -118,12 +118,7 @@ impl ToSql for PgExternEntity {
                 let graph_index = context
                     .graph
                     .neighbors_undirected(self_index)
-                    .find(|neighbor| match &context.graph[*neighbor] {
-                        SqlGraphEntity::Type(ty) => ty.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::Enum(en) => en.id_matches(&arg.used_ty.ty_id),
-                        SqlGraphEntity::BuiltinType(defined) => defined == arg.used_ty.full_path,
-                        _ => false,
-                    })
+                    .find(|neighbor| context.graph[*neighbor].type_matches(&arg.used_ty))
                     .ok_or_else(|| eyre!("Could not find arg type in graph. Got: {:?}", arg))?;
                 let needs_comma = idx < (metadata_without_arg_skips.len().saturating_sub(1));
                 let metadata_argument = &self.metadata.arguments[idx];
@@ -182,12 +177,7 @@ impl ToSql for PgExternEntity {
                 let graph_index = context
                     .graph
                     .neighbors_undirected(self_index)
-                    .find(|neighbor| match &context.graph[*neighbor] {
-                        SqlGraphEntity::Type(neighbor_ty) => neighbor_ty.id_matches(&ty.ty_id),
-                        SqlGraphEntity::Enum(neighbor_en) => neighbor_en.id_matches(&ty.ty_id),
-                        SqlGraphEntity::BuiltinType(defined) => defined == ty.full_path,
-                        _ => false,
-                    })
+                    .find(|neighbor| context.graph[*neighbor].type_matches(ty))
                     .ok_or_else(|| eyre!("Could not find return type in graph."))?;
                 let metadata_retval = self.metadata.retval.clone();
                 let sql_type = match metadata_retval.return_sql {
@@ -206,12 +196,7 @@ impl ToSql for PgExternEntity {
                 let graph_index = context
                     .graph
                     .neighbors_undirected(self_index)
-                    .find(|neighbor| match &context.graph[*neighbor] {
-                        SqlGraphEntity::Type(neighbor_ty) => neighbor_ty.id_matches(&ty.ty_id),
-                        SqlGraphEntity::Enum(neighbor_en) => neighbor_en.id_matches(&ty.ty_id),
-                        SqlGraphEntity::BuiltinType(defined) => defined == ty.full_path,
-                        _ => false,
-                    })
+                    .find(|neighbor| context.graph[*neighbor].type_matches(ty))
                     .ok_or_else(|| eyre!("Could not find return type in graph."))?;
                 let metadata_retval = self.metadata.retval.clone();
                 let sql_type = match metadata_retval.return_sql {

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -30,8 +30,7 @@ use crate::metadata::{Returns, SqlMapping};
 use crate::pgrx_sql::PgrxSql;
 use crate::to_sql::entity::ToSqlConfigEntity;
 use crate::to_sql::ToSql;
-use crate::ExternArgs;
-use crate::{SqlGraphEntity, SqlGraphIdentifier};
+use crate::{ExternArgs, SqlGraphEntity, SqlGraphIdentifier, TypeMatch};
 
 use eyre::{eyre, WrapErr};
 

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -236,16 +236,7 @@ impl ToSql for PgExternEntity {
                 {
                     let graph_index =
                         context.graph.neighbors_undirected(self_index).find(|neighbor| {
-                            match &context.graph[*neighbor] {
-                                SqlGraphEntity::Type(neighbor_ty) => {
-                                    neighbor_ty.id_matches(&ty.ty_id)
-                                }
-                                SqlGraphEntity::Enum(neighbor_en) => {
-                                    neighbor_en.id_matches(&ty.ty_id)
-                                }
-                                SqlGraphEntity::BuiltinType(defined) => defined == ty.ty_source,
-                                _ => false,
-                            }
+                            context.graph[*neighbor].id_or_name_matches(&ty.ty_id, ty.ty_source)
                         });
 
                     let needs_comma = idx < (table_items.len() - 1);
@@ -366,11 +357,9 @@ impl ToSql for PgExternEntity {
             let left_arg_graph_index = context
                 .graph
                 .neighbors_undirected(self_index)
-                .find(|neighbor| match &context.graph[*neighbor] {
-                    SqlGraphEntity::Type(ty) => ty.id_matches(&left_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::Enum(en) => en.id_matches(&left_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::BuiltinType(defined) => defined == left_arg.type_name,
-                    _ => false,
+                .find(|neighbor| {
+                    context.graph[*neighbor]
+                        .id_or_name_matches(&left_fn_arg.used_ty.ty_id, left_arg.type_name)
                 })
                 .ok_or_else(|| {
                     eyre!("Could not find left arg type in graph. Got: {:?}", left_arg)
@@ -406,11 +395,9 @@ impl ToSql for PgExternEntity {
             let right_arg_graph_index = context
                 .graph
                 .neighbors_undirected(self_index)
-                .find(|neighbor| match &context.graph[*neighbor] {
-                    SqlGraphEntity::Type(ty) => ty.id_matches(&right_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::Enum(en) => en.id_matches(&right_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::BuiltinType(defined) => defined == right_arg.type_name,
-                    _ => false,
+                .find(|neighbor| {
+                    context.graph[*neighbor]
+                        .id_or_name_matches(&right_fn_arg.used_ty.ty_id, right_arg.type_name)
                 })
                 .ok_or_else(|| {
                     eyre!("Could not find right arg type in graph. Got: {:?}", right_arg)
@@ -522,11 +509,9 @@ impl ToSql for PgExternEntity {
             let source_arg_graph_index = context
                 .graph
                 .neighbors_undirected(self_index)
-                .find(|neighbor| match &context.graph[*neighbor] {
-                    SqlGraphEntity::Type(ty) => ty.id_matches(&source_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::Enum(en) => en.id_matches(&source_fn_arg.used_ty.ty_id),
-                    SqlGraphEntity::BuiltinType(defined) => defined == source_arg.type_name,
-                    _ => false,
+                .find(|neighbor| {
+                    context.graph[*neighbor]
+                        .id_or_name_matches(&source_fn_arg.used_ty.ty_id, source_arg.type_name)
                 })
                 .ok_or_else(|| {
                     eyre!("Could not find source type in graph. Got: {:?}", source_arg)

--- a/pgrx-sql-entity-graph/src/postgres_enum/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_enum/entity.rs
@@ -19,7 +19,7 @@ use crate::mapping::RustSqlMapping;
 use crate::pgrx_sql::PgrxSql;
 use crate::to_sql::entity::ToSqlConfigEntity;
 use crate::to_sql::ToSql;
-use crate::{SqlGraphEntity, SqlGraphIdentifier};
+use crate::{SqlGraphEntity, SqlGraphIdentifier, TypeMatch};
 use std::collections::BTreeSet;
 
 /// The output of a [`PostgresEnum`](crate::postgres_enum::PostgresEnum) from `quote::ToTokens::to_tokens`.
@@ -35,8 +35,8 @@ pub struct PostgresEnumEntity {
     pub to_sql_config: ToSqlConfigEntity,
 }
 
-impl PostgresEnumEntity {
-    pub fn id_matches(&self, candidate: &core::any::TypeId) -> bool {
+impl TypeMatch for PostgresEnumEntity {
+    fn id_matches(&self, candidate: &core::any::TypeId) -> bool {
         self.mappings.iter().any(|tester| *candidate == tester.id)
     }
 }

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -19,7 +19,7 @@ use crate::mapping::RustSqlMapping;
 use crate::pgrx_sql::PgrxSql;
 use crate::to_sql::entity::ToSqlConfigEntity;
 use crate::to_sql::ToSql;
-use crate::{SqlGraphEntity, SqlGraphIdentifier};
+use crate::{SqlGraphEntity, SqlGraphIdentifier, TypeMatch};
 use std::collections::BTreeSet;
 
 use eyre::eyre;
@@ -39,8 +39,8 @@ pub struct PostgresTypeEntity {
     pub to_sql_config: ToSqlConfigEntity,
 }
 
-impl PostgresTypeEntity {
-    pub fn id_matches(&self, candidate: &core::any::TypeId) -> bool {
+impl TypeMatch for PostgresTypeEntity {
+    fn id_matches(&self, candidate: &core::any::TypeId) -> bool {
         self.mappings.iter().any(|tester| *candidate == tester.id)
     }
 }

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -367,6 +367,15 @@ pub struct UsedTypeEntity {
     pub metadata: FunctionMetadataTypeEntity,
 }
 
+impl crate::TypeIdentifiable for UsedTypeEntity {
+    fn ty_id(&self) -> &core::any::TypeId {
+        &self.ty_id
+    }
+    fn ty_name(&self) -> &str {
+        self.full_path
+    }
+}
+
 fn resolve_vec_inner(
     original: syn::TypePath,
 ) -> syn::Result<(syn::Type, Option<CompositeTypeMacro>)> {


### PR DESCRIPTION
There's a lot of segments of code in pgrx-sql-entity-graph that have a lot of imperative state, *not* because that's essential to describing them, but simply to implement a bit of relatively minor control flow. Instead of continuing to do that, let's simplify the graph code by allowing similar types to be described by a behavior they both implement. Abstractions can sometimes clarify things! Who'd have thought?