### PR TITLE
Split out pgrx-bindgen crate

### DIFF
--- a/.github/workflows/package-test.yaml
+++ b/.github/workflows/package-test.yaml
@@ -1,0 +1,45 @@
+name: verify package can build
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  TOOL_DIR: ./tools
+  PG_VER: 14
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-pgrx--package-test"
+
+      - name: Install Postgres deps
+        run: |
+          sudo apt-get update -y -qq --fix-missing
+          sudo apt-get install -y postgresql-server-dev-$PG_VER
+
+      - name: Rustup
+        run: $TOOL_DIR/rustup.sh nightly
+
+      - name: Install cargo pgrx
+        run: cargo +nightly install --path cargo-pgrx --debug
+
+      - name: cargo pgrx init
+        run: cargo +nightly pgrx init "--pg$PG_VER=$(which pg_config)"
+
+      - name: Test pgrx can be packaged as a new version
+        run: |
+          ./update-versions.sh 0.0.999-rc.999 && \
+              cargo +nightly package \
+                  --workspace -Zpackage-workspace \
+                  --allow-dirty \
+                  --features "pg$PG_VER"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -343,9 +343,6 @@ jobs:
       - name: Run `cargo pgrx schema` against the versioned_custom_libname_so example
         run: cd pgrx-examples/versioned_custom_libname_so && cargo pgrx schema pg$PG_VER
 
