### PR TITLE
 Prefer `super::Item` over `crate::test::Item` in tests

### DIFF
--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -189,7 +189,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
-    use crate::tests::array_tests::ArrayTestEnum;
+    use super::ArrayTestEnum;
     use pgrx::prelude::*;
     use pgrx::{IntoDatum, Json};
     use serde_json::json;

--- a/pgrx-tests/src/tests/complex.rs
+++ b/pgrx-tests/src/tests/complex.rs
@@ -1,0 +1,88 @@
+//! Type used by various tests.
+use core::ffi::CStr;
+use pgrx::pgrx_sql_entity_graph::metadata::{
+    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+};
+use pgrx::prelude::*;
+use pgrx::stringinfo::StringInfo;
+
+use crate::get_named_capture;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Complex {
+    pub r: f64,
+    pub i: f64,
+}
+
+impl Eq for Complex {}
+impl PartialEq for Complex {
+    fn eq(&self, other: &Self) -> bool {
+        self.r == other.r && self.i == other.i
+    }
+}
+
+impl Complex {
+    #[allow(dead_code)]
+    pub fn random() -> PgBox<Complex> {
+        unsafe {
+            let mut c = PgBox::<Complex>::alloc0();
+            c.r = rand::random();
+            c.i = rand::random();
+            c.into_pg_boxed()
+        }
+    }
+}
+
+extension_sql!(
+    r#"CREATE TYPE complex;"#,
+    name = "create_complex_shell_type",
+    creates = [Type(Complex)]
+);
+
+unsafe impl SqlTranslatable for Complex {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("Complex"))
+    }
+
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("Complex")))
+    }
+}
+
+#[pg_extern(immutable)]
+fn complex_in(input: &CStr) -> PgBox<Complex, AllocatedByRust> {
+    let input_as_str = input.to_str().unwrap();
+    let re = regex::Regex::new(
+        r#"(?P<x>[-+]?([0-9]*\.[0-9]+|[0-9]+)),\s*(?P<y>[-+]?([0-9]*\.[0-9]+|[0-9]+))"#,
+    )
+    .unwrap();
+    let x = get_named_capture(&re, "x", input_as_str).unwrap();
+    let y = get_named_capture(&re, "y", input_as_str).unwrap();
+    let mut complex = unsafe { PgBox::<Complex>::alloc() };
+
+    complex.r = str::parse::<f64>(&x).unwrap_or_else(|_| panic!("{x} isn't a f64"));
+    complex.i = str::parse::<f64>(&y).unwrap_or_else(|_| panic!("{y} isn't a f64"));
+
+    complex
+}
+
+#[pg_extern(immutable)]
+fn complex_out(complex: PgBox<Complex>) -> &'static CStr {
+    let mut sb = StringInfo::new();
+    sb.push_str(&format!("{}, {}", complex.r, complex.i));
+    unsafe { sb.leak_cstr() }
+}
+
+extension_sql!(
+    r#"
+CREATE TYPE complex (
+   internallength = 16,
+   input = complex_in,
+   output = complex_out,
+   alignment = double
+);
+"#,
+    name = "create_complex_type",
+    requires = ["create_complex_shell_type", complex_in, complex_out]
+);

--- a/pgrx-tests/src/tests/enum_type_tests.rs
+++ b/pgrx-tests/src/tests/enum_type_tests.rs
@@ -30,7 +30,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
-    use crate::tests::enum_type_tests::Foo;
+    use super::Foo;
     use pgrx::prelude::*;
 
     #[test]

--- a/pgrx-tests/src/tests/fcinfo_tests.rs
+++ b/pgrx-tests/src/tests/fcinfo_tests.rs
@@ -175,8 +175,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
-    use super::{NullError, NullStrict};
-    use crate::tests::fcinfo_tests::same_name;
+    use super::{same_name, NullError, NullStrict};
     use pgrx::prelude::*;
     use pgrx::{direct_pg_extern_function_call, IntoDatum};
 

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod attributes_tests;
 mod bgworker_tests;
 mod bytea_tests;
 mod cfg_tests;
+mod complex;
 mod composite_type_tests;
 mod datetime_tests;
 mod default_arg_value_tests;
@@ -63,3 +64,5 @@ mod variadic_tests;
 mod xact_callback_tests;
 mod xid64_tests;
 mod zero_datum_edge_cases;
+
+use complex::Complex;

