### PR TITLE
Allow real borrow-checking of `#[pg_extern] fn` lifetimes

### DIFF
--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -40,7 +40,6 @@ pub fn finfo_v1_extern_c(
         #[no_mangle]
         #[doc(hidden)]
         #unused_lifetimes
-        #[::pgrx::pgrx_macros::pg_guard]
         pub unsafe extern "C" fn #wrapper_symbol #lifetimes(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
             #contents
         }

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
 use syn::{self, spanned::Spanned, ItemFn};
 
@@ -22,15 +22,11 @@ pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
 pub fn finfo_v1_extern_c(
     original: &syn::ItemFn,
     fcinfo: Ident,
-    fc_ltparam: syn::LifetimeParam,
     contents: TokenStream,
 ) -> syn::Result<ItemFn> {
     let original_name = &original.sig.ident;
     let wrapper_symbol = format_ident!("{}_wrapper", original_name);
-    let mut lifetimes = original.sig.generics.clone();
-    let fc_lt = fc_ltparam.lifetime.clone();
-    lifetimes.params.push(syn::GenericParam::Lifetime(fc_ltparam));
-
+    let lifetimes = &original.sig.generics;
     // the wrapper function declaration may contain lifetimes that are not used, since
     // our input type is FunctionCallInfo and our return type is Datum
     let unused_lifetimes = match lifetimes.lifetimes().next() {
@@ -40,13 +36,12 @@ pub fn finfo_v1_extern_c(
         None => quote! {},
     };
 
-    let tokens = quote_spanned! { Span::call_site() =>
+    let tokens = quote_spanned! { original.sig.span() =>
         #[no_mangle]
         #[doc(hidden)]
         #unused_lifetimes
         #[::pgrx::pgrx_macros::pg_guard]
-        pub unsafe extern "C" fn #wrapper_symbol #lifetimes(#fcinfo: ::pgrx::callconv::Fcinfo<#fc_lt>) -> ::pgrx::pg_sys::Datum {
-            let #fcinfo = #fcinfo.0;
+        pub unsafe extern "C" fn #wrapper_symbol #lifetimes(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
             #contents
         }
     };

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
 use syn::{self, spanned::Spanned, ItemFn};
 
@@ -22,11 +22,15 @@ pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
 pub fn finfo_v1_extern_c(
     original: &syn::ItemFn,
     fcinfo: Ident,
+    fc_ltparam: syn::LifetimeParam,
     contents: TokenStream,
 ) -> syn::Result<ItemFn> {
     let original_name = &original.sig.ident;
     let wrapper_symbol = format_ident!("{}_wrapper", original_name);
-    let lifetimes = &original.sig.generics;
+    let mut lifetimes = original.sig.generics.clone();
+    let fc_lt = fc_ltparam.lifetime.clone();
+    lifetimes.params.push(syn::GenericParam::Lifetime(fc_ltparam));
+
     // the wrapper function declaration may contain lifetimes that are not used, since
     // our input type is FunctionCallInfo and our return type is Datum
     let unused_lifetimes = match lifetimes.lifetimes().next() {
@@ -36,12 +40,13 @@ pub fn finfo_v1_extern_c(
         None => quote! {},
     };
 
-    let tokens = quote_spanned! { original.sig.span() =>
+    let tokens = quote_spanned! { Span::call_site() =>
         #[no_mangle]
         #[doc(hidden)]
         #unused_lifetimes
         #[::pgrx::pgrx_macros::pg_guard]
-        pub unsafe extern "C" fn #wrapper_symbol #lifetimes(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
+        pub unsafe extern "C" fn #wrapper_symbol #lifetimes(#fcinfo: ::pgrx::callconv::Fcinfo<#fc_lt>) -> ::pgrx::pg_sys::Datum {
+            let #fcinfo = #fcinfo.0;
             #contents
         }
     };

--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -46,7 +46,7 @@ pub enum SqlMapping {
     Composite {
         array_brackets: bool,
     },
-    /// Placeholder for some types with no simple translation
+    /// A type which does not actually appear in SQL
     Skip,
 }
 

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -377,6 +377,8 @@ impl PgExtern {
         let is_raw = self.extern_attrs().contains(&Attribute::Raw);
         // We use a `_` prefix to make functions with no args more satisfied during linting.
         let fcinfo_ident = syn::Ident::new("_fcinfo", self.func.sig.ident.span());
+        let fc_lt = syn::Lifetime::new("'fcx", self.func.sig.generics.span());
+        let fc_ltparam = syn::LifetimeParam::new(fc_lt);
 
         let args = &self.inputs;
         let arg_pats = args.iter().map(|v| format_ident!("{}_", &v.pat)).collect::<Vec<_>>();
@@ -432,7 +434,7 @@ impl PgExtern {
                         unsafe { <#ret_ty as ::pgrx::callconv::RetAbi>::box_ret_in_fcinfo(fcinfo, result) }
                     }
                 };
-                finfo_v1_extern_c(&self.func, fcinfo_ident, wrapper_code)
+                finfo_v1_extern_c(&self.func, fcinfo_ident, fc_ltparam, wrapper_code)
             }
         }
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -434,7 +434,7 @@ impl PgExtern {
                         unsafe { <#ret_ty as ::pgrx::callconv::RetAbi>::box_ret_in_fcinfo(fcinfo, result) }
                     }
                 };
-                finfo_v1_extern_c(&self.func, fcinfo_ident, fc_ltparam, wrapper_code)
+                finfo_v1_extern_c(&self.func, fcinfo_ident, wrapper_code)
             }
         }
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use attribute::Attribute;
 pub use cast::PgCast;
 pub use operator::PgOperator;
 pub use returning::NameMacro;
+use syn::token::Comma;
 
 use self::returning::Returning;
 use super::UsedType;
@@ -38,7 +39,7 @@ use crate::ToSqlConfig;
 use operator::{PgrxOperatorAttributeWithIdent, PgrxOperatorOpName};
 use search_path::SearchPathList;
 
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, quote_spanned};
 use syn::parse::{Parse, ParseStream, Parser};
 use syn::punctuated::Punctuated;
