### PR TITLE
Add support for --extension-name in new extension creation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -461,6 +461,23 @@ jobs:
       - name: Test sample
         run: cd /tmp/sample && cargo pgrx test pg$PG_VER
 
+      - name: create new sample extension using --extension-name
+        run: cd /tmp/ && cargo pgrx new --extension-name sample pg-sample
+
+      # hack Cargo.toml to use this version of pgrx from github
+      - name: hack Cargo.toml
+        run: |
+          echo "[patch.crates-io]" >> /tmp/pg-sample/Cargo.toml
+          echo "pgrx        = { path = \"${GITHUB_WORKSPACE}/pgrx\"        }" >> /tmp/pg-sample/Cargo.toml
+          echo "pgrx-macros = { path = \"${GITHUB_WORKSPACE}/pgrx-macros\" }" >> /tmp/pg-sample/Cargo.toml
+          echo "pgrx-tests  = { path = \"${GITHUB_WORKSPACE}/pgrx-tests\"  }" >> /tmp/pg-sample/Cargo.toml
+
+      - name: show Cargo.toml
+        run: cat /tmp/pg-sample/Cargo.toml
+
+      - name: Test pg-sample
+        run: cd /tmp/pg-sample && cargo pgrx test pg$PG_VER
+
       - name: Stop sccache server
         run: sccache --stop-server || true
 

--- a/cargo-pgrx/src/command/new.rs
+++ b/cargo-pgrx/src/command/new.rs
@@ -92,7 +92,9 @@ fn create_control_file(mut filename: PathBuf, extension_name: &str) -> Result<()
     filename.push(format!("{extension_name}.control"));
     let mut file = std::fs::File::create(filename)?;
 
-    file.write_all(format!(include_str!("../templates/control"), name = extension_name).as_bytes())?;
+    file.write_all(
+        format!(include_str!("../templates/control"), name = extension_name).as_bytes(),
+    )?;
 
     Ok(())
 }
@@ -127,10 +129,14 @@ fn create_lib_rs(
 
     if is_bgworker {
         file.write_all(
-            format!(include_str!("../templates/bgworker_lib_rs"), extension_name = extension_name).as_bytes(),
+            format!(include_str!("../templates/bgworker_lib_rs"), extension_name = extension_name)
+                .as_bytes(),
         )?;
     } else {
-        file.write_all(format!(include_str!("../templates/lib_rs"), extension_name = extension_name).as_bytes())?;
+        file.write_all(
+            format!(include_str!("../templates/lib_rs"), extension_name = extension_name)
+                .as_bytes(),
+        )?;
     }
 
     Ok(())

--- a/cargo-pgrx/src/templates/bgworker_lib_rs
+++ b/cargo-pgrx/src/templates/bgworker_lib_rs
@@ -9,7 +9,7 @@ In order to use this bgworker with a cargo-pgrx managed database, you'll need to
 "$PGRX_HOME/data-$PGVER/postgresql.conf" if the `shared_preload_libraries` entry is absent:
 
 ```
-shared_preload_libraries = '{name}.so'
+shared_preload_libraries = '{extension_name}.so'
 ```
 
 Background workers *must* be initialized in the extension's `_PG_init()` function, and can *only*
@@ -22,9 +22,9 @@ this background worker
 #[allow(non_snake_case)]
 #[pg_guard]
 pub extern "C" fn _PG_init() {{
-    BackgroundWorkerBuilder::new("{name}")
+    BackgroundWorkerBuilder::new("{extension_name}")
         .set_function("background_worker_main")
-        .set_library("{name}")
+        .set_library("{extension_name}")
         .set_argument(42i32.into_datum())
         .enable_spi_access()
         .load();

--- a/cargo-pgrx/src/templates/lib_rs
+++ b/cargo-pgrx/src/templates/lib_rs
@@ -3,8 +3,8 @@ use pgrx::prelude::*;
 ::pgrx::pg_module_magic!();
 
 #[pg_extern]
-fn hello_{name}() -> &'static str {{
-    "Hello, {name}"
+fn hello_{extension_name}() -> &'static str {{
+    "Hello, {extension_name}"
 }}
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -13,8 +13,8 @@ mod tests {{
     use pgrx::prelude::*;
 
     #[pg_test]
-    fn test_hello_{name}() {{
-        assert_eq!("Hello, {name}", crate::hello_{name}());
+    fn test_hello_{extension_name}() {{
+        assert_eq!("Hello, {extension_name}", crate::hello_{extension_name}());
     }}
 
 }}

--- a/cargo-pgrx/src/templates/lib_rs
+++ b/cargo-pgrx/src/templates/lib_rs
@@ -2,21 +2,36 @@ use pgrx::prelude::*;
 
 ::pgrx::pg_module_magic!();
 
-#[pg_extern]
-fn hello_{extension_name}() -> &'static str {{
-    "Hello, {extension_name}"
-}}
-
-#[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
-mod tests {{
-    use pgrx::prelude::*;
+mod {extension_name} {{
+    use super::*;
 
-    #[pg_test]
-    fn test_hello_{extension_name}() {{
-        assert_eq!("Hello, {extension_name}", crate::hello_{extension_name}());
+    #[pg_extern]
+    fn hello_world() -> &'static str {{
+        "Hello, world!"
     }}
 
+    #[pg_extern]
+    fn hello_name(name: &str) -> String {{
+        format!("Hello, {{}}!", name)
+    }}
+
+    #[cfg(any(test, feature = "pg_test"))]
+    #[pg_schema]
+    mod tests {{
+        use pgrx::prelude::*;
+
+        #[pg_test]
+        fn test_hello_world() {{
+            assert_eq!("Hello, world!", crate::{extension_name}::hello_world());
+        }}
+
+        #[pg_test]
+        fn test_hello_name() {{
+            assert_eq!("Hello, Alice!", crate::{extension_name}::hello_name("Alice"));
+        }}
+
+    }}
 }}
 
 /// This module is required by `cargo pgrx test` invocations.


### PR DESCRIPTION
- Added an optional `--extension-name` parameter to the `New` struct in `cargo-pgrx`.
- Updated the `execute` method to use the provided `extension_name` if available, defaulting to the crate name otherwise.
- Modified `create_crate_template` to pass `extension_name` to template functions.
- Adjusted `create_control_file`, `create_lib_rs`, and template files to use `extension_name` instead of `name`.
- Ensured that the control file and related files reflect the custom extension name.

This change allows users to specify a different PostgreSQL extension name when creating a new extension crate using `pgrx new`.