### PR TITLE
fix(cargo-pgrx): fix artifact naming on newer rust versions

### DIFF
--- a/pgrx/src/toast.rs
+++ b/pgrx/src/toast.rs
@@ -18,6 +18,7 @@ where
 }
 
 pub(crate) trait Toasty: Sized {
+    #[allow(unused)]
     fn detoast(self) -> Toast<Self>;
     /// Why does it always land butter-side down?
     unsafe fn drop_toast(&mut self);


### PR DESCRIPTION
On newer versions of Rust (1.79+), artifacts that are produced by `cargo` are reliably snake_cased rather than kebab-cased, so older code checking for artifact names didn't work.

Came across this when trying to run *in-repo* tests with an *in-repo* build of `cargo-pgrx` on 1.79 which is now stable.