### PR TITLE
Fixups of issues left from #1837

### DIFF
--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -244,19 +244,19 @@ mod tests {
     }
 
     #[pg_test]
-    #[should_panic]
+    #[should_panic(expected = "PreparedStatementArgumentMismatch { expected: 1, got: 0 }")]
     fn test_cursor_prepared_statement_panics_none_args() -> Result<(), pgrx::spi::Error> {
         test_cursor_prepared_statement_panics_impl(None)
     }
 
     #[pg_test]
-    #[should_panic]
+    #[should_panic(expected = "PreparedStatementArgumentMismatch { expected: 1, got: 0 }")]
     fn test_cursor_prepared_statement_panics_less_args() -> Result<(), pgrx::spi::Error> {
         test_cursor_prepared_statement_panics_impl(Some([].to_vec()))
     }
 
     #[pg_test]
-    #[should_panic]
+    #[should_panic(expected = "PreparedStatementArgumentMismatch { expected: 1, got: 2 }")]
     fn test_cursor_prepared_statement_panics_more_args() -> Result<(), pgrx::spi::Error> {
         test_cursor_prepared_statement_panics_impl(Some([None, None].to_vec()))
     }

--- a/pgrx-tests/src/tests/spi_tests.rs
+++ b/pgrx-tests/src/tests/spi_tests.rs
@@ -570,7 +570,6 @@ mod tests {
     }
 
     #[pg_test]
-    #[allow(deprecated)]
     fn can_return_borrowed_str() -> Result<(), Box<dyn Error>> {
         let res = Spi::connect(|c| {
             let mut cursor = c.open_cursor("SELECT 'hello' FROM generate_series(1, 10000)", None);


### PR DESCRIPTION
Fixes issues left from #1837, but nothing critical.

The problem with `unreachable!` in tests is that it requires to have a non-empty `expected` in the `#[should_panic]` attribute. So we provide a message to verify that panicking happens for the right reason.