### PR TITLE
Begin synthesizing spans

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -434,7 +434,7 @@ jobs:
 
       # We can't do this with other lints because we need $PGRX_HOME
       - name: Clippy -Awarnings
-        run: cargo clippy -p pgrx --features pg$PG_VER -- -Awarnings
+        run: cargo clippy --tests --features pg$PG_VER -- -Awarnings
 
       # This also requires $PGRX_HOME
       - name: Check doc-links

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -434,7 +434,7 @@ jobs:
 
       # We can't do this with other lints because we need $PGRX_HOME
       - name: Clippy -Awarnings
-        run: cargo clippy --tests --features pg$PG_VER -- -Awarnings
+        run: cargo clippy --tests --features pg$PG_VER --no-default-features -- -Awarnings
 
       # This also requires $PGRX_HOME
       - name: Check doc-links

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -27,7 +27,10 @@ pub fn finfo_v1_extern_c(
     let original_name = &original.sig.ident;
     let wrapper_symbol = format_ident!("{}_wrapper", original_name);
 
-    let tokens = quote_spanned! { original.sig.span() =>
+    let synthetic = proc_macro2::Span::mixed_site();
+    let synthetic = synthetic.located_at(original.sig.span());
+
+    let tokens = quote_spanned! { synthetic =>
         #[no_mangle]
         #[doc(hidden)]
         pub unsafe extern "C" fn #wrapper_symbol(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -22,7 +22,7 @@ use crate::enrich::{ToEntityGraphTokens, ToRustCodeTokens};
 use crate::finfo::{finfo_v1_extern_c, finfo_v1_tokens};
 use crate::{CodeEnrichment, ToSqlConfig};
 use attribute::PgTriggerAttribute;
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::{spanned::Spanned, ItemFn, Token};
 
@@ -70,7 +70,8 @@ impl PgTrigger {
 
     pub fn wrapper_tokens(&self) -> Result<ItemFn, syn::Error> {
         let function_ident = self.func.sig.ident.clone();
-        let fcinfo_ident = Ident::new("_fcinfo", function_ident.span());
+        let fcinfo_ident =
+            Ident::new("_fcinfo", Span::mixed_site().located_at(function_ident.span()));
 
         let tokens = quote! {
             fn _internal(fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {

--- a/pgrx-tests/src/tests/attributes_tests.rs
+++ b/pgrx-tests/src/tests/attributes_tests.rs
@@ -18,7 +18,7 @@ mod tests {
     #[pg_test]
     #[ignore = "This test should be ignored."]
     fn test_for_ignore_attribute() {
-        assert_eq!(true, true);
+        assert_eq!(true, false);
     }
 
     #[pg_test]

--- a/pgrx-tests/tests/compile-fail/aggregate-functions-dont-run-forever.stderr
+++ b/pgrx-tests/tests/compile-fail/aggregate-functions-dont-run-forever.stderr
@@ -9,7 +9,7 @@ error[E0521]: borrowed data escapes outside of function
    | lifetime `'fcx` defined here
    | argument requires that `'fcx` must outlive `'static`
    |
-   = note: this error originates in the attribute macro `pg_aggregate` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `::pgrx::pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0521]: borrowed data escapes outside of function
   --> tests/compile-fail/aggregate-functions-dont-run-forever.rs:47:1
@@ -22,7 +22,7 @@ error[E0521]: borrowed data escapes outside of function
    | lifetime `'fcx` defined here
    | argument requires that `'fcx` must outlive `'static`
    |
-   = note: this error originates in the attribute macro `pg_aggregate` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `::pgrx::pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0521]: borrowed data escapes outside of function
   --> tests/compile-fail/aggregate-functions-dont-run-forever.rs:70:1
@@ -35,7 +35,7 @@ error[E0521]: borrowed data escapes outside of function
    | lifetime `'fcx` defined here
    | argument requires that `'fcx` must outlive `'static`
    |
-   = note: this error originates in the attribute macro `pg_aggregate` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `::pgrx::pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0521]: borrowed data escapes outside of function
    --> tests/compile-fail/aggregate-functions-dont-run-forever.rs:113:1
@@ -48,7 +48,7 @@ error[E0521]: borrowed data escapes outside of function
     | lifetime `'fcx` defined here
     | argument requires that `'fcx` must outlive `'static`
     |
-    = note: this error originates in the attribute macro `pg_aggregate` (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this error originates in the attribute macro `::pgrx::pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0521]: borrowed data escapes outside of function
    --> tests/compile-fail/aggregate-functions-dont-run-forever.rs:141:1
@@ -61,4 +61,4 @@ error[E0521]: borrowed data escapes outside of function
     | lifetime `'fcx` defined here
     | argument requires that `'fcx` must outlive `'static`
     |
-    = note: this error originates in the attribute macro `pg_aggregate` (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this error originates in the attribute macro `::pgrx::pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/compile-fail/eq-for-postgres_hash.stderr
+++ b/pgrx-tests/tests/compile-fail/eq-for-postgres_hash.stderr
@@ -39,7 +39,7 @@ note: required by a bound in `brokentype_hash`
   |                                                ^^^^^^^^^^^^ required by this bound in `brokentype_hash`
 5 | pub struct BrokenType {
   |            ---------- required by a bound in this function
-  = note: this error originates in the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `::pgrx::pgrx_macros::pg_extern` which comes from the expansion of the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Hash)]`
   |
 5 + #[derive(Hash)]
@@ -59,7 +59,7 @@ note: required by a bound in `brokentype_hash`
   |                                                ^^^^^^^^^^^^ required by this bound in `brokentype_hash`
 5 | pub struct BrokenType {
   |            ---------- required by a bound in this function
-  = note: this error originates in the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `::pgrx::pgrx_macros::pg_extern` which comes from the expansion of the derive macro `PostgresHash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Eq)]`
   |
 5 + #[derive(Eq)]

--- a/pgrx-tests/tests/compile-fail/postgres-strings-arent-immortal.stderr
+++ b/pgrx-tests/tests/compile-fail/postgres-strings-arent-immortal.stderr
@@ -2,7 +2,10 @@ error[E0521]: borrowed data escapes outside of function
  --> tests/compile-fail/postgres-strings-arent-immortal.rs:4:67
   |
 3 |   #[pg_extern]
-  |   ------------ lifetime `'fcx` defined here
+  |   ------------
+  |   |
+  |   lifetime `'fcx` defined here
+  |   in this procedural macro expansion
 4 |   fn split(input: &'static str, pattern: &str) -> Vec<&'static str> {
   |  ___________________________________________________________________^
 5 | |     input.split_terminator(pattern).collect()
@@ -12,3 +15,5 @@ error[E0521]: borrowed data escapes outside of function
   | | `fcinfo` is a reference that is only valid in the function body
   | |_`fcinfo` escapes the function body here
   |   argument requires that `'fcx` must outlive `'static`
+  |
+  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.stderr
+++ b/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.stderr
@@ -2,7 +2,10 @@ error[E0521]: borrowed data escapes outside of function
  --> tests/compile-fail/table-iterators-arent-immortal.rs:6:78
   |
 3 |   #[pg_extern]
-  |   ------------ lifetime `'fcx` defined here
+  |   ------------
+  |   |
+  |   lifetime `'fcx` defined here
+  |   in this procedural macro expansion
 ...
 6 |   ) -> TableIterator<(name!(a, &'static str), name!(b, Option<&'static str>))> {
   |  ______________________________________________________________________________^
@@ -13,3 +16,5 @@ error[E0521]: borrowed data escapes outside of function
   | | `fcinfo` is a reference that is only valid in the function body
   | |_`fcinfo` escapes the function body here
   |   argument requires that `'fcx` must outlive `'static`
+  |
+  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/compile-fail/total-eq-for-postgres_eq.stderr
+++ b/pgrx-tests/tests/compile-fail/total-eq-for-postgres_eq.stderr
@@ -25,7 +25,7 @@ note: required by a bound in `brokentype_eq`
   |                                                           ^^^^^^^^^^ required by this bound in `brokentype_eq`
 5 | pub struct BrokenType {
   |            ---------- required by a bound in this function
-  = note: this error originates in the derive macro `PostgresEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `::pgrx::pgrx_macros::pg_operator` which comes from the expansion of the derive macro `PostgresEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Eq)]`
   |
 5 + #[derive(Eq)]

--- a/pgrx-tests/tests/todo/busted-exotic-signature.stderr
+++ b/pgrx-tests/tests/todo/busted-exotic-signature.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
   --> tests/todo/busted-exotic-signature.rs:12:9
    |
+10 |     #[pg_extern]
+   |     ------------ in this procedural macro expansion
+11 |     fn exotic_signature(
 12 |         _cats: pgrx::default!(
    |         ^^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>`, which is required by `Option<Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>>: ArgAbi<'_>`
    |
@@ -14,3 +17,4 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/todo/composite-types-broken-on-spi.stderr
+++ b/pgrx-tests/tests/todo/composite-types-broken-on-spi.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
   --> tests/todo/composite-types-broken-on-spi.rs:60:9
    |
+58 |     #[pg_extern]
+   |     ------------ in this procedural macro expansion
+59 |     fn sum_scritches_for_names_strict_optional_items(
 60 |         dogs: Vec<Option<pgrx::composite_type!("Dog")>>,
    |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
    |
@@ -13,10 +16,14 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
   --> tests/todo/composite-types-broken-on-spi.rs:77:9
    |
+75 |     #[pg_extern]
+   |     ------------ in this procedural macro expansion
+76 |     fn sum_scritches_for_names_default_optional_items(
 77 |         dogs: pgrx::default!(
    |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
    |
@@ -29,10 +36,14 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
   --> tests/todo/composite-types-broken-on-spi.rs:97:9
    |
+95 |     #[pg_extern]
+   |     ------------ in this procedural macro expansion
+96 |     fn sum_scritches_for_names_optional_items(
 97 |         dogs: Option<Vec<Option<pgrx::composite_type!("Dog")>>>,
    |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`, which is required by `Option<Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>>: ArgAbi<'_>`
    |
@@ -46,6 +57,7 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Array<'_, pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>` is not an iterator
    --> tests/todo/composite-types-broken-on-spi.rs:125:20

--- a/pgrx-tests/tests/todo/random-vec-strs-arent-okay.stderr
+++ b/pgrx-tests/tests/todo/random-vec-strs-arent-okay.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Vec<Option<&str>>: ArgAbi<'_>` is not satisfied
  --> tests/todo/random-vec-strs-arent-okay.rs:8:5
   |
+5 | #[pg_extern]
+  | ------------ in this procedural macro expansion
+...
 8 |     args: default!(Vec<Option<&'a str>>, "ARRAY[]::text[]"),
   |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<&str>>`
   |
@@ -13,3 +16,4 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
   |
   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/todo/roundtrip-tests.stderr
+++ b/pgrx-tests/tests/todo/roundtrip-tests.stderr
@@ -13,6 +13,15 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> tests/todo/roundtrip-tests.rs:69:21
    |
 67 |         rt_array_refstr,
+   |                        - lifetime `'a` is missing in item created through this procedural macro
+68 |         test_rt_array_refstr,
+69 |         Vec<Option<&'a str>>,
+   |                     ^^ undeclared lifetime
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> tests/todo/roundtrip-tests.rs:69:21
+   |
+67 |         rt_array_refstr,
    |                        - help: consider introducing lifetime `'a` here: `<'a>`
 68 |         test_rt_array_refstr,
 69 |         Vec<Option<&'a str>>,
@@ -62,7 +71,7 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `pg_extern` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<&[u8]>>: FromDatum` is not satisfied
   --> tests/todo/roundtrip-tests.rs:36:38
@@ -147,7 +156,7 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `pg_extern` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<&CStr>>: FromDatum` is not satisfied
   --> tests/todo/roundtrip-tests.rs:36:38

--- a/pgrx-tests/tests/todo/vec-option-composite_type-nesting-problems.stderr
+++ b/pgrx-tests/tests/todo/vec-option-composite_type-nesting-problems.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
   --> tests/todo/vec-option-composite_type-nesting-problems.rs:55:5
    |
+53 | #[pg_extern]
+   | ------------ in this procedural macro expansion
+54 | fn sum_scritches_for_names_strict_optional_items(
 55 |     dogs: Vec<Option<pgrx::composite_type!("Dog")>>,
    |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
    |
@@ -13,10 +16,14 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
   --> tests/todo/vec-option-composite_type-nesting-problems.rs:72:5
    |
+70 | #[pg_extern]
+   | ------------ in this procedural macro expansion
+71 | fn sum_scritches_for_names_default_optional_items(
 72 |     dogs: pgrx::default!(Vec<Option<pgrx::composite_type!("Dog")>>, "ARRAY[ROW('Nami', 0)]::Dog[]"),
    |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
    |
@@ -29,10 +36,14 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
   --> tests/todo/vec-option-composite_type-nesting-problems.rs:89:5
    |
+87 | #[pg_extern]
+   | ------------ in this procedural macro expansion
+88 | fn sum_scritches_for_names_optional_items(
 89 |     dogs: Option<Vec<Option<pgrx::composite_type!("Dog")>>>,
    |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`, which is required by `Option<Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>>: ArgAbi<'_>`
    |
@@ -46,6 +57,7 @@ note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_uncheck
    |
    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
  --> tests/todo/vec-option-composite_type-nesting-problems.rs:8:1


### PR DESCRIPTION
I consulted other rust-lang devs and they agree proc-macros should use what I refer to as "synthetic" spans. These spans have their root context derived from `Span::mixed_site()` or `Span::call_site()` but have been given a location in the code somewhere.

- Fixes remaining `used_underscore_binding` warnings.
- Closes #1667