-      - name: Test that version bumps work
-        run: ./update-versions.sh 0.0.999-rc.999 && cargo +nightly package --workspace -Zpackage-workspace --allow-dirty --features "pg$PG_VER"
-
       # Attempt to make the cache payload slightly smaller.
       - name: Clean up built PGRX files
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgrx-bindgen"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "clang-sys",
+ "eyre",
+ "pgrx-pg-config",
+ "proc-macro2",
+ "quote",
+ "shlex",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
 name = "pgrx-macros"
 version = "0.12.0-beta.3"
 dependencies = [
@@ -1535,11 +1550,10 @@ dependencies = [
 name = "pgrx-pg-sys"
 version = "0.12.0-beta.3"
 dependencies = [
- "bindgen",
  "cee-scape",
- "clang-sys",
  "eyre",
  "libc",
+ "pgrx-bindgen",
  "pgrx-macros",
  "pgrx-pg-config",
  "pgrx-sql-entity-graph",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,19 +1551,12 @@ name = "pgrx-pg-sys"
 version = "0.12.0-beta.3"
 dependencies = [
  "cee-scape",
- "eyre",
  "libc",
  "pgrx-bindgen",
  "pgrx-macros",
- "pgrx-pg-config",
  "pgrx-sql-entity-graph",
- "proc-macro2",
- "quote",
  "serde",
- "shlex",
  "sptr",
- "syn",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "pgrx-pg-sys",
     "pgrx-sql-entity-graph",
     "pgrx-tests",
+    "pgrx-bindgen",
 ]
 exclude = [
     # "pgrx-examples/*",
@@ -57,6 +58,7 @@ pgrx-macros = { path = "./pgrx-macros", version = "=0.12.0-beta.3" }
 pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.0-beta.3" }
 pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.0-beta.3" }
 pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.12.0-beta.3" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "0.1" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "0.12.2" # format-preserving edits to cargo.toml

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -4,6 +4,9 @@ description = "additional bindgen support for pgrx"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+homepage = "https://github.com/pgcentralfoundation/pgrx"
+repository = "https://github.com/pgcentralfoundation/pgrx"
+docs = "https://docs.rs/pgrx-bindgen"
 
 [dependencies]
 pgrx-pg-config.workspace = true

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pgrx-bindgen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pgrx-pg-config.workspace = true
+
+eyre.workspace = true
+proc-macro2.workspace = true
+syn.workspace = true
+walkdir.workspace = true
+
+bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
+clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
+quote = "1.0.33"
+shlex = "1.3" # shell lexing, also used by many of our deps

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "pgrx-bindgen"
+description = "additional bindgen support for pgrx"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 pgrx-pg-config.workspace = true

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -26,10 +26,8 @@ use syn::{ForeignItem, Item, ItemConst};
 
 const BLOCKLISTED_TYPES: [&str; 3] = ["Datum", "NullableDatum", "Oid"];
 
-mod build {
-    pub(super) mod clang;
-    pub(super) mod sym_blocklist;
-}
+pub(super) mod clang;
+pub(super) mod sym_blocklist;
 
 #[derive(Debug)]
 struct BindingOverride {
@@ -138,7 +136,7 @@ impl bindgen::callbacks::ParseCallbacks for BindingOverride {
     }
 }
 
-fn main() -> eyre::Result<()> {
+pub fn main() -> eyre::Result<()> {
     if env_tracked("DOCS_RS").as_deref() == Some("1") {
         return Ok(());
     }
@@ -756,7 +754,7 @@ fn run_bindgen(
     let configure = pg_config.configure()?;
     let preferred_clang: Option<&std::path::Path> = configure.get("CLANG").map(|s| s.as_ref());
     eprintln!("pg_config --configure CLANG = {preferred_clang:?}");
-    let (autodetect, includes) = build::clang::detect_include_paths_for(preferred_clang);
+    let (autodetect, includes) = clang::detect_include_paths_for(preferred_clang);
     let mut binder = bindgen::Builder::default();
     binder = add_blocklists(binder);
     binder = add_derives(binder);
@@ -1110,7 +1108,7 @@ fn is_blocklisted_item(item: &ForeignItem) -> bool {
         _ => return false,
     };
     BLOCKLISTED
-        .get_or_init(|| build::sym_blocklist::SYMBOLS.iter().copied().collect::<BTreeSet<&str>>())
+        .get_or_init(|| sym_blocklist::SYMBOLS.iter().copied().collect::<BTreeSet<&str>>())
         .contains(sym_name.to_string().as_str())
 }
 

--- a/pgrx-bindgen/src/build/clang.rs
+++ b/pgrx-bindgen/src/build/clang.rs
@@ -1,4 +1,4 @@
-use crate::target_env_tracked;
+use super::target_env_tracked;
 use bindgen::ClangVersion;
 use clang_sys::support::Clang as ClangSys;
 use std::{ffi::OsStr, path::PathBuf};

--- a/pgrx-bindgen/src/build/sym_blocklist.rs
+++ b/pgrx-bindgen/src/build/sym_blocklist.rs
@@ -37,7 +37,7 @@
 ///
 /// A future version of pgrx will achieve this effect in a more complete and less
 /// hacky manner. Effort should be spent there rather than updating this list.
-pub(crate) const SYMBOLS: &[&str] = &[
+pub const SYMBOLS: &[&str] = &[
     "a64l",
     "abort",
     "__abort_msg",

--- a/pgrx-bindgen/src/lib.rs
+++ b/pgrx-bindgen/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod build;

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -54,16 +54,7 @@ sptr = "0.3"
 cee-scape = "0.2"
 
 [build-dependencies]
-pgrx-pg-config.workspace = true
 pgrx-bindgen.workspace = true
-
-eyre.workspace = true
-proc-macro2.workspace = true
-syn.workspace = true
-walkdir.workspace = true
-
-quote = "1.0.33"
-shlex = "1.3" # shell lexing, also used by many of our deps
 
 [lints]
 # we allow improper_ctypes just to eliminate these warnings:

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -20,6 +20,7 @@ documentation = "https://docs.rs/pgrx-pg-sys"
 readme = "README.md"
 edition = "2021"
 include = ["src/**/*", "README.md", "include/*", "cshim/*", "build.rs", "build/*"]
+build = "bindgen.rs"
 
 [features]
 default = []
@@ -54,14 +55,13 @@ cee-scape = "0.2"
 
 [build-dependencies]
 pgrx-pg-config.workspace = true
+pgrx-bindgen.workspace = true
 
 eyre.workspace = true
 proc-macro2.workspace = true
 syn.workspace = true
 walkdir.workspace = true
 
-bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
-clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
 quote = "1.0.33"
 shlex = "1.3" # shell lexing, also used by many of our deps
 

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/pgcentralfoundation/pgrx/"
 documentation = "https://docs.rs/pgrx-pg-sys"
 readme = "README.md"
 edition = "2021"
-include = ["src/**/*", "README.md", "include/*", "cshim/*", "build.rs", "build/*"]
+include = ["src/**/*", "README.md", "include/*", "cshim/*", "bindgen.rs"]
 build = "bindgen.rs"
 
 [features]

--- a/pgrx-pg-sys/bindgen.rs
+++ b/pgrx-pg-sys/bindgen.rs
@@ -1,0 +1,4 @@
+// not a build.rs so that it doesn't inherit the git history of the build.rs
+
+// little-known Rust quirk: you can import main from wherever
+use pgrx_bindgen::build::main;

--- a/publish.sh
+++ b/publish.sh
@@ -14,6 +14,7 @@ DIR=`pwd`
 set -x
 
 cd $DIR/pgrx-pg-config && cargo publish
+cd $DIR/pgrx-bindgen && cargo publish
 cd $DIR/pgrx-sql-entity-graph && cargo publish
 cd $DIR/pgrx-macros && cargo publish
 cd $DIR/pgrx-pg-sys && cargo publish --no-verify

--- a/publish.sh
+++ b/publish.sh
@@ -23,8 +23,6 @@ set -x
 # │       └── pgrx
 # │           └── pgrx-tests
 # └── pgrx-tests
-# [build-dependencies]
-# └── pgrx-pg-sys
 
 cd $DIR/pgrx-pg-config && cargo publish
 cd $DIR/pgrx-bindgen && cargo publish

--- a/publish.sh
+++ b/publish.sh
@@ -13,6 +13,19 @@
 DIR=`pwd`
 set -x
 
+# dependency graph, from roots to facades
+#
+# pgrx-pg-config
+# ├── cargo-pgrx
+# ├── pgrx-bindgen
+# │   [build-dependencies]
+# │   └── pgrx-pg-sys
+# │       └── pgrx
+# │           └── pgrx-tests
+# └── pgrx-tests
+# [build-dependencies]
+# └── pgrx-pg-sys
+
 cd $DIR/pgrx-pg-config && cargo publish
 cd $DIR/pgrx-bindgen && cargo publish
 cd $DIR/pgrx-sql-entity-graph && cargo publish

--- a/publish.sh
+++ b/publish.sh
@@ -23,6 +23,18 @@ set -x
 # │       └── pgrx
 # │           └── pgrx-tests
 # └── pgrx-tests
+#
+# pgrx-sql-entity-graph
+# ├── cargo-pgrx
+# ├── pgrx
+# │   └── pgrx-tests
+# ├── pgrx-macros
+# │   ├── pgrx
+# │   ├── pgrx-pg-sys
+# │   │   └── pgrx
+# │   └── pgrx-tests
+# └── pgrx-pg-sys
+
 
 cd $DIR/pgrx-pg-config && cargo publish
 cd $DIR/pgrx-bindgen && cargo publish


### PR DESCRIPTION
One last essentially-administrative change, and part of the reason that I did all the mucking-about in #1796. We have a lot of code in pgrx-pg-sys's build.rs, and it's high time that we actually split out the real crate that it is. Currently this *just* moves that around, rather than doing any refactoring, to make the git blame trackable.

The packaging test generates a sufficiently large cache that it cannot be done for every version of pgrx in the combinatoric fashion that we usually do, thus, we don't anymore! We simply run it for one version.