### PR TITLE
Refactor BoxRet to be easier to impl before showing it

### DIFF
--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -104,10 +104,6 @@ where
 }
 
 unsafe impl BoxRet for HexInt {
-    unsafe fn box_in_fcinfo(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
-        Datum::from(self.value)
-    }
-
     unsafe fn box_into<'fcx>(self, fcinfo: &mut pgrx::callconv::FcInfo<'fcx>) -> pgrx::Datum<'fcx> {
         unsafe { fcinfo.return_raw_datum(Datum::from(self.value)) }
     }

--- a/pgrx-examples/custom_types/src/hexint.rs
+++ b/pgrx-examples/custom_types/src/hexint.rs
@@ -107,6 +107,10 @@ unsafe impl BoxRet for HexInt {
     unsafe fn box_in_fcinfo(self, _fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         Datum::from(self.value)
     }
+
+    unsafe fn box_into<'fcx>(self, fcinfo: &mut pgrx::callconv::FcInfo<'fcx>) -> pgrx::Datum<'fcx> {
+        unsafe { fcinfo.return_raw_datum(Datum::from(self.value)) }
+    }
 }
 
 /// Input function for `HexInt`.  Parses any valid "radix(16)" text string, with or without a leading

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -732,10 +732,6 @@ fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         }
 
         unsafe impl ::pgrx::callconv::BoxRet for #enum_ident {
-            unsafe fn box_in_fcinfo(self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
-                ::pgrx::datum::IntoDatum::into_datum(self).unwrap()
-            }
-
             unsafe fn box_into<'fcx>(self, fcinfo: &mut ::pgrx::callconv::FcInfo<'fcx>) -> ::pgrx::datum::Datum<'fcx> {
                 match ::pgrx::datum::IntoDatum::into_datum(self) {
                     None => fcinfo.return_null(),
@@ -866,13 +862,6 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 }
 
                 unsafe impl #generics ::pgrx::callconv::BoxRet for #name #generics {
-                    unsafe fn box_in_fcinfo(self, fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
-                        match ::pgrx::datum::IntoDatum::into_datum(self) {
-                            None => ::pgrx::fcinfo::pg_return_null(fcinfo),
-                            Some(datum) => datum,
-                        }
-                    }
-
                     unsafe fn box_into<'fcx>(self, fcinfo: &mut ::pgrx::callconv::FcInfo<'fcx>) -> ::pgrx::datum::Datum<'fcx> {
                         match ::pgrx::datum::IntoDatum::into_datum(self) {
                             None => fcinfo.return_null(),

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -348,9 +348,7 @@ pub unsafe trait BoxRet: Sized {
 
     /// # Safety
     /// You have to actually return the resulting Datum to the function.
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        unsafe { fcinfo.return_raw_datum(self.box_in_fcinfo(fcinfo.0)) }
-    }
+    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx>;
 }
 
 unsafe impl<T> RetAbi for T

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -341,11 +341,6 @@ pub unsafe trait RetAbi: Sized {
 /// types do not need to think about its many sharp-edged cases. Instead, they should implement
 /// this simplified trait, BoxRet. A blanket impl of RetAbi for BoxRet takes care of the rest.
 pub unsafe trait BoxRet: Sized {
-    #[doc(hidden)]
-    unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
-        unsafe { Self::box_into(self, &mut FcInfo::from_ptr(fcinfo)).sans_lifetime() }
-    }
-
     /// # Safety
     /// You have to actually return the resulting Datum to the function.
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx>;

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -342,6 +342,10 @@ pub unsafe trait RetAbi: Sized {
 /// this simplified trait, BoxRet. A blanket impl of RetAbi for BoxRet takes care of the rest.
 pub unsafe trait BoxRet: Sized {
     unsafe fn box_in_fcinfo(self, fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+
+    fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
+        unsafe { mem::transmute(Self::box_in_fcinfo(self, fcinfo.as_mut_ptr())) }
+    }
 }
 
 unsafe impl<T> RetAbi for T

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -365,7 +365,7 @@ where
     }
 
     unsafe fn box_ret_in_fcinfo(fcinfo: pg_sys::FunctionCallInfo, ret: Self::Ret) -> pg_sys::Datum {
-        unsafe { ret.box_in_fcinfo(fcinfo) }
+        unsafe { ret.box_into(&mut FcInfo::from_ptr(fcinfo)) }.sans_lifetime()
     }
 
     unsafe fn box_ret_in<'fcx>(fcinfo: &mut FcInfo<'fcx>, ret: Self::Ret) -> Datum<'fcx> {

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -296,7 +296,7 @@ pub unsafe trait RetAbi: Sized {
     fn to_ret(self) -> Self::Ret;
 
     // move into the function context and obtain a Datum
-    fn box_ret_in<'fcx>(fcinfo: &mut FcInfo<'fcx>, ret: Self::Ret) -> Datum<'fcx> {
+    unsafe fn box_ret_in<'fcx>(fcinfo: &mut FcInfo<'fcx>, ret: Self::Ret) -> Datum<'fcx> {
         let fcinfo = fcinfo.0;
         unsafe { mem::transmute(Self::box_ret_in_fcinfo(fcinfo, ret)) }
     }
