### PR TITLE
fix segfault converting a null `pg_sys::Datum` to a `String`

### DIFF
--- a/pgrx-tests/src/tests/from_into_datum_tests.rs
+++ b/pgrx-tests/src/tests/from_into_datum_tests.rs
@@ -43,4 +43,17 @@ mod tests {
         assert_eq!(cstr, expected);
         Ok(())
     }
+
+    #[pg_test]
+    fn null_string_is_none() {
+        let val: pg_sys::Datum = pg_sys::Datum::null();
+        let is_null: bool = true;
+
+        unsafe {
+            if let Some(_) = String::from_datum(val, is_null) {
+                // <- this seg fault
+                panic!("converted a null Datum into a valid string")
+            }
+        }
+    }
 }


### PR DESCRIPTION
This closes #1852, which reports a segfault when converting an honestly null `Datum` into a `String`.

Looks like this was introduced in https://github.com/pgcentralfoundation/pgrx/commit/beb79011a377bb96c34fcc50ae2d652aa1419eb5 and we didn't have test coverage around this specific case.

I quickly audited `src/datum/from.rs` and everything else there looks fine.