### PR TITLE
Address `clippy::must_use_candidate` in template

### DIFF
--- a/cargo-pgrx/src/templates/lib_rs
+++ b/cargo-pgrx/src/templates/lib_rs
@@ -23,10 +23,12 @@ mod tests {{
 /// It must be visible at the root of your extension crate.
 #[cfg(test)]
 pub mod pg_test {{
+    #[allow(clippy::needless_pass_by_value)]
     pub fn setup(_options: Vec<&str>) {{
         // perform one-off initialization when the pg_test framework starts
     }}
 
+    #[must_use]
     pub fn postgresql_conf_options() -> Vec<&'static str> {{
         // return any postgresql.conf settings that are required for your tests
         vec![]

--- a/cargo-pgrx/src/templates/lib_rs
+++ b/cargo-pgrx/src/templates/lib_rs
@@ -23,7 +23,6 @@ mod tests {{
 /// It must be visible at the root of your extension crate.
 #[cfg(test)]
 pub mod pg_test {{
-    #[allow(clippy::needless_pass_by_value)]
     pub fn setup(_options: Vec<&str>) {{
         // perform one-off initialization when the pg_test framework starts
     }}

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -10,6 +10,7 @@
 extern crate proc_macro;
 
 use quote::{format_ident, quote, quote_spanned};
+use std::mem::take;
 use std::ops::Deref;
 use std::str::FromStr;
 use syn::punctuated::Punctuated;
@@ -35,8 +36,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     let input_func_name = func.sig.ident.to_string();
     let sig = func.sig.clone();
     let vis = func.vis.clone();
-    let attrs = func.attrs.clone();
-
+    let mut attrs = take(&mut func.attrs);
     let generics = func.sig.generics.clone();
 
     if attrs.iter().any(|attr| attr.path().is_ident("no_mangle"))
@@ -49,10 +49,12 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
         panic!("#[pg_guard] for function with generic parameters must not be combined with #[no_mangle]");
     }
 
+    attrs.push(syn::parse_quote!(#[automatically_derived]));
+    attrs.push(syn::parse_quote!(#[allow(clippy::used_underscore_binding)]));
+
     // but for the inner function (the one we're wrapping) we don't need any kind of
     // abi classification
     func.sig.abi = None;
-    func.attrs.clear();
 
     // nor do we need a visibility beyond "private"
     func.vis = Visibility::Inherited;

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -10,7 +10,7 @@
 extern crate proc_macro;
 
 use quote::{format_ident, quote, quote_spanned};
-use std::mem::take;
+use std::mem;
 use std::ops::Deref;
 use std::str::FromStr;
 use syn::punctuated::Punctuated;
@@ -36,7 +36,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     let input_func_name = func.sig.ident.to_string();
     let sig = func.sig.clone();
     let vis = func.vis.clone();
-    let mut attrs = take(&mut func.attrs);
+    let mut attrs = mem::take(&mut func.attrs);
     let generics = func.sig.generics.clone();
 
     if attrs.iter().any(|attr| attr.path().is_ident("no_mangle"))
@@ -48,9 +48,6 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     {
         panic!("#[pg_guard] for function with generic parameters must not be combined with #[no_mangle]");
     }
-
-    attrs.push(syn::parse_quote!(#[automatically_derived]));
-    attrs.push(syn::parse_quote!(#[allow(clippy::used_underscore_binding)]));
 
     // but for the inner function (the one we're wrapping) we don't need any kind of
     // abi classification


### PR DESCRIPTION
This addresses `clippy::must_use_candidate` and applies a minor optimization: it removes a Vec realloc by simply taking the existing one, instead of cloning and clearing it.