### PR TITLE
Missing ArgAbi and BoxRet trait implementations for datums

### DIFF
--- a/pgrx-tests/src/tests/anyelement_tests.rs
+++ b/pgrx-tests/src/tests/anyelement_tests.rs
@@ -1,0 +1,28 @@
+use pgrx::{prelude::*, AnyElement};
+
+#[pg_extern]
+fn anyelement_arg(element: AnyElement) -> AnyElement {
+    element
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgrx_tests;
+
+    use pgrx::{prelude::*, AnyElement};
+
+    #[pg_test]
+    fn test_anyelement_arg() -> Result<(), pgrx::spi::Error> {
+        let element = Spi::get_one_with_args::<AnyElement>(
+            "SELECT anyelement_arg($1);",
+            vec![(PgBuiltInOids::ANYELEMENTOID.oid(), 123.into_datum())],
+        )?
+        .map(|e| e.datum());
+
+        assert_eq!(element, 123.into_datum());
+
+        Ok(())
+    }
+}

--- a/pgrx-tests/src/tests/anynumeric_tests.rs
+++ b/pgrx-tests/src/tests/anynumeric_tests.rs
@@ -1,0 +1,28 @@
+use pgrx::{prelude::*, AnyNumeric};
+
+#[pg_extern]
+fn anynumeric_arg(numeric: AnyNumeric) -> AnyNumeric {
+    numeric
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgrx_tests;
+
+    use pgrx::{prelude::*, AnyNumeric};
+
+    #[pg_test]
+    fn test_anynumeric_arg() -> Result<(), pgrx::spi::Error> {
+        let numeric = Spi::get_one_with_args::<AnyNumeric>(
+            "SELECT anynumeric_arg($1);",
+            vec![(PgBuiltInOids::INT4OID.oid(), 123.into_datum())],
+        )?
+        .map(|n| n.normalize().to_string());
+
+        assert_eq!(numeric, Some("123".to_string()));
+
+        Ok(())
+    }
+}

--- a/pgrx-tests/src/tests/json_tests.rs
+++ b/pgrx-tests/src/tests/json_tests.rs
@@ -7,6 +7,19 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::prelude::*;
+use pgrx::{Json, JsonB};
+
+#[pg_extern]
+fn json_arg(json: Json) -> Json {
+    json
+}
+
+#[pg_extern]
+fn jsonb_arg(json: JsonB) -> JsonB {
+    json
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
@@ -59,6 +72,38 @@ mod tests {
         assert_eq!(user.username, "blahblahblah");
         assert_eq!(user.first_name, "Blah");
         assert_eq!(user.last_name, "McBlahFace");
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_json_arg() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one_with_args::<Json>(
+            "SELECT json_arg($1);",
+            vec![(
+                PgBuiltInOids::JSONOID.oid(),
+                Json(serde_json::json!({ "foo": "bar" })).into_datum(),
+            )],
+        )?
+        .expect("json was null");
+
+        assert_eq!(json.0, serde_json::json!({ "foo": "bar" }));
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_jsonb_arg() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one_with_args::<JsonB>(
+            "SELECT jsonb_arg($1);",
+            vec![(
+                PgBuiltInOids::JSONBOID.oid(),
+                JsonB(serde_json::json!({ "foo": "bar" })).into_datum(),
+            )],
+        )?
+        .expect("json was null");
+
+        assert_eq!(json.0, serde_json::json!({ "foo": "bar" }));
+
         Ok(())
     }
 }

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -10,6 +10,7 @@
 mod aggregate_tests;
 mod anyarray_tests;
 mod anyelement_tests;
+mod anynumeric_tests;
 mod array_tests;
 mod attributes_tests;
 mod bgworker_tests;

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -9,6 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 mod aggregate_tests;
 mod anyarray_tests;
+mod anyelement_tests;
 mod array_tests;
 mod attributes_tests;
 mod bgworker_tests;

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -16,7 +16,7 @@ use crate::heap_tuple::PgHeapTuple;
 use crate::nullable::Nullable;
 use crate::{
     pg_return_null, pg_sys, AnyArray, AnyElement, AnyNumeric, Date, FromDatum, Inet, Internal,
-    Interval, IntoDatum, Json, PgBox, PgMemoryContexts, PgVarlena, Time, TimeWithTimeZone,
+    Interval, IntoDatum, Json, JsonB, PgBox, PgMemoryContexts, PgVarlena, Time, TimeWithTimeZone,
     Timestamp, TimestampWithTimeZone, UnboxDatum, Uuid,
 };
 use core::marker::PhantomData;
@@ -258,7 +258,7 @@ macro_rules! argue_from_datum {
 argue_from_datum! { 'fcx; i8, i16, i32, i64, f32, f64, bool, char, String, Vec<u8> }
 argue_from_datum! { 'fcx; Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone }
 argue_from_datum! { 'fcx; AnyArray, AnyElement, AnyNumeric }
-argue_from_datum! { 'fcx; Inet, Internal, Json, Uuid }
+argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid }
 argue_from_datum! { 'fcx; pg_sys::Oid, pg_sys::Point, pg_sys::BOX  }
 argue_from_datum! { 'fcx; &'fcx str, &'fcx CStr, &'fcx [u8] }
 
@@ -505,7 +505,7 @@ macro_rules! impl_repackage_into_datum {
 
 impl_repackage_into_datum! {
     String, CString, Vec<u8>, char,
-    Json, Inet, Uuid, AnyNumeric, Internal,
+    Json, JsonB, Inet, Uuid, AnyNumeric, AnyArray, AnyElement, Internal,
     Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone,
     pg_sys::Oid, pg_sys::BOX, pg_sys::Point
 }


### PR DESCRIPTION
After updating to version `0.12.0-beta.0` I can no longer use `JsonB` as a `pg_extern` function argument, and I can no longer use `JsonB`, `AnyArray`, or `AnyElement` as state type in `pg_aggregate`. Unfortunately, pgrx lacked any tests for these types, so they were not checked for compilation when adding ArgAbi and RetAbi.