### PR TITLE
[ `CPPFLAGS`] Switch to `USE_ASSERT_CHECKING`

### DIFF
--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -408,8 +408,7 @@ fn configure_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::
     let mut command = std::process::Command::new(configure_path);
     // Some of these are redundant with `--enable-debug`.
     let mut existing_cppflags = std::env::var("CPPFLAGS").unwrap_or_default();
-    existing_cppflags += " -DMEMORY_CONTEXT_CHECKING=1 \
-        -DCLOBBER_FREED_MEMORY=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 ";
+    existing_cppflags += " -DUSE_ASSERT_CHECKING=1 -DRANDOMIZE_ALLOCATED_MEMORY=1 ";
     if init.valgrind {
         // `USE_VALGRIND` allows valgrind to understand PG's memory context
         // shenanigans. It requires Valgrind be installed (since it causes


### PR DESCRIPTION
> [cargo-pgrx/src/command/init.rs] Use `USE_ASSERT_CHECKING` over `MEMORY_CONTEXT_CHECKING` & `CLOBBER_FREED_MEMORY` to avoid symbol redefinition warnings from postgres @ src/include/pg_config_manual.h

Related: My patch to PostgreSQL's pgsql-hackers mailing-list https://www.postgresql.org/message-id/CAMfPbcYq94UKjAr_R5YOPXWPNC9Sx9AOa6fS4Fio6tobEsmf5g%40mail.gmail.com