@@ -366,6 +366,10 @@ where
 
     unsafe fn box_ret_in_fcinfo(fcinfo: pg_sys::FunctionCallInfo, ret: Self::Ret) -> pg_sys::Datum {
         unsafe { ret.box_in_fcinfo(fcinfo) }
+    }
+
+    unsafe fn box_ret_in<'fcx>(fcinfo: &mut FcInfo<'fcx>, ret: Self::Ret) -> Datum<'fcx> {
+        unsafe { ret.box_into(fcinfo) }
     }
 
     unsafe fn check_fcinfo_and_prepare(_fcinfo: pg_sys::FunctionCallInfo) -> CallCx {

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -681,6 +681,7 @@ impl<'fcx> FcInfo<'fcx> {
     /// ```
     #[inline]
     pub fn return_null(&mut self) -> Datum<'fcx> {
+        // SAFETY: returning null is always safe
         unsafe { *self.set_return_is_null() = true };
         Datum::null()
     }
@@ -694,7 +695,10 @@ impl<'fcx> FcInfo<'fcx> {
     ///   to an object that will not last for the caller's lifetime, this is *undefined behavior*.
     /// - If the function call expects a by-value return, and the `pg_sys::Datum` is not a valid
     ///   instance of that type when interpreted as such, this is **undefined behavior**.
-    /// - If the return must be null, then calling this function is **undefined behavior**.
+    /// - If the return must be the SQL null, then calling this function is **undefined behavior**.
+    ///
+    /// Functionally, this can be thought of as a convenience for a [`mem::transmute`]
+    /// from `pg_sys::Datum` to `pgrx::datum::Datum<'fcx>`. This gives it similar constraints.
     #[inline]
     pub unsafe fn return_raw_datum(&mut self, datum: pg_sys::Datum) -> Datum<'fcx> {
         // SAFETY: Caller asserts

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -656,7 +656,7 @@ impl<'fcx> FcInfo<'fcx> {
     /// # Safety
     /// If this flag is set to "false", then the resulting return must be a valid [`Datum`] for
     /// the function call's result type.
-    pub unsafe fn return_is_null(&mut self) -> &mut bool {
+    pub unsafe fn set_return_is_null(&mut self) -> &mut bool {
         unsafe { &mut (*self.0).isnull }
     }
 
@@ -681,7 +681,7 @@ impl<'fcx> FcInfo<'fcx> {
     /// ```
     #[inline]
     pub fn return_null(&mut self) -> Datum<'fcx> {
-        unsafe { *self.return_is_null() = true };
+        unsafe { *self.set_return_is_null() = true };
         Datum::null()
     }
 
@@ -699,7 +699,7 @@ impl<'fcx> FcInfo<'fcx> {
     pub unsafe fn return_raw_datum(&mut self, datum: pg_sys::Datum) -> Datum<'fcx> {
         // SAFETY: Caller asserts
         unsafe {
-            *self.return_is_null() = false;
+            *self.set_return_is_null() = false;
             mem::transmute(datum)
         }
     }


### PR DESCRIPTION
People need to implement some of the code in this module, but I want to make sure it is easier to actually do so. To that end, refactor BoxRet to have a more user-friendly interface, ish, and then expose it.

While doing so, adjust some safety requirements here and there.