### PR TITLE
add bindings of fmgroids.h, OIDs of built-in functions

### DIFF
--- a/pgrx-pg-sys/include/pg12.h
+++ b/pgrx-pg-sys/include/pg12.h
@@ -148,6 +148,7 @@
 #include "utils/datetime.h"
 #include "utils/elog.h"
 #include "utils/float.h"
+#include "utils/fmgroids.h"
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -146,6 +146,7 @@
 #include "utils/datetime.h"
 #include "utils/elog.h"
 #include "utils/float.h"
+#include "utils/fmgroids.h"
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -147,6 +147,7 @@
 #include "utils/datetime.h"
 #include "utils/elog.h"
 #include "utils/float.h"
+#include "utils/fmgroids.h"
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -148,6 +148,7 @@
 #include "utils/datetime.h"
 #include "utils/elog.h"
 #include "utils/float.h"
+#include "utils/fmgroids.h"
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -150,6 +150,7 @@
 #include "utils/datetime.h"
 #include "utils/elog.h"
 #include "utils/float.h"
+#include "utils/fmgroids.h"
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"


### PR DESCRIPTION
`fmgroids.h` is helpful to perform an index scan.

For example, https://github.com/apache/age/blob/ef9e0bd67bb8c342c4f6dd04761e2c4b3a3a5f80/src/backend/catalog/ag_graph.c#L74. It uses `F_NAMEEQ` to perform a search for catalog defined by extension.
