### PR TITLE
Add an example of a WAL decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 #LICENSE All rights reserved.
 #LICENSE
 #LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
- 
+
 [workspace]
 resolver = "2"
 members = [
@@ -32,6 +32,7 @@ exclude = [
     "pgrx-examples/custom_types",
     "pgrx-examples/custom_sql",
     "pgrx-examples/datetime",
+    "pgrx-examples/wal_decoder",
     "pgrx-examples/errors",
     "pgrx-examples/nostd",
     "pgrx-examples/numeric",

--- a/pgrx-examples/wal_decoder/.gitignore
+++ b/pgrx-examples/wal_decoder/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock

--- a/pgrx-examples/wal_decoder/Cargo.toml
+++ b/pgrx-examples/wal_decoder/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "wal_decoder"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[[bin]]
+name = "pgrx_embed_wal_decoder"
+path = "./src/bin/pgrx_embed.rs"
+
+[features]
+default = ["pg13"]
+pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg_test = []
+
+[dependencies]
+pgrx = { path = "../../pgrx", default-features = false }
+serde = "1.0.209"
+serde_json = "1.0.128"
+
+[dev-dependencies]
+pgrx-tests = { path = "../../pgrx-tests" }
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/pgrx-examples/wal_decoder/README.md
+++ b/pgrx-examples/wal_decoder/README.md
@@ -1,0 +1,118 @@
+
+# A simple Change Data Capture ([CDC]) extension.
+
+This extension will extract the [DML] changes from Postgres WAL
+using [Logical Decoding] and export them in JSON format using [serde].
+
+## Principles
+
+* Postgres triggers various callbacks at the different stages of a transaction
+* The decoder defines some of these callbacks: begin, change, commit, etc.
+* The callbacks extract the changes made during the transaction
+* They build Rust structs (Action, Tuple) to represent those changes
+* The structs are then serialized into JSON
+* The JSON output is sent into a logical replication slot (i.e. a queue)
+* The output can be consumed in various ways by a remote client
+
+## Requirements
+
+In order to use this extension with a cargo-pgrx managed instance, you'll
+need to add the configuration below in "$PGRX_HOME/data-$PGVER/postgresql.conf".
+
+``` ini
+shared_preload_libraries = 'wal_decoder'
+wal_level = logical
+```
+
+## Example
+
+1- Create a table and publish it
+
+``` sql
+CREATE TABLE person (name TEXT, age INT);
+ALTER TABLE person REPLICA IDENTITY FULL;
+CREATE PUBLICATION gotham_pub FOR TABLE person;
+```
+
+2- Create a replication slot fed by the decoder
+
+``` sql
+SELECT pg_create_logical_replication_slot('gotham_slot', 'wal_decoder');
+```
+
+3- Consume the changes from the replication slot
+
+``` sql
+INSERT INTO person
+VALUES ('Bruce Wayne',42),('Clark Kent',33);
+```
+
+``` sql
+SELECT * FROM pg_logical_slot_get_changes('gotham_slot', NULL, NULL);
+
+    lsn    | xid |                                     data
+-----------+-----+------------------------------------------------------------------------------
+ 0/16A87C8 | 581 | {"typ":"BEGIN"}
+ 0/16A87C8 | 581 | {"typ":"INSERT","rel":"public.person","new":{"name":"Bruce Wayne","age":42}}
+ 0/16A8810 | 581 | {"typ":"INSERT","rel":"public.person","new":{"name":"Clark Kent","age":33}}
+ 0/16A8888 | 581 | {"typ":"COMMIT","committed":779145498360779,"change_count":2}
+```
+
+``` sql
+UPDATE person SET name = 'Batman' WHERE name= 'Bruce Wayne';
+```
+
+``` sql
+SELECT xid, jsonb_pretty(data::JSONB)
+FROM pg_logical_slot_get_changes('gotham_slot', NULL, NULL);
+
+ xid |           jsonb_pretty
+-----+-----------------------------------
+ 587 | {                                +
+     |     "typ": "BEGIN"               +
+     | }
+ 587 | {                                +
+     |     "new": {                     +
+     |         "age": 42,               +
+     |         "name": "Batman"         +
+     |     },                           +
+     |     "old": {                     +
+     |         "age": 42,               +
+     |         "name": "Bruce Wayne"    +
+     |     },                           +
+     |     "rel": "public.person",      +
+     |     "typ": "UPDATE"              +
+     | }
+ 587 | {                                +
+     |     "typ": "COMMIT",             +
+     |     "committed": 779179731927669,+
+     |     "change_count": 1            +
+     | }
+```
+
+## Limitations
+
+This decoder is designed as a basic example and it has the following limitations:
+
+* Only the REPLICA IDENTITY FULL mode is fully supported. Supporting REPLICA IDENTITY DEFAULT
+  would require additional work.
+
+* Only TEXT and INT values are serialized. Supporting other types should be trivial.
+
+
+## Other WAL decoders
+
+Here are some other implementations in C that can be useful:
+
+* <https://github.com/dalibo/hackingpg/blob/main/journee5/audit/plugin_audit.c>
+* <https://github.com/leptonix/decoding-json/blob/master/decoding_json.c>
+* <https://github.com/michaelpq/pg_plugins/blob/main/decoder_raw/decoder_raw.c>
+* <https://github.com/eulerto/wal2json/blob/master/wal2json.c>
+
+<!-- Links -->
+
+[CDC]: https://en.wikipedia.org/wiki/Change_data_capture
+[DML]: https://en.wikipedia.org/wiki/Data_manipulation_language
+[Logical Decoding]: https://www.postgresql.org/docs/current/logicaldecoding-explanation.html
+[serde]: https://serde.rs
+

--- a/pgrx-examples/wal_decoder/src/bin/pgrx_embed.rs
+++ b/pgrx-examples/wal_decoder/src/bin/pgrx_embed.rs
@@ -1,0 +1,1 @@
+::pgrx::pgrx_embed!();

--- a/pgrx-examples/wal_decoder/src/lib.rs
+++ b/pgrx-examples/wal_decoder/src/lib.rs
@@ -1,0 +1,319 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+use pgrx::prelude::*;
+use serde::ser::{SerializeStruct, Serializer};
+use serde::Serialize;
+use std::alloc::{alloc, dealloc, Layout};
+
+::pgrx::pg_module_magic!();
+
+// An Action describe a change that occurred on a table
+#[derive(Serialize)]
+struct Action {
+    typ: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    committed: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rel: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old: Option<Tuple>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new: Option<Tuple>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    change_count: Option<i64>,
+}
+
+// Multiple constructors depending on the type of action logged
+impl Action {
+    // This is a simple BEGIN Statement
+    pub fn begin() -> Self {
+        Self {
+            typ: "BEGIN".into(),
+            committed: None,
+            rel: None,
+            old: None,
+            new: None,
+            change_count: None,
+        }
+    }
+
+    // This is a simple COMMIT Statement
+    pub fn commit(txn: PgBox<pg_sys::ReorderBufferTXN>, change_count: i64) -> Self {
+        Self {
+            typ: "COMMIT".into(),
+            // TODO: convert the commit timestamp into a human readable format ?
+            committed: Some(txn.commit_time),
+            rel: None,
+            old: None,
+            new: None,
+            change_count: Some(change_count),
+        }
+    }
+
+    // A change can be either an INSERT, a DELETE or an UPDATE
+    pub fn change(rel: pgrx::PgRelation, change: PgBox<pg_sys::ReorderBufferChange>) -> Self {
+        use pgrx::pg_sys::ReorderBufferChangeType::*;
+        use pgrx::spi;
+
+        Self {
+            typ: match change.action {
+                REORDER_BUFFER_CHANGE_DELETE => "DELETE".into(),
+                REORDER_BUFFER_CHANGE_INSERT => "INSERT".into(),
+                REORDER_BUFFER_CHANGE_UPDATE => "UPDATE".into(),
+                _ => "Unknown".into(),
+            },
+            committed: None,
+            rel: Some(format!(
+                "{}.{}",
+                spi::quote_identifier(rel.namespace()),
+                spi::quote_identifier(rel.name())
+            )),
+
+            // old tuple (updated or deleted)
+            //
+            // For UPDATE, the oldtuple is only provided when :
+            //  - REPLICA IDENTITY is FULL
+            //  - The primary key is changed
+            //  - replica identity is index and indexed column changes.
+            //
+            // Outside of these 3 cases, the `old` PgBox will contain a null
+            // pointer !
+            //
+            // TODO: when the oldtuple is not available, we should fetch the
+            // index values with RelationGetIndexAttrBitmap
+            //
+            old: match change.action {
+                REORDER_BUFFER_CHANGE_UPDATE | REORDER_BUFFER_CHANGE_DELETE => Some(Tuple {
+                    rel: rel.clone(),
+                    data: unsafe { PgBox::from_pg(change.data.tp.oldtuple) },
+                }),
+                _ => None,
+            },
+
+            // the new tuple (updated or inserted)
+            new: match change.action {
+                REORDER_BUFFER_CHANGE_UPDATE | REORDER_BUFFER_CHANGE_INSERT => Some(Tuple {
+                    rel: rel.clone(),
+                    data: unsafe { PgBox::from_pg(change.data.tp.newtuple) },
+                }),
+                _ => None,
+            },
+            change_count: None,
+        }
+    }
+}
+
+// Serialize an Action into a JSON string and write it to the plugin output
+trait OutputPluginWrite {
+    fn output_plugin_write(&self, ctx: PgBox<pg_sys::LogicalDecodingContext>)
+    where
+        Self: Serialize,
+    {
+        use std::ffi::CString;
+
+        unsafe {
+            pg_sys::OutputPluginPrepareWrite(ctx.as_ptr(), true);
+        }
+        // Serialize yourself to a JSON string.
+        let json = serde_json::to_string(&self).expect("Serde Error");
+        let json_cstring = CString::new(json).unwrap();
+        unsafe {
+            pg_sys::appendStringInfo(ctx.out, json_cstring.as_c_str().as_ptr());
+            pg_sys::OutputPluginWrite(ctx.as_ptr(), true);
+        }
+    }
+}
+
+impl OutputPluginWrite for Action {}
+
+// The decoding state will be an object shared between the callbacks
+// It will track how many changes occurred during a transaction
+struct DecodingState {
+    xact_change_counter: i64,
+}
+
+// A Tuple describes the values of a table row before or after a change
+struct Tuple {
+    rel: pgrx::PgRelation,
+    data: PgBox<pg_sys::ReorderBufferTupleBuf>,
+}
+
+// Loop over the Tuple attributes and serialize them
+impl Serialize for Tuple {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use std::ffi::CStr;
+
+        let desc = self.rel.tuple_desc();
+        let mut isnull: bool = false;
+
+        let mut serde_state = serializer.serialize_struct("Tuple", desc.len())?;
+
+        for attribute in desc.iter() {
+            if self.data.is_null() {
+                continue;
+            }
+            let attname = unsafe {
+                CStr::from_ptr(pg_sys::quote_identifier(attribute.attname.data.as_ptr()))
+            }
+            .to_str()
+            .unwrap();
+            let mut tuple = self.data.tuple;
+            let datum = unsafe {
+                pg_sys::heap_getattr(
+                    &mut tuple,
+                    attribute.attnum.into(),
+                    desc.as_ptr(),
+                    &mut isnull,
+                )
+            };
+            if isnull {
+                continue;
+            }
+            match attribute.atttypid {
+                pg_sys::INT4OID => {
+                    let value = unsafe { i32::from_datum(datum, isnull) };
+                    serde_state.serialize_field(attname, &(value.unwrap()))?
+                }
+                pg_sys::TEXTOID => {
+                    let value = unsafe { String::from_datum(datum, isnull) };
+                    serde_state.serialize_field(attname, &(value.unwrap()))?
+                }
+                _ => todo!(),
+            };
+        }
+        serde_state.end()
+    }
+}
+
+// Initialize the output plugin
+#[allow(non_snake_case)]
+#[no_mangle]
+#[pg_guard]
+pub unsafe extern "C" fn _PG_output_plugin_init(cb_ptr: *mut pg_sys::OutputPluginCallbacks) {
+    let mut callbacks = unsafe { PgBox::from_pg(cb_ptr) };
+    callbacks.startup_cb = Some(pg_decode_startup);
+    callbacks.begin_cb = Some(pg_decode_begin_txn);
+    callbacks.change_cb = Some(pg_decode_change);
+    callbacks.commit_cb = Some(pg_decode_commit_txn);
+    callbacks.shutdown_cb = Some(pg_decode_shutdown);
+    callbacks.into_pg();
+    debug1!("Anon: output plugin initialized");
+}
+
+// Callbacks
+//
+// The complete list of callbacks is available at:
+// https://www.postgresql.org/docs/current/logicaldecoding-output-plugin.html
+//
+
+#[pg_guard]
+unsafe extern "C" fn pg_decode_startup(
+    ctx_ptr: *mut pg_sys::LogicalDecodingContext,
+    options_ptr: *mut pg_sys::OutputPluginOptions,
+    _is_init: bool,
+) {
+    let mut options = unsafe { PgBox::from_pg(options_ptr) };
+    options.output_type = pg_sys::OutputPluginOutputType::OUTPUT_PLUGIN_TEXTUAL_OUTPUT;
+    options.into_pg();
+
+    // output_plugin_private is used to store a pointer to a common state shared
+    // between all the callbacks of the same transaction. There may be a better
+    // way to manage this pointer, but currently alloc/dealloc the cleanest way
+    // I could think of...
+    let layout = Layout::new::<DecodingState>();
+    let mut ctx = unsafe { PgBox::from_pg(ctx_ptr) };
+    ctx.output_plugin_private = unsafe { alloc(layout) as *mut std::ffi::c_void };
+    ctx.into_pg();
+}
+
+#[pg_guard]
+unsafe extern "C" fn pg_decode_begin_txn(
+    ctx_ptr: *mut pg_sys::LogicalDecodingContext,
+    _txn_ptr: *mut pg_sys::ReorderBufferTXN,
+) {
+    let ctx = unsafe { PgBox::from_pg(ctx_ptr) };
+    let mut state = unsafe { PgBox::from_pg(ctx.output_plugin_private as *mut DecodingState) };
+    state.xact_change_counter = 0;
+    Action::begin().output_plugin_write(ctx);
+}
+
+#[pg_guard]
+unsafe extern "C" fn pg_decode_commit_txn(
+    ctx_ptr: *mut pg_sys::LogicalDecodingContext,
+    txn_ptr: *mut pg_sys::ReorderBufferTXN,
+    _commit_lsn: pg_sys::XLogRecPtr,
+) {
+    let ctx = unsafe { PgBox::from_pg(ctx_ptr) };
+    let txn = unsafe { PgBox::from_pg(txn_ptr) };
+    let state = unsafe { PgBox::from_pg(ctx.output_plugin_private as *mut DecodingState) };
+    Action::commit(txn, state.xact_change_counter).output_plugin_write(ctx);
+}
+
+#[pg_guard]
+unsafe extern "C" fn pg_decode_change(
+    ctx_ptr: *mut pg_sys::LogicalDecodingContext,
+    _txn_ptr: *mut pg_sys::ReorderBufferTXN,
+    relation: pg_sys::Relation,
+    change_ptr: *mut pg_sys::ReorderBufferChange,
+) {
+    let ctx = unsafe { PgBox::from_pg(ctx_ptr) };
+    let mut state = unsafe { PgBox::from_pg(ctx.output_plugin_private as *mut DecodingState) };
+    state.xact_change_counter += 1;
+
+    let pgrelation = unsafe { pgrx::PgRelation::from_pg(relation) };
+    let change = unsafe { PgBox::from_pg(change_ptr) };
+
+    Action::change(pgrelation, change).output_plugin_write(ctx);
+}
+
+#[pg_guard]
+unsafe extern "C" fn pg_decode_shutdown(ctx_ptr: *mut pg_sys::LogicalDecodingContext) {
+    let layout = Layout::new::<DecodingState>();
+    let ctx = unsafe { PgBox::from_pg(ctx_ptr) };
+    unsafe { dealloc(ctx.output_plugin_private as *mut u8, layout) };
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_action_begin() {
+        use crate::Action;
+
+        let input = Action::begin();
+        let json = serde_json::to_string(&input).expect("Serde Error");
+        assert_eq!(json, r#"{"typ":"BEGIN"}"#);
+    }
+
+    #[pg_test]
+    #[ignore]
+    fn test_callbacks() {
+        //
+        // Not sure how to handle the tests of the callbacks....
+        // This function is running *inside* a transaction
+        // and the WAL decoder will output the changes only when they are
+        // committed.
+        //
+    }
+}
+
+/// This module is required by `cargo pgrx test` invocations.
+/// It must be visible at the root of your extension crate.
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    #[must_use]
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}
+
+// <!-- EOL -->

--- a/pgrx-examples/wal_decoder/wal_decoder.control
+++ b/pgrx-examples/wal_decoder/wal_decoder.control
@@ -1,0 +1,6 @@
+comment = 'wal_decoder:  Created by pgrx'
+default_version = '@CARGO_VERSION@'
+module_pathname = '$libdir/wal_decoder'
+relocatable = false
+superuser = true
+trusted = false


### PR DESCRIPTION
Hi !

I recently wrote this example as an exercice to learn how to build a WAL decoder with PGRX.... I built this as « the thing I would have loved to have before » when I started digging on this topic. Feel free to modify it heavily or discard it completely if it is too specific or if the coding style is not up to the PGRX standards. I tried my best to write idiomic Rust but there may be some naïve/unsound parts...

This example shows how to build a basic Change Data Capture (CDC) mechanism using the Postgres Logical Decoding capabilities. The changes occurring on the database are serialized into JSON and pushed to a queue (a "logical replication slot") where they can be consumed by remote clients.

A Postgres CDC extension can be a used in various purposes:

* Ad hoc replication systems (e.g. Postgres => SQL Server )
* External commit-log for a distributed system (such as Kafka)
* Advanced Monitoring ( e.g. Prometheus/Loki )

This example tries to find the right tradeoff between simplicity and usefulness. Currently it has strong limitations but they should be easy to overcome.

Rust really shines in this example compared to similar implementations in C (see the wal2json extension). The Serde crate provides JSON serialization out of the box, whereas all the C implementations are forced to write their own JSON formatter.