@@ -377,8 +378,10 @@ impl PgExtern {
         let is_raw = self.extern_attrs().contains(&Attribute::Raw);
         // We use a `_` prefix to make functions with no args more satisfied during linting.
         let fcinfo_ident = syn::Ident::new("_fcinfo", self.func.sig.ident.span());
-        let fc_lt = syn::Lifetime::new("'fcx", self.func.sig.generics.span());
-        let fc_ltparam = syn::LifetimeParam::new(fc_lt);
+        let lifetimes =
+            self.func.sig.generics.lifetimes().collect::<syn::punctuated::Punctuated<_, Comma>>();
+        let fc_lt = syn::Lifetime::new("'fcx", Span::mixed_site());
+        let fc_ltparam = syn::LifetimeParam::new(fc_lt.clone());
 
         let args = &self.inputs;
         let arg_pats = args.iter().map(|v| format_ident!("{}_", &v.pat)).collect::<Vec<_>>();
@@ -418,7 +421,7 @@ impl PgExtern {
                     syn::ReturnType::Type(_, ret_ty) => ret_ty.clone(),
                 };
                 let wrapper_code = quote_spanned! { self.func.block.span() =>
-                    fn _internal_wrapper<'a>(fcinfo: ::pgrx::callconv::Fcinfo<'a>) -> ::pgrx::datum::Datum<'a> {
+                    fn _internal_wrapper<#fc_ltparam, #lifetimes>(fcinfo: ::pgrx::callconv::Fcinfo<#fc_lt>) -> ::pgrx::datum::Datum<#fc_lt> {
                     #[allow(unused_unsafe)]
                      unsafe {
                         let #fcinfo_ident = fcinfo.0;
@@ -435,7 +438,8 @@ impl PgExtern {
                         ::core::mem::transmute(unsafe { <#ret_ty as ::pgrx::callconv::RetAbi>::box_ret_in_fcinfo(#fcinfo_ident, result) })
                     }}
                     let fcinfo = ::pgrx::callconv::Fcinfo(#fcinfo_ident, ::core::marker::PhantomData);
-                    let datum = _internal_wrapper(fcinfo);
+                    // We preserve the invariants
+                    let datum = unsafe { ::pgrx::pg_sys::submodules::panic::pgrx_extern_c_guard(move || _internal_wrapper(fcinfo)) };
                     datum.sans_lifetime()
                 };
                 finfo_v1_extern_c(&self.func, fcinfo_ident, wrapper_code)

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -423,7 +423,7 @@ impl PgExtern {
                 let wrapper_code = quote_spanned! { self.func.block.span() =>
                     fn _internal_wrapper<#fc_ltparam, #lifetimes>(fcinfo: ::pgrx::callconv::Fcinfo<#fc_lt>) -> ::pgrx::datum::Datum<#fc_lt> {
                     #[allow(unused_unsafe)]
-                     unsafe {
+                    unsafe {
                         let #fcinfo_ident = fcinfo.0;
                         let result = match <#ret_ty as ::pgrx::callconv::RetAbi>::check_fcinfo_and_prepare(#fcinfo_ident) {
                             ::pgrx::callconv::CallCx::WrappedFn(mcx) => {

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -71,6 +71,9 @@ impl PgTrigger {
     pub fn wrapper_tokens(&self) -> Result<ItemFn, syn::Error> {
         let function_ident = self.func.sig.ident.clone();
         let fcinfo_ident = Ident::new("_fcinfo", function_ident.span());
+        let fc_lt = syn::Lifetime::new("'fcx", self.func.sig.generics.span());
+        let fc_ltparam = syn::LifetimeParam::new(fc_lt);
+
         let tokens = quote! {
             let fcinfo_ref = unsafe {
                 // SAFETY:  The caller should be Postgres in this case and it will give us a valid "fcinfo" pointer
@@ -96,7 +99,7 @@ impl PgTrigger {
             }
         };
 
-        finfo_v1_extern_c(&self.func, fcinfo_ident, tokens)
+        finfo_v1_extern_c(&self.func, fcinfo_ident, fc_ltparam, tokens)
     }
 }
 

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -99,7 +99,7 @@ impl PgTrigger {
             }
         };
 
-        finfo_v1_extern_c(&self.func, fcinfo_ident, fc_ltparam, tokens)
+        finfo_v1_extern_c(&self.func, fcinfo_ident, tokens)
     }
 }
 

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -71,32 +71,33 @@ impl PgTrigger {
     pub fn wrapper_tokens(&self) -> Result<ItemFn, syn::Error> {
         let function_ident = self.func.sig.ident.clone();
         let fcinfo_ident = Ident::new("_fcinfo", function_ident.span());
-        let fc_lt = syn::Lifetime::new("'fcx", self.func.sig.generics.span());
-        let fc_ltparam = syn::LifetimeParam::new(fc_lt);
 
         let tokens = quote! {
-            let fcinfo_ref = unsafe {
-                // SAFETY:  The caller should be Postgres in this case and it will give us a valid "fcinfo" pointer
-                #fcinfo_ident.as_ref().expect("fcinfo was NULL from Postgres")
-            };
-            let maybe_pg_trigger = unsafe { ::pgrx::trigger_support::PgTrigger::from_fcinfo(fcinfo_ref) };
-            let pg_trigger = maybe_pg_trigger.expect("PgTrigger::from_fcinfo failed");
-            let trigger_fn_result: Result<
-                Option<::pgrx::heap_tuple::PgHeapTuple<'_, _>>,
-                _,
-            > = #function_ident(&pg_trigger);
+            fn _internal(fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
+                let fcinfo_ref = unsafe {
+                    // SAFETY:  The caller should be Postgres in this case and it will give us a valid "fcinfo" pointer
+                    fcinfo.as_ref().expect("fcinfo was NULL from Postgres")
+                };
+                let maybe_pg_trigger = unsafe { ::pgrx::trigger_support::PgTrigger::from_fcinfo(fcinfo_ref) };
+                let pg_trigger = maybe_pg_trigger.expect("PgTrigger::from_fcinfo failed");
+                let trigger_fn_result: Result<
+                    Option<::pgrx::heap_tuple::PgHeapTuple<'_, _>>,
+                    _,
+                > = #function_ident(&pg_trigger);
 
 
-            // The trigger "protocol" allows a function to return the null pointer, but NOT to
-            // set the isnull result flag.  This is why we return `Datum::from(0)` in the None cases
-            let trigger_retval = trigger_fn_result.expect("Trigger function panic");
-            match trigger_retval {
-                None => unsafe { ::pgrx::pg_sys::Datum::from(0) },
-                Some(trigger_retval) => match trigger_retval.into_trigger_datum() {
+                // The trigger "protocol" allows a function to return the null pointer, but NOT to
+                // set the isnull result flag.  This is why we return `Datum::from(0)` in the None cases
+                let trigger_retval = trigger_fn_result.expect("Trigger function panic");
+                match trigger_retval {
                     None => unsafe { ::pgrx::pg_sys::Datum::from(0) },
-                    Some(datum) => datum,
+                    Some(trigger_retval) => match trigger_retval.into_trigger_datum() {
+                        None => unsafe { ::pgrx::pg_sys::Datum::from(0) },
+                        Some(datum) => datum,
+                    }
                 }
             }
+            ::pgrx::pg_sys::submodules::panic::pgrx_extern_c_guard(move || _internal(#fcinfo_ident))
         };
 
         finfo_v1_extern_c(&self.func, fcinfo_ident, tokens)

--- a/pgrx-tests/tests/todo/roundtrip-tests.stderr
+++ b/pgrx-tests/tests/todo/roundtrip-tests.stderr
@@ -21,6 +21,18 @@ error[E0261]: use of undeclared lifetime name `'a`
 error[E0261]: use of undeclared lifetime name `'a`
   --> tests/todo/roundtrip-tests.rs:69:21
    |
+22 |               fn $fname(i: $rtype) -> $rtype {
+   |  ____________________________________________-
+23 | |                 i
+24 | |             }
+   | |_____________- lifetime `'a` is missing in item created through this procedural macro
+...
+69 |           Vec<Option<&'a str>>,
+   |                       ^^ undeclared lifetime
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> tests/todo/roundtrip-tests.rs:69:21
+   |
 68 |         test_rt_array_refstr,
    |                             - help: consider introducing lifetime `'a` here: `<'a>`
 69 |         Vec<Option<&'a str>>,

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -10,12 +10,21 @@
 #![doc(hidden)]
 #![deny(unsafe_op_in_unsafe_fn)]
 //! Helper implementations for returning sets and tables from `#[pg_extern]`-style functions
+
 use crate::heap_tuple::PgHeapTuple;
 use crate::{
     pg_return_null, pg_sys, AnyNumeric, Date, Inet, Internal, Interval, IntoDatum, Json, PgBox,
     PgVarlena, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone, Uuid,
 };
+use core::marker::PhantomData;
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use std::ffi::{CStr, CString};
+
+type FcinfoData = pg_sys::FunctionCallInfoBaseData;
+#[repr(transparent)]
+pub struct Fcinfo<'a>(pub pg_sys::FunctionCallInfo, PhantomData<&'a mut FcinfoData>);
+impl<'fcx> UnwindSafe for Fcinfo<'fcx> {}
+impl<'fcx> RefUnwindSafe for Fcinfo<'fcx> {}
 
 /// How to return a value from Rust to Postgres
 ///

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -21,6 +21,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use std::ffi::{CStr, CString};
 
 type FcinfoData = pg_sys::FunctionCallInfoBaseData;
+// FIXME: replace with a real implementation
 pub struct Fcinfo<'a>(pub pg_sys::FunctionCallInfo, pub PhantomData<&'a mut FcinfoData>);
 impl<'fcx> UnwindSafe for Fcinfo<'fcx> {}
 impl<'fcx> RefUnwindSafe for Fcinfo<'fcx> {}

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -21,8 +21,7 @@ use core::panic::{RefUnwindSafe, UnwindSafe};
 use std::ffi::{CStr, CString};
 
 type FcinfoData = pg_sys::FunctionCallInfoBaseData;
-#[repr(transparent)]
-pub struct Fcinfo<'a>(pub pg_sys::FunctionCallInfo, PhantomData<&'a mut FcinfoData>);
+pub struct Fcinfo<'a>(pub pg_sys::FunctionCallInfo, pub PhantomData<&'a mut FcinfoData>);
 impl<'fcx> UnwindSafe for Fcinfo<'fcx> {}
 impl<'fcx> RefUnwindSafe for Fcinfo<'fcx> {}
 


### PR DESCRIPTION
This doesn't finish fixing things, but it introduces a skeleton for actually trying to impose borrow-checking further on the rest of pgrx's code. This small refactor is effectively a chokepoint that all future code has to build from.