### PR TITLE
Correct release instructions for current repo tools

### DIFF
--- a/docs/src/contributing/release.md
+++ b/docs/src/contributing/release.md
@@ -8,13 +8,10 @@
 - edit them as best as you can while channeling @workingjubilee's spirit
 - request a review
 - do a squash merge into develop
-
-```shell
-./finalize-release.sh
-```
-
 - create the actual release on GitHub, tagging the `develop` branch with "${NEW_VERSION}", using the release notes you made in your PR
 
 ```shell
+git switch develop
+git pull origin/develop
 ./publish.sh
 ```

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -25,7 +25,10 @@ elif [ "$NEW_VERSION" = "" ]; then
 else
     git pull origin develop --ff-only
     git switch -c "prepare-${NEW_VERSION}"
-   
+
+    cargo install --path cargo-pgrx --locked
+    cargo pgrx init
+
     # exit early if the script fails 
     ./update-versions.sh "${NEW_VERSION}" || exit $?
 


### PR DESCRIPTION
- Remove a reference to a script that doesn't exist anymore.
- Remind people to pull off develop so they publish the same commit.