### PR TITLE
Add UnboxDatum for Range<T>

### DIFF
--- a/pgrx-tests/src/tests/range_tests.rs
+++ b/pgrx-tests/src/tests/range_tests.rs
@@ -30,6 +30,11 @@ fn accept_range_date(range: Range<Date>) -> Range<Date> {
 }
 
 #[pg_extern]
+fn accept_range_date_array(arr: Array<Range<Date>>) -> Vec<Range<Date>> {
+    arr.iter_deny_null().collect()
+}
+
+#[pg_extern]
 fn accept_range_ts(range: Range<Timestamp>) -> Range<Timestamp> {
     range
 }
@@ -140,6 +145,13 @@ mod tests {
     fn test_accept_range_date() {
         let matched =
             Spi::get_one::<bool>("SELECT accept_range_date(daterange'[2000-01-01,2022-01-01)') = daterange'[2000-01-01,2022-01-01)'");
+        assert_eq!(matched, Ok(Some(true)));
+    } 
+    
+    #[pg_test]
+    fn test_accept_range_date_array() {
+        let matched =
+            Spi::get_one::<bool>("SELECT accept_range_date_array(ARRAY[daterange'[2000-01-01,2022-01-01)']::daterange[]) = ARRAY[daterange'[2000-01-01,2022-01-01)']::daterange[]");
         assert_eq!(matched, Ok(Some(true)));
     }
 

--- a/pgrx-tests/src/tests/range_tests.rs
+++ b/pgrx-tests/src/tests/range_tests.rs
@@ -146,8 +146,8 @@ mod tests {
         let matched =
             Spi::get_one::<bool>("SELECT accept_range_date(daterange'[2000-01-01,2022-01-01)') = daterange'[2000-01-01,2022-01-01)'");
         assert_eq!(matched, Ok(Some(true)));
-    } 
-    
+    }
+
     #[pg_test]
     fn test_accept_range_date_array() {
         let matched =

--- a/pgrx/src/datum/unbox.rs
+++ b/pgrx/src/datum/unbox.rs
@@ -323,6 +323,16 @@ unsafe impl<T: FromDatum + UnboxDatum> UnboxDatum for VariadicArray<'_, T> {
     }
 }
 
+unsafe impl<T: FromDatum + UnboxDatum + RangeSubType> UnboxDatum for Range<T> {
+    type As<'src> = Range<T> where Self: 'src;
+    unsafe fn unbox<'src>(d: Datum<'src>) -> Self::As<'src>
+    where
+        Self: 'src,
+    {
+        Range::<T>::from_datum(d.0, false).unwrap()
+    }
+}
+
 unsafe impl<const P: u32, const S: u32> UnboxDatum for Numeric<P, S> {
     type As<'src> = Numeric<P, S>;
     #[inline]


### PR DESCRIPTION
I was getting compiler complaints from this input type `my_func(arr: Array<Range<Date>>)`  and calling `.get_by_name::<Range<Date>>`. Implement the required trait.