### PR TITLE
pgrx-pg-sys missing build directory in Cargo.toml

### DIFF
--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/pgcentralfoundation/pgrx/"
 documentation = "https://docs.rs/pgrx-pg-sys"
 readme = "README.md"
 edition = "2021"
-include = ["src/**/*", "README.md", "include/*", "cshim/*", "build.rs"]
+include = ["src/**/*", "README.md", "include/*", "cshim/*", "build.rs", "build/*"]
 
 [features]
 default = [ ]


### PR DESCRIPTION
0.12.0-beta.0 errors in pgrx-pg-sys/build.rs due to the toml's `include` directive not including the build script's module.