### PR TITLE
Update versions even if no specifier

### DIFF
--- a/tools/version-updater/Cargo.lock
+++ b/tools/version-updater/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "clap",
  "owo-colors",
  "rustc-hash",
+ "toml",
  "toml_edit",
  "walkdir",
 ]

--- a/tools/version-updater/Cargo.lock
+++ b/tools/version-updater/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "cargo_toml",
  "clap",
  "owo-colors",
+ "rustc-hash",
  "toml_edit",
  "walkdir",
 ]
@@ -181,6 +182,12 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "same-file"

--- a/tools/version-updater/Cargo.lock
+++ b/tools/version-updater/Cargo.lock
@@ -52,6 +52,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_toml"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad639525b1c67b6a298f378417b060fbc04618bea559482a8484381cce27d965"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +157,7 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 name = "pgrx-version-updater"
 version = "0.1.1"
 dependencies = [
+ "cargo_toml",
  "clap",
  "owo-colors",
  "toml_edit",
@@ -181,6 +192,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.207"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.207"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,10 +238,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -210,6 +265,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/tools/version-updater/Cargo.toml
+++ b/tools/version-updater/Cargo.toml
@@ -18,10 +18,11 @@ description = "Standalone tool to update PGRX Cargo.toml versions and dependenci
 publish = false
 
 [dependencies]
+cargo_toml = "0.20.4"
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
 owo-colors = "4"
+rustc-hash = "2"
 toml_edit = { version = "0.22" }
-cargo_toml = "*"
 walkdir = "2"
 
 [workspace]

--- a/tools/version-updater/Cargo.toml
+++ b/tools/version-updater/Cargo.toml
@@ -21,6 +21,7 @@ publish = false
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
 owo-colors = "4"
 toml_edit = { version = "0.22" }
+cargo_toml = "*"
 walkdir = "2"
 
 [workspace]

--- a/tools/version-updater/Cargo.toml
+++ b/tools/version-updater/Cargo.toml
@@ -22,6 +22,7 @@ cargo_toml = "0.20.4"
 clap = { version = "4.4.2", features = [ "env", "derive" ] }
 owo-colors = "4"
 rustc-hash = "2"
+toml = "0.8.19"
 toml_edit = { version = "0.22" }
 walkdir = "2"
 

--- a/tools/version-updater/src/main.rs
+++ b/tools/version-updater/src/main.rs
@@ -430,7 +430,7 @@ fn parse_new_version(current_version_specifier: &str, new_version: &str) -> Stri
     match current_version_specifier.chars().nth(0) {
         // If first character is numeric, then we have just a version specified,
         // such as "0.5.2" or "4.15.0"
-        Some(c) if c.is_numeric() => result.push_str(current_version_specifier),
+        Some(c) if c.is_numeric() => result.push_str(new_version),
 
         // Otherwise, we have a specifier such as "=0.5.2" or "~0.4.6" or ">= 1.2.0"
         // Extract out the non-numeric prefix and join it with the new version to


### PR DESCRIPTION
Found a bug after doing some refactoring to improve how this tool works in general, making it more resilient to whatever the hell we do to our repo. This should allow us to have packages with different names than the paths to them, allowing arbitrary nesting and relocation, and also applies a less ad-hoc rule regarding "what packages are we updating".

Unblocks #1802.