### PR TITLE
add bindings of syslogger.h

### DIFF
--- a/pgrx-pg-sys/include/pg12.h
+++ b/pgrx-pg-sys/include/pg12.h
@@ -121,6 +121,7 @@
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/syslogger.h"
 #include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -121,6 +121,7 @@
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/syslogger.h"
 #include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -122,6 +122,7 @@
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/syslogger.h"
 #include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -123,6 +123,7 @@
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/syslogger.h"
 #include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -125,6 +125,7 @@
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/syslogger.h"
 #include "replication/logical.h"
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"


### PR DESCRIPTION
`syslogger.h` defines `PipeProtoHeader` and `PipeProtoChunk`. These definitions helps a background worker to print CSV/JSON logs.