### PR TITLE
Upgrade owo-colors to v4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -386,7 +386,7 @@ dependencies = [
  "jobslot",
  "libc",
  "object",
- "owo-colors",
+ "owo-colors 4.0.0",
  "pgrx-pg-config",
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -572,7 +572,7 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors",
+ "owo-colors 3.5.0",
  "tracing-error",
 ]
 
@@ -583,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
 dependencies = [
  "once_cell",
- "owo-colors",
+ "owo-colors 3.5.0",
  "tracing-core",
  "tracing-error",
 ]
@@ -1121,6 +1121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1187,17 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1581,6 +1598,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 dependencies = [
  "supports-color",
 ]
@@ -1697,7 +1720,7 @@ dependencies = [
  "cargo_toml",
  "eyre",
  "home",
- "owo-colors",
+ "owo-colors 4.0.0",
  "pathsearch",
  "serde",
  "serde_json",
@@ -1733,7 +1756,7 @@ version = "0.12.0-beta.2"
 dependencies = [
  "convert_case",
  "eyre",
- "owo-colors",
+ "owo-colors 4.0.0",
  "petgraph",
  "proc-macro2",
  "quote",
@@ -1750,7 +1773,7 @@ dependencies = [
  "clap-cargo 0.14.0",
  "eyre",
  "libc",
- "owo-colors",
+ "owo-colors 4.0.0",
  "paste",
  "pgrx",
  "pgrx-macros",
@@ -1771,7 +1794,7 @@ name = "pgrx-version-updater"
 version = "0.1.1"
 dependencies = [
  "clap",
- "owo-colors",
+ "owo-colors 4.0.0",
  "toml_edit 0.22.12",
  "walkdir",
 ]
@@ -2529,11 +2552,11 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supports-color"
-version = "1.3.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
 dependencies = [
- "atty",
+ "is-terminal",
  "is_ci",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ cargo_toml = "0.19" # used for building projects
 clap-cargo = { version = "0.14.0", features = [ "cargo_metadata" ] }
 eyre = "~0.6.12" # simplifies error-handling
 libc = "0.2" # FFI compat
-owo-colors =  { version = "3.5", features = [ "supports-colors" ] } # for output highlighting
+owo-colors =  { version = "4.0", features = [ "supports-colors" ] } # for output highlighting
 proc-macro2 = { version = "1.0.78", features = [ "span-locations" ] }
 quote = "1.0.33"
 regex = "1.1" # used for build/test


### PR DESCRIPTION
Removes one dependency on atty, which has a security vulnerability and appears to be unmaintained.

Remaining dependencies to be fixed and/or released:

*   killercup/cargo-edit#900
*   eyre-rs/eyre#167