### PR TITLE
Changed query methods to accept slices

### DIFF
--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -69,7 +69,7 @@ pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {
                 let tuple_table = client.select(
                     "SELECT 'Hi', id, ''||a FROM (SELECT id, 42 from generate_series(1,10) id) a ",
                     None,
-                    None,
+                    &[][..],
                 )?;
                 for tuple in tuple_table {
                     let a = tuple.get_datum_by_ordinal(1)?.value::<String>()?;

--- a/pgrx-examples/custom_sql/src/lib.rs
+++ b/pgrx-examples/custom_sql/src/lib.rs
@@ -89,7 +89,7 @@ mod tests {
         let buf = Spi::connect(|client| {
             Ok::<_, spi::Error>(
                 client
-                    .select("SELECT * FROM extension_sql", None, None)?
+                    .select("SELECT * FROM extension_sql", None, &[][..])?
                     .flat_map(|tup| {
                         tup.get_datum_by_ordinal(1)
                             .ok()

--- a/pgrx-examples/schemas/src/lib.rs
+++ b/pgrx-examples/schemas/src/lib.rs
@@ -103,10 +103,10 @@ mod tests {
     fn test_my_some_schema_type() -> Result<(), spi::Error> {
         Spi::connect(|mut c| {
             // "MySomeSchemaType" is in 'some_schema', so it needs to be discoverable
-            c.update("SET search_path TO some_schema,public", None, None)?;
+            c.update("SET search_path TO some_schema,public", None, &[][..])?;
             assert_eq!(
                 String::from("test"),
-                c.select("SELECT '\"test\"'::MySomeSchemaType", None, None)?
+                c.select("SELECT '\"test\"'::MySomeSchemaType", None, &[][..])?
                     .first()
                     .get_one::<MySomeSchemaType>()
                     .expect("get_one::<MySomeSchemaType>() failed")

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -48,7 +48,7 @@ fn spi_return_query() -> Result<
 
     Spi::connect(|client| {
         client
-            .select(query, None, None)?
+            .select(query, None, &[][..])?
             .map(|row| Ok((row["oid"].value()?, row[2].value()?)))
             .collect::<Result<Vec<_>, _>>()
     })
@@ -75,7 +75,7 @@ fn spi_query_by_id(id: i64) -> Result<Option<String>, spi::Error> {
             .select(
                 "SELECT id, title FROM spi.spi_example WHERE id = $1",
                 None,
-                Some(&[(PgBuiltInOids::INT8OID.oid(), id.into_datum())]),
+                &[(PgBuiltInOids::INT8OID.oid(), id.into_datum())],
             )?
             .first();
 
@@ -111,7 +111,7 @@ fn spi_insert_title2(
 fn issue1209_fixed() -> Result<Option<String>, Box<dyn std::error::Error>> {
     let res = Spi::connect(|c| {
         let mut cursor =
-            c.try_open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", None)?;
+            c.try_open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", &[][..])?;
         let table = cursor.fetch(10000)?;
         table.into_iter().map(|row| row.get::<&str>(1)).collect::<Result<Vec<_>, _>>()
     })?;

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -64,7 +64,7 @@ fn spi_query_random_id() -> Result<Option<i64>, pgrx::spi::Error> {
 fn spi_query_title(title: &str) -> Result<Option<i64>, pgrx::spi::Error> {
     Spi::get_one_with_args(
         "SELECT id FROM spi.spi_example WHERE title = $1;",
-        vec![(PgBuiltInOids::TEXTOID.oid(), title.into_datum())],
+        &[(PgBuiltInOids::TEXTOID.oid(), title.into_datum())],
     )
 }
 
@@ -75,7 +75,7 @@ fn spi_query_by_id(id: i64) -> Result<Option<String>, spi::Error> {
             .select(
                 "SELECT id, title FROM spi.spi_example WHERE id = $1",
                 None,
-                Some(vec![(PgBuiltInOids::INT8OID.oid(), id.into_datum())]),
+                Some(&[(PgBuiltInOids::INT8OID.oid(), id.into_datum())]),
             )?
             .first();
 
@@ -90,7 +90,7 @@ fn spi_query_by_id(id: i64) -> Result<Option<String>, spi::Error> {
 fn spi_insert_title(title: &str) -> Result<Option<i64>, spi::Error> {
     Spi::get_one_with_args(
         "INSERT INTO spi.spi_example(title) VALUES ($1) RETURNING id",
-        vec![(PgBuiltInOids::TEXTOID.oid(), title.into_datum())],
+        &[(PgBuiltInOids::TEXTOID.oid(), title.into_datum())],
     )
 }
 
@@ -100,7 +100,7 @@ fn spi_insert_title2(
 ) -> TableIterator<(name!(id, Option<i64>), name!(title, Option<String>))> {
     let tuple = Spi::get_two_with_args(
         "INSERT INTO spi.spi_example(title) VALUES ($1) RETURNING id, title",
-        vec![(PgBuiltInOids::TEXTOID.oid(), title.into_datum())],
+        &[(PgBuiltInOids::TEXTOID.oid(), title.into_datum())],
     )
     .unwrap();
 
@@ -110,7 +110,8 @@ fn spi_insert_title2(
 #[pg_extern]
 fn issue1209_fixed() -> Result<Option<String>, Box<dyn std::error::Error>> {
     let res = Spi::connect(|c| {
-        let mut cursor = c.open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", None);
+        let mut cursor =
+            c.try_open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", None)?;
         let table = cursor.fetch(10000)?;
         table.into_iter().map(|row| row.get::<&str>(1)).collect::<Result<Vec<_>, _>>()
     })?;

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -55,7 +55,7 @@ fn calculate_human_years() -> Result<
 
     Spi::connect(|client| {
         let mut results = Vec::new();
-        let tup_table = client.select(query, None, None)?;
+        let tup_table = client.select(query, None, &[][..])?;
 
         for row in tup_table {
             let dog_name = row["dog_name"].value::<String>();
@@ -92,7 +92,7 @@ fn filter_by_breed(
     let args = vec![(PgBuiltInOids::TEXTOID.oid(), breed.into_datum())];
 
     Spi::connect(|client| {
-        let tup_table = client.select(query, None, Some(args))?;
+        let tup_table = client.select(query, None, &args)?;
 
         let filtered = tup_table
             .map(|row| {

--- a/pgrx-tests/src/tests/aggregate_tests.rs
+++ b/pgrx-tests/src/tests/aggregate_tests.rs
@@ -263,7 +263,7 @@ mod tests {
     fn aggregate_first_json() -> Result<(), pgrx::spi::Error> {
         let retval = Spi::get_one_with_args::<pgrx::Json>(
             "SELECT FirstJson(value) FROM UNNEST(ARRAY [$1, $2]) as value;",
-            vec![
+            &[
                 (
                     PgBuiltInOids::JSONOID.oid(),
                     pgrx::Json(serde_json::json!({ "foo": "one" })).into_datum(),
@@ -285,7 +285,7 @@ mod tests {
     fn aggregate_first_jsonb() -> Result<(), pgrx::spi::Error> {
         let retval = Spi::get_one_with_args::<pgrx::JsonB>(
             "SELECT FirstJsonB(value) FROM UNNEST(ARRAY [$1, $2]) as value;",
-            vec![
+            &[
                 (
                     PgBuiltInOids::JSONBOID.oid(),
                     pgrx::JsonB(serde_json::json!({ "foo": "one" })).into_datum(),

--- a/pgrx-tests/src/tests/anyelement_tests.rs
+++ b/pgrx-tests/src/tests/anyelement_tests.rs
@@ -17,7 +17,7 @@ mod tests {
     fn test_anyelement_arg() -> Result<(), pgrx::spi::Error> {
         let element = Spi::get_one_with_args::<AnyElement>(
             "SELECT anyelement_arg($1);",
-            vec![(PgBuiltInOids::ANYELEMENTOID.oid(), 123.into_datum())],
+            &[(PgBuiltInOids::ANYELEMENTOID.oid(), 123.into_datum())],
         )?
         .map(|e| e.datum());
 

--- a/pgrx-tests/src/tests/anynumeric_tests.rs
+++ b/pgrx-tests/src/tests/anynumeric_tests.rs
@@ -17,7 +17,7 @@ mod tests {
     fn test_anynumeric_arg() -> Result<(), pgrx::spi::Error> {
         let numeric = Spi::get_one_with_args::<AnyNumeric>(
             "SELECT anynumeric_arg($1);",
-            vec![(PgBuiltInOids::INT4OID.oid(), 123.into_datum())],
+            &[(PgBuiltInOids::INT4OID.oid(), 123.into_datum())],
         )?
         .map(|n| n.normalize().to_string());
 

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -300,7 +300,7 @@ mod tests {
                 .select(
                     "SELECT serde_serialize_array_i32($1)",
                     None,
-                    Some(&[(PgBuiltInOids::INT4ARRAYOID.oid(), owned_vec.as_slice().into_datum())]),
+                    &[(PgBuiltInOids::INT4ARRAYOID.oid(), owned_vec.as_slice().into_datum())],
                 )?
                 .first()
                 .get_one::<Json>()

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -300,10 +300,7 @@ mod tests {
                 .select(
                     "SELECT serde_serialize_array_i32($1)",
                     None,
-                    Some(vec![(
-                        PgBuiltInOids::INT4ARRAYOID.oid(),
-                        owned_vec.as_slice().into_datum(),
-                    )]),
+                    Some(&[(PgBuiltInOids::INT4ARRAYOID.oid(), owned_vec.as_slice().into_datum())]),
                 )?
                 .first()
                 .get_one::<Json>()

--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -30,7 +30,7 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
                     .update(
                         "INSERT INTO tests.bgworker_test VALUES ($1);",
                         None,
-                        Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())]),
+                        Some(&[(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())]),
                     )
                     .map(|_| ())
             })
@@ -63,7 +63,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
             Spi::run("CREATE TABLE tests.bgworker_test_return (v INTEGER);")?;
             Spi::get_one_with_args::<i32>(
                 "SELECT $1",
-                vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())],
+                &[(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())],
             )
         })
         .expect("bgworker transaction failed")
@@ -77,7 +77,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
             c.update(
                 "INSERT INTO tests.bgworker_test_return VALUES ($1)",
                 None,
-                Some(vec![(PgOid::BuiltIn(PgBuiltInOids::INT4OID), val.into_datum())]),
+                Some(&[(PgOid::BuiltIn(PgBuiltInOids::INT4OID), val.into_datum())]),
             )
             .map(|_| ())
         })

--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -30,7 +30,7 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
                     .update(
                         "INSERT INTO tests.bgworker_test VALUES ($1);",
                         None,
-                        Some(&[(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())]),
+                        &[(PgOid::BuiltIn(PgBuiltInOids::INT4OID), arg.into_datum())],
                     )
                     .map(|_| ())
             })
@@ -77,7 +77,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
             c.update(
                 "INSERT INTO tests.bgworker_test_return VALUES ($1)",
                 None,
-                Some(&[(PgOid::BuiltIn(PgBuiltInOids::INT4OID), val.into_datum())]),
+                &[(PgOid::BuiltIn(PgBuiltInOids::INT4OID), val.into_datum())],
             )
             .map(|_| ())
         })

--- a/pgrx-tests/src/tests/heap_tuple.rs
+++ b/pgrx-tests/src/tests/heap_tuple.rs
@@ -881,7 +881,7 @@ mod tests {
     fn test_tuple_desc_clone() -> Result<(), spi::Error> {
         let result = Spi::connect(|client| {
             let query = "select * from generate_lots_of_dogs()";
-            client.select(query, None, None).map(|table| table.len())
+            client.select(query, None, &[][..]).map(|table| table.len())
         })?;
         assert_eq!(result, 10_000);
         Ok(())

--- a/pgrx-tests/src/tests/json_tests.rs
+++ b/pgrx-tests/src/tests/json_tests.rs
@@ -79,7 +79,7 @@ mod tests {
     fn test_json_arg() -> Result<(), pgrx::spi::Error> {
         let json = Spi::get_one_with_args::<Json>(
             "SELECT json_arg($1);",
-            vec![(
+            &[(
                 PgBuiltInOids::JSONOID.oid(),
                 Json(serde_json::json!({ "foo": "bar" })).into_datum(),
             )],
@@ -95,7 +95,7 @@ mod tests {
     fn test_jsonb_arg() -> Result<(), pgrx::spi::Error> {
         let json = Spi::get_one_with_args::<JsonB>(
             "SELECT jsonb_arg($1);",
-            vec![(
+            &[(
                 PgBuiltInOids::JSONBOID.oid(),
                 JsonB(serde_json::json!({ "foo": "bar" })).into_datum(),
             )],

--- a/pgrx-tests/src/tests/pg_cast_tests.rs
+++ b/pgrx-tests/src/tests/pg_cast_tests.rs
@@ -48,8 +48,12 @@ mod tests {
     #[pg_test]
     fn test_pg_cast_assignment_type_cast() {
         let _ = Spi::connect(|mut client| {
-            client.update("CREATE TABLE test_table(value int4);", None, None)?;
-            client.update("INSERT INTO test_table VALUES('{\"a\": 1}'::json->'a');", None, None)?;
+            client.update("CREATE TABLE test_table(value int4);", None, &[][..])?;
+            client.update(
+                "INSERT INTO test_table VALUES('{\"a\": 1}'::json->'a');",
+                None,
+                &[][..],
+            )?;
 
             Ok::<_, spi::Error>(())
         });

--- a/pgrx-tests/src/tests/proptests.rs
+++ b/pgrx-tests/src/tests/proptests.rs
@@ -32,7 +32,7 @@ pub fn [<$datetime_ty:lower _spi_roundtrip>] () {
         .run(&strat, |datetime| {
             let query = concat!("SELECT ", stringify!($nop_fn), "($1)");
             let builtin_oid = PgOid::BuiltIn(pg_sys::BuiltinOid::from_u32(<$datetime_ty as IntoDatum>::type_oid().as_u32()).unwrap());
-            let args = vec![(builtin_oid, datetime.into_datum())];
+            let args = &[(builtin_oid, datetime.into_datum())];
             let spi_ret: $datetime_ty = Spi::get_one_with_args(query, args).unwrap().unwrap();
             // 5. A condition on which the test is accepted or rejected:
             //    this is easily done via `prop_assert!` and its friends,

--- a/pgrx-tests/src/tests/roundtrip_tests.rs
+++ b/pgrx-tests/src/tests/roundtrip_tests.rs
@@ -79,7 +79,7 @@ mod tests {
                 let expected: $rtype = Clone::clone(&value);
                 let result: $rtype = Spi::get_one_with_args(
                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-                    vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+                    &[(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
                 )?
                 .unwrap();
 

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -21,7 +21,7 @@ mod tests {
 
     #[pg_test(error = "syntax error at or near \"THIS\"")]
     fn test_spi_failure() -> Result<(), spi::Error> {
-        Spi::connect(|client| client.select("THIS IS NOT A VALID QUERY", None, None).map(|_| ()))
+        Spi::connect(|client| client.select("THIS IS NOT A VALID QUERY", None, &[][..]).map(|_| ()))
     }
 
     #[pg_test]
@@ -33,8 +33,9 @@ mod tests {
 
     #[pg_test]
     fn test_spi_returns_primitive() -> Result<(), spi::Error> {
-        let rc =
-            Spi::connect(|client| client.select("SELECT 42", None, None)?.first().get::<i32>(1))?;
+        let rc = Spi::connect(|client| {
+            client.select("SELECT 42", None, &[][..])?.first().get::<i32>(1)
+        })?;
 
         assert_eq!(Some(42), rc);
         Ok(())
@@ -43,7 +44,7 @@ mod tests {
     #[pg_test]
     fn test_spi_returns_str() -> Result<(), spi::Error> {
         let rc = Spi::connect(|client| {
-            client.select("SELECT 'this is a test'", None, None)?.first().get::<&str>(1)
+            client.select("SELECT 'this is a test'", None, &[][..])?.first().get::<&str>(1)
         })?;
 
         assert_eq!(Some("this is a test"), rc);
@@ -53,7 +54,7 @@ mod tests {
     #[pg_test]
     fn test_spi_returns_string() -> Result<(), spi::Error> {
         let rc = Spi::connect(|client| {
-            client.select("SELECT 'this is a test'", None, None)?.first().get::<&str>(1)
+            client.select("SELECT 'this is a test'", None, &[][..])?.first().get::<&str>(1)
         })?;
 
         assert_eq!(Some("this is a test"), rc);
@@ -63,7 +64,7 @@ mod tests {
     #[pg_test]
     fn test_spi_get_one() -> Result<(), spi::Error> {
         Spi::connect(|client| {
-            let i = client.select("SELECT 42::bigint", None, None)?.first().get_one::<i64>()?;
+            let i = client.select("SELECT 42::bigint", None, &[][..])?.first().get_one::<i64>()?;
             assert_eq!(Some(42), i);
             Ok(())
         })
@@ -72,8 +73,10 @@ mod tests {
     #[pg_test]
     fn test_spi_get_two() -> Result<(), spi::Error> {
         Spi::connect(|client| {
-            let (i, s) =
-                client.select("SELECT 42, 'test'", None, None)?.first().get_two::<i64, &str>()?;
+            let (i, s) = client
+                .select("SELECT 42, 'test'", None, &[][..])?
+                .first()
+                .get_two::<i64, &str>()?;
 
             assert_eq!(Some(42), i);
             assert_eq!(Some("test"), s);
@@ -85,7 +88,7 @@ mod tests {
     fn test_spi_get_three() -> Result<(), spi::Error> {
         Spi::connect(|client| {
             let (i, s, b) = client
-                .select("SELECT 42, 'test', true", None, None)?
+                .select("SELECT 42, 'test', true", None, &[][..])?
                 .first()
                 .get_three::<i64, &str, bool>()?;
 
@@ -100,7 +103,7 @@ mod tests {
     fn test_spi_get_two_with_failure() -> Result<(), spi::Error> {
         Spi::connect(|client| {
             assert!(client
-                .select("SELECT 42", None, None)?
+                .select("SELECT 42", None, &[][..])?
                 .first()
                 .get_two::<i64, &str>()
                 .is_err());
@@ -112,7 +115,7 @@ mod tests {
     fn test_spi_get_three_failure() -> Result<(), spi::Error> {
         Spi::connect(|client| {
             assert!(client
-                .select("SELECT 42, 'test'", None, None)?
+                .select("SELECT 42, 'test'", None, &[][..])?
                 .first()
                 .get_three::<i64, &str, bool>()
                 .is_err());
@@ -137,10 +140,10 @@ mod tests {
 
         assert!(Spi::run_with_args(
             "SELECT $1 + $2 = 3",
-            Some(&[
+            &[
                 (PgBuiltInOids::INT4OID.oid(), Some(i.into())),
                 (PgBuiltInOids::INT8OID.oid(), Some(j.into())),
-            ]),
+            ],
         )
         .is_ok());
     }
@@ -159,10 +162,10 @@ mod tests {
 
         let result = Spi::explain_with_args(
             "SELECT $1 + $2 = 3",
-            Some(&[
+            &[
                 (PgBuiltInOids::INT4OID.oid(), Some(i.into())),
                 (PgBuiltInOids::INT8OID.oid(), Some(j.into())),
-            ]),
+            ],
         )?;
 
         assert!(result.0.get(0).unwrap().get("Plan").is_some());
@@ -182,7 +185,7 @@ mod tests {
     #[pg_test]
     fn test_inserting_null() -> Result<(), pgrx::spi::Error> {
         Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.null_test (id uuid)", None, None).map(|_| ())
+            client.update("CREATE TABLE tests.null_test (id uuid)", None, &[][..]).map(|_| ())
         })?;
         assert_eq!(
             Spi::get_one_with_args::<i32>(
@@ -205,14 +208,14 @@ mod tests {
     #[pg_test]
     fn test_cursor() -> Result<(), spi::Error> {
         Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, &[][..])?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
             SELECT i FROM generate_series(1, 10) AS t(i)",
                 None,
-                None,
+                &[][..],
             )?;
-            let mut portal = client.open_cursor("SELECT * FROM tests.cursor_table", None);
+            let mut portal = client.open_cursor("SELECT * FROM tests.cursor_table", &[][..]);
 
             assert_eq!(sum_all(portal.fetch(3)?), 1 + 2 + 3);
             assert_eq!(sum_all(portal.fetch(3)?), 4 + 5 + 6);
@@ -225,15 +228,15 @@ mod tests {
     #[pg_test]
     fn test_cursor_prepared_statement() -> Result<(), pgrx::spi::Error> {
         Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, &[][..])?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
             SELECT i FROM generate_series(1, 10) AS t(i)",
                 None,
-                None,
+                &[][..],
             )?;
             let prepared = client.prepare("SELECT * FROM tests.cursor_table", None)?;
-            let mut portal = client.open_cursor(&prepared, None);
+            let mut portal = client.open_cursor(&prepared, &[][..]);
 
             assert_eq!(sum_all(portal.fetch(3)?), 1 + 2 + 3);
             assert_eq!(sum_all(portal.fetch(3)?), 4 + 5 + 6);
@@ -245,31 +248,25 @@ mod tests {
 
     #[pg_test]
     #[should_panic(expected = "PreparedStatementArgumentMismatch { expected: 1, got: 0 }")]
-    fn test_cursor_prepared_statement_panics_none_args() -> Result<(), pgrx::spi::Error> {
-        test_cursor_prepared_statement_panics_impl(None)
-    }
-
-    #[pg_test]
-    #[should_panic(expected = "PreparedStatementArgumentMismatch { expected: 1, got: 0 }")]
     fn test_cursor_prepared_statement_panics_less_args() -> Result<(), pgrx::spi::Error> {
-        test_cursor_prepared_statement_panics_impl(Some([].to_vec()))
+        test_cursor_prepared_statement_panics_impl(&[][..])
     }
 
     #[pg_test]
     #[should_panic(expected = "PreparedStatementArgumentMismatch { expected: 1, got: 2 }")]
     fn test_cursor_prepared_statement_panics_more_args() -> Result<(), pgrx::spi::Error> {
-        test_cursor_prepared_statement_panics_impl(Some([None, None].to_vec()))
+        test_cursor_prepared_statement_panics_impl(&[None, None])
     }
     fn test_cursor_prepared_statement_panics_impl(
-        args: Option<&[Option<pg_sys::Datum>]>,
+        args: &[Option<pg_sys::Datum>],
     ) -> Result<(), pgrx::spi::Error> {
         Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, &[][..])?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
             SELECT i FROM generate_series(1, 10) AS t(i)",
                 None,
-                None,
+                &[][..],
             )?;
             let prepared = client.prepare(
                 "SELECT * FROM tests.cursor_table WHERE id = $1",
@@ -283,14 +280,14 @@ mod tests {
     #[pg_test]
     fn test_cursor_by_name() -> Result<(), pgrx::spi::Error> {
         let cursor_name = Spi::connect(|mut client| {
-            client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
+            client.update("CREATE TABLE tests.cursor_table (id int)", None, &[][..])?;
             client.update(
                 "INSERT INTO tests.cursor_table (id) \
             SELECT i FROM generate_series(1, 10) AS t(i)",
                 None,
-                None,
+                &[][..],
             )?;
-            let mut cursor = client.open_cursor("SELECT * FROM tests.cursor_table", None);
+            let mut cursor = client.open_cursor("SELECT * FROM tests.cursor_table", &[][..]);
             assert_eq!(sum_all(cursor.fetch(3)?), 1 + 2 + 3);
             Ok::<_, spi::Error>(cursor.detach_into_name())
         })?;
@@ -314,7 +311,7 @@ mod tests {
     #[pg_test(error = "syntax error at or near \"THIS\"")]
     fn test_cursor_failure() {
         Spi::connect(|client| {
-            client.open_cursor("THIS IS NOT SQL", None);
+            client.open_cursor("THIS IS NOT SQL", &[][..]);
         })
     }
 
@@ -326,7 +323,7 @@ mod tests {
     #[pg_test]
     fn test_columns() -> Result<(), spi::Error> {
         Spi::connect(|client| {
-            let res = client.select("SELECT 42 AS a, 'test' AS b", None, None)?;
+            let res = client.select("SELECT 42 AS a, 'test' AS b", None, &[][..])?;
 
             assert_eq!(Ok(2), res.columns());
             assert_eq!(res.column_type_oid(1).unwrap(), PgOid::BuiltIn(PgBuiltInOids::INT4OID));
@@ -337,7 +334,7 @@ mod tests {
         })?;
 
         Spi::connect(|mut client| {
-            let res = client.update("SET TIME ZONE 'PST8PDT'", None, None)?;
+            let res = client.update("SET TIME ZONE 'PST8PDT'", None, &[][..])?;
 
             assert_eq!(Err(spi::Error::NoTupleTable), res.columns());
             Ok(())
@@ -354,8 +351,8 @@ mod tests {
     fn test_spi_non_mut() -> Result<(), pgrx::spi::Error> {
         // Ensures update and cursor APIs do not need mutable reference to SpiClient
         Spi::connect(|mut client| {
-            client.update("SELECT 1", None, None).expect("SPI failed");
-            let cursor = client.open_cursor("SELECT 1", None).detach_into_name();
+            client.update("SELECT 1", None, &[][..]).expect("SPI failed");
+            let cursor = client.open_cursor("SELECT 1", &[][..]).detach_into_name();
             client.find_cursor(&cursor).map(|_| ())
         })
     }
@@ -365,8 +362,8 @@ mod tests {
         // Regression test to ensure a new `SpiTupTable` instance does not override the
         // effective length of an already open one due to misuse of Spi statics
         Spi::connect(|client| {
-            let a = client.select("SELECT 1", None, None)?.first();
-            let _b = client.select("SELECT 1 WHERE 'f'", None, None)?;
+            let a = client.select("SELECT 1", None, &[][..])?.first();
+            let _b = client.select("SELECT 1 WHERE 'f'", None, &[][..])?;
             assert!(!a.is_empty());
             assert_eq!(1, a.len());
             assert!(a.get_heap_tuple().is_ok());
@@ -381,8 +378,8 @@ mod tests {
         // effective length of an already open one.
         // Same as `test_open_multiple_tuptables`, but with the second tuptable being empty
         Spi::connect(|client| {
-            let a = client.select("SELECT 1 WHERE 'f'", None, None)?.first();
-            let _b = client.select("SELECT 1", None, None)?;
+            let a = client.select("SELECT 1 WHERE 'f'", None, &[][..])?.first();
+            let _b = client.select("SELECT 1", None, &[][..])?;
             assert!(a.is_empty());
             assert_eq!(0, a.len());
             assert!(a.get_heap_tuple().is_ok());
@@ -396,7 +393,7 @@ mod tests {
         let rc = Spi::connect(|client| {
             let prepared =
                 client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]))?;
-            client.select(&prepared, None, Some(&[42.into_datum()]))?.first().get::<i32>(1)
+            client.select(&prepared, None, &[42.into_datum()])?.first().get::<i32>(1)
         })?;
 
         assert_eq!(42, rc.expect("SPI failed to return proper value"));
@@ -408,7 +405,7 @@ mod tests {
         let err = Spi::connect(|client| {
             let prepared =
                 client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]))?;
-            client.select(&prepared, None, None).map(|_| ())
+            client.select(&prepared, None, &[][..]).map(|_| ())
         })
         .unwrap_err();
 
@@ -428,7 +425,7 @@ mod tests {
             )
         })?;
         let rc = Spi::connect(|client| {
-            client.select(&prepared, None, Some(&[42.into_datum()]))?.first().get::<i32>(1)
+            client.select(&prepared, None, &[42.into_datum()])?.first().get::<i32>(1)
         })?;
 
         assert_eq!(Some(42), rc);
@@ -443,16 +440,16 @@ mod tests {
     #[pg_test(error = "CREATE TABLE is not allowed in a non-volatile function")]
     fn test_readwrite_in_readonly() -> Result<(), spi::Error> {
         // This is supposed to run in read-only
-        Spi::connect(|client| client.select("CREATE TABLE a ()", None, None).map(|_| ()))
+        Spi::connect(|client| client.select("CREATE TABLE a ()", None, &[][..]).map(|_| ()))
     }
 
     #[pg_test]
     fn test_readwrite_in_select_readwrite() -> Result<(), spi::Error> {
         Spi::connect(|mut client| {
             // This is supposed to switch connection to read-write and run it there
-            client.update("CREATE TABLE a (id INT)", None, None)?;
+            client.update("CREATE TABLE a (id INT)", None, &[][..])?;
             // This is supposed to run in read-write
-            client.select("INSERT INTO a VALUES (1)", None, None)?;
+            client.select("INSERT INTO a VALUES (1)", None, &[][..])?;
             Ok(())
         })
     }
@@ -462,7 +459,7 @@ mod tests {
         Spi::connect(|client| {
             let stmt = client.prepare("CREATE TABLE a ()", None)?;
             // This is supposed to run in read-only
-            stmt.execute(&client, Some(1), None)?;
+            stmt.execute(&client, Some(1), &[][..])?;
             Ok(())
         })
     }
@@ -472,7 +469,7 @@ mod tests {
         Spi::connect(|client| {
             let stmt = client.prepare_mut("CREATE TABLE a ()", None)?;
             // This is supposed to run in read-write
-            stmt.execute(&client, Some(1), None)?;
+            stmt.execute(&client, Some(1), &[][..])?;
             Ok(())
         })
     }
@@ -480,9 +477,9 @@ mod tests {
     #[pg_test]
     fn test_spi_select_sees_update() -> spi::Result<()> {
         let with_select = Spi::connect(|mut client| {
-            client.update("CREATE TABLE asd(id int)", None, None)?;
-            client.update("INSERT INTO asd(id) VALUES (1)", None, None)?;
-            client.select("SELECT COUNT(*) FROM asd", None, None)?.first().get_one::<i64>()
+            client.update("CREATE TABLE asd(id int)", None, &[][..])?;
+            client.update("INSERT INTO asd(id) VALUES (1)", None, &[][..])?;
+            client.select("SELECT COUNT(*) FROM asd", None, &[][..])?.first().get_one::<i64>()
         })?;
         let with_get_one = Spi::get_one::<i64>("SELECT COUNT(*) FROM asd")?;
 
@@ -495,7 +492,7 @@ mod tests {
         Spi::run("CREATE TABLE asd(id int)")?;
         Spi::run("INSERT INTO asd(id) VALUES (1)")?;
         let with_select = Spi::connect(|client| {
-            client.select("SELECT COUNT(*) FROM asd", None, None)?.first().get_one::<i64>()
+            client.select("SELECT COUNT(*) FROM asd", None, &[][..])?.first().get_one::<i64>()
         })?;
         let with_get_one = Spi::get_one::<i64>("SELECT COUNT(*) FROM asd")?;
 
@@ -506,12 +503,12 @@ mod tests {
     #[pg_test]
     fn test_spi_select_sees_update_in_other_session() -> spi::Result<()> {
         Spi::connect::<spi::Result<()>, _>(|mut client| {
-            client.update("CREATE TABLE asd(id int)", None, None)?;
-            client.update("INSERT INTO asd(id) VALUES (1)", None, None)?;
+            client.update("CREATE TABLE asd(id int)", None, &[][..])?;
+            client.update("INSERT INTO asd(id) VALUES (1)", None, &[][..])?;
             Ok(())
         })?;
         let with_select = Spi::connect(|client| {
-            client.select("SELECT COUNT(*) FROM asd", None, None)?.first().get_one::<i64>()
+            client.select("SELECT COUNT(*) FROM asd", None, &[][..])?.first().get_one::<i64>()
         })?;
         let with_get_one = Spi::get_one::<i64>("SELECT COUNT(*) FROM asd")?;
 
@@ -571,7 +568,8 @@ mod tests {
     #[pg_test]
     fn can_return_borrowed_str() -> Result<(), Box<dyn Error>> {
         let res = Spi::connect(|c| {
-            let mut cursor = c.open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", None);
+            let mut cursor =
+                c.open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", &[][..]);
             let table = cursor.fetch(10000)?;
             table.into_iter().map(|row| row.get::<&str>(1)).collect::<Result<Vec<_>, _>>()
         })?;

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -137,7 +137,7 @@ mod tests {
 
         assert!(Spi::run_with_args(
             "SELECT $1 + $2 = 3",
-            Some(vec![
+            Some(&[
                 (PgBuiltInOids::INT4OID.oid(), Some(i.into())),
                 (PgBuiltInOids::INT8OID.oid(), Some(j.into())),
             ]),
@@ -159,7 +159,7 @@ mod tests {
 
         let result = Spi::explain_with_args(
             "SELECT $1 + $2 = 3",
-            Some(vec![
+            Some(&[
                 (PgBuiltInOids::INT4OID.oid(), Some(i.into())),
                 (PgBuiltInOids::INT8OID.oid(), Some(j.into())),
             ]),
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(
             Spi::get_one_with_args::<i32>(
                 "INSERT INTO tests.null_test VALUES ($1) RETURNING 1",
-                vec![(PgBuiltInOids::UUIDOID.oid(), None)],
+                &[(PgBuiltInOids::UUIDOID.oid(), None)],
             )?
             .unwrap(),
             1
@@ -260,9 +260,8 @@ mod tests {
     fn test_cursor_prepared_statement_panics_more_args() -> Result<(), pgrx::spi::Error> {
         test_cursor_prepared_statement_panics_impl(Some([None, None].to_vec()))
     }
-
     fn test_cursor_prepared_statement_panics_impl(
-        args: Option<Vec<Option<pg_sys::Datum>>>,
+        args: Option<&[Option<pg_sys::Datum>]>,
     ) -> Result<(), pgrx::spi::Error> {
         Spi::connect(|mut client| {
             client.update("CREATE TABLE tests.cursor_table (id int)", None, None)?;
@@ -397,7 +396,7 @@ mod tests {
         let rc = Spi::connect(|client| {
             let prepared =
                 client.prepare("SELECT $1", Some(vec![PgOid::BuiltIn(PgBuiltInOids::INT4OID)]))?;
-            client.select(&prepared, None, Some(vec![42.into_datum()]))?.first().get::<i32>(1)
+            client.select(&prepared, None, Some(&[42.into_datum()]))?.first().get::<i32>(1)
         })?;
 
         assert_eq!(42, rc.expect("SPI failed to return proper value"));
@@ -429,7 +428,7 @@ mod tests {
             )
         })?;
         let rc = Spi::connect(|client| {
-            client.select(&prepared, None, Some(vec![42.into_datum()]))?.first().get::<i32>(1)
+            client.select(&prepared, None, Some(&[42.into_datum()]))?.first().get::<i32>(1)
         })?;
 
         assert_eq!(Some(42), rc);

--- a/pgrx-tests/src/tests/srf_tests.rs
+++ b/pgrx-tests/src/tests/srf_tests.rs
@@ -154,7 +154,7 @@ mod tests {
     fn test_generate_series() {
         let cnt = Spi::connect(|client| {
             let mut table =
-                client.select("SELECT * FROM example_generate_series(1, 10)", None, None)?;
+                client.select("SELECT * FROM example_generate_series(1, 10)", None, &[][..])?;
 
             let mut expect = 0;
             while table.next().is_some() {
@@ -174,7 +174,8 @@ mod tests {
     #[pg_test]
     fn test_composite_set() {
         let cnt = Spi::connect(|client| {
-            let mut table = client.select("SELECT * FROM example_composite_set()", None, None)?;
+            let mut table =
+                client.select("SELECT * FROM example_composite_set()", None, &[][..])?;
 
             let mut expect = 0;
             while table.next().is_some() {
@@ -200,7 +201,7 @@ mod tests {
     #[pg_test]
     fn test_return_table_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_table_iterator();", None, None)?;
+            let table = client.select("SELECT * from return_table_iterator();", None, &[][..])?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });
@@ -211,7 +212,7 @@ mod tests {
     #[pg_test]
     fn test_return_empty_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_empty_iterator();", None, None)?;
+            let table = client.select("SELECT * from return_empty_iterator();", None, &[][..])?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });
@@ -222,7 +223,7 @@ mod tests {
     #[pg_test]
     fn test_return_setof_iterator() {
         let cnt = Spi::connect(|client| {
-            let table = client.select("SELECT * from return_setof_iterator();", None, None)?;
+            let table = client.select("SELECT * from return_setof_iterator();", None, &[][..])?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });
@@ -234,7 +235,7 @@ mod tests {
     fn test_return_empty_setof_iterator() {
         let cnt = Spi::connect(|client| {
             let table =
-                client.select("SELECT * from return_empty_setof_iterator();", None, None)?;
+                client.select("SELECT * from return_empty_setof_iterator();", None, &[][..])?;
 
             Ok::<_, spi::Error>(table.len() as i64)
         });
@@ -246,13 +247,13 @@ mod tests {
     fn test_srf_setof_datum_detoasting_with_borrow() {
         let cnt = Spi::connect(|mut client| {
             // build up a table with one large column that Postgres will be forced to TOAST
-            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000)) x;", None, None)?;
+            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000)) x;", None, &[][..])?;
 
             // and make sure we can use the DETOASTED value with our SRF function
             let table = client.select(
                 "SELECT split_set_with_borrow(s, ' ') FROM test_srf_datum_detoasting",
                 None,
-                None,
+                &[][..],
             )?;
 
             Ok::<_, spi::Error>(table.len() as i64)
@@ -264,13 +265,13 @@ mod tests {
     fn test_srf_table_datum_detoasting_with_borrow() {
         let cnt = Spi::connect(|mut client| {
             // build up a table with one large column that Postgres will be forced to TOAST
-            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000)) x;", None, None)?;
+            client.update("CREATE TABLE test_srf_datum_detoasting AS SELECT array_to_string(array_agg(g),' ') s FROM (SELECT 'a' g FROM generate_series(1, 1000)) x;", None, &[][..])?;
 
             // and make sure we can use the DETOASTED value with our SRF function
             let table = client.select(
                 "SELECT split_table_with_borrow(s, ' ') FROM test_srf_datum_detoasting",
                 None,
-                None,
+                &[][..],
             )?;
 
             Ok::<_, spi::Error>(table.len() as i64)

--- a/pgrx-tests/src/tests/struct_type_tests.rs
+++ b/pgrx-tests/src/tests/struct_type_tests.rs
@@ -22,7 +22,7 @@ mod tests {
     fn test_complex_in() -> Result<(), pgrx::spi::Error> {
         Spi::connect(|client| {
             let complex = client
-                .select("SELECT '1.1,2.2'::complex;", None, None)?
+                .select("SELECT '1.1,2.2'::complex;", None, &[][..])?
                 .first()
                 .get_one::<PgBox<Complex>>()?
                 .expect("datum was null");
@@ -44,7 +44,7 @@ mod tests {
     fn test_complex_from_text() -> Result<(), pgrx::spi::Error> {
         Spi::connect(|client| {
             let complex = client
-                .select("SELECT '1.1, 2.2'::complex;", None, None)?
+                .select("SELECT '1.1, 2.2'::complex;", None, &[][..])?
                 .first()
                 .get_one::<PgBox<Complex>>()?
                 .expect("datum was null");
@@ -60,7 +60,7 @@ mod tests {
         let complex = Spi::connect(|mut client| {
             client.update(
                 "CREATE TABLE complex_test AS SELECT s as id, (s || '.0, 2.0' || s)::complex as value FROM generate_series(1, 1000) s;\
-                SELECT value FROM complex_test ORDER BY id;", None, None)?.first().get_one::<PgBox<Complex>>()
+                SELECT value FROM complex_test ORDER BY id;", None, &[][..])?.first().get_one::<PgBox<Complex>>()
         })?.expect("datum was null");
 
         assert_eq!(&complex.r, &1.0);

--- a/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-cursor.rs
+++ b/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-cursor.rs
@@ -6,14 +6,14 @@ use std::error::Error;
 fn issue1209() -> Result<Option<String>, Box<dyn Error>> {
     // create the cursor we actually care about
     let mut res = Spi::connect(|c| {
-        c.open_cursor("select 'hello world' from generate_series(1, 1000)", None)
+        c.open_cursor("select 'hello world' from generate_series(1, 1000)", &[][..])
             .fetch(1000)
             .unwrap()
     });
 
     // here we just perform some allocations to make sure that the previous cursor gets invalidated
     for _ in 0..100 {
-        Spi::connect(|c| c.open_cursor("select 1", None).fetch(1).unwrap());
+        Spi::connect(|c| c.open_cursor("select 1", &[][..]).fetch(1).unwrap());
     }
 
     // later elements are probably more likely to point to deallocated memory

--- a/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-cursor.stderr
+++ b/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-cursor.stderr
@@ -5,7 +5,7 @@ error: lifetime may not live long enough
    |                                   -- return type of closure is SpiTupleTable<'2>
    |                                   |
    |                                   has type `SpiClient<'1>`
-9  | /         c.open_cursor("select 'hello world' from generate_series(1, 1000)", None)
+9  | /         c.open_cursor("select 'hello world' from generate_series(1, 1000)", &[][..])
 10 | |             .fetch(1000)
 11 | |             .unwrap()
    | |_____________________^ returning this value requires that `'1` must outlive `'2`
@@ -13,8 +13,8 @@ error: lifetime may not live long enough
 error[E0515]: cannot return value referencing temporary value
   --> tests/compile-fail/escaping-spiclient-1209-cursor.rs:9:9
    |
-9  |           c.open_cursor("select 'hello world' from generate_series(1, 1000)", None)
-   |           ^------------------------------------------------------------------------
+9  |           c.open_cursor("select 'hello world' from generate_series(1, 1000)", &[][..])
+   |           ^---------------------------------------------------------------------------
    |           |
    |  _________temporary value created here
    | |
@@ -27,8 +27,8 @@ error[E0515]: cannot return value referencing temporary value
 error: lifetime may not live long enough
   --> tests/compile-fail/escaping-spiclient-1209-cursor.rs:16:26
    |
-16 |         Spi::connect(|c| c.open_cursor("select 1", None).fetch(1).unwrap());
-   |                       -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+16 |         Spi::connect(|c| c.open_cursor("select 1", &[][..]).fetch(1).unwrap());
+   |                       -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |                       ||
    |                       |return type of closure is SpiTupleTable<'2>
    |                       has type `SpiClient<'1>`
@@ -36,8 +36,8 @@ error: lifetime may not live long enough
 error[E0515]: cannot return value referencing temporary value
   --> tests/compile-fail/escaping-spiclient-1209-cursor.rs:16:26
    |
-16 |         Spi::connect(|c| c.open_cursor("select 1", None).fetch(1).unwrap());
-   |                          -------------------------------^^^^^^^^^^^^^^^^^^
+16 |         Spi::connect(|c| c.open_cursor("select 1", &[][..]).fetch(1).unwrap());
+   |                          ----------------------------------^^^^^^^^^^^^^^^^^^
    |                          |
    |                          returns a value referencing data owned by the current function
    |                          temporary value created here

--- a/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-prep-stmt.rs
+++ b/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-prep-stmt.rs
@@ -7,7 +7,7 @@ fn issue1209_prepared_stmt(q: &str) -> Result<Option<String>, Box<dyn Error>> {
 
     let prepared = { Spi::connect(|c| c.prepare(q, None))? };
 
-    Ok(Spi::connect(|c| prepared.execute(&c, Some(1), None)?.first().get(1))?)
+    Ok(Spi::connect(|c| prepared.execute(&c, Some(1), &[][..])?.first().get(1))?)
 }
 
 fn main() {}

--- a/pgrx-tests/tests/todo/roundtrip-tests.rs
+++ b/pgrx-tests/tests/todo/roundtrip-tests.rs
@@ -1,9 +1,9 @@
 fn main() {}
 
 mod tests {
+    use pgrx::prelude::*;
     use std::error::Error;
     use std::ffi::CStr;
-    use pgrx::prelude::*;
 
     #[allow(unused_imports)]
     use crate as pgrx_tests;
@@ -35,7 +35,7 @@ mod tests {
                 let expected: $rtype = Clone::clone(&value);
                 let result: $rtype = Spi::get_one_with_args(
                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-                    vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+                    &[(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
                 )?
                 .unwrap();
 

--- a/pgrx-tests/tests/todo/roundtrip-tests.stderr
+++ b/pgrx-tests/tests/todo/roundtrip-tests.stderr
@@ -79,7 +79,7 @@ error[E0277]: the trait bound `Vec<Option<&[u8]>>: FromDatum` is not satisfied
 36 |                   let result: $rtype = Spi::get_one_with_args(
    |  ______________________________________^
 37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-38 | |                     vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+38 | |                     &[(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
 39 | |                 )?
    | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&[u8]>>`
 ...
@@ -109,7 +109,7 @@ error[E0277]: the trait bound `Vec<Option<&str>>: FromDatum` is not satisfied
 36 |                   let result: $rtype = Spi::get_one_with_args(
    |  ______________________________________^
 37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-38 | |                     vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+38 | |                     &[(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
 39 | |                 )?
    | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&str>>`
 ...
@@ -164,7 +164,7 @@ error[E0277]: the trait bound `Vec<Option<&CStr>>: FromDatum` is not satisfied
 36 |                   let result: $rtype = Spi::get_one_with_args(
    |  ______________________________________^
 37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-38 | |                     vec![(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
+38 | |                     &[(PgOid::from(<$rtype>::type_oid()), value.into_datum())],
 39 | |                 )?
    | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&CStr>>`
 ...

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -238,13 +238,13 @@ impl Spi {
     }
 
     pub fn get_one<A: FromDatum + IntoDatum>(query: &str) -> Result<Option<A>> {
-        Spi::connect(|mut client| client.update(query, Some(1), None)?.first().get_one())
+        Spi::connect(|mut client| client.update(query, Some(1), &[][..])?.first().get_one())
     }
 
     pub fn get_two<A: FromDatum + IntoDatum, B: FromDatum + IntoDatum>(
         query: &str,
     ) -> Result<(Option<A>, Option<B>)> {
-        Spi::connect(|mut client| client.update(query, Some(1), None)?.first().get_two::<A, B>())
+        Spi::connect(|mut client| client.update(query, Some(1), &[][..])?.first().get_two::<A, B>())
     }
 
     pub fn get_three<
@@ -255,7 +255,7 @@ impl Spi {
         query: &str,
     ) -> Result<(Option<A>, Option<B>, Option<C>)> {
         Spi::connect(|mut client| {
-            client.update(query, Some(1), None)?.first().get_three::<A, B, C>()
+            client.update(query, Some(1), &[][..])?.first().get_three::<A, B, C>()
         })
     }
 
@@ -263,16 +263,14 @@ impl Spi {
         query: &str,
         args: &[(PgOid, Option<pg_sys::Datum>)],
     ) -> Result<Option<A>> {
-        Spi::connect(|mut client| client.update(query, Some(1), Some(args))?.first().get_one())
+        Spi::connect(|mut client| client.update(query, Some(1), args)?.first().get_one())
     }
 
     pub fn get_two_with_args<A: FromDatum + IntoDatum, B: FromDatum + IntoDatum>(
         query: &str,
         args: &[(PgOid, Option<pg_sys::Datum>)],
     ) -> Result<(Option<A>, Option<B>)> {
-        Spi::connect(|mut client| {
-            client.update(query, Some(1), Some(args))?.first().get_two::<A, B>()
-        })
+        Spi::connect(|mut client| client.update(query, Some(1), args)?.first().get_two::<A, B>())
     }
 
     pub fn get_three_with_args<
@@ -284,7 +282,7 @@ impl Spi {
         args: &[(PgOid, Option<pg_sys::Datum>)],
     ) -> Result<(Option<A>, Option<B>, Option<C>)> {
         Spi::connect(|mut client| {
-            client.update(query, Some(1), Some(args))?.first().get_three::<A, B, C>()
+            client.update(query, Some(1), args)?.first().get_three::<A, B, C>()
         })
     }
 
@@ -294,7 +292,7 @@ impl Spi {
     ///
     /// The statement runs in read/write mode
     pub fn run(query: &str) -> std::result::Result<(), Error> {
-        Spi::run_with_args(query, None)
+        Spi::run_with_args(query, &[][..])
     }
 
     /// run an arbitrary SQL statement with args.
@@ -304,21 +302,18 @@ impl Spi {
     /// The statement runs in read/write mode
     pub fn run_with_args(
         query: &str,
-        args: Option<&[(PgOid, Option<pg_sys::Datum>)]>,
+        args: &[(PgOid, Option<pg_sys::Datum>)],
     ) -> std::result::Result<(), Error> {
         Spi::connect(|mut client| client.update(query, None, args).map(|_| ()))
     }
 
     /// explain a query, returning its result in json form
     pub fn explain(query: &str) -> Result<Json> {
-        Spi::explain_with_args(query, None)
+        Spi::explain_with_args(query, &[][..])
     }
 
     /// explain a query with args, returning its result in json form
-    pub fn explain_with_args(
-        query: &str,
-        args: Option<&[(PgOid, Option<pg_sys::Datum>)]>,
-    ) -> Result<Json> {
+    pub fn explain_with_args(query: &str, args: &[(PgOid, Option<pg_sys::Datum>)]) -> Result<Json> {
         Ok(Spi::connect(|mut client| {
             client
                 .update(&format!("EXPLAIN (format json) {query}"), None, args)?
@@ -343,7 +338,7 @@ impl Spi {
     /// use pgrx::prelude::*;
     /// # fn foo() -> spi::Result<Option<String>> {
     /// let name = Spi::connect(|client| {
-    ///     client.select("SELECT 'Bob'", None, None)?.first().get_one()
+    ///     client.select("SELECT 'Bob'", None, &[][..])?.first().get_one()
     /// })?;
     /// assert_eq!(name, Some("Bob"));
     /// # return Ok(name.map(str::to_string))

--- a/pgrx/src/spi.rs
+++ b/pgrx/src/spi.rs
@@ -261,14 +261,14 @@ impl Spi {
 
     pub fn get_one_with_args<A: FromDatum + IntoDatum>(
         query: &str,
-        args: Vec<(PgOid, Option<pg_sys::Datum>)>,
+        args: &[(PgOid, Option<pg_sys::Datum>)],
     ) -> Result<Option<A>> {
         Spi::connect(|mut client| client.update(query, Some(1), Some(args))?.first().get_one())
     }
 
     pub fn get_two_with_args<A: FromDatum + IntoDatum, B: FromDatum + IntoDatum>(
         query: &str,
-        args: Vec<(PgOid, Option<pg_sys::Datum>)>,
+        args: &[(PgOid, Option<pg_sys::Datum>)],
     ) -> Result<(Option<A>, Option<B>)> {
         Spi::connect(|mut client| {
             client.update(query, Some(1), Some(args))?.first().get_two::<A, B>()
@@ -281,7 +281,7 @@ impl Spi {
         C: FromDatum + IntoDatum,
     >(
         query: &str,
-        args: Vec<(PgOid, Option<pg_sys::Datum>)>,
+        args: &[(PgOid, Option<pg_sys::Datum>)],
     ) -> Result<(Option<A>, Option<B>, Option<C>)> {
         Spi::connect(|mut client| {
             client.update(query, Some(1), Some(args))?.first().get_three::<A, B, C>()
@@ -304,7 +304,7 @@ impl Spi {
     /// The statement runs in read/write mode
     pub fn run_with_args(
         query: &str,
-        args: Option<Vec<(PgOid, Option<pg_sys::Datum>)>>,
+        args: Option<&[(PgOid, Option<pg_sys::Datum>)]>,
     ) -> std::result::Result<(), Error> {
         Spi::connect(|mut client| client.update(query, None, args).map(|_| ()))
     }
@@ -317,7 +317,7 @@ impl Spi {
     /// explain a query with args, returning its result in json form
     pub fn explain_with_args(
         query: &str,
-        args: Option<Vec<(PgOid, Option<pg_sys::Datum>)>>,
+        args: Option<&[(PgOid, Option<pg_sys::Datum>)]>,
     ) -> Result<Json> {
         Ok(Spi::connect(|mut client| {
             client

--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -74,7 +74,7 @@ impl<'conn> SpiClient<'conn> {
         &self,
         query: Q,
         limit: Option<libc::c_long>,
-        args: Option<&[Q::Argument]>,
+        args: &[Q::Argument],
     ) -> SpiResult<SpiTupleTable<'conn>> {
         query.execute(self, limit, args)
     }
@@ -84,7 +84,7 @@ impl<'conn> SpiClient<'conn> {
         &mut self,
         query: Q,
         limit: Option<libc::c_long>,
-        args: Option<&[Q::Argument]>,
+        args: &[Q::Argument],
     ) -> SpiResult<SpiTupleTable<'conn>> {
         Spi::mark_mutable();
         query.execute(self, limit, args)
@@ -123,11 +123,7 @@ impl<'conn> SpiClient<'conn> {
     /// # Panics
     ///
     /// Panics if a cursor wasn't opened.
-    pub fn open_cursor<Q: Query<'conn>>(
-        &self,
-        query: Q,
-        args: Option<&[Q::Argument]>,
-    ) -> SpiCursor<'conn> {
+    pub fn open_cursor<Q: Query<'conn>>(&self, query: Q, args: &[Q::Argument]) -> SpiCursor<'conn> {
         self.try_open_cursor(query, args).unwrap()
     }
 
@@ -139,7 +135,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn try_open_cursor<Q: Query<'conn>>(
         &self,
         query: Q,
-        args: Option<&[Q::Argument]>,
+        args: &[Q::Argument],
     ) -> SpiResult<SpiCursor<'conn>> {
         query.try_open_cursor(self, args)
     }
@@ -158,7 +154,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn open_cursor_mut<Q: Query<'conn>>(
         &mut self,
         query: Q,
-        args: Option<&[Q::Argument]>,
+        args: &[Q::Argument],
     ) -> SpiCursor<'conn> {
         Spi::mark_mutable();
         self.try_open_cursor_mut(query, args).unwrap()
@@ -172,7 +168,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn try_open_cursor_mut<Q: Query<'conn>>(
         &mut self,
         query: Q,
-        args: Option<&[Q::Argument]>,
+        args: &[Q::Argument],
     ) -> SpiResult<SpiCursor<'conn>> {
         Spi::mark_mutable();
         query.try_open_cursor(self, args)

--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -74,7 +74,7 @@ impl<'conn> SpiClient<'conn> {
         &self,
         query: Q,
         limit: Option<libc::c_long>,
-        args: Q::Arguments,
+        args: Option<&[Q::Argument]>,
     ) -> SpiResult<SpiTupleTable<'conn>> {
         query.execute(self, limit, args)
     }
@@ -84,7 +84,7 @@ impl<'conn> SpiClient<'conn> {
         &mut self,
         query: Q,
         limit: Option<libc::c_long>,
-        args: Q::Arguments,
+        args: Option<&[Q::Argument]>,
     ) -> SpiResult<SpiTupleTable<'conn>> {
         Spi::mark_mutable();
         query.execute(self, limit, args)
@@ -123,7 +123,11 @@ impl<'conn> SpiClient<'conn> {
     /// # Panics
     ///
     /// Panics if a cursor wasn't opened.
-    pub fn open_cursor<Q: Query<'conn>>(&self, query: Q, args: Q::Arguments) -> SpiCursor<'conn> {
+    pub fn open_cursor<Q: Query<'conn>>(
+        &self,
+        query: Q,
+        args: Option<&[Q::Argument]>,
+    ) -> SpiCursor<'conn> {
         self.try_open_cursor(query, args).unwrap()
     }
 
@@ -135,7 +139,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn try_open_cursor<Q: Query<'conn>>(
         &self,
         query: Q,
-        args: Q::Arguments,
+        args: Option<&[Q::Argument]>,
     ) -> SpiResult<SpiCursor<'conn>> {
         query.try_open_cursor(self, args)
     }
@@ -154,7 +158,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn open_cursor_mut<Q: Query<'conn>>(
         &mut self,
         query: Q,
-        args: Q::Arguments,
+        args: Option<&[Q::Argument]>,
     ) -> SpiCursor<'conn> {
         Spi::mark_mutable();
         self.try_open_cursor_mut(query, args).unwrap()
@@ -168,7 +172,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn try_open_cursor_mut<Q: Query<'conn>>(
         &mut self,
         query: Q,
-        args: Q::Arguments,
+        args: Option<&[Q::Argument]>,
     ) -> SpiResult<SpiCursor<'conn>> {
         Spi::mark_mutable();
         query.try_open_cursor(self, args)

--- a/pgrx/src/spi/cursor.rs
+++ b/pgrx/src/spi/cursor.rs
@@ -33,7 +33,7 @@ type CursorName = String;
 /// use pgrx::prelude::*;
 /// # fn foo() -> spi::Result<()> {
 /// Spi::connect(|mut client| {
-///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);
+///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", &[][..]);
 ///     assert_eq!(Some(1), cursor.fetch(1)?.get_one::<i32>()?);
 ///     assert_eq!(Some(2), cursor.fetch(2)?.get_one::<i32>()?);
 ///     assert_eq!(Some(3), cursor.fetch(3)?.get_one::<i32>()?);
@@ -48,7 +48,7 @@ type CursorName = String;
 /// use pgrx::prelude::*;
 /// # fn foo() -> spi::Result<()> {
 /// let cursor_name = Spi::connect(|mut client| {
-///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", None);
+///     let mut cursor = client.open_cursor("SELECT * FROM generate_series(1, 5)", &[][..]);
 ///     assert_eq!(Ok(Some(1)), cursor.fetch(1)?.get_one::<i32>());
 ///     Ok::<_, spi::Error>(cursor.detach_into_name()) // <-- cursor gets dropped here
 ///     // <--- first SpiTupleTable gets freed by Spi::connect at this point


### PR DESCRIPTION
Why to allocate query arguments on the heap only while they can also be placed on the stack? Why not both? (there should be that meme)

Another option is to introduce a little bit of generics and use `AsRef<T>` to accept anything, but deeply under the hood make non-generic methods using slices. Would it be better?

I'm also thinking about that `Option<T>` used for the arguments. As for me, it's not different from having an empty slice or whatever from the implementation perspective, but from the usability point of view it's much clearer.

Depends on #1837.