### PR TITLE
Demand at least bindgen 0.69.4

### DIFF
--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2.workspace = true
 syn.workspace = true
 walkdir.workspace = true
 
-bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.69.4", default-features = false, features = ["runtime"] }
 clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
 quote = "1.0.33"
 shlex = "1.3" # shell lexing, also used by many of our deps


### PR DESCRIPTION
bindgen 0.69.2 doesn't work on aarch64,
so we must demand 0.69.3 or better. Let's go for better.

Closes #1799 