### PR TITLE
WIP: add support for ClientAuthentication_hook

### DIFF
--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -15,6 +15,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 
+#include "libpq/auth.h"
 #include "access/amapi.h"
 #include "access/genam.h"
 #include "access/generic_xlog.h"


### PR DESCRIPTION
Hi, after https://github.com/pgcentralfoundation/pgrx/issues/1738 a colleague and I tried our hands at implementing the `ClientAuthentication_hook`.

We took inspiration from https://github.com/pgcentralfoundation/pgrx/commit/0703e630e9c26202fb2b267f02619430860fa954 but the tests don't pass and we can't figure out why. Do the tests not go through an auth phase? Any advice?

Thanks!