### PR TITLE
Deprecate `pgrx::hooks` without replacement

### DIFF
--- a/pgrx/src/hooks.rs
+++ b/pgrx/src/hooks.rs
@@ -9,6 +9,10 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! A trait and registration system for hooking Postgres internal operations such as its planner and executor
 #![allow(clippy::unit_arg)]
+#![deprecated(
+    since = "0.12.1",
+    note = "currently always UB, use FFI + pointers to `static UnsafeCell`"
+)]
 use crate as pgrx; // for #[pg_guard] support from within ourself
 use crate::prelude::*;
 use crate::{void_mut_ptr, PgList};


### PR DESCRIPTION
Even if we could fix this with internal refactors, I think it's a sufficiently bad pattern, and sufficiently hard to reason about the soundness of it, that we should just tell people to drop this API.