### PR TITLE
Prepare pgrx 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "bzip2",
  "cargo-edit",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.2",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "bindgen",
  "clang-sys",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "cee-scape",
  "libc",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 dependencies = [
  "clap-cargo 0.14.0",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,11 @@ exclude = [
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-macros = { path = "./pgrx-macros", version = "=0.12.0-beta.5" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.0-beta.5" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.0-beta.5" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.12.0-beta.5" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "0.12.0-beta.5" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.12.0" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.0" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.0" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.12.0" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "0.12.0" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "0.12.2" # format-preserving edits to cargo.toml

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -21,10 +21,10 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.12.0-beta.5"
+pgrx = "=0.12.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.12.0-beta.5"
+pgrx-tests = "=0.12.0"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -72,7 +72,7 @@ rand = "0.8.5"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.12.0-beta.5"
+version = "=0.12.0"
 
 [dev-dependencies]
 eyre.workspace = true # testing functions that return `eyre::Result`

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.12.0-beta.5"
+version = "0.12.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"


### PR DESCRIPTION
Cutting the 0.12.0 release as-is!

You may need to:
- rearrange some imports
- sed some types to use `pg_sys::EnumName::Type` (only the typedef, not the constants)
- bump heapless to 0.8
- `impl ArgAbi` and `impl BoxRet` for custom types

Code which updates to this version of pgrx is actually sound for the Postgres function ABI, so sorry about the breakages!