### PR TITLE
Make bindgen generate CStrs and such

### DIFF
--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pgcentralfoundation/pgrx"
 repository = "https://github.com/pgcentralfoundation/pgrx"
-docs = "https://docs.rs/pgrx-bindgen"
+documentation = "https://docs.rs/pgrx-bindgen"
 
 [dependencies]
 pgrx-pg-config.workspace = true

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -822,9 +822,9 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
         .blocklist_function(".*(?:set|long)jmp")
         .blocklist_function("pg_re_throw")
         .blocklist_function("err(start|code|msg|detail|context_msg|hint|finish)")
-        .blocklist_item("CONFIGURE_ARGS") // configuration during build is hopefully irrelevant
-        .blocklist_item("_*(?:HAVE|have)_.*") // header tracking metadata
-        .blocklist_item("_[A-Z_]+_H") // more header metadata
+        .blocklist_var("CONFIGURE_ARGS") // configuration during build is hopefully irrelevant
+        .blocklist_var("_*(?:HAVE|have)_.*") // header tracking metadata
+        .blocklist_var("_[A-Z_]+_H") // more header metadata
         .blocklist_item("__[A-Z].*") // these are reserved and unused by Postgres
         .blocklist_item("__darwin.*") // this should always be Apple's names
         .blocklist_function("pq(?:Strerror|Get.*)") // wrappers around platform functions: user can call those themselves

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -777,6 +777,7 @@ fn run_bindgen(
         .merge_extern_blocks(true)
         .wrap_unsafe_ops(true)
         .use_core()
+        .disable_nested_struct_naming()
         .formatter(bindgen::Formatter::None)
         .layout_tests(false)
         .default_non_copy_union_style(NonCopyUnionStyle::ManuallyDrop)

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -777,6 +777,7 @@ fn run_bindgen(
         .merge_extern_blocks(true)
         .wrap_unsafe_ops(true)
         .use_core()
+        .generate_cstr(true)
         .disable_nested_struct_naming()
         .formatter(bindgen::Formatter::None)
         .layout_tests(false)

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -775,6 +775,8 @@ fn run_bindgen(
         .rustified_non_exhaustive_enum("NodeTag")
         .size_t_is_usize(true)
         .merge_extern_blocks(true)
+        .wrap_unsafe_ops(true)
+        .use_core()
         .formatter(bindgen::Formatter::None)
         .layout_tests(false)
         .default_non_copy_union_style(NonCopyUnionStyle::ManuallyDrop)

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -137,8 +137,7 @@ pub const VARHDRSZ_SHORT: usize = offset_of!(super::varattrib_1b, va_data);
 
 #[inline]
 pub fn get_pg_major_version_string() -> &'static str {
-    let mver = core::ffi::CStr::from_bytes_with_nul(super::PG_MAJORVERSION).unwrap();
-    mver.to_str().unwrap()
+    super::PG_MAJORVERSION.to_str().unwrap()
 }
 
 #[inline]
@@ -148,14 +147,12 @@ pub fn get_pg_major_version_num() -> u16 {
 
 #[inline]
 pub fn get_pg_version_string() -> &'static str {
-    let ver = core::ffi::CStr::from_bytes_with_nul(super::PG_VERSION_STR).unwrap();
-    ver.to_str().unwrap()
+    super::PG_VERSION_STR.to_str().unwrap()
 }
 
 #[inline]
 pub fn get_pg_major_minor_version_string() -> &'static str {
-    let mver = core::ffi::CStr::from_bytes_with_nul(super::PG_VERSION).unwrap();
-    mver.to_str().unwrap()
+    super::PG_VERSION.to_str().unwrap()
 }
 
 #[inline]

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -243,11 +243,11 @@ macro_rules! pg_magic_func {
                 abi_extra: {
                     // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then we'll
                     // raise a compilation error unless the `unsafe-postgres` feature is set
-                    let magic = ::pgrx::pg_sys::FMGR_ABI_EXTRA;
+                    let magic = ::pgrx::pg_sys::FMGR_ABI_EXTRA.to_bytes_with_nul();
                     let mut abi = [0 as ::pgrx::ffi::c_char; 32];
                     let mut i = 0;
                     while i < magic.len() {
-                        abi[i] = magic[i] as _;
+                        abi[i] = magic[i] as ::pgrx::ffi::c_char;
                         i += 1;
                     }
                     abi

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -145,14 +145,15 @@ mod seal {
     not(feature = "unsafe-postgres")
 ))]
 const _: () = {
+    use core::ffi::CStr;
     // to appease `const`
-    const fn same_slice(a: &[u8], b: &[u8]) -> bool {
-        if a.len() != b.len() {
+    const fn same_cstr(a: &CStr, b: &CStr) -> bool {
+        if a.to_bytes().len() != b.to_bytes().len() {
             return false;
         }
         let mut i = 0;
-        while i < a.len() {
-            if a[i] != b[i] {
+        while i < a.to_bytes().len() {
+            if a.to_bytes()[i] != b.to_bytes()[i] {
                 return false;
             }
             i += 1;
@@ -160,7 +161,7 @@ const _: () = {
         true
     }
     assert!(
-        same_slice(pg_sys::FMGR_ABI_EXTRA, b"PostgreSQL\0"),
+        same_cstr(pg_sys::FMGR_ABI_EXTRA, c"PostgreSQL"),
         "Unsupported Postgres ABI. Perhaps you need `--features unsafe-postgres`?",
     );
 };


### PR DESCRIPTION
While cutting a release, I noticed our bindgen options were wonky. I fixed a few blocklistings and adjusted the bindgen settings. Most of this should be invisible. There's only one case affected by nested struct naming, and it's not even present in pg16 and later. But the most notable change, and one that I expect might force people to have to update their code: now const strings from C are CStrs!