### PR TITLE
Update version to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bzip2",
  "cargo-edit",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.2",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bindgen",
  "clang-sys",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "cee-scape",
  "libc",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "clap-cargo 0.14.0",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,11 @@ exclude = [
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-macros = { path = "./pgrx-macros", version = "=0.12.1" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.1" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.1" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.12.1" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "0.12.1" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.12.2" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.2" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.2" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.12.2" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "0.12.2" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "0.12.2" # format-preserving edits to cargo.toml

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -21,10 +21,10 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.12.1"
+pgrx = "=0.12.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.12.1"
+pgrx-tests = "=0.12.2"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-pg-sys/src/include/pg12.rs
+++ b/pgrx-pg-sys/src/include/pg12.rs
@@ -166,9 +166,7 @@ pub const PG_VERSION: &::core::ffi::CStr =
 pub const PG_VERSION_NUM: u32 = 120020;
 #[allow(unsafe_code)]
 pub const PG_VERSION_STR: &::core::ffi::CStr = unsafe {
-    ::core::ffi::CStr::from_bytes_with_nul_unchecked(
-        b"PostgreSQL 12.20 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 14.1.1 20240522, 64-bit\0",
-    )
+    :: core :: ffi :: CStr :: from_bytes_with_nul_unchecked (b"PostgreSQL 12.20 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0")
 };
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
@@ -232,7 +230,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
@@ -240,7 +237,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
@@ -250,6 +247,7 @@ pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
@@ -266,7 +264,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -699,9 +696,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _SS_SIZE: u32 = 128;
 pub const __BITS_PER_LONG: u32 = 64;
@@ -789,11 +783,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
-pub const SO_PASSPIDFD: u32 = 76;
-pub const SO_PEERPIDFD: u32 = 77;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -859,8 +848,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
-pub const IP_PROTOCOL: u32 = 52;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1179,6 +1166,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1222,11 +1214,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2095,6 +2082,10 @@ pub const XLOG_MULTIXACT_ZERO_OFF_PAGE: u32 = 0;
 pub const XLOG_MULTIXACT_ZERO_MEM_PAGE: u32 = 16;
 pub const XLOG_MULTIXACT_CREATE_ID: u32 = 32;
 pub const XLOG_MULTIXACT_TRUNCATE_ID: u32 = 48;
+pub const BITS_PER_HEAPBLOCK: u32 = 2;
+pub const VISIBILITYMAP_ALL_VISIBLE: u32 = 1;
+pub const VISIBILITYMAP_ALL_FROZEN: u32 = 2;
+pub const VISIBILITYMAP_VALID_BITS: u32 = 3;
 pub const SHAREDINVALCATALOG_ID: i32 = -1;
 pub const SHAREDINVALRELCACHE_ID: i32 = -2;
 pub const SHAREDINVALSMGR_ID: i32 = -3;
@@ -5953,6 +5944,7 @@ pub const RANGESTRAT_CONTAINED_BY: u32 = 8;
 pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type pg_int64 = ::core::ffi::c_long;
+pub type va_list = __builtin_va_list;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type __u_char = ::core::ffi::c_uchar;
 pub type __u_short = ::core::ffi::c_ushort;
@@ -6143,40 +6135,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *mut ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *const ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __pos: *mut __off64_t,
-        __w: ::core::ffi::c_int,
-    ) -> ::core::ffi::c_int,
->;
-pub type cookie_close_function_t = ::core::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
-pub type va_list = __gnuc_va_list;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -6975,6 +6933,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::core::ffi::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::core::ffi::c_int,
     pub ipi_spec_dst: in_addr,
@@ -7003,7 +6968,6 @@ pub mod _bindgen_ty_5 {
     pub const IPPROTO_ENCAP: Type = 98;
     pub const IPPROTO_PIM: Type = 103;
     pub const IPPROTO_COMP: Type = 108;
-    pub const IPPROTO_L2TP: Type = 115;
     pub const IPPROTO_SCTP: Type = 132;
     pub const IPPROTO_UDPLITE: Type = 136;
     pub const IPPROTO_MPLS: Type = 137;
@@ -7113,13 +7077,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -17323,7 +17280,6 @@ pub mod _bindgen_ty_13 {
     pub const SEGV_ADIPERR: Type = 7;
     pub const SEGV_MTEAERR: Type = 8;
     pub const SEGV_MTESERR: Type = 9;
-    pub const SEGV_CPERR: Type = 10;
 }
 pub mod _bindgen_ty_14 {
     pub type Type = ::core::ffi::c_uint;
@@ -30368,9 +30324,6 @@ extern "C" {
         __format: *const ::core::ffi::c_char,
         __arg: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
-    pub fn arc4random() -> __uint32_t;
-    pub fn arc4random_buf(__buf: *mut ::core::ffi::c_void, __size: usize);
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
     pub fn alloca(__size: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
     pub fn atexit(__func: ::core::option::Option<unsafe extern "C" fn()>) -> ::core::ffi::c_int;
     pub fn at_quick_exit(
@@ -30381,16 +30334,6 @@ extern "C" {
         __s2: *const ::core::ffi::c_void,
         __n: usize,
     ) -> ::core::ffi::c_int;
-    pub fn strlcpy(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
-    pub fn strlcat(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         errorType: *const ::core::ffi::c_char,
@@ -30753,6 +30696,16 @@ extern "C" {
     pub fn __fminl(__x: u128, __y: u128) -> u128;
     pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
     pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn strlcat(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
+    pub fn strlcpy(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
     pub fn pg_qsort(
         base: *mut ::core::ffi::c_void,
         nel: usize,
@@ -34861,6 +34814,34 @@ extern "C" {
     pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
+    pub fn visibilitymap_clear(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: Buffer,
+        flags: uint8,
+    ) -> bool;
+    pub fn visibilitymap_pin(rel: Relation, heapBlk: BlockNumber, vmbuf: *mut Buffer);
+    pub fn visibilitymap_pin_ok(heapBlk: BlockNumber, vmbuf: Buffer) -> bool;
+    pub fn visibilitymap_set(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        heapBuf: Buffer,
+        recptr: XLogRecPtr,
+        vmBuf: Buffer,
+        cutoff_xid: TransactionId,
+        flags: uint8,
+    );
+    pub fn visibilitymap_get_status(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: *mut Buffer,
+    ) -> uint8;
+    pub fn visibilitymap_count(
+        rel: Relation,
+        all_visible: *mut BlockNumber,
+        all_frozen: *mut BlockNumber,
+    );
+    pub fn visibilitymap_truncate(rel: Relation, nheapblocks: BlockNumber);
     pub fn SendSharedInvalidMessages(msgs: *const SharedInvalidationMessage, n: ::core::ffi::c_int);
     pub fn ReceiveSharedInvalidMessages(
         invalFunction: ::core::option::Option<

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -169,9 +169,7 @@ pub const PG_VERSION: &::core::ffi::CStr =
 pub const PG_VERSION_NUM: u32 = 130016;
 #[allow(unsafe_code)]
 pub const PG_VERSION_STR: &::core::ffi::CStr = unsafe {
-    ::core::ffi::CStr::from_bytes_with_nul_unchecked(
-        b"PostgreSQL 13.16 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 14.1.1 20240522, 64-bit\0",
-    )
+    :: core :: ffi :: CStr :: from_bytes_with_nul_unchecked (b"PostgreSQL 13.16 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0")
 };
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
@@ -234,7 +232,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
@@ -242,7 +239,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
@@ -252,6 +249,7 @@ pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
@@ -268,7 +266,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -700,9 +697,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _SS_SIZE: u32 = 128;
 pub const __BITS_PER_LONG: u32 = 64;
@@ -790,11 +784,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
-pub const SO_PASSPIDFD: u32 = 76;
-pub const SO_PEERPIDFD: u32 = 77;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -860,8 +849,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
-pub const IP_PROTOCOL: u32 = 52;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1163,6 +1150,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1206,11 +1198,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2299,6 +2286,10 @@ pub const XLOG_MULTIXACT_ZERO_OFF_PAGE: u32 = 0;
 pub const XLOG_MULTIXACT_ZERO_MEM_PAGE: u32 = 16;
 pub const XLOG_MULTIXACT_CREATE_ID: u32 = 32;
 pub const XLOG_MULTIXACT_TRUNCATE_ID: u32 = 48;
+pub const BITS_PER_HEAPBLOCK: u32 = 2;
+pub const VISIBILITYMAP_ALL_VISIBLE: u32 = 1;
+pub const VISIBILITYMAP_ALL_FROZEN: u32 = 2;
+pub const VISIBILITYMAP_VALID_BITS: u32 = 3;
 pub const SHAREDINVALCATALOG_ID: i32 = -1;
 pub const SHAREDINVALRELCACHE_ID: i32 = -2;
 pub const SHAREDINVALSMGR_ID: i32 = -3;
@@ -6069,6 +6060,7 @@ pub const RANGESTRAT_CONTAINED_BY: u32 = 8;
 pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type pg_int64 = ::core::ffi::c_long;
+pub type va_list = __builtin_va_list;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type __u_char = ::core::ffi::c_uchar;
 pub type __u_short = ::core::ffi::c_ushort;
@@ -6259,40 +6251,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *mut ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *const ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __pos: *mut __off64_t,
-        __w: ::core::ffi::c_int,
-    ) -> ::core::ffi::c_int,
->;
-pub type cookie_close_function_t = ::core::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
-pub type va_list = __gnuc_va_list;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -7091,6 +7049,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::core::ffi::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::core::ffi::c_int,
     pub ipi_spec_dst: in_addr,
@@ -7119,7 +7084,6 @@ pub mod _bindgen_ty_5 {
     pub const IPPROTO_ENCAP: Type = 98;
     pub const IPPROTO_PIM: Type = 103;
     pub const IPPROTO_COMP: Type = 108;
-    pub const IPPROTO_L2TP: Type = 115;
     pub const IPPROTO_SCTP: Type = 132;
     pub const IPPROTO_UDPLITE: Type = 136;
     pub const IPPROTO_MPLS: Type = 137;
@@ -7229,13 +7193,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -17980,7 +17937,6 @@ pub mod _bindgen_ty_13 {
     pub const SEGV_ADIPERR: Type = 7;
     pub const SEGV_MTEAERR: Type = 8;
     pub const SEGV_MTESERR: Type = 9;
-    pub const SEGV_CPERR: Type = 10;
 }
 pub mod _bindgen_ty_14 {
     pub type Type = ::core::ffi::c_uint;
@@ -31304,9 +31260,6 @@ extern "C" {
         __format: *const ::core::ffi::c_char,
         __arg: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
-    pub fn arc4random() -> __uint32_t;
-    pub fn arc4random_buf(__buf: *mut ::core::ffi::c_void, __size: usize);
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
     pub fn alloca(__size: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
     pub fn atexit(__func: ::core::option::Option<unsafe extern "C" fn()>) -> ::core::ffi::c_int;
     pub fn at_quick_exit(
@@ -31317,16 +31270,6 @@ extern "C" {
         __s2: *const ::core::ffi::c_void,
         __n: usize,
     ) -> ::core::ffi::c_int;
-    pub fn strlcpy(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
-    pub fn strlcat(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         errorType: *const ::core::ffi::c_char,
@@ -31694,6 +31637,16 @@ extern "C" {
     pub fn __fminl(__x: u128, __y: u128) -> u128;
     pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
     pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn strlcat(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
+    pub fn strlcpy(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
     pub fn pg_qsort(
         base: *mut ::core::ffi::c_void,
         nel: usize,
@@ -35763,6 +35716,34 @@ extern "C" {
     pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
+    pub fn visibilitymap_clear(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: Buffer,
+        flags: uint8,
+    ) -> bool;
+    pub fn visibilitymap_pin(rel: Relation, heapBlk: BlockNumber, vmbuf: *mut Buffer);
+    pub fn visibilitymap_pin_ok(heapBlk: BlockNumber, vmbuf: Buffer) -> bool;
+    pub fn visibilitymap_set(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        heapBuf: Buffer,
+        recptr: XLogRecPtr,
+        vmBuf: Buffer,
+        cutoff_xid: TransactionId,
+        flags: uint8,
+    );
+    pub fn visibilitymap_get_status(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: *mut Buffer,
+    ) -> uint8;
+    pub fn visibilitymap_count(
+        rel: Relation,
+        all_visible: *mut BlockNumber,
+        all_frozen: *mut BlockNumber,
+    );
+    pub fn visibilitymap_prepare_truncate(rel: Relation, nheapblocks: BlockNumber) -> BlockNumber;
     pub fn SendSharedInvalidMessages(msgs: *const SharedInvalidationMessage, n: ::core::ffi::c_int);
     pub fn ReceiveSharedInvalidMessages(
         invalFunction: ::core::option::Option<

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -169,9 +169,7 @@ pub const PG_VERSION: &::core::ffi::CStr =
 pub const PG_VERSION_NUM: u32 = 140013;
 #[allow(unsafe_code)]
 pub const PG_VERSION_STR: &::core::ffi::CStr = unsafe {
-    ::core::ffi::CStr::from_bytes_with_nul_unchecked(
-        b"PostgreSQL 14.13 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 14.1.1 20240522, 64-bit\0",
-    )
+    :: core :: ffi :: CStr :: from_bytes_with_nul_unchecked (b"PostgreSQL 14.13 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0")
 };
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
@@ -233,7 +231,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
@@ -241,7 +238,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
@@ -251,6 +248,7 @@ pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
@@ -267,7 +265,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -697,9 +694,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _SS_SIZE: u32 = 128;
 pub const __BITS_PER_LONG: u32 = 64;
@@ -787,11 +781,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
-pub const SO_PASSPIDFD: u32 = 76;
-pub const SO_PEERPIDFD: u32 = 77;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -857,8 +846,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
-pub const IP_PROTOCOL: u32 = 52;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -1168,6 +1155,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -1211,11 +1203,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -2340,6 +2327,10 @@ pub const InvalidLocalTransactionId: u32 = 0;
 pub const MAX_LOCKMODES: u32 = 10;
 pub const DEFAULT_LOCKMETHOD: u32 = 1;
 pub const USER_LOCKMETHOD: u32 = 2;
+pub const BITS_PER_HEAPBLOCK: u32 = 2;
+pub const VISIBILITYMAP_ALL_VISIBLE: u32 = 1;
+pub const VISIBILITYMAP_ALL_FROZEN: u32 = 2;
+pub const VISIBILITYMAP_VALID_BITS: u32 = 3;
 pub const OLD_SNAPSHOT_PADDING_ENTRIES: u32 = 10;
 pub const MAX_IO_CONCURRENCY: u32 = 1000;
 pub const BUFFER_LOCK_UNLOCK: u32 = 0;
@@ -6673,6 +6664,7 @@ pub const RANGESTRAT_CONTAINED_BY: u32 = 8;
 pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type pg_int64 = ::core::ffi::c_long;
+pub type va_list = __builtin_va_list;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type __u_char = ::core::ffi::c_uchar;
 pub type __u_short = ::core::ffi::c_ushort;
@@ -6863,40 +6855,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *mut ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *const ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __pos: *mut __off64_t,
-        __w: ::core::ffi::c_int,
-    ) -> ::core::ffi::c_int,
->;
-pub type cookie_close_function_t = ::core::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
-pub type va_list = __gnuc_va_list;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -7691,6 +7649,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::core::ffi::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::core::ffi::c_int,
     pub ipi_spec_dst: in_addr,
@@ -7719,7 +7684,6 @@ pub mod _bindgen_ty_5 {
     pub const IPPROTO_ENCAP: Type = 98;
     pub const IPPROTO_PIM: Type = 103;
     pub const IPPROTO_COMP: Type = 108;
-    pub const IPPROTO_L2TP: Type = 115;
     pub const IPPROTO_SCTP: Type = 132;
     pub const IPPROTO_UDPLITE: Type = 136;
     pub const IPPROTO_MPLS: Type = 137;
@@ -7829,13 +7793,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -18991,7 +18948,6 @@ pub mod _bindgen_ty_13 {
     pub const SEGV_ADIPERR: Type = 7;
     pub const SEGV_MTEAERR: Type = 8;
     pub const SEGV_MTESERR: Type = 9;
-    pub const SEGV_CPERR: Type = 10;
 }
 pub mod _bindgen_ty_14 {
     pub type Type = ::core::ffi::c_uint;
@@ -33304,9 +33260,6 @@ extern "C" {
         __format: *const ::core::ffi::c_char,
         __arg: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
-    pub fn arc4random() -> __uint32_t;
-    pub fn arc4random_buf(__buf: *mut ::core::ffi::c_void, __size: usize);
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
     pub fn alloca(__size: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
     pub fn atexit(__func: ::core::option::Option<unsafe extern "C" fn()>) -> ::core::ffi::c_int;
     pub fn at_quick_exit(
@@ -33317,16 +33270,6 @@ extern "C" {
         __s2: *const ::core::ffi::c_void,
         __n: usize,
     ) -> ::core::ffi::c_int;
-    pub fn strlcpy(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
-    pub fn strlcat(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         errorType: *const ::core::ffi::c_char,
@@ -33689,6 +33632,16 @@ extern "C" {
     pub fn __fminl(__x: u128, __y: u128) -> u128;
     pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
     pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn strlcat(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
+    pub fn strlcpy(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
     pub fn pg_qsort(
         base: *mut ::core::ffi::c_void,
         nel: usize,
@@ -38058,6 +38011,34 @@ extern "C" {
     pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
+    pub fn visibilitymap_clear(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: Buffer,
+        flags: uint8,
+    ) -> bool;
+    pub fn visibilitymap_pin(rel: Relation, heapBlk: BlockNumber, vmbuf: *mut Buffer);
+    pub fn visibilitymap_pin_ok(heapBlk: BlockNumber, vmbuf: Buffer) -> bool;
+    pub fn visibilitymap_set(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        heapBuf: Buffer,
+        recptr: XLogRecPtr,
+        vmBuf: Buffer,
+        cutoff_xid: TransactionId,
+        flags: uint8,
+    );
+    pub fn visibilitymap_get_status(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: *mut Buffer,
+    ) -> uint8;
+    pub fn visibilitymap_count(
+        rel: Relation,
+        all_visible: *mut BlockNumber,
+        all_frozen: *mut BlockNumber,
+    );
+    pub fn visibilitymap_prepare_truncate(rel: Relation, nheapblocks: BlockNumber) -> BlockNumber;
     pub fn ResourceOwnerCreate(
         parent: ResourceOwner,
         name: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -172,9 +172,7 @@ pub const PG_VERSION: &::core::ffi::CStr =
 pub const PG_VERSION_NUM: u32 = 150008;
 #[allow(unsafe_code)]
 pub const PG_VERSION_STR: &::core::ffi::CStr = unsafe {
-    ::core::ffi::CStr::from_bytes_with_nul_unchecked(
-        b"PostgreSQL 15.8 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 14.1.1 20240522, 64-bit\0",
-    )
+    :: core :: ffi :: CStr :: from_bytes_with_nul_unchecked (b"PostgreSQL 15.8 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0")
 };
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
@@ -239,7 +237,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
@@ -247,7 +244,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
@@ -257,6 +254,7 @@ pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
@@ -273,7 +271,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -751,6 +748,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -794,11 +796,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -1687,9 +1684,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _SS_SIZE: u32 = 128;
 pub const __BITS_PER_LONG: u32 = 64;
@@ -1777,11 +1771,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
-pub const SO_PASSPIDFD: u32 = 76;
-pub const SO_PEERPIDFD: u32 = 77;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1847,8 +1836,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
-pub const IP_PROTOCOL: u32 = 52;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -2371,6 +2358,10 @@ pub const InvalidLocalTransactionId: u32 = 0;
 pub const MAX_LOCKMODES: u32 = 10;
 pub const DEFAULT_LOCKMETHOD: u32 = 1;
 pub const USER_LOCKMETHOD: u32 = 2;
+pub const BITS_PER_HEAPBLOCK: u32 = 2;
+pub const VISIBILITYMAP_ALL_VISIBLE: u32 = 1;
+pub const VISIBILITYMAP_ALL_FROZEN: u32 = 2;
+pub const VISIBILITYMAP_VALID_BITS: u32 = 3;
 pub const PG_CONTROL_VERSION: u32 = 1300;
 pub const MOCK_AUTH_NONCE_LEN: u32 = 32;
 pub const XLOG_CHECKPOINT_SHUTDOWN: u32 = 0;
@@ -6767,6 +6758,7 @@ pub const RANGESTRAT_CONTAINED_BY: u32 = 8;
 pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type pg_int64 = ::core::ffi::c_long;
+pub type va_list = __builtin_va_list;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type __u_char = ::core::ffi::c_uchar;
 pub type __u_short = ::core::ffi::c_ushort;
@@ -6957,40 +6949,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *mut ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *const ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __pos: *mut __off64_t,
-        __w: ::core::ffi::c_int,
-    ) -> ::core::ffi::c_int,
->;
-pub type cookie_close_function_t = ::core::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
-pub type va_list = __gnuc_va_list;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -18862,7 +18820,6 @@ pub mod _bindgen_ty_7 {
     pub const SEGV_ADIPERR: Type = 7;
     pub const SEGV_MTEAERR: Type = 8;
     pub const SEGV_MTESERR: Type = 9;
-    pub const SEGV_CPERR: Type = 10;
 }
 pub mod _bindgen_ty_8 {
     pub type Type = ::core::ffi::c_uint;
@@ -19518,6 +19475,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::core::ffi::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::core::ffi::c_int,
     pub ipi_spec_dst: in_addr,
@@ -19546,7 +19510,6 @@ pub mod _bindgen_ty_16 {
     pub const IPPROTO_ENCAP: Type = 98;
     pub const IPPROTO_PIM: Type = 103;
     pub const IPPROTO_COMP: Type = 108;
-    pub const IPPROTO_L2TP: Type = 115;
     pub const IPPROTO_SCTP: Type = 132;
     pub const IPPROTO_UDPLITE: Type = 136;
     pub const IPPROTO_MPLS: Type = 137;
@@ -19656,13 +19619,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -33456,9 +33412,6 @@ extern "C" {
         __format: *const ::core::ffi::c_char,
         __arg: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
-    pub fn arc4random() -> __uint32_t;
-    pub fn arc4random_buf(__buf: *mut ::core::ffi::c_void, __size: usize);
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
     pub fn alloca(__size: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
     pub fn atexit(__func: ::core::option::Option<unsafe extern "C" fn()>) -> ::core::ffi::c_int;
     pub fn at_quick_exit(
@@ -33469,16 +33422,6 @@ extern "C" {
         __s2: *const ::core::ffi::c_void,
         __n: usize,
     ) -> ::core::ffi::c_int;
-    pub fn strlcpy(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
-    pub fn strlcat(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         errorType: *const ::core::ffi::c_char,
@@ -33833,6 +33776,16 @@ extern "C" {
     pub fn __fminl(__x: u128, __y: u128) -> u128;
     pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
     pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn strlcat(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
+    pub fn strlcpy(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
     pub fn pg_get_user_name(
         user_id: uid_t,
         buffer: *mut ::core::ffi::c_char,
@@ -38355,6 +38308,34 @@ extern "C" {
     pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
+    pub fn visibilitymap_clear(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: Buffer,
+        flags: uint8,
+    ) -> bool;
+    pub fn visibilitymap_pin(rel: Relation, heapBlk: BlockNumber, vmbuf: *mut Buffer);
+    pub fn visibilitymap_pin_ok(heapBlk: BlockNumber, vmbuf: Buffer) -> bool;
+    pub fn visibilitymap_set(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        heapBuf: Buffer,
+        recptr: XLogRecPtr,
+        vmBuf: Buffer,
+        cutoff_xid: TransactionId,
+        flags: uint8,
+    );
+    pub fn visibilitymap_get_status(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: *mut Buffer,
+    ) -> uint8;
+    pub fn visibilitymap_count(
+        rel: Relation,
+        all_visible: *mut BlockNumber,
+        all_frozen: *mut BlockNumber,
+    );
+    pub fn visibilitymap_prepare_truncate(rel: Relation, nheapblocks: BlockNumber) -> BlockNumber;
     pub fn XLogRecoveryShmemSize() -> Size;
     pub fn XLogRecoveryShmemInit();
     pub fn InitWalRecovery(

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -172,9 +172,7 @@ pub const PG_VERSION: &::core::ffi::CStr =
 pub const PG_VERSION_NUM: u32 = 160004;
 #[allow(unsafe_code)]
 pub const PG_VERSION_STR: &::core::ffi::CStr = unsafe {
-    ::core::ffi::CStr::from_bytes_with_nul_unchecked(
-        b"PostgreSQL 16.4 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 14.1.1 20240522, 64-bit\0",
-    )
+    :: core :: ffi :: CStr :: from_bytes_with_nul_unchecked (b"PostgreSQL 16.4 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0")
 };
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
@@ -240,7 +238,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
@@ -248,7 +245,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
@@ -258,6 +255,7 @@ pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
@@ -274,7 +272,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -749,6 +746,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -792,11 +794,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -1690,9 +1687,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _SS_SIZE: u32 = 128;
 pub const __BITS_PER_LONG: u32 = 64;
@@ -1780,11 +1774,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
-pub const SO_PASSPIDFD: u32 = 76;
-pub const SO_PEERPIDFD: u32 = 77;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -1850,8 +1839,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
-pub const IP_PROTOCOL: u32 = 52;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -2342,6 +2329,12 @@ pub const InvalidLocalTransactionId: u32 = 0;
 pub const MAX_LOCKMODES: u32 = 10;
 pub const DEFAULT_LOCKMETHOD: u32 = 1;
 pub const USER_LOCKMETHOD: u32 = 2;
+pub const BITS_PER_HEAPBLOCK: u32 = 2;
+pub const VISIBILITYMAP_ALL_VISIBLE: u32 = 1;
+pub const VISIBILITYMAP_ALL_FROZEN: u32 = 2;
+pub const VISIBILITYMAP_VALID_BITS: u32 = 3;
+pub const VISIBILITYMAP_XLOG_CATALOG_REL: u32 = 4;
+pub const VISIBILITYMAP_XLOG_VALID_BITS: u32 = 7;
 pub const PG_CONTROL_VERSION: u32 = 1300;
 pub const MOCK_AUTH_NONCE_LEN: u32 = 32;
 pub const XLOG_CHECKPOINT_SHUTDOWN: u32 = 0;
@@ -6840,6 +6833,7 @@ pub const RANGESTRAT_CONTAINED_BY: u32 = 8;
 pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type pg_int64 = ::core::ffi::c_long;
+pub type va_list = __builtin_va_list;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type __u_char = ::core::ffi::c_uchar;
 pub type __u_short = ::core::ffi::c_ushort;
@@ -7030,40 +7024,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *mut ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *const ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __pos: *mut __off64_t,
-        __w: ::core::ffi::c_int,
-    ) -> ::core::ffi::c_int,
->;
-pub type cookie_close_function_t = ::core::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
-pub type va_list = __gnuc_va_list;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -19363,7 +19323,6 @@ pub mod _bindgen_ty_7 {
     pub const SEGV_ADIPERR: Type = 7;
     pub const SEGV_MTEAERR: Type = 8;
     pub const SEGV_MTESERR: Type = 9;
-    pub const SEGV_CPERR: Type = 10;
 }
 pub mod _bindgen_ty_8 {
     pub type Type = ::core::ffi::c_uint;
@@ -20018,6 +19977,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::core::ffi::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::core::ffi::c_int,
     pub ipi_spec_dst: in_addr,
@@ -20046,7 +20012,6 @@ pub mod _bindgen_ty_16 {
     pub const IPPROTO_ENCAP: Type = 98;
     pub const IPPROTO_PIM: Type = 103;
     pub const IPPROTO_COMP: Type = 108;
-    pub const IPPROTO_L2TP: Type = 115;
     pub const IPPROTO_SCTP: Type = 132;
     pub const IPPROTO_UDPLITE: Type = 136;
     pub const IPPROTO_MPLS: Type = 137;
@@ -20156,13 +20121,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -34317,9 +34275,6 @@ extern "C" {
         __format: *const ::core::ffi::c_char,
         __arg: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
-    pub fn arc4random() -> __uint32_t;
-    pub fn arc4random_buf(__buf: *mut ::core::ffi::c_void, __size: usize);
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
     pub fn alloca(__size: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
     pub fn atexit(__func: ::core::option::Option<unsafe extern "C" fn()>) -> ::core::ffi::c_int;
     pub fn at_quick_exit(
@@ -34330,16 +34285,6 @@ extern "C" {
         __s2: *const ::core::ffi::c_void,
         __n: usize,
     ) -> ::core::ffi::c_int;
-    pub fn strlcpy(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
-    pub fn strlcat(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         fileName: *const ::core::ffi::c_char,
@@ -34692,6 +34637,16 @@ extern "C" {
     pub fn __fminl(__x: u128, __y: u128) -> u128;
     pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
     pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn strlcat(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
+    pub fn strlcpy(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
     pub fn pg_get_user_name(
         user_id: uid_t,
         buffer: *mut ::core::ffi::c_char,
@@ -38899,6 +38854,34 @@ extern "C" {
     pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
+    pub fn visibilitymap_clear(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: Buffer,
+        flags: uint8,
+    ) -> bool;
+    pub fn visibilitymap_pin(rel: Relation, heapBlk: BlockNumber, vmbuf: *mut Buffer);
+    pub fn visibilitymap_pin_ok(heapBlk: BlockNumber, vmbuf: Buffer) -> bool;
+    pub fn visibilitymap_set(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        heapBuf: Buffer,
+        recptr: XLogRecPtr,
+        vmBuf: Buffer,
+        cutoff_xid: TransactionId,
+        flags: uint8,
+    );
+    pub fn visibilitymap_get_status(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: *mut Buffer,
+    ) -> uint8;
+    pub fn visibilitymap_count(
+        rel: Relation,
+        all_visible: *mut BlockNumber,
+        all_frozen: *mut BlockNumber,
+    );
+    pub fn visibilitymap_prepare_truncate(rel: Relation, nheapblocks: BlockNumber) -> BlockNumber;
     pub fn XLogRecoveryShmemSize() -> Size;
     pub fn XLogRecoveryShmemInit();
     pub fn InitWalRecovery(

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -171,7 +171,7 @@ pub const PG_VERSION: &::core::ffi::CStr =
 pub const PG_VERSION_NUM: u32 = 170000;
 #[allow(unsafe_code)]
 pub const PG_VERSION_STR: &::core::ffi::CStr = unsafe {
-    :: core :: ffi :: CStr :: from_bytes_with_nul_unchecked (b"PostgreSQL 17beta3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 14.1.1 20240522, 64-bit\0")
+    :: core :: ffi :: CStr :: from_bytes_with_nul_unchecked (b"PostgreSQL 17beta3 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit\0")
 };
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
@@ -238,7 +238,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
@@ -246,7 +245,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
+pub const __GLIBC_MINOR__: u32 = 35;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
@@ -256,6 +255,7 @@ pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const __GNUC_VA_LIST: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
@@ -272,7 +272,6 @@ pub const __struct_FILE_defined: u32 = 1;
 pub const _IO_EOF_SEEN: u32 = 16;
 pub const _IO_ERR_SEEN: u32 = 32;
 pub const _IO_USER_LOCK: u32 = 32768;
-pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
@@ -748,6 +747,11 @@ pub const POSIX_FADV_SEQUENTIAL: u32 = 2;
 pub const POSIX_FADV_WILLNEED: u32 = 3;
 pub const POSIX_FADV_DONTNEED: u32 = 4;
 pub const POSIX_FADV_NOREUSE: u32 = 5;
+pub const AT_FDCWD: i32 = -100;
+pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
+pub const AT_REMOVEDIR: u32 = 512;
+pub const AT_SYMLINK_FOLLOW: u32 = 1024;
+pub const AT_EACCESS: u32 = 512;
 pub const __S_IFMT: u32 = 61440;
 pub const __S_IFDIR: u32 = 16384;
 pub const __S_IFCHR: u32 = 8192;
@@ -791,11 +795,6 @@ pub const R_OK: u32 = 4;
 pub const W_OK: u32 = 2;
 pub const X_OK: u32 = 1;
 pub const F_OK: u32 = 0;
-pub const AT_FDCWD: i32 = -100;
-pub const AT_SYMLINK_NOFOLLOW: u32 = 256;
-pub const AT_REMOVEDIR: u32 = 512;
-pub const AT_SYMLINK_FOLLOW: u32 = 1024;
-pub const AT_EACCESS: u32 = 512;
 pub const F_ULOCK: u32 = 0;
 pub const F_LOCK: u32 = 1;
 pub const F_TLOCK: u32 = 2;
@@ -1850,9 +1849,6 @@ pub const SOL_NFC: u32 = 280;
 pub const SOL_KCM: u32 = 281;
 pub const SOL_TLS: u32 = 282;
 pub const SOL_XDP: u32 = 283;
-pub const SOL_MPTCP: u32 = 284;
-pub const SOL_MCTP: u32 = 285;
-pub const SOL_SMC: u32 = 286;
 pub const SOMAXCONN: u32 = 4096;
 pub const _SS_SIZE: u32 = 128;
 pub const __BITS_PER_LONG: u32 = 64;
@@ -1940,11 +1936,6 @@ pub const SO_PREFER_BUSY_POLL: u32 = 69;
 pub const SO_BUSY_POLL_BUDGET: u32 = 70;
 pub const SO_NETNS_COOKIE: u32 = 71;
 pub const SO_BUF_LOCK: u32 = 72;
-pub const SO_RESERVE_MEM: u32 = 73;
-pub const SO_TXREHASH: u32 = 74;
-pub const SO_RCVMARK: u32 = 75;
-pub const SO_PASSPIDFD: u32 = 76;
-pub const SO_PEERPIDFD: u32 = 77;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -2010,8 +2001,6 @@ pub const IP_PMTUDISC_DO: u32 = 2;
 pub const IP_PMTUDISC_PROBE: u32 = 3;
 pub const IP_PMTUDISC_INTERFACE: u32 = 4;
 pub const IP_PMTUDISC_OMIT: u32 = 5;
-pub const IP_LOCAL_PORT_RANGE: u32 = 51;
-pub const IP_PROTOCOL: u32 = 52;
 pub const SOL_IP: u32 = 0;
 pub const IP_DEFAULT_MULTICAST_TTL: u32 = 1;
 pub const IP_DEFAULT_MULTICAST_LOOP: u32 = 1;
@@ -2532,6 +2521,12 @@ pub const InvalidLocalTransactionId: u32 = 0;
 pub const MAX_LOCKMODES: u32 = 10;
 pub const DEFAULT_LOCKMETHOD: u32 = 1;
 pub const USER_LOCKMETHOD: u32 = 2;
+pub const BITS_PER_HEAPBLOCK: u32 = 2;
+pub const VISIBILITYMAP_ALL_VISIBLE: u32 = 1;
+pub const VISIBILITYMAP_ALL_FROZEN: u32 = 2;
+pub const VISIBILITYMAP_VALID_BITS: u32 = 3;
+pub const VISIBILITYMAP_XLOG_CATALOG_REL: u32 = 4;
+pub const VISIBILITYMAP_XLOG_VALID_BITS: u32 = 7;
 pub const XLOG_PAGE_MAGIC: u32 = 53526;
 pub const XLP_FIRST_IS_CONTRECORD: u32 = 1;
 pub const XLP_LONG_HEADER: u32 = 2;
@@ -7064,6 +7059,7 @@ pub const RANGESTRAT_CONTAINED_BY: u32 = 8;
 pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
 pub type pg_int64 = ::core::ffi::c_long;
+pub type va_list = __builtin_va_list;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type __u_char = ::core::ffi::c_uchar;
 pub type __u_short = ::core::ffi::c_ushort;
@@ -7254,40 +7250,6 @@ impl Default for _IO_FILE {
         }
     }
 }
-pub type cookie_read_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *mut ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_write_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __buf: *const ::core::ffi::c_char,
-        __nbytes: usize,
-    ) -> __ssize_t,
->;
-pub type cookie_seek_function_t = ::core::option::Option<
-    unsafe extern "C" fn(
-        __cookie: *mut ::core::ffi::c_void,
-        __pos: *mut __off64_t,
-        __w: ::core::ffi::c_int,
-    ) -> ::core::ffi::c_int,
->;
-pub type cookie_close_function_t = ::core::option::Option<
-    unsafe extern "C" fn(__cookie: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
->;
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct _IO_cookie_io_functions_t {
-    pub read: cookie_read_function_t,
-    pub write: cookie_write_function_t,
-    pub seek: cookie_seek_function_t,
-    pub close: cookie_close_function_t,
-}
-pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
-pub type va_list = __gnuc_va_list;
 pub type off_t = __off_t;
 pub type fpos_t = __fpos_t;
 pub type _Float32 = f32;
@@ -20863,7 +20825,6 @@ pub mod _bindgen_ty_10 {
     pub const SEGV_ADIPERR: Type = 7;
     pub const SEGV_MTEAERR: Type = 8;
     pub const SEGV_MTESERR: Type = 9;
-    pub const SEGV_CPERR: Type = 10;
 }
 pub mod _bindgen_ty_11 {
     pub type Type = ::core::ffi::c_uint;
@@ -21493,6 +21454,13 @@ impl Default for ip_opts {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
+pub struct ip_mreqn {
+    pub imr_multiaddr: in_addr,
+    pub imr_address: in_addr,
+    pub imr_ifindex: ::core::ffi::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct in_pktinfo {
     pub ipi_ifindex: ::core::ffi::c_int,
     pub ipi_spec_dst: in_addr,
@@ -21521,7 +21489,6 @@ pub mod _bindgen_ty_19 {
     pub const IPPROTO_ENCAP: Type = 98;
     pub const IPPROTO_PIM: Type = 103;
     pub const IPPROTO_COMP: Type = 108;
-    pub const IPPROTO_L2TP: Type = 115;
     pub const IPPROTO_SCTP: Type = 132;
     pub const IPPROTO_UDPLITE: Type = 136;
     pub const IPPROTO_MPLS: Type = 137;
@@ -21631,13 +21598,6 @@ impl Default for sockaddr_in6 {
 pub struct ip_mreq {
     pub imr_multiaddr: in_addr,
     pub imr_interface: in_addr,
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct ip_mreqn {
-    pub imr_multiaddr: in_addr,
-    pub imr_address: in_addr,
-    pub imr_ifindex: ::core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -35615,9 +35575,6 @@ extern "C" {
         __format: *const ::core::ffi::c_char,
         __arg: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
-    pub fn arc4random() -> __uint32_t;
-    pub fn arc4random_buf(__buf: *mut ::core::ffi::c_void, __size: usize);
-    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
     pub fn alloca(__size: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
     pub fn atexit(__func: ::core::option::Option<unsafe extern "C" fn()>) -> ::core::ffi::c_int;
     pub fn at_quick_exit(
@@ -35628,16 +35585,6 @@ extern "C" {
         __s2: *const ::core::ffi::c_void,
         __n: usize,
     ) -> ::core::ffi::c_int;
-    pub fn strlcpy(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
-    pub fn strlcat(
-        __dest: *mut ::core::ffi::c_char,
-        __src: *const ::core::ffi::c_char,
-        __n: ::core::ffi::c_ulong,
-    ) -> ::core::ffi::c_ulong;
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         fileName: *const ::core::ffi::c_char,
@@ -35986,6 +35933,16 @@ extern "C" {
     pub fn __fminl(__x: u128, __y: u128) -> u128;
     pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
     pub fn __scalbl(__x: u128, __n: u128) -> u128;
+    pub fn strlcat(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
+    pub fn strlcpy(
+        dst: *mut ::core::ffi::c_char,
+        src: *const ::core::ffi::c_char,
+        siz: usize,
+    ) -> usize;
     pub fn pg_get_user_name(
         user_id: uid_t,
         buffer: *mut ::core::ffi::c_char,
@@ -40608,6 +40565,34 @@ extern "C" {
     pub fn attribute_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn tablespace_reloptions(reloptions: Datum, validate: bool) -> *mut bytea;
     pub fn AlterTableGetRelOptionsLockLevel(defList: *mut List) -> LOCKMODE;
+    pub fn visibilitymap_clear(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: Buffer,
+        flags: uint8,
+    ) -> bool;
+    pub fn visibilitymap_pin(rel: Relation, heapBlk: BlockNumber, vmbuf: *mut Buffer);
+    pub fn visibilitymap_pin_ok(heapBlk: BlockNumber, vmbuf: Buffer) -> bool;
+    pub fn visibilitymap_set(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        heapBuf: Buffer,
+        recptr: XLogRecPtr,
+        vmBuf: Buffer,
+        cutoff_xid: TransactionId,
+        flags: uint8,
+    );
+    pub fn visibilitymap_get_status(
+        rel: Relation,
+        heapBlk: BlockNumber,
+        vmbuf: *mut Buffer,
+    ) -> uint8;
+    pub fn visibilitymap_count(
+        rel: Relation,
+        all_visible: *mut BlockNumber,
+        all_frozen: *mut BlockNumber,
+    );
+    pub fn visibilitymap_prepare_truncate(rel: Relation, nheapblocks: BlockNumber) -> BlockNumber;
     pub fn RmgrStartup();
     pub fn RmgrCleanup();
     pub fn RmgrNotFound(rmid: RmgrId);

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -72,7 +72,7 @@ rand = "0.8.5"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.12.1"
+version = "=0.12.2"
 
 [dev-dependencies]
 eyre.workspace = true # testing functions that return `eyre::Result`

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"


### PR DESCRIPTION
Welcome to pgrx v0.12.2.  This is a minor release that fixes a few bugs, improves compilation times with `cargo pgrx run/install/test`, and adds a few more Postgres headers.

As usual, please `cargo install cargo-pgrx --version 0.12.2 --locked`.  Then you can run `cargo pgrx upgrade` in your extension crate's root to update its dependencies.

## What's Changed

* [ `CPPFLAGS`] Switch to `USE_ASSERT_CHECKING` by @SamuelMarks in https://github.com/pgcentralfoundation/pgrx/pull/1826
* Add UnboxDatum for Range<T> by @mhov in https://github.com/pgcentralfoundation/pgrx/pull/1827
* Moved Sized from FromDatum methods to trait by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/1831
* Used SPI result type for cursor API by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/1836
* always compile `pgrx_embed_*` without opts by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1838
* Fixed out of bounds reads for open_cursor by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/1837
* Include `access/visibilitymap.h` and `utils/tuplestore.h` by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1841

## New Contributors

Thanks to these folks for their first-time contributions -- it's greatly appreciated!

* @SamuelMarks made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1826
* @YohDeadfall made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1831

**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.12.1...v0.12.2