### PR TITLE
Implement ArgAbi for PgRelation

### DIFF
--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -51,6 +51,7 @@ mod postgres_type_tests;
 #[cfg(feature = "proptest")]
 mod proptests;
 mod range_tests;
+mod rel_tests;
 mod result_tests;
 mod roundtrip_tests;
 mod schema_tests;

--- a/pgrx-tests/src/tests/rel_tests.rs
+++ b/pgrx-tests/src/tests/rel_tests.rs
@@ -1,0 +1,30 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::prelude::*;
+use pgrx::rel::PgRelation;
+#[pg_extern]
+fn accept_relation(rel: PgRelation) {
+    _ = rel;
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgrx_tests;
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_accept_relation() {
+        Spi::run("CREATE TABLE relation_test(name TEXT);").unwrap();
+        Spi::run("CREATE INDEX relation_test_index ON relation_test(name);").unwrap();
+        Spi::run("SELECT accept_relation('relation_test_index');").unwrap();
+    }
+}

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -21,6 +21,7 @@ use crate::heap_tuple::PgHeapTuple;
 use crate::nullable::Nullable;
 use crate::pg_sys;
 use crate::pgbox::*;
+use crate::rel::PgRelation;
 use crate::{PgBox, PgMemoryContexts};
 
 use core::marker::PhantomData;
@@ -262,7 +263,7 @@ macro_rules! argue_from_datum {
 argue_from_datum! { 'fcx; i8, i16, i32, i64, f32, f64, bool, char, String, Vec<u8> }
 argue_from_datum! { 'fcx; Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone }
 argue_from_datum! { 'fcx; AnyArray, AnyElement, AnyNumeric }
-argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid, crate::rel::PgRelation }
+argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid, PgRelation }
 argue_from_datum! { 'fcx; pg_sys::BOX, pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point }
 argue_from_datum! { 'fcx; &'fcx str, &'fcx CStr, &'fcx [u8] }
 

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -262,7 +262,7 @@ macro_rules! argue_from_datum {
 argue_from_datum! { 'fcx; i8, i16, i32, i64, f32, f64, bool, char, String, Vec<u8> }
 argue_from_datum! { 'fcx; Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone }
 argue_from_datum! { 'fcx; AnyArray, AnyElement, AnyNumeric }
-argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid }
+argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid, crate::rel::PgRelation }
 argue_from_datum! { 'fcx; pg_sys::BOX, pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point }
 argue_from_datum! { 'fcx; &'fcx str, &'fcx CStr, &'fcx [u8] }
 


### PR DESCRIPTION
This is missing in 0.12.0.

It was originally thought that perhaps extensions didn't need this, as pgrx makes a lot of opinionated choices with PgRelation that aren't always applicable. In actuality there are extensions where this proves to be a significant amount of the 0.12 update friction.