### PR TITLE
C enums as module consts + deprecation

### DIFF
--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn _PG_init() {
         event: pg_sys::XactEvent::Type,
         _arg: *mut std::os::raw::c_void,
     ) {
-        if event == pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT && rand::random::<bool>() {
+        if event == pg_sys::XactEvent::XACT_EVENT_PRE_COMMIT && rand::random::<bool>() {
             // panic!("aborting transaction");
         }
     }

--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -110,7 +110,10 @@ fn random_abort() {
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
     #[pg_guard]
-    extern "C" fn random_abort_callback(event: pg_sys::XactEvent, _arg: *mut std::os::raw::c_void) {
+    extern "C" fn random_abort_callback(
+        event: pg_sys::XactEvent::Type,
+        _arg: *mut std::os::raw::c_void,
+    ) {
         if event == pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT && rand::random::<bool>() {
             // panic!("aborting transaction");
         }

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -784,6 +784,7 @@ fn run_bindgen(
         .wrap_err_with(|| format!("Unable to generate bindings for pg{major_version}"))?;
     let mut binding_str = bindings.to_string();
     drop(bindings); // So the Rc::into_inner can unwrap
+
     // FIXME: do this for the Node graph instead of reparsing?
     let enum_names: EnumMap = Rc::into_inner(enum_names).unwrap().into_inner();
     binding_str.extend(enum_names.into_iter().flat_map(|(name, variants)| {

--- a/pgrx-pg-sys/build.rs
+++ b/pgrx-pg-sys/build.rs
@@ -7,18 +7,20 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use bindgen::callbacks::{DeriveTrait, ImplementsTrait, MacroParsingBehavior};
+use bindgen::callbacks::{DeriveTrait, EnumVariantValue, ImplementsTrait, MacroParsingBehavior};
 use bindgen::NonCopyUnionStyle;
 use eyre::{eyre, WrapErr};
 use pgrx_pg_config::{
     is_supported_major_version, prefix_path, PgConfig, PgConfigSelector, Pgrx, SUPPORTED_VERSIONS,
 };
 use quote::{quote, ToTokens};
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{self, Path, PathBuf}; // disambiguate path::Path and syn::Type::Path
 use std::process::{Command, Output};
+use std::rc::Rc;
 use std::sync::OnceLock;
 use syn::{ForeignItem, Item, ItemConst};
 
@@ -32,10 +34,14 @@ mod build {
 #[derive(Debug)]
 struct BindingOverride {
     ignore_macros: HashSet<&'static str>,
+    enum_names: InnerMut<EnumMap>,
 }
 
+type InnerMut<T> = Rc<RefCell<T>>;
+type EnumMap = BTreeMap<String, Vec<(String, EnumVariantValue)>>;
+
 impl BindingOverride {
-    fn new() -> Self {
+    fn new_from(enum_names: InnerMut<EnumMap>) -> Self {
         // these cause duplicate definition problems on linux
         // see: https://github.com/rust-lang/rust-bindgen/issues/687
         BindingOverride {
@@ -61,6 +67,7 @@ impl BindingOverride {
                 "M_SQRT1_2",
                 "M_2_SQRTPI",
             ]),
+            enum_names,
         }
     }
 }
@@ -99,13 +106,24 @@ impl bindgen::callbacks::ParseCallbacks for BindingOverride {
     // FIXME: implement a... C compiler?
     fn func_macro(&self, _name: &str, _value: &[&[u8]]) {}
 
-    // FIXME: impl temporary migration code
     fn enum_variant_behavior(
         &self,
-        _enum_name: Option<&str>,
-        _original_variant_name: &str,
-        _variant_value: bindgen::callbacks::EnumVariantValue,
+        enum_name: Option<&str>,
+        variant_name: &str,
+        variant_value: bindgen::callbacks::EnumVariantValue,
     ) -> Option<bindgen::callbacks::EnumVariantCustomBehavior> {
+        enum_name.inspect(|name| match name.strip_prefix("enum").unwrap_or(name).trim() {
+            "NodeTag" => return,
+            name if name.contains("unnamed at") => return,
+            // to prevent problems with BuiltinOid
+            _ if variant_name.contains("OID") => return,
+            name => self
+                .enum_names
+                .borrow_mut()
+                .entry(name.to_string())
+                .or_insert(Vec::new())
+                .push((variant_name.to_string(), variant_value)),
+        });
         None
     }
 
@@ -744,12 +762,15 @@ fn run_bindgen(
         let builtin_includes = includes.iter().filter_map(|p| Some(format!("-I{}", p.to_str()?)));
         binder = binder.clang_args(builtin_includes);
     };
+    let enum_names = Rc::new(RefCell::new(BTreeMap::new()));
+    let overrides = BindingOverride::new_from(Rc::clone(&enum_names));
     let bindings = binder
         .header(include_h.display().to_string())
         .clang_args(extra_bindgen_clang_args(pg_config)?)
         .clang_args(pg_target_include_flags(major_version, pg_config)?)
         .detect_include_paths(autodetect)
-        .parse_callbacks(Box::new(BindingOverride::new()))
+        .parse_callbacks(Box::new(overrides))
+        .default_enum_style(bindgen::EnumVariation::ModuleConsts)
         // The NodeTag enum is closed: additions break existing values in the set, so it is not extensible
         .rustified_non_exhaustive_enum("NodeTag")
         .size_t_is_usize(true)
@@ -759,8 +780,31 @@ fn run_bindgen(
         .default_non_copy_union_style(NonCopyUnionStyle::ManuallyDrop)
         .generate()
         .wrap_err_with(|| format!("Unable to generate bindings for pg{major_version}"))?;
+    let mut binding_str = bindings.to_string();
+    drop(bindings);
+    let enum_names = Rc::into_inner(enum_names).unwrap().into_inner();
+    binding_str.extend(enum_names.into_iter().flat_map(|(name, variants)| {
+        const MIN_I32: i64 = i32::MIN as _;
+        const MAX_I32: i64 = i32::MAX as _;
+        const MAX_U32: u64 = u32::MAX as _;
+        variants.into_iter().map(move |(variant, value)| {
+            let (ty, value) = match value {
+                EnumVariantValue::Boolean(b) => ("bool", b.to_string()),
+                EnumVariantValue::Signed(v @ MIN_I32..=MAX_I32) => ("i32", v.to_string()),
+                EnumVariantValue::Signed(v) => ("i64", v.to_string()),
+                EnumVariantValue::Unsigned(v @ 0..=MAX_U32) => ("u32", v.to_string()),
+                EnumVariantValue::Unsigned(v) => ("u64", v.to_string()),
+            };
+            format!(
+                r#"
+#[deprecated(since = "0.12.0", note = "you want pg_sys::{module}::{variant}")]
+pub const {module}_{variant}: {ty} = {value};"#,
+                module = &*name,
+            )
+        })
+    }));
 
-    Ok(bindings.to_string())
+    Ok(binding_str)
 }
 
 fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -61,9 +61,9 @@ bitflags! {
 /// The various points in which a BackgroundWorker can be started by Postgres
 #[derive(Copy, Clone)]
 pub enum BgWorkerStartTime {
-    PostmasterStart = pg_sys::BgWorkerStartTime_BgWorkerStart_PostmasterStart as isize,
-    ConsistentState = pg_sys::BgWorkerStartTime_BgWorkerStart_ConsistentState as isize,
-    RecoveryFinished = pg_sys::BgWorkerStartTime_BgWorkerStart_RecoveryFinished as isize,
+    PostmasterStart = pg_sys::BgWorkerStartTime::BgWorkerStart_PostmasterStart as isize,
+    ConsistentState = pg_sys::BgWorkerStartTime::BgWorkerStart_ConsistentState as isize,
+    RecoveryFinished = pg_sys::BgWorkerStartTime::BgWorkerStart_RecoveryFinished as isize,
 }
 
 /// Static interface into a running Background Worker
@@ -254,7 +254,7 @@ impl BackgroundWorker {
 
 unsafe extern "C" fn worker_spi_sighup(_signal_args: i32) {
     GOT_SIGHUP.store(true, Ordering::SeqCst);
-    pg_sys::ProcessConfigFile(pg_sys::GucContext_PGC_SIGHUP);
+    pg_sys::ProcessConfigFile(pg_sys::GucContext::PGC_SIGHUP);
     pg_sys::SetLatch(pg_sys::MyLatch);
 }
 
@@ -301,10 +301,10 @@ pub enum BackgroundWorkerStatus {
 impl From<pg_sys::BgwHandleStatus::Type> for BackgroundWorkerStatus {
     fn from(s: pg_sys::BgwHandleStatus::Type) -> Self {
         match s {
-            pg_sys::BgwHandleStatus_BGWH_STARTED => BackgroundWorkerStatus::Started,
-            pg_sys::BgwHandleStatus_BGWH_NOT_YET_STARTED => BackgroundWorkerStatus::NotYetStarted,
-            pg_sys::BgwHandleStatus_BGWH_STOPPED => BackgroundWorkerStatus::Stopped,
-            pg_sys::BgwHandleStatus_BGWH_POSTMASTER_DIED => BackgroundWorkerStatus::PostmasterDied,
+            pg_sys::BgwHandleStatus::BGWH_STARTED => BackgroundWorkerStatus::Started,
+            pg_sys::BgwHandleStatus::BGWH_NOT_YET_STARTED => BackgroundWorkerStatus::NotYetStarted,
+            pg_sys::BgwHandleStatus::BGWH_STOPPED => BackgroundWorkerStatus::Stopped,
+            pg_sys::BgwHandleStatus::BGWH_POSTMASTER_DIED => BackgroundWorkerStatus::PostmasterDied,
             _ => unreachable!(),
         }
     }

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -300,11 +300,12 @@ pub enum BackgroundWorkerStatus {
 
 impl From<pg_sys::BgwHandleStatus::Type> for BackgroundWorkerStatus {
     fn from(s: pg_sys::BgwHandleStatus::Type) -> Self {
+        use pg_sys::BgwHandleStatus::*;
         match s {
-            pg_sys::BgwHandleStatus::BGWH_STARTED => BackgroundWorkerStatus::Started,
-            pg_sys::BgwHandleStatus::BGWH_NOT_YET_STARTED => BackgroundWorkerStatus::NotYetStarted,
-            pg_sys::BgwHandleStatus::BGWH_STOPPED => BackgroundWorkerStatus::Stopped,
-            pg_sys::BgwHandleStatus::BGWH_POSTMASTER_DIED => BackgroundWorkerStatus::PostmasterDied,
+            BGWH_STARTED => BackgroundWorkerStatus::Started,
+            BGWH_NOT_YET_STARTED => BackgroundWorkerStatus::NotYetStarted,
+            BGWH_STOPPED => BackgroundWorkerStatus::Stopped,
+            BGWH_POSTMASTER_DIED => BackgroundWorkerStatus::PostmasterDied,
             _ => unreachable!(),
         }
     }

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -298,8 +298,8 @@ pub enum BackgroundWorkerStatus {
     },
 }
 
-impl From<pg_sys::BgwHandleStatus> for BackgroundWorkerStatus {
-    fn from(s: pg_sys::BgwHandleStatus) -> Self {
+impl From<pg_sys::BgwHandleStatus::Type> for BackgroundWorkerStatus {
+    fn from(s: pg_sys::BgwHandleStatus::Type) -> Self {
         match s {
             pg_sys::BgwHandleStatus_BGWH_STARTED => BackgroundWorkerStatus::Started,
             pg_sys::BgwHandleStatus_BGWH_NOT_YET_STARTED => BackgroundWorkerStatus::NotYetStarted,

--- a/pgrx/src/callbacks.rs
+++ b/pgrx/src/callbacks.rs
@@ -59,16 +59,16 @@ pub enum PgXactCallbackEvent {
 impl PgXactCallbackEvent {
     fn translate_pg_event(pg_event: pg_sys::XactEvent::Type) -> Self {
         match pg_event {
-            pg_sys::XactEvent_XACT_EVENT_ABORT => PgXactCallbackEvent::Abort,
-            pg_sys::XactEvent_XACT_EVENT_COMMIT => PgXactCallbackEvent::Commit,
-            pg_sys::XactEvent_XACT_EVENT_PARALLEL_ABORT => PgXactCallbackEvent::ParallelAbort,
-            pg_sys::XactEvent_XACT_EVENT_PARALLEL_COMMIT => PgXactCallbackEvent::ParallelCommit,
-            pg_sys::XactEvent_XACT_EVENT_PARALLEL_PRE_COMMIT => {
+            pg_sys::XactEvent::XACT_EVENT_ABORT => PgXactCallbackEvent::Abort,
+            pg_sys::XactEvent::XACT_EVENT_COMMIT => PgXactCallbackEvent::Commit,
+            pg_sys::XactEvent::XACT_EVENT_PARALLEL_ABORT => PgXactCallbackEvent::ParallelAbort,
+            pg_sys::XactEvent::XACT_EVENT_PARALLEL_COMMIT => PgXactCallbackEvent::ParallelCommit,
+            pg_sys::XactEvent::XACT_EVENT_PARALLEL_PRE_COMMIT => {
                 PgXactCallbackEvent::ParallelPreCommit
             }
-            pg_sys::XactEvent_XACT_EVENT_PREPARE => PgXactCallbackEvent::Prepare,
-            pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT => PgXactCallbackEvent::PreCommit,
-            pg_sys::XactEvent_XACT_EVENT_PRE_PREPARE => PgXactCallbackEvent::PrePrepare,
+            pg_sys::XactEvent::XACT_EVENT_PREPARE => PgXactCallbackEvent::Prepare,
+            pg_sys::XactEvent::XACT_EVENT_PRE_COMMIT => PgXactCallbackEvent::PreCommit,
+            pg_sys::XactEvent::XACT_EVENT_PRE_PREPARE => PgXactCallbackEvent::PrePrepare,
             unknown => panic!("Unrecognized XactEvent: {unknown}"),
         }
     }
@@ -257,12 +257,12 @@ pub enum PgSubXactCallbackEvent {
 impl PgSubXactCallbackEvent {
     fn translate_pg_event(event: pg_sys::SubXactEvent::Type) -> Self {
         match event {
-            pg_sys::SubXactEvent_SUBXACT_EVENT_ABORT_SUB => PgSubXactCallbackEvent::AbortSub,
-            pg_sys::SubXactEvent_SUBXACT_EVENT_COMMIT_SUB => PgSubXactCallbackEvent::CommitSub,
-            pg_sys::SubXactEvent_SUBXACT_EVENT_PRE_COMMIT_SUB => {
+            pg_sys::SubXactEvent::SUBXACT_EVENT_ABORT_SUB => PgSubXactCallbackEvent::AbortSub,
+            pg_sys::SubXactEvent::SUBXACT_EVENT_COMMIT_SUB => PgSubXactCallbackEvent::CommitSub,
+            pg_sys::SubXactEvent::SUBXACT_EVENT_PRE_COMMIT_SUB => {
                 PgSubXactCallbackEvent::PreCommitSub
             }
-            pg_sys::SubXactEvent_SUBXACT_EVENT_START_SUB => PgSubXactCallbackEvent::StartSub,
+            pg_sys::SubXactEvent::SUBXACT_EVENT_START_SUB => PgSubXactCallbackEvent::StartSub,
             _ => panic!("Unrecognized SubXactEvent: {event}"),
         }
     }

--- a/pgrx/src/callbacks.rs
+++ b/pgrx/src/callbacks.rs
@@ -57,7 +57,7 @@ pub enum PgXactCallbackEvent {
 }
 
 impl PgXactCallbackEvent {
-    fn translate_pg_event(pg_event: pg_sys::XactEvent) -> Self {
+    fn translate_pg_event(pg_event: pg_sys::XactEvent::Type) -> Self {
         match pg_event {
             pg_sys::XactEvent_XACT_EVENT_ABORT => PgXactCallbackEvent::Abort,
             pg_sys::XactEvent_XACT_EVENT_COMMIT => PgXactCallbackEvent::Commit,
@@ -164,7 +164,10 @@ where
 
     // internal function that we register as an XactCallback
     #[pg_guard]
-    unsafe extern "C" fn callback(event: pg_sys::XactEvent, _arg: *mut ::std::os::raw::c_void) {
+    unsafe extern "C" fn callback(
+        event: pg_sys::XactEvent::Type,
+        _arg: *mut ::std::os::raw::c_void,
+    ) {
         let which_event = PgXactCallbackEvent::translate_pg_event(event);
 
         let hooks = match which_event {
@@ -252,7 +255,7 @@ pub enum PgSubXactCallbackEvent {
 }
 
 impl PgSubXactCallbackEvent {
-    fn translate_pg_event(event: pg_sys::SubXactEvent) -> Self {
+    fn translate_pg_event(event: pg_sys::SubXactEvent::Type) -> Self {
         match event {
             pg_sys::SubXactEvent_SUBXACT_EVENT_ABORT_SUB => PgSubXactCallbackEvent::AbortSub,
             pg_sys::SubXactEvent_SUBXACT_EVENT_COMMIT_SUB => PgSubXactCallbackEvent::CommitSub,
@@ -317,7 +320,7 @@ where
 
     #[pg_guard]
     unsafe extern "C" fn callback(
-        event: pg_sys::SubXactEvent,
+        event: pg_sys::SubXactEvent::Type,
         my_subid: pg_sys::SubTransactionId,
         parent_subid: pg_sys::SubTransactionId,
         _arg: *mut ::std::os::raw::c_void,

--- a/pgrx/src/callbacks.rs
+++ b/pgrx/src/callbacks.rs
@@ -58,17 +58,16 @@ pub enum PgXactCallbackEvent {
 
 impl PgXactCallbackEvent {
     fn translate_pg_event(pg_event: pg_sys::XactEvent::Type) -> Self {
+        use pg_sys::XactEvent::*;
         match pg_event {
-            pg_sys::XactEvent::XACT_EVENT_ABORT => PgXactCallbackEvent::Abort,
-            pg_sys::XactEvent::XACT_EVENT_COMMIT => PgXactCallbackEvent::Commit,
-            pg_sys::XactEvent::XACT_EVENT_PARALLEL_ABORT => PgXactCallbackEvent::ParallelAbort,
-            pg_sys::XactEvent::XACT_EVENT_PARALLEL_COMMIT => PgXactCallbackEvent::ParallelCommit,
-            pg_sys::XactEvent::XACT_EVENT_PARALLEL_PRE_COMMIT => {
-                PgXactCallbackEvent::ParallelPreCommit
-            }
-            pg_sys::XactEvent::XACT_EVENT_PREPARE => PgXactCallbackEvent::Prepare,
-            pg_sys::XactEvent::XACT_EVENT_PRE_COMMIT => PgXactCallbackEvent::PreCommit,
-            pg_sys::XactEvent::XACT_EVENT_PRE_PREPARE => PgXactCallbackEvent::PrePrepare,
+            XACT_EVENT_ABORT => PgXactCallbackEvent::Abort,
+            XACT_EVENT_COMMIT => PgXactCallbackEvent::Commit,
+            XACT_EVENT_PARALLEL_ABORT => PgXactCallbackEvent::ParallelAbort,
+            XACT_EVENT_PARALLEL_COMMIT => PgXactCallbackEvent::ParallelCommit,
+            XACT_EVENT_PARALLEL_PRE_COMMIT => PgXactCallbackEvent::ParallelPreCommit,
+            XACT_EVENT_PREPARE => PgXactCallbackEvent::Prepare,
+            XACT_EVENT_PRE_COMMIT => PgXactCallbackEvent::PreCommit,
+            XACT_EVENT_PRE_PREPARE => PgXactCallbackEvent::PrePrepare,
             unknown => panic!("Unrecognized XactEvent: {unknown}"),
         }
     }
@@ -256,13 +255,12 @@ pub enum PgSubXactCallbackEvent {
 
 impl PgSubXactCallbackEvent {
     fn translate_pg_event(event: pg_sys::SubXactEvent::Type) -> Self {
+        use pg_sys::SubXactEvent::*;
         match event {
-            pg_sys::SubXactEvent::SUBXACT_EVENT_ABORT_SUB => PgSubXactCallbackEvent::AbortSub,
-            pg_sys::SubXactEvent::SUBXACT_EVENT_COMMIT_SUB => PgSubXactCallbackEvent::CommitSub,
-            pg_sys::SubXactEvent::SUBXACT_EVENT_PRE_COMMIT_SUB => {
-                PgSubXactCallbackEvent::PreCommitSub
-            }
-            pg_sys::SubXactEvent::SUBXACT_EVENT_START_SUB => PgSubXactCallbackEvent::StartSub,
+            SUBXACT_EVENT_ABORT_SUB => PgSubXactCallbackEvent::AbortSub,
+            SUBXACT_EVENT_COMMIT_SUB => PgSubXactCallbackEvent::CommitSub,
+            SUBXACT_EVENT_PRE_COMMIT_SUB => PgSubXactCallbackEvent::PreCommitSub,
+            SUBXACT_EVENT_START_SUB => PgSubXactCallbackEvent::StartSub,
             _ => panic!("Unrecognized SubXactEvent: {event}"),
         }
     }

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -723,7 +723,7 @@ impl<'fcx> FcInfo<'fcx> {
     pub unsafe fn srf_return_next(&mut self) {
         unsafe {
             self.deref_fcx().call_cntr += 1;
-            self.get_result_info().set_is_done(pg_sys::ExprDoneCond_ExprMultipleResult);
+            self.get_result_info().set_is_done(pg_sys::ExprDoneCond::ExprMultipleResult);
         }
     }
 
@@ -733,7 +733,7 @@ impl<'fcx> FcInfo<'fcx> {
     pub unsafe fn srf_return_done(&mut self) {
         unsafe {
             pg_sys::end_MultiFuncCall(self.0, self.deref_fcx());
-            self.get_result_info().set_is_done(pg_sys::ExprDoneCond_ExprEndResult);
+            self.get_result_info().set_is_done(pg_sys::ExprDoneCond::ExprEndResult);
         }
     }
 

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -872,23 +872,23 @@ impl<'fcx> ReturnSetInfoWrapper<'fcx> {
     */
     // These four fields are, in-practice, owned by the callee.
     /// Status for ValuePerCall mode.
-    pub fn set_is_done(&mut self, value: pg_sys::ExprDoneCond) {
+    pub fn set_is_done(&mut self, value: pg_sys::ExprDoneCond::Type) {
         unsafe {
             (*self.0).isDone = value;
         }
     }
     /// Status for ValuePerCall mode.
-    pub fn get_is_done(&self) -> pg_sys::ExprDoneCond {
+    pub fn get_is_done(&self) -> pg_sys::ExprDoneCond::Type {
         unsafe { (*self.0).isDone }
     }
     /// Actual return mode.
-    pub fn set_return_mode(&mut self, return_mode: pgrx_pg_sys::SetFunctionReturnMode) {
+    pub fn set_return_mode(&mut self, return_mode: pgrx_pg_sys::SetFunctionReturnMode::Type) {
         unsafe {
             (*self.0).returnMode = return_mode;
         }
     }
     /// Actual return mode.
-    pub fn get_return_mode(&self) -> pgrx_pg_sys::SetFunctionReturnMode {
+    pub fn get_return_mode(&self) -> pgrx_pg_sys::SetFunctionReturnMode::Type {
         unsafe { (*self.0).returnMode }
     }
     /// Holds the complete returned tuple set.

--- a/pgrx/src/enum_helper.rs
+++ b/pgrx/src/enum_helper.rs
@@ -15,7 +15,7 @@ use crate::{ereport, pg_sys, PgLogLevel, PgSqlErrorCode};
 pub fn lookup_enum_by_oid(enumval: pg_sys::Oid) -> (String, pg_sys::Oid, f32) {
     let tup = unsafe {
         pg_sys::SearchSysCache(
-            pg_sys::SysCacheIdentifier_ENUMOID as i32,
+            pg_sys::SysCacheIdentifier::ENUMOID as i32,
             pg_sys::Datum::from(enumval),
             pg_sys::Datum::from(0),
             pg_sys::Datum::from(0),
@@ -61,7 +61,7 @@ pub fn lookup_enum_by_label(typname: &str, label: &str) -> pg_sys::Datum {
         let label =
             alloc::ffi::CString::new(label).expect("failed to convert enum typname to a CString");
         pg_sys::SearchSysCache(
-            pg_sys::SysCacheIdentifier_ENUMTYPOIDNAME as i32,
+            pg_sys::SysCacheIdentifier::ENUMTYPOIDNAME as i32,
             pg_sys::Datum::from(enumtypoid),
             pg_sys::Datum::from(label.as_ptr()),
             pg_sys::Datum::from(0usize),

--- a/pgrx/src/fcinfo.rs
+++ b/pgrx/src/fcinfo.rs
@@ -408,7 +408,7 @@ pub unsafe fn srf_return_next(
 ) {
     (*funcctx).call_cntr += 1;
     (*((*fcinfo).resultinfo as *mut pg_sys::ReturnSetInfo)).isDone =
-        pg_sys::ExprDoneCond_ExprMultipleResult;
+        pg_sys::ExprDoneCond::ExprMultipleResult;
 }
 
 #[inline]
@@ -418,5 +418,5 @@ pub unsafe fn srf_return_done(
 ) {
     pg_sys::end_MultiFuncCall(fcinfo, funcctx);
     (*((*fcinfo).resultinfo as *mut pg_sys::ReturnSetInfo)).isDone =
-        pg_sys::ExprDoneCond_ExprEndResult;
+        pg_sys::ExprDoneCond::ExprEndResult;
 }

--- a/pgrx/src/guc.rs
+++ b/pgrx/src/guc.rs
@@ -18,11 +18,11 @@ pub enum GucContext {
     /// cannot be set by the user at all, but only through
     /// internal processes ("server_version" is an example).  These are GUC
     /// variables only so they can be shown by SHOW, etc.
-    Internal = pg_sys::GucContext_PGC_INTERNAL as isize,
+    Internal = pg_sys::GucContext::PGC_INTERNAL as isize,
 
     /// can only be set when the postmaster starts,
     /// either from the configuration file or the command line.
-    Postmaster = pg_sys::GucContext_PGC_POSTMASTER as isize,
+    Postmaster = pg_sys::GucContext::PGC_POSTMASTER as isize,
 
     /// can only be set at postmaster startup or by changing
     /// the configuration file and sending the HUP signal to the postmaster
@@ -30,26 +30,26 @@ pub enum GucContext {
     /// evaluated immediately. The postmaster and the backend check it at a
     /// certain point in their main loop. It's safer to wait than to read a
     /// file asynchronously.)
-    Sighup = pg_sys::GucContext_PGC_SIGHUP as isize,
+    Sighup = pg_sys::GucContext::PGC_SIGHUP as isize,
 
     /// can only be set at postmaster startup, from the configuration file, or by
     /// client request in the connection startup packet (e.g., from libpq's PGOPTIONS
     /// variable).  
-    SuBackend = pg_sys::GucContext_PGC_SU_BACKEND as isize,
+    SuBackend = pg_sys::GucContext::PGC_SU_BACKEND as isize,
 
     /// can be set from the startup packet only when the user is a
     /// superuser.  Furthermore, an already-started backend will ignore changes
     /// to such an option in the configuration file.  The idea is that these
     /// options are fixed for a given backend once it's started, but they can
     /// vary across backends.
-    Backend = pg_sys::GucContext_PGC_BACKEND as isize,
+    Backend = pg_sys::GucContext::PGC_BACKEND as isize,
 
     /// can be set at postmaster startup, with the SIGHUP
     /// mechanism, or from the startup packet or SQL if you're a superuser.
-    Suset = pg_sys::GucContext_PGC_SUSET as isize,
+    Suset = pg_sys::GucContext::PGC_SUSET as isize,
 
     /// can be set by anyone any time.
-    Userset = pg_sys::GucContext_PGC_USERSET as isize,
+    Userset = pg_sys::GucContext::PGC_USERSET as isize,
 }
 
 bitflags! {

--- a/pgrx/src/hooks.rs
+++ b/pgrx/src/hooks.rs
@@ -66,12 +66,12 @@ pub trait PgHooks {
     fn executor_run(
         &mut self,
         query_desc: PgBox<pg_sys::QueryDesc>,
-        direction: pg_sys::ScanDirection,
+        direction: pg_sys::ScanDirection::Type,
         count: u64,
         execute_once: bool,
         prev_hook: fn(
             query_desc: PgBox<pg_sys::QueryDesc>,
-            direction: pg_sys::ScanDirection,
+            direction: pg_sys::ScanDirection::Type,
             count: u64,
             execute_once: bool,
         ) -> HookResult<()>,
@@ -118,7 +118,7 @@ pub trait PgHooks {
         pstmt: PgBox<pg_sys::PlannedStmt>,
         query_string: &core::ffi::CStr,
         read_only_tree: Option<bool>,
-        context: pg_sys::ProcessUtilityContext,
+        context: pg_sys::ProcessUtilityContext::Type,
         params: PgBox<pg_sys::ParamListInfoData>,
         query_env: PgBox<pg_sys::QueryEnvironment>,
         dest: PgBox<pg_sys::DestReceiver>,
@@ -127,7 +127,7 @@ pub trait PgHooks {
             pstmt: PgBox<pg_sys::PlannedStmt>,
             query_string: &core::ffi::CStr,
             read_only_tree: Option<bool>,
-            context: pg_sys::ProcessUtilityContext,
+            context: pg_sys::ProcessUtilityContext::Type,
             params: PgBox<pg_sys::ParamListInfoData>,
             query_env: PgBox<pg_sys::QueryEnvironment>,
             dest: PgBox<pg_sys::DestReceiver>,
@@ -241,7 +241,7 @@ pub unsafe fn register_hook(hook: &'static mut (dyn PgHooks)) {
     });
 
     #[pg_guard]
-    unsafe extern "C" fn xact_callback(event: pg_sys::XactEvent, _data: void_mut_ptr) {
+    unsafe extern "C" fn xact_callback(event: pg_sys::XactEvent::Type, _data: void_mut_ptr) {
         match event {
             pg_sys::XactEvent_XACT_EVENT_ABORT => HOOKS.as_mut().unwrap().current_hook.abort(),
             pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT => {
@@ -272,13 +272,13 @@ unsafe extern "C" fn pgrx_executor_start(query_desc: *mut pg_sys::QueryDesc, efl
 #[pg_guard]
 unsafe extern "C" fn pgrx_executor_run(
     query_desc: *mut pg_sys::QueryDesc,
-    direction: pg_sys::ScanDirection,
+    direction: pg_sys::ScanDirection::Type,
     count: u64,
     execute_once: bool,
 ) {
     fn prev(
         query_desc: PgBox<pg_sys::QueryDesc>,
-        direction: pg_sys::ScanDirection,
+        direction: pg_sys::ScanDirection::Type,
         count: u64,
         execute_once: bool,
     ) -> HookResult<()> {
@@ -379,7 +379,7 @@ unsafe extern "C" fn pgrx_executor_check_perms(
 unsafe extern "C" fn pgrx_process_utility(
     pstmt: *mut pg_sys::PlannedStmt,
     query_string: *const ::std::os::raw::c_char,
-    context: pg_sys::ProcessUtilityContext,
+    context: pg_sys::ProcessUtilityContext::Type,
     params: pg_sys::ParamListInfo,
     query_env: *mut pg_sys::QueryEnvironment,
     dest: *mut pg_sys::DestReceiver,
@@ -389,7 +389,7 @@ unsafe extern "C" fn pgrx_process_utility(
         pstmt: PgBox<pg_sys::PlannedStmt>,
         query_string: &core::ffi::CStr,
         _read_only_tree: Option<bool>,
-        context: pg_sys::ProcessUtilityContext,
+        context: pg_sys::ProcessUtilityContext::Type,
         params: PgBox<pg_sys::ParamListInfoData>,
         query_env: PgBox<pg_sys::QueryEnvironment>,
         dest: PgBox<pg_sys::DestReceiver>,
@@ -428,7 +428,7 @@ unsafe extern "C" fn pgrx_process_utility(
     pstmt: *mut pg_sys::PlannedStmt,
     query_string: *const ::std::os::raw::c_char,
     read_only_tree: bool,
-    context: pg_sys::ProcessUtilityContext,
+    context: pg_sys::ProcessUtilityContext::Type,
     params: pg_sys::ParamListInfo,
     query_env: *mut pg_sys::QueryEnvironment,
     dest: *mut pg_sys::DestReceiver,
@@ -438,7 +438,7 @@ unsafe extern "C" fn pgrx_process_utility(
         pstmt: PgBox<pg_sys::PlannedStmt>,
         query_string: &core::ffi::CStr,
         read_only_tree: Option<bool>,
-        context: pg_sys::ProcessUtilityContext,
+        context: pg_sys::ProcessUtilityContext::Type,
         params: PgBox<pg_sys::ParamListInfoData>,
         query_env: PgBox<pg_sys::QueryEnvironment>,
         dest: PgBox<pg_sys::DestReceiver>,
@@ -620,7 +620,7 @@ unsafe extern "C" fn pgrx_standard_executor_start_wrapper(
 #[pg_guard]
 unsafe extern "C" fn pgrx_standard_executor_run_wrapper(
     query_desc: *mut pg_sys::QueryDesc,
-    direction: pg_sys::ScanDirection,
+    direction: pg_sys::ScanDirection::Type,
     count: u64,
     execute_once: bool,
 ) {
@@ -661,7 +661,7 @@ unsafe extern "C" fn pgrx_standard_executor_check_perms_wrapper(
 unsafe extern "C" fn pgrx_standard_process_utility_wrapper(
     pstmt: *mut pg_sys::PlannedStmt,
     query_string: *const ::std::os::raw::c_char,
-    context: pg_sys::ProcessUtilityContext,
+    context: pg_sys::ProcessUtilityContext::Type,
     params: pg_sys::ParamListInfo,
     query_env: *mut pg_sys::QueryEnvironment,
     dest: *mut pg_sys::DestReceiver,
@@ -684,7 +684,7 @@ unsafe extern "C" fn pgrx_standard_process_utility_wrapper(
     pstmt: *mut pg_sys::PlannedStmt,
     query_string: *const ::std::os::raw::c_char,
     read_only_tree: bool,
-    context: pg_sys::ProcessUtilityContext,
+    context: pg_sys::ProcessUtilityContext::Type,
     params: pg_sys::ParamListInfo,
     query_env: *mut pg_sys::QueryEnvironment,
     dest: *mut pg_sys::DestReceiver,

--- a/pgrx/src/hooks.rs
+++ b/pgrx/src/hooks.rs
@@ -243,8 +243,8 @@ pub unsafe fn register_hook(hook: &'static mut (dyn PgHooks)) {
     #[pg_guard]
     unsafe extern "C" fn xact_callback(event: pg_sys::XactEvent::Type, _data: void_mut_ptr) {
         match event {
-            pg_sys::XactEvent_XACT_EVENT_ABORT => HOOKS.as_mut().unwrap().current_hook.abort(),
-            pg_sys::XactEvent_XACT_EVENT_PRE_COMMIT => {
+            pg_sys::XactEvent::XACT_EVENT_ABORT => HOOKS.as_mut().unwrap().current_hook.abort(),
+            pg_sys::XactEvent::XACT_EVENT_PRE_COMMIT => {
                 HOOKS.as_mut().unwrap().current_hook.commit()
             }
             _ => { /* noop */ }

--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -14,7 +14,6 @@ use crate::callconv::{BoxRet, CallCx, RetAbi};
 use crate::fcinfo::{pg_return_null, srf_is_first_call, srf_return_done, srf_return_next};
 use crate::ptr::PointerExt;
 use crate::{pg_sys, IntoDatum, IntoHeapTuple, PgMemoryContexts};
-use pgrx_pg_sys::TypeFuncClass_TYPEFUNC_COMPOSITE;
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
@@ -435,7 +434,7 @@ macro_rules! impl_table_iter {
                         let mut tupdesc = ptr::null_mut();
                         let mut oid = pg_sys::Oid::default();
                         let ty_class = pg_sys::get_call_result_type(fcinfo, &mut oid, &mut tupdesc);
-                        if tupdesc.is_non_null() && ty_class == TypeFuncClass_TYPEFUNC_COMPOSITE {
+                        if tupdesc.is_non_null() && ty_class == pg_sys::TypeFuncClass::TYPEFUNC_COMPOSITE {
                             pg_sys::BlessTupleDesc(tupdesc);
                             (*fcx).tuple_desc = tupdesc;
                         }

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -261,17 +261,18 @@ macro_rules! pg_magic_func {
 }
 
 pub(crate) static UTF8DATABASE: Lazy<Utf8Compat> = Lazy::new(|| {
-    let encoding_int = unsafe { pgrx_pg_sys::GetDatabaseEncoding() };
+    use pg_sys::pg_enc::*;
+    let encoding_int = unsafe { pg_sys::GetDatabaseEncoding() };
     match encoding_int as core::ffi::c_uint {
-        pg_sys::pg_enc_PG_UTF8 => Utf8Compat::Yes,
+        PG_UTF8 => Utf8Compat::Yes,
         // The 0 encoding. It... may be UTF-8
-        pg_sys::pg_enc_PG_SQL_ASCII => Utf8Compat::Maybe,
+        PG_SQL_ASCII => Utf8Compat::Maybe,
         // Modifies ASCII, and should never be seen as PG doesn't support it as server encoding
-        pg_sys::pg_enc_PG_SJIS | pg_sys::pg_enc_PG_SHIFT_JIS_2004
+        PG_SJIS | PG_SHIFT_JIS_2004
         // Not specified as an ASCII extension, also not a server encoding
-        | pg_sys::pg_enc_PG_BIG5
+        | PG_BIG5
         // Wild vendor differences including non-ASCII are possible, also not a server encoding
-        | pg_sys::pg_enc_PG_JOHAB => unreachable!("impossible? unsupported non-ASCII-compatible database encoding is not a server encoding"),
+        | PG_JOHAB => unreachable!("impossible? unsupported non-ASCII-compatible database encoding is not a server encoding"),
         // Other Postgres encodings either extend US-ASCII or CP437 (which includes US-ASCII)
         // There may be a subtlety that requires us to revisit this later
         1..=41=> Utf8Compat::Ascii,

--- a/pgrx/src/lwlock.rs
+++ b/pgrx/src/lwlock.rs
@@ -115,7 +115,7 @@ impl<'a, T> PgLwLockInner<T> {
             panic!("PgLwLock is not initialized");
         }
         unsafe {
-            pg_sys::LWLockAcquire(self.lock_ptr, pg_sys::LWLockMode_LW_SHARED);
+            pg_sys::LWLockAcquire(self.lock_ptr, pg_sys::LWLockMode::LW_SHARED);
 
             PgLwLockShareGuard { data: self.data.as_ref().unwrap(), lock: self.lock_ptr }
         }
@@ -126,7 +126,7 @@ impl<'a, T> PgLwLockInner<T> {
             panic!("PgLwLock is not initialized");
         }
         unsafe {
-            pg_sys::LWLockAcquire(self.lock_ptr, pg_sys::LWLockMode_LW_EXCLUSIVE);
+            pg_sys::LWLockAcquire(self.lock_ptr, pg_sys::LWLockMode::LW_EXCLUSIVE);
 
             PgLwLockExclusiveGuard { data: self.data.as_mut().unwrap(), lock: self.lock_ptr }
         }

--- a/pgrx/src/pg_catalog/pg_proc.rs
+++ b/pgrx/src/pg_catalog/pg_proc.rs
@@ -125,7 +125,7 @@ impl PgProc {
             // SAFETY:  SearchSysCache1 will give us a valid HeapTuple or it'll return null.
             // Either way, using NonNull::new()? will make the right decision for us
             let entry = pg_sys::SearchSysCache1(
-                pg_sys::SysCacheIdentifier_PROCOID as _,
+                pg_sys::SysCacheIdentifier::PROCOID as _,
                 pg_proc_oid.into_datum()?,
             );
             let inner = NonNull::new(entry)?;
@@ -322,7 +322,7 @@ impl PgProc {
 
             let mut is_null = false;
             let proargdefaults = pg_sys::SysCacheGetAttr(
-                pg_sys::SysCacheIdentifier_PROCOID as _,
+                pg_sys::SysCacheIdentifier::PROCOID as _,
                 self.inner.as_ptr(),
                 pg_sys::Anum_pg_proc_proargdefaults as _,
                 &mut is_null,
@@ -343,7 +343,7 @@ impl PgProc {
             // and this PgProc type ensures we have a valid "arg_tup" pointer for the cache entry
             let mut is_null = false;
             let datum = pg_sys::SysCacheGetAttr(
-                pg_sys::SysCacheIdentifier_PROCOID as _,
+                pg_sys::SysCacheIdentifier::PROCOID as _,
                 self.inner.as_ptr(),
                 attribute as _,
                 &mut is_null,

--- a/pgrx/src/shmem.rs
+++ b/pgrx/src/shmem.rs
@@ -183,7 +183,7 @@ impl PgSharedMem {
             let shm_name = alloc::ffi::CString::new(lock.get_name()).expect("CString::new failed");
             let addin_shmem_init_lock: *mut pg_sys::LWLock =
                 &mut (*pg_sys::MainLWLockArray.add(21)).lock;
-            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode_LW_EXCLUSIVE);
+            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode::LW_EXCLUSIVE);
 
             let fv_shmem =
                 pg_sys::ShmemInitStruct(shm_name.into_raw(), std::mem::size_of::<T>(), &mut found)
@@ -207,7 +207,7 @@ impl PgSharedMem {
                 &mut (*pg_sys::MainLWLockArray.add(21)).lock;
 
             let mut found = false;
-            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode_LW_EXCLUSIVE);
+            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode::LW_EXCLUSIVE);
             let fv_shmem =
                 pg_sys::ShmemInitStruct(shm_name.into_raw(), std::mem::size_of::<T>(), &mut found)
                     as *mut T;

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -65,7 +65,7 @@ pub unsafe fn set_varsize_short(ptr: *mut pg_sys::varlena, len: i32) {
 /// ```
 #[inline]
 pub unsafe fn varsize_external(ptr: *const pg_sys::varlena) -> usize {
-    pg_sys::VARHDRSZ_EXTERNAL + vartag_size(vartag_external(ptr) as pg_sys::vartag_external)
+    pg_sys::VARHDRSZ_EXTERNAL + vartag_size(vartag_external(ptr) as pg_sys::vartag_external::Type)
 }
 
 /// ```c
@@ -81,7 +81,7 @@ pub unsafe fn vartag_external(ptr: *const pg_sys::varlena) -> u8 {
 ///      (((tag) & ~1) == VARTAG_EXPANDED_RO)
 /// ```
 #[inline]
-pub unsafe fn vartag_is_expanded(tag: pg_sys::vartag_external) -> bool {
+pub unsafe fn vartag_is_expanded(tag: pg_sys::vartag_external::Type) -> bool {
     (tag & !1) == pg_sys::vartag_external_VARTAG_EXPANDED_RO
 }
 
@@ -93,7 +93,7 @@ pub unsafe fn vartag_is_expanded(tag: pg_sys::vartag_external) -> bool {
 ///       TrapMacro(true, "unrecognized TOAST vartag"))
 /// ```
 #[inline]
-pub unsafe fn vartag_size(tag: pg_sys::vartag_external) -> usize {
+pub unsafe fn vartag_size(tag: pg_sys::vartag_external::Type) -> usize {
     if tag == pg_sys::vartag_external_VARTAG_INDIRECT {
         std::mem::size_of::<pg_sys::varatt_indirect>()
     } else if vartag_is_expanded(tag) {

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -82,7 +82,7 @@ pub unsafe fn vartag_external(ptr: *const pg_sys::varlena) -> u8 {
 /// ```
 #[inline]
 pub unsafe fn vartag_is_expanded(tag: pg_sys::vartag_external::Type) -> bool {
-    (tag & !1) == pg_sys::vartag_external_VARTAG_EXPANDED_RO
+    (tag & !1) == pg_sys::vartag_external::VARTAG_EXPANDED_RO
 }
 
 /// ```c
@@ -94,11 +94,11 @@ pub unsafe fn vartag_is_expanded(tag: pg_sys::vartag_external::Type) -> bool {
 /// ```
 #[inline]
 pub unsafe fn vartag_size(tag: pg_sys::vartag_external::Type) -> usize {
-    if tag == pg_sys::vartag_external_VARTAG_INDIRECT {
+    if tag == pg_sys::vartag_external::VARTAG_INDIRECT {
         std::mem::size_of::<pg_sys::varatt_indirect>()
     } else if vartag_is_expanded(tag) {
         std::mem::size_of::<pg_sys::varatt_expanded>()
-    } else if tag == pg_sys::vartag_external_VARTAG_ONDISK {
+    } else if tag == pg_sys::vartag_external::VARTAG_ONDISK {
         std::mem::size_of::<pg_sys::varatt_external>()
     } else {
         panic!("unrecognized TOAST vartag")


### PR DESCRIPTION
I tried to do without the deprecation warning code but I found it simply so annoying that rustc couldn't find the right names (its Levenshtein-derived algorithm doesn't reason about pathnames quite that way) that I figured it would be easiest to simply add the relevant codegen. That made it possible to distinguish between disappearing types and now-outdated names.

Closes #1370.