### PR TITLE
Fix Fedora Dockerfile

### DIFF
--- a/.github/docker/Dockerfile.fedora
+++ b/.github/docker/Dockerfile.fedora
@@ -7,7 +7,7 @@
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
 
-ARG FEDORA_VER=38
+ARG FEDORA_VER=40
 FROM fedora:${FEDORA_VER}
 ARG FEDORA_VER
 ENV FEDORA_VER=${FEDORA_VER}


### PR DESCRIPTION
Getting errors like this
```
  > [ 3/11] RUN dnf install -y   clang   clang-tools-extra   cmake   make   gcc   openssl   openssl-devel   postgresql12-server   postgresql12-devel   redhat-rpm-config   util-linux:
4.231 Error: Failed to download metadata for repo 'pgdg13': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
5.018 PostgreSQL 12 for Fedora 38 - x86_64            186  B/s | 146  B     00:00    
5.018 Errors during downloading metadata for repository 'pgdg12':
5.018   - Status code: 404 for https://download.postgresql.org/pub/repos/yum/12/fedora/fedora-38-x86_64/repodata/repomd.xml (IP: 87.238.57.227)
5.018 Error: Failed to download metadata for repo 'pgdg12': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
5.018 Ignoring repositories: pgdg-common, pgdg16, pgdg15, pgdg14, pgdg13, pgdg12
5.019 Last metadata expiration check: 0:00:08 ago on Wed Jul  3 07:03:39 2024.
5.257 No match for argument: postgresql12-server
5.275 No match for argument: postgresql12-devel
5.298 Error: Unable to find a match: postgresql12-server postgresql12-devel
```

Use Fedora 40 to address them.