### PR TITLE
Added into_iter for anyarray

### DIFF
--- a/pgrx/src/datum/anyarray.rs
+++ b/pgrx/src/datum/anyarray.rs
@@ -92,11 +92,11 @@ where
     Self: 'a,
 {
     type Item = Option<AnyElement>;
-    type IntoIter = AnyArrayIntoIterator<'a>;
+    type IntoIter = AnyArrayIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         unsafe {
-            AnyArrayIntoIterator {
+            AnyArrayIterator {
                 inner: Array::<pg_sys::Datum>::from_polymorphic_datum(
                     self.datum(),
                     false,
@@ -109,12 +109,12 @@ where
     }
 }
 
-pub struct AnyArrayIntoIterator<'a> {
+pub struct AnyArrayIterator<'a> {
     inner: Option<ArrayIntoIterator<'a, pg_sys::Datum>>,
     typelem: pg_sys::Oid,
 }
 
-impl<'a> Iterator for AnyArrayIntoIterator<'a> {
+impl<'a> Iterator for AnyArrayIterator<'a> {
     type Item = Option<AnyElement>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -134,5 +134,5 @@ impl<'a> Iterator for AnyArrayIntoIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for AnyArrayIntoIterator<'a> {}
-impl<'a> FusedIterator for AnyArrayIntoIterator<'a> {}
+impl<'a> ExactSizeIterator for AnyArrayIterator<'a> {}
+impl<'a> FusedIterator for AnyArrayIterator<'a> {}

--- a/pgrx/src/datum/anyarray.rs
+++ b/pgrx/src/datum/anyarray.rs
@@ -7,10 +7,12 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use crate::{pg_sys, FromDatum, IntoDatum};
+use super::ArrayIntoIterator;
+use crate::{pg_sys, AnyElement, Array, FromDatum, IntoDatum};
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
+use std::iter::FusedIterator;
 
 /// The [`anyarray` polymorphic pseudo-type][anyarray].
 ///
@@ -84,3 +86,53 @@ unsafe impl SqlTranslatable for AnyArray {
         Ok(Returns::One(SqlMapping::literal("anyarray")))
     }
 }
+
+impl<'a> IntoIterator for &'a AnyArray
+where
+    Self: 'a,
+{
+    type Item = Option<AnyElement>;
+    type IntoIter = AnyArrayIntoIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        unsafe {
+            AnyArrayIntoIterator {
+                inner: Array::<pg_sys::Datum>::from_polymorphic_datum(
+                    self.datum(),
+                    false,
+                    self.oid(),
+                )
+                .map(|a| a.into_iter()),
+                typelem: pg_sys::get_element_type(self.oid()),
+            }
+        }
+    }
+}
+
+pub struct AnyArrayIntoIterator<'a> {
+    inner: Option<ArrayIntoIterator<'a, pg_sys::Datum>>,
+    typelem: pg_sys::Oid,
+}
+
+impl<'a> Iterator for AnyArrayIntoIterator<'a> {
+    type Item = Option<AnyElement>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.as_mut().and_then(|i| {
+            i.next().map(|d| match d {
+                Some(d) => unsafe { AnyElement::from_polymorphic_datum(d, false, self.typelem) },
+                None => None,
+            })
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.inner {
+            Some(inner) => inner.size_hint(),
+            None => (0, Some(0)),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for AnyArrayIntoIterator<'a> {}
+impl<'a> FusedIterator for AnyArrayIntoIterator<'a> {}


### PR DESCRIPTION
Fixes #1832.

The implementation isn't what I want, but it adds `into_iter` for `&AnyArray` and I hope unblocking @thomcc. Later it would be better to get rid of `AnyArray` in its current state and use `Array<AnyElement>` instead, I will investigate that possibility. But for now that is how it is and without any breaking change.