--- a/pgrx-tests/src/tests/postgres_type_tests.rs
+++ b/pgrx-tests/src/tests/postgres_type_tests.rs
@@ -159,7 +159,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
-    use crate::tests::postgres_type_tests::{
+    use super::{
         CustomTextFormatSerializedEnumType, CustomTextFormatSerializedType, JsonEnumType, JsonType,
         VarlenaEnumType, VarlenaType,
     };

--- a/pgrx-tests/src/tests/roundtrip_tests.rs
+++ b/pgrx-tests/src/tests/roundtrip_tests.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[allow(unused_imports)]
     use crate as pgrx_tests;
-    use crate::tests::struct_type_tests::Complex;
+    use crate::tests::struct_type::Complex;
 
     use super::RandomData;
 

--- a/pgrx-tests/src/tests/roundtrip_tests.rs
+++ b/pgrx-tests/src/tests/roundtrip_tests.rs
@@ -1,7 +1,7 @@
+use super::Complex;
+use pgrx::Date;
 use rand::distributions::{Alphanumeric, Standard};
 use rand::Rng;
-
-use pgrx::Date;
 
 #[derive(pgrx::PostgresType, Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct RandomData {
@@ -46,9 +46,9 @@ mod tests {
     use pgrx::prelude::*;
     use pgrx::Uuid;
 
+    use super::Complex;
     #[allow(unused_imports)]
     use crate as pgrx_tests;
-    use crate::tests::struct_type::Complex;
 
     use super::RandomData;
 

--- a/pgrx-tests/src/tests/shmem_tests.rs
+++ b/pgrx-tests/src/tests/shmem_tests.rs
@@ -26,7 +26,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
-    use crate::tests::shmem_tests::LWLOCK;
+    use super::LWLOCK;
     use pgrx::prelude::*;
 
     #[pg_test]

--- a/pgrx-tests/src/tests/struct_type_tests.rs
+++ b/pgrx-tests/src/tests/struct_type_tests.rs
@@ -7,96 +7,10 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use core::ffi::CStr;
-use pgrx::pgrx_sql_entity_graph::metadata::{
-    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
-};
-use pgrx::prelude::*;
-use pgrx::stringinfo::StringInfo;
-
-use crate::get_named_capture;
-
-#[derive(Debug, Clone, Copy)]
-#[repr(C)]
-pub struct Complex {
-    x: f64,
-    y: f64,
-}
-
-impl Eq for Complex {}
-impl PartialEq for Complex {
-    fn eq(&self, other: &Self) -> bool {
-        self.x == other.x && self.y == other.y
-    }
-}
-
-impl Complex {
-    #[allow(dead_code)]
-    pub fn random() -> PgBox<Complex> {
-        unsafe {
-            let mut c = PgBox::<Complex>::alloc0();
-            c.x = rand::random();
-            c.y = rand::random();
-            c.into_pg_boxed()
-        }
-    }
-}
-
-extension_sql!(
-    r#"CREATE TYPE complex;"#,
-    name = "create_complex_shell_type",
-    creates = [Type(Complex)]
-);
-
-unsafe impl SqlTranslatable for Complex {
-    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
-        Ok(SqlMapping::literal("Complex"))
-    }
-
-    fn return_sql() -> Result<Returns, ReturnsError> {
-        Ok(Returns::One(SqlMapping::literal("Complex")))
-    }
-}
-
-#[pg_extern(immutable)]
-fn complex_in(input: &CStr) -> PgBox<Complex, AllocatedByRust> {
-    let input_as_str = input.to_str().unwrap();
-    let re = regex::Regex::new(
-        r#"(?P<x>[-+]?([0-9]*\.[0-9]+|[0-9]+)),\s*(?P<y>[-+]?([0-9]*\.[0-9]+|[0-9]+))"#,
-    )
-    .unwrap();
-    let x = get_named_capture(&re, "x", input_as_str).unwrap();
-    let y = get_named_capture(&re, "y", input_as_str).unwrap();
-    let mut complex = unsafe { PgBox::<Complex>::alloc() };
-
-    complex.x = str::parse::<f64>(&x).unwrap_or_else(|_| panic!("{x} isn't a f64"));
-    complex.y = str::parse::<f64>(&y).unwrap_or_else(|_| panic!("{y} isn't a f64"));
-
-    complex
-}
-
-#[pg_extern(immutable)]
-fn complex_out(complex: PgBox<Complex>) -> &'static CStr {
-    let mut sb = StringInfo::new();
-    sb.push_str(&format!("{}, {}", complex.x, complex.y));
-    unsafe { sb.leak_cstr() }
-}
-
-extension_sql!(
-    r#"
-CREATE TYPE complex (
-   internallength = 16,
-   input = complex_in,
-   output = complex_out,
-   alignment = double
-);
-"#,
-    name = "create_complex_type",
-    requires = ["create_complex_shell_type", complex_in, complex_out]
-);
+use super::Complex;
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
@@ -113,8 +27,8 @@ mod tests {
                 .get_one::<PgBox<Complex>>()?
                 .expect("datum was null");
 
-            assert_eq!(&complex.x, &1.1);
-            assert_eq!(&complex.y, &2.2);
+            assert_eq!(&complex.r, &1.1);
+            assert_eq!(&complex.i, &2.2);
             Ok(())
         })
     }
@@ -135,8 +49,8 @@ mod tests {
                 .get_one::<PgBox<Complex>>()?
                 .expect("datum was null");
 
-            assert_eq!(&complex.x, &1.1);
-            assert_eq!(&complex.y, &2.2);
+            assert_eq!(&complex.r, &1.1);
+            assert_eq!(&complex.i, &2.2);
             Ok(())
         })
     }
@@ -149,8 +63,8 @@ mod tests {
                 SELECT value FROM complex_test ORDER BY id;", None, None)?.first().get_one::<PgBox<Complex>>()
         })?.expect("datum was null");
 
-        assert_eq!(&complex.x, &1.0);
-        assert_eq!(&complex.y, &2.01);
+        assert_eq!(&complex.r, &1.0);
+        assert_eq!(&complex.i, &2.01);
         Ok(())
     }
 }

--- a/pgrx-tests/src/tests/struct_type_tests.rs
+++ b/pgrx-tests/src/tests/struct_type_tests.rs
@@ -101,7 +101,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
-    use crate::tests::struct_type_tests::Complex;
+    use super::Complex;
     use pgrx::prelude::*;
 
     #[pg_test]


### PR DESCRIPTION
It makes for a somewhat pointless refactoring/code-organization barrier.

Also move the Complex type, which is referred to from two different test modules into its own module, from which it is then reexported.