### PR TITLE
Remove ArgAbi for `Numeric<P, S>`

### DIFF
--- a/pgrx-examples/numeric/src/lib.rs
+++ b/pgrx-examples/numeric/src/lib.rs
@@ -13,7 +13,7 @@ use pgrx::prelude::*;
 pg_module_magic!();
 
 #[pg_extern]
-fn add_numeric(a: Numeric<1000, 33>, b: Numeric<1000, 33>) -> Numeric<1000, 33> {
+fn add_numeric(a: AnyNumeric, b: AnyNumeric) -> Numeric<1000, 33> {
     (a + b).rescale().unwrap()
 }
 

--- a/pgrx-tests/src/tests/roundtrip_tests.rs
+++ b/pgrx-tests/src/tests/roundtrip_tests.rs
@@ -111,7 +111,6 @@ mod tests {
     roundtrip!(rt_refstr, test_rt_refstr, &'a str, "foo");
     roundtrip!(rt_bool, test_rt_bool, bool, true);
     roundtrip!(rt_f32, test_rt_f32, f32, f32::MAX);
-    roundtrip!(rt_numeric, test_rt_numeric, Numeric<100,0>, Numeric::from_str("31241234123412341234").unwrap());
     roundtrip!(
         rt_anynumeric,
         test_rt_anynumeric,
@@ -302,19 +301,6 @@ mod tests {
         test_rt_array_f32,
         Vec<Option<f32>>,
         vec![None, Some(f32::MIN), Some(f32::MAX), None, Some(42.42), None]
-    );
-    roundtrip!(
-        rt_array_numeric,
-        test_rt_array_numeric,
-        Vec<Option<Numeric<100, 0>>>,
-        vec![
-            None,
-            Some(Numeric::try_from(i128::MIN).unwrap()),
-            Some(Numeric::try_from(u128::MAX).unwrap()),
-            None,
-            Some(Numeric::from_str("31241234123412341234").unwrap()),
-            None
-        ]
     );
     roundtrip!(
         rt_array_anynumeric,

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -223,12 +223,6 @@ unsafe impl<'fcx, T: Copy> ArgAbi<'fcx> for PgVarlena<T> {
     }
 }
 
-unsafe impl<'fcx, const P: u32, const S: u32> ArgAbi<'fcx> for crate::Numeric<P, S> {
-    unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> Self {
-        unsafe { arg.unbox_arg_using_from_datum().unwrap() }
-    }
-}
-
 unsafe impl<'fcx> ArgAbi<'fcx> for pg_sys::FunctionCallInfo {
     unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> Self {
         unsafe { arg.0.as_mut_ptr() }


### PR DESCRIPTION
This implementation is actually false as Postgres does not check typmods before calling a function, thus we can't use them to define arguments.