### PR TITLE
Don't hide docs for the callconv module

### DIFF
--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -7,7 +7,6 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-#![doc(hidden)]
 #![deny(unsafe_op_in_unsafe_fn)]
 //! Helper implementations for returning sets and tables from `#[pg_extern]`-style functions
 


### PR DESCRIPTION
There are types in `callconv` that are needed by user code (e.g. when manually implementing a Postgres type used in function signatures). It was really confusing when I saw errors referencing types that I couldn't find in the documentation.