### PR TITLE
use bindgen to generate wrappers of static inline functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width",
+ "yansi-term",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,16 +169,15 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
@@ -1116,12 +1125,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -2707,6 +2710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,4 +3131,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
 ]

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2.workspace = true
 syn.workspace = true
 walkdir.workspace = true
 
-bindgen = { version = "0.69.4", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.70.1", default-features = false, features = ["experimental", "runtime"] }
 clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
 quote = "1.0.33"
 shlex = "1.3" # shell lexing, also used by many of our deps

--- a/pgrx-pg-sys/cshim/pgrx-cshim.c
+++ b/pgrx-pg-sys/cshim/pgrx-cshim.c
@@ -63,37 +63,4 @@ bool pgrx_SpinLockFree(slock_t *lock) {
     return SpinLockFree(lock);
 }
 
-PGDLLEXPORT char * pgrx_PageGetSpecialPointer(Page page);
-char * pgrx_PageGetSpecialPointer(Page page) {
-    return PageGetSpecialPointer(page);
-}
-
-PGDLLEXPORT Item pgrx_PageGetItem(Page page, ItemId itemId);
-Item pgrx_PageGetItem(Page page, ItemId itemId) {
-    return PageGetItem(page, itemId);
-}
-
-PGDLLEXPORT ItemId pgrx_PageGetItemId(Page page, OffsetNumber offsetNumber);
-ItemId pgrx_PageGetItemId(Page page, OffsetNumber offsetNumber) {
-    return PageGetItemId(page, offsetNumber);
-}
-
-PGDLLEXPORT TableScanDesc pgrx_table_beginscan_strat(Relation relation, Snapshot snapshot, int nkeys, struct ScanKeyData * key, bool allow_strat, bool allow_sync);
-TableScanDesc pgrx_table_beginscan_strat(Relation relation, Snapshot snapshot, int nkeys, struct ScanKeyData * key, bool allow_strat, bool allow_sync) {
-    return table_beginscan_strat(relation, snapshot, nkeys, key, allow_strat, allow_sync);
-}
-
-PGDLLEXPORT void pgrx_table_endscan(TableScanDesc scan);
-void pgrx_table_endscan(TableScanDesc scan) {
-    return table_endscan(scan);
-}
-
-PGDLLEXPORT bool pgrx_ExecQual(ExprState * state, ExprContext * econtext);
-bool pgrx_ExecQual(ExprState * state, ExprContext * econtext) {
-    return ExecQual(state, econtext);
-}
-
-PGDLLEXPORT HeapTuple pgrx_ExecCopySlotHeapTuple(TupleTableSlot * slot);
-HeapTuple pgrx_ExecCopySlotHeapTuple(TupleTableSlot * slot) {
-    return ExecCopySlotHeapTuple(slot);
-}
+#include "../wrap_static_fns.c"

--- a/pgrx-pg-sys/src/cshim.rs
+++ b/pgrx-pg-sys/src/cshim.rs
@@ -19,25 +19,4 @@ extern "C" {
     pub fn SpinLockRelease(lock: *mut pg_sys::slock_t);
     #[link_name = "pgrx_SpinLockFree"]
     pub fn SpinLockFree(lock: *mut pg_sys::slock_t) -> bool;
-    #[link_name = "pgrx_PageGetSpecialPointer"]
-    pub fn PageGetSpecialPointer(page: pg_sys::Page) -> *mut i8;
-    #[link_name = "pgrx_PageGetItem"]
-    pub fn PageGetItem(page: pg_sys::Page, itemId: pg_sys::ItemId) -> pg_sys::Item;
-    #[link_name = "pgrx_PageGetItemId"]
-    pub fn PageGetItemId(page: pg_sys::Page, offsetNumber: pg_sys::OffsetNumber) -> pg_sys::ItemId;
-    #[link_name = "pgrx_table_beginscan_strat"]
-    pub fn table_beginscan_strat(
-        relation: pg_sys::Relation,
-        snapshot: pg_sys::Snapshot,
-        nkeys: i32,
-        keys: *mut pg_sys::ScanKeyData,
-        allow_strat: bool,
-        allow_sync: bool,
-    ) -> pg_sys::TableScanDesc;
-    #[link_name = "pgrx_table_endscan"]
-    pub fn table_endscan(scan: pg_sys::TableScanDesc);
-    #[link_name = "pgrx_ExecQual"]
-    pub fn ExecQual(state: *mut pg_sys::ExprState, econtext: *mut pg_sys::ExprContext) -> bool;
-    #[link_name = "pgrx_ExecCopySlotHeapTuple"]
-    pub fn ExecCopySlotHeapTuple(slot: pg_sys::TupleTableSlot) -> pg_sys::HeapTuple;
 }

--- a/pgrx-tests/src/tests/bindings_of_inline_fn_tests.rs
+++ b/pgrx-tests/src/tests/bindings_of_inline_fn_tests.rs
@@ -1,0 +1,31 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgrx_tests;
+
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_static_inline_fns() {
+        unsafe {
+            use pgrx::pg_sys::{itemptr_encode, BlockIdData, ItemPointerData};
+            assert_eq!(
+                itemptr_encode(&mut ItemPointerData {
+                    ip_blkid: BlockIdData { bi_hi: 111, bi_lo: 222 },
+                    ip_posid: 333
+                }),
+                476755919181
+            );
+        }
+    }
+}

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -14,6 +14,8 @@ mod anynumeric_tests;
 mod array_tests;
 mod attributes_tests;
 mod bgworker_tests;
+#[cfg(feature = "cshim")]
+mod bindings_of_inline_fn_tests;
 mod bytea_tests;
 mod cfg_tests;
 mod complex;


### PR DESCRIPTION
It generates wrappers of static inline functions if `cshim` is enabled, so that we do not have to write wrappers by translating C to Rust and check if it's correct in all PG versions.