### PR TITLE
Fix lifetimes for IO functions

### DIFF
--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -791,7 +791,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
     let lifetime = match has_lifetimes {
         Some(lifetime) => quote! {#lifetime},
-        None => quote! {'static},
+        None => quote! {'_},
     };
 
     // all #[derive(PostgresType)] need to implement that trait
@@ -868,35 +868,22 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     // and if we don't have custom inout/funcs, we use the JsonInOutFuncs trait
     // which implements _in and _out #[pg_extern] functions that just return the type itself
     if args.contains(&PostgresTypeAttribute::Default) {
-        let inout_generics = if has_lifetimes.is_some() {
-            quote! {#generics}
-        } else {
-            quote! {<'_>}
-        };
-
         stream.extend(quote! {
-            impl #generics ::pgrx::inoutfuncs::JsonInOutFuncs #inout_generics for #name #generics {}
-
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable,parallel_safe)]
             pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<#name #generics> {
-                input.map_or_else(|| {
-                    for m in <#name as ::pgrx::inoutfuncs::JsonInOutFuncs>::NULL_ERROR_MESSAGE {
-                        ::pgrx::pg_sys::error!("{m}");
-                    }
-                    None
-                }, |i| Some(<#name as ::pgrx::inoutfuncs::JsonInOutFuncs>::input(i)))
+                use ::pgrx::inoutfuncs::json_from_slice;
+                input.map(|cstr| json_from_slice(cstr.to_bytes()).ok()).flatten()
             }
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern (immutable,parallel_safe)]
-            pub fn #funcname_out #generics(input: #name #generics) -> &'static ::core::ffi::CStr {
-                let mut buffer = ::pgrx::stringinfo::StringInfo::new();
-                ::pgrx::inoutfuncs::JsonInOutFuncs::output(&input, &mut buffer);
-                // SAFETY: We just constructed this StringInfo ourselves
-                unsafe { buffer.leak_cstr() }
+            pub fn #funcname_out #generics(input: #name #generics) -> ::pgrx::ffi::CString {
+                use ::pgrx::inoutfuncs::json_to_vec;
+                let mut bytes = json_to_vec(&input).unwrap();
+                bytes.push(0); // terminate
+                ::pgrx::ffi::CString::from_vec_with_nul(bytes).unwrap()
             }
-
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {
         // otherwise if it's InOutFuncs our _in/_out functions use an owned type instance

--- a/pgrx/src/ffi.rs
+++ b/pgrx/src/ffi.rs
@@ -8,4 +8,5 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Reexport FFI definitions here.
+pub use alloc::ffi::CString;
 pub use libc::c_char;

--- a/pgrx/src/prelude.rs
+++ b/pgrx/src/prelude.rs
@@ -32,7 +32,7 @@ pub use crate::datum::{
     Numeric, PgVarlena, PostgresType, Range, RangeBound, RangeSubType, Time, TimeWithTimeZone,
     Timestamp, TimestampWithTimeZone, VariadicArray,
 };
-pub use crate::inoutfuncs::{InOutFuncs, JsonInOutFuncs, PgVarlenaInOutFuncs};
+pub use crate::inoutfuncs::{InOutFuncs, PgVarlenaInOutFuncs};
 
 // Trigger support
 pub use crate::trigger_support::{


### PR DESCRIPTION
While sorting out lifetime problems to make #1731 landable, I noticed JsonInOutFuncs is completely replaceable with two reexports. So I replaced it. This also made the changes to sort out the rest of the lifetimes obvious, and now we return CString always from these functions.