### PR TITLE
Include `access/visibilitymap.h` and `utils/tuplestore.h`

### DIFF
--- a/pgrx-pg-sys/include/pg12.h
+++ b/pgrx-pg-sys/include/pg12.h
@@ -31,6 +31,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/tableam.h"
+#include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"

--- a/pgrx-pg-sys/include/pg12.h
+++ b/pgrx-pg-sys/include/pg12.h
@@ -178,6 +178,7 @@
 #include "utils/sortsupport.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 #include "utils/rangetypes.h"
 #include "utils/rel.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -175,6 +175,7 @@
 #include "utils/sortsupport.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 #include "utils/rangetypes.h"
 #include "utils/rel.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -31,6 +31,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -176,6 +176,7 @@
 #include "utils/sortsupport.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 #include "utils/rangetypes.h"
 #include "utils/rel.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -31,6 +31,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -177,6 +177,7 @@
 #include "utils/sortsupport.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 #include "utils/rangetypes.h"
 #include "utils/rel.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -31,6 +31,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -179,6 +179,7 @@
 #include "utils/sortsupport.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 #include "utils/rangetypes.h"
 #include "utils/rel.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -32,6 +32,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -178,6 +178,7 @@
 #include "utils/sortsupport.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
+#include "utils/tuplestore.h"
 #include "utils/typcache.h"
 #include "utils/rangetypes.h"
 #include "utils/rel.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -32,6 +32,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"
 #include "access/xlogreader.h"


### PR DESCRIPTION
The ability to inspect the visibility map is useful.  So is being able to work with the result of SRFs that return a tuplestore.