### PR TITLE
FlatArray and Text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.5",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1503,7 @@ dependencies = [
  "atomic-traits",
  "bitflags 2.4.2",
  "bitvec",
+ "bstr",
  "enum-map",
  "heapless",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,8 +241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.5",
- "serde",
 ]
 
 [[package]]

--- a/pgrx-tests/src/tests/array_borrowed.rs
+++ b/pgrx-tests/src/tests/array_borrowed.rs
@@ -16,7 +16,7 @@ use pgrx::PostgresEnum;
 use serde::Serialize;
 use serde_json::json;
 
-#[pg_extern(name = "sum_array")]
+#[pg_extern(name = "borrow_sum_array")]
 fn borrow_sum_array_i32(values: &FlatArray<'_, i32>) -> i32 {
     // we implement it this way so we can trap an overflow (as we have a test for this) and
     // catch it correctly in both --debug and --release modes
@@ -33,7 +33,7 @@ fn borrow_sum_array_i32(values: &FlatArray<'_, i32>) -> i32 {
     sum
 }
 
-#[pg_extern(name = "sum_array")]
+#[pg_extern(name = "borrow_sum_array")]
 fn borrow_sum_array_i64(values: &FlatArray<'_, i64>) -> i64 {
     values.iter().map(|v| v.into_option().copied().unwrap_or(0i64)).sum()
 }
@@ -268,22 +268,22 @@ mod tests {
         assert_eq!(sum, Ok(Some(6)));
     }
 
-    #[pg_test]
-    fn borrow_test_serde_serialize_array_i32() -> Result<(), pgrx::spi::Error> {
-        let json = Spi::get_one::<Json>(
-            "SELECT borrow_serde_serialize_array_i32(ARRAY[1, null, 2, 3, null, 4, 5])",
-        )?
-        .expect("returned json was null");
-        assert_eq!(json.0, json! {{"values": [1,null,2,3,null,4, 5]}});
-        Ok(())
-    }
+    // #[pg_test]
+    // fn borrow_test_serde_serialize_array_i32() -> Result<(), pgrx::spi::Error> {
+    //     let json = Spi::get_one::<Json>(
+    //         "SELECT borrow_serde_serialize_array_i32(ARRAY[1, null, 2, 3, null, 4, 5])",
+    //     )?
+    //     .expect("returned json was null");
+    //     assert_eq!(json.0, json! {{"values": [1,null,2,3,null,4, 5]}});
+    //     Ok(())
+    // }
 
-    #[pg_test(expected = "array contains NULL")]
-    fn borrow_test_serde_serialize_array_i32_deny_null() -> Result<Option<Json>, pgrx::spi::Error> {
-        Spi::get_one::<Json>(
-            "SELECT borrow_serde_serialize_array_i32_deny_null(ARRAY[1, 2, 3, null, 4, 5])",
-        )
-    }
+    // #[pg_test(expected = "array contains NULL")]
+    // fn borrow_test_serde_serialize_array_i32_deny_null() -> Result<Option<Json>, pgrx::spi::Error> {
+    //     Spi::get_one::<Json>(
+    //         "SELECT borrow_serde_serialize_array_i32_deny_null(ARRAY[1, 2, 3, null, 4, 5])",
+    //     )
+    // }
 
     #[pg_test]
     fn borrow_test_return_text_array() {
@@ -324,12 +324,12 @@ mod tests {
         assert_eq!(len, Ok(Some(5)));
     }
 
-    #[pg_test]
-    fn borrow_test_get_arr_data_ptr_nth_elem() {
-        let nth =
-            Spi::get_one::<i32>("SELECT borrow_get_arr_data_ptr_nth_elem('{1,2,3,4,5}'::int[], 2)");
-        assert_eq!(nth, Ok(Some(3)));
-    }
+    // #[pg_test]
+    // fn borrow_test_get_arr_data_ptr_nth_elem() {
+    //     let nth =
+    //         Spi::get_one::<i32>("SELECT borrow_get_arr_data_ptr_nth_elem('{1,2,3,4,5}'::int[], 2)");
+    //     assert_eq!(nth, Ok(Some(3)));
+    // }
 
     #[pg_test]
     fn borrow_test_display_get_arr_nullbitmap() -> Result<(), pgrx::spi::Error> {

--- a/pgrx-tests/src/tests/array_borrowed.rs
+++ b/pgrx-tests/src/tests/array_borrowed.rs
@@ -22,7 +22,7 @@ fn borrow_sum_array_i32(values: &FlatArray<'_, i32>) -> i32 {
     // we implement it this way so we can trap an overflow (as we have a test for this) and
     // catch it correctly in both --debug and --release modes
     let mut sum = 0_i32;
-    for v in values.iter() {
+    for v in values {
         let v = v.into_option().copied().unwrap_or(0);
         let (val, overflow) = sum.overflowing_add(v);
         if overflow {

--- a/pgrx-tests/src/tests/array_borrowed.rs
+++ b/pgrx-tests/src/tests/array_borrowed.rs
@@ -156,13 +156,13 @@ fn borrow_validate_cstring_array(
     assert_eq!(
         a.iter().map(|v| v.into_option()).collect::<Vec<_>>(),
         vec![
-            Some(CStr::from_bytes_with_nul(b"one\0")?),
-            Some(CStr::from_bytes_with_nul(b"two\0")?),
+            Some(c"one"),
+            Some(c"two"),
             None,
-            Some(CStr::from_bytes_with_nul(b"four\0")?),
-            Some(CStr::from_bytes_with_nul(b"five\0")?),
+            Some(c"four"),
+            Some(c"five"),
             None,
-            Some(CStr::from_bytes_with_nul(b"seven\0")?),
+            Some(c"seven"),
             None,
             None
         ]

--- a/pgrx-tests/src/tests/array_borrowed.rs
+++ b/pgrx-tests/src/tests/array_borrowed.rs
@@ -1,0 +1,523 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::array::{FlatArray, RawArray};
+use pgrx::prelude::*;
+use pgrx::Json;
+use pgrx::PostgresEnum;
+use serde::Serialize;
+use serde_json::json;
+
+#[pg_extern(name = "sum_array")]
+fn borrow_sum_array_i32(values: &FlatArray<'_, i32>) -> i32 {
+    // we implement it this way so we can trap an overflow (as we have a test for this) and
+    // catch it correctly in both --debug and --release modes
+    let mut sum = 0_i32;
+    for v in values {
+        let v = v.unwrap_or(0);
+        let (val, overflow) = sum.overflowing_add(v);
+        if overflow {
+            panic!("attempt to add with overflow");
+        } else {
+            sum = val;
+        }
+    }
+    sum
+}
+
+#[pg_extern(name = "sum_array")]
+fn borrow_sum_array_i64(values: &FlatArray<'_, i64>) -> i64 {
+    values.iter().map(|v| v.unwrap_or(0i64)).sum()
+}
+
+#[pg_extern]
+fn borrow_count_true(values: &FlatArray<'_, bool>) -> i32 {
+    values.iter().filter(|b| b.unwrap_or(false)).count() as i32
+}
+
+#[pg_extern]
+fn borrow_count_nulls(values: &FlatArray<'_, i32>) -> i32 {
+    values.iter().map(|v| v.is_none()).filter(|v| *v).count() as i32
+}
+
+#[pg_extern]
+fn borrow_optional_array_arg(values: Option<&FlatArray<'_, f32>>) -> f32 {
+    values.unwrap().iter().map(|v| v.unwrap_or(0f32)).sum()
+}
+
+#[pg_extern]
+fn borrow_iterate_array_with_deny_null(values: &FlatArray<'_, i32>) {
+    for _ in values.iter_deny_null() {
+        // noop
+    }
+}
+
+#[pg_extern]
+fn borrow_optional_array_with_default(
+    values: default!(Option<&FlatArray<'_, i32>>, "NULL"),
+) -> i32 {
+    values.unwrap().iter().map(|v| v.unwrap_or(0)).sum()
+}
+
+// TODO: fix this test by fixing serde impls for `FlatArray<'a, &'a str> -> Json`
+// #[pg_extern]
+// fn borrow_serde_serialize_array<'dat>(values: &FlatArray<'dat, &'dat str>) -> Json {
+//     Json(json! { { "values": values } })
+// }
+
+#[pg_extern]
+fn borrow_serde_serialize_array_i32(values: &FlatArray<'_, i32>) -> Json {
+    Json(json! { { "values": values } })
+}
+
+#[pg_extern]
+fn borrow_serde_serialize_array_i32_deny_null(values: &FlatArray<'_, i32>) -> Json {
+    Json(json! { { "values": values.iter_deny_null() } })
+}
+
+#[pg_extern]
+fn borrow_return_text_array() -> Vec<&'static str> {
+    vec!["a", "b", "c", "d"]
+}
+
+#[pg_extern]
+fn borrow_return_zero_length_vec() -> Vec<i32> {
+    Vec::new()
+}
+
+#[pg_extern]
+fn borrow_get_arr_nelems(arr: &FlatArray<'_, i32>) -> libc::c_int {
+    // SAFETY: Eh it's fine, it's just a len check.
+    unsafe { RawFlatArray::from_array(arr) }.unwrap().len() as _
+}
+
+#[pg_extern]
+fn borrow_get_arr_data_ptr_nth_elem(arr: &FlatArray<'_, i32>, elem: i32) -> Option<i32> {
+    // SAFETY: this is Known to be an FlatArray from FlatArrayType,
+    // and it's valid-ish to see any bitpattern of an i32 inbounds of a slice.
+    unsafe {
+        let raw = RawFlatArray::from_array(arr).unwrap().data::<i32>();
+        let slice = &(*raw.as_ptr());
+        slice.get(elem as usize).copied()
+    }
+}
+
+#[pg_extern]
+fn borrow_display_get_arr_nullbitmap(arr: &FlatArray<'_, i32>) -> String {
+    let mut raw = unsafe { RawFlatArray::from_array(arr) }.unwrap();
+
+    if let Some(slice) = raw.nulls() {
+        // SAFETY: If the test has gotten this far, the ptr is good for 0+ bytes,
+        // so reborrow NonNull<[u8]> as &[u8] for the hot second we're looking at it.
+        let slice = unsafe { &*slice.as_ptr() };
+        // might panic if the array is len 0
+        format!("{:#010b}", slice[0])
+    } else {
+        String::from("")
+    }
+}
+
+#[pg_extern]
+fn borrow_get_arr_ndim(arr: &FlatArray<'_, i32>) -> libc::c_int {
+    // SAFETY: This is a valid FlatArrayType and it's just a field access.
+    unsafe { RawFlatArray::from_array(arr) }.unwrap().dims().len() as _
+}
+
+// This deliberately iterates the FlatArray.
+// Because FlatArray::iter currently iterates the FlatArray as Datums, this is guaranteed to be "bug-free" regarding size.
+#[pg_extern]
+fn borrow_arr_mapped_vec(arr: &FlatArray<'_, i32>) -> Vec<i32> {
+    arr.iter().filter_map(|x| x).collect()
+}
+
+/// Naive conversion.
+#[pg_extern]
+#[allow(deprecated)]
+fn borrow_arr_into_vec(arr: &FlatArray<'_, i32>) -> Vec<i32> {
+    arr.iter_deny_null().collect()
+}
+
+#[pg_extern]
+#[allow(deprecated)]
+fn borrow_arr_sort_uniq(arr: &FlatArray<'_, i32>) -> Vec<i32> {
+    let mut v: Vec<i32> = arr.iter_deny_null().collect();
+    v.sort();
+    v.dedup();
+    v
+}
+
+#[derive(Debug, Eq, PartialEq, PostgresEnum, Serialize)]
+pub enum BorrowFlatArrayTestEnum {
+    One,
+    Two,
+    Three,
+}
+
+#[pg_extern]
+fn borrow_enum_array_roundtrip(
+    a: &FlatArray<'_, BorrowFlatArrayTestEnum>,
+) -> Vec<Option<BorrowFlatArrayTestEnum>> {
+    a.into_iter().collect()
+}
+
+#[pg_extern]
+fn borrow_validate_cstring_array<'a>(
+    a: &FlatArray<'a, &'a core::ffi::CStr>,
+) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+    assert_eq!(
+        a.iter().collect::<Vec<_>>(),
+        vec![
+            Some(core::ffi::CStr::from_bytes_with_nul(b"one\0")?),
+            Some(core::ffi::CStr::from_bytes_with_nul(b"two\0")?),
+            None,
+            Some(core::ffi::CStr::from_bytes_with_nul(b"four\0")?),
+            Some(core::ffi::CStr::from_bytes_with_nul(b"five\0")?),
+            None,
+            Some(core::ffi::CStr::from_bytes_with_nul(b"seven\0")?),
+            None,
+            None
+        ]
+    );
+    Ok(true)
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgrx_tests;
+
+    use super::*;
+    use pgrx::prelude::*;
+    use pgrx::{IntoDatum, Json};
+    use serde_json::json;
+
+    #[pg_test]
+    fn borrow_test_enum_array_roundtrip() -> spi::Result<()> {
+        let a = Spi::get_one::<Vec<Option<BorrowFlatArrayTestEnum>>>(
+            "SELECT borrow_enum_array_roundtrip(ARRAY['One', 'Two']::BorrowFlatArrayTestEnum[])",
+        )?
+        .expect("SPI result was null");
+        assert_eq!(a, vec![Some(BorrowFlatArrayTestEnum::One), Some(BorrowFlatArrayTestEnum::Two)]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_sum_array_i32() {
+        let sum = Spi::get_one::<i32>("SELECT borrow_sum_array(ARRAY[1,2,3]::integer[])");
+        assert_eq!(sum, Ok(Some(6)));
+    }
+
+    #[pg_test]
+    fn borrow_test_sum_array_i64() {
+        let sum = Spi::get_one::<i64>("SELECT borrow_sum_array(ARRAY[1,2,3]::bigint[])");
+        assert_eq!(sum, Ok(Some(6)));
+    }
+
+    #[pg_test(expected = "attempt to add with overflow")]
+    fn borrow_test_sum_array_i32_overflow() -> Result<Option<i64>, pgrx::spi::Error> {
+        Spi::get_one::<i64>(
+            "SELECT borrow_sum_array(a) FROM (SELECT borrow_array_agg(s) a FROM generate_series(1, 1000000) s) x;",
+        )
+    }
+
+    #[pg_test]
+    fn borrow_test_count_true() {
+        let cnt = Spi::get_one::<i32>("SELECT borrow_count_true(ARRAY[true, true, false, true])");
+        assert_eq!(cnt, Ok(Some(3)));
+    }
+
+    #[pg_test]
+    fn borrow_test_count_nulls() {
+        let cnt =
+            Spi::get_one::<i32>("SELECT borrow_count_nulls(ARRAY[NULL, 1, 2, NULL]::integer[])");
+        assert_eq!(cnt, Ok(Some(2)));
+    }
+
+    #[pg_test]
+    fn borrow_test_optional_array() {
+        let sum = Spi::get_one::<f32>("SELECT borrow_optional_array_arg(ARRAY[1,2,3]::real[])");
+        assert_eq!(sum, Ok(Some(6f32)));
+    }
+
+    #[pg_test(expected = "array contains NULL")]
+    fn borrow_test_array_deny_nulls() -> Result<(), spi::Error> {
+        Spi::run("SELECT borrow_iterate_array_with_deny_null(ARRAY[1,2,3, NULL]::int[])")
+    }
+
+    // TODO: fix this test by redesigning SPI.
+    // #[pg_test]
+    // fn borrow_test_serde_serialize_array() -> Result<(), pgrx::spi::Error> {
+    //     let json = Spi::get_one::<Json>(
+    //         "SELECT borrow_serde_serialize_array(ARRAY['one', null, 'two', 'three'])",
+    //     )?
+    //     .expect("returned json was null");
+    //     assert_eq!(json.0, json! {{"values": ["one", null, "two", "three"]}});
+    //     Ok(())
+    // }
+
+    #[pg_test]
+    fn borrow_test_optional_array_with_default() {
+        let sum = Spi::get_one::<i32>("SELECT borrow_optional_array_with_default(ARRAY[1,2,3])");
+        assert_eq!(sum, Ok(Some(6)));
+    }
+
+    #[pg_test]
+    fn borrow_test_serde_serialize_array_i32() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT borrow_serde_serialize_array_i32(ARRAY[1, null, 2, 3, null, 4, 5])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": [1,null,2,3,null,4, 5]}});
+        Ok(())
+    }
+
+    #[pg_test(expected = "array contains NULL")]
+    fn borrow_test_serde_serialize_array_i32_deny_null() -> Result<Option<Json>, pgrx::spi::Error> {
+        Spi::get_one::<Json>(
+            "SELECT borrow_serde_serialize_array_i32_deny_null(ARRAY[1, 2, 3, null, 4, 5])",
+        )
+    }
+
+    #[pg_test]
+    fn borrow_test_return_text_array() {
+        let rc = Spi::get_one::<bool>("SELECT ARRAY['a', 'b', 'c', 'd'] = return_text_array();");
+        assert_eq!(rc, Ok(Some(true)));
+    }
+
+    #[pg_test]
+    fn borrow_test_return_zero_length_vec() {
+        let rc = Spi::get_one::<bool>("SELECT ARRAY[]::integer[] = return_zero_length_vec();");
+        assert_eq!(rc, Ok(Some(true)));
+    }
+
+    #[pg_test]
+    fn borrow_test_slice_to_array() -> Result<(), pgrx::spi::Error> {
+        let owned_vec = vec![Some(1), None, Some(2), Some(3), None, Some(4), Some(5)];
+        let json = Spi::connect(|client| {
+            client
+                .select(
+                    "SELECT borrow_serde_serialize_array_i32($1)",
+                    None,
+                    Some(vec![(
+                        PgBuiltInOids::INT4ARRAYOID.oid(),
+                        owned_vec.as_slice().into_datum(),
+                    )]),
+                )?
+                .first()
+                .get_one::<Json>()
+        })?
+        .expect("Failed to return json even though it's right there ^^");
+        assert_eq!(json.0, json! {{"values": [1, null, 2, 3, null, 4, 5]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_arr_data_ptr() {
+        let len = Spi::get_one::<i32>("SELECT borrow_get_arr_nelems('{1,2,3,4,5}'::int[])");
+        assert_eq!(len, Ok(Some(5)));
+    }
+
+    #[pg_test]
+    fn borrow_test_get_arr_data_ptr_nth_elem() {
+        let nth =
+            Spi::get_one::<i32>("SELECT borrow_get_arr_data_ptr_nth_elem('{1,2,3,4,5}'::int[], 2)");
+        assert_eq!(nth, Ok(Some(3)));
+    }
+
+    #[pg_test]
+    fn borrow_test_display_get_arr_nullbitmap() -> Result<(), pgrx::spi::Error> {
+        let bitmap_str = Spi::get_one::<String>(
+            "SELECT borrow_display_get_arr_nullbitmap(ARRAY[1,NULL,3,NULL,5]::int[])",
+        )?
+        .expect("datum was null");
+
+        assert_eq!(bitmap_str, "0b00010101");
+
+        let bitmap_str = Spi::get_one::<String>(
+            "SELECT borrow_display_get_arr_nullbitmap(ARRAY[1,2,3,4,5]::int[])",
+        )?
+        .expect("datum was null");
+
+        assert_eq!(bitmap_str, "");
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_get_arr_ndim() -> Result<(), pgrx::spi::Error> {
+        let ndim = Spi::get_one::<i32>("SELECT borrow_get_arr_ndim(ARRAY[1,2,3,4,5]::int[])")?
+            .expect("datum was null");
+
+        assert_eq!(ndim, 1);
+
+        let ndim = Spi::get_one::<i32>("SELECT borrow_get_arr_ndim('{{1,2,3},{4,5,6}}'::int[])")?
+            .expect("datum was null");
+
+        assert_eq!(ndim, 2);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_arr_to_vec() {
+        let result =
+            Spi::get_one::<Vec<i32>>("SELECT borrow_arr_mapped_vec(ARRAY[3,2,2,1]::integer[])");
+        let other =
+            Spi::get_one::<Vec<i32>>("SELECT borrow_arr_into_vec(ARRAY[3,2,2,1]::integer[])");
+        // One should be equivalent to the canonical form.
+        assert_eq!(result, Ok(Some(vec![3, 2, 2, 1])));
+        // And they should be equal to each other.
+        assert_eq!(result, other);
+    }
+
+    #[pg_test]
+    fn borrow_test_arr_sort_uniq() {
+        let result =
+            Spi::get_one::<Vec<i32>>("SELECT borrow_arr_sort_uniq(ARRAY[3,2,2,1]::integer[])");
+        assert_eq!(result, Ok(Some(vec![1, 2, 3])));
+    }
+
+    #[pg_test]
+    #[should_panic]
+    fn borrow_test_arr_sort_uniq_with_null() -> Result<(), pgrx::spi::Error> {
+        Spi::get_one::<Vec<i32>>("SELECT borrow_arr_sort_uniq(ARRAY[3,2,NULL,2,1]::integer[])")
+            .map(|_| ())
+    }
+
+    #[pg_test]
+    fn borrow_test_cstring_array() -> Result<(), pgrx::spi::Error> {
+        let strings = Spi::get_one::<bool>("SELECT borrow_validate_cstring_array(ARRAY['one', 'two', NULL, 'four', 'five', NULL, 'seven', NULL, NULL]::cstring[])")?.expect("datum was NULL");
+        assert_eq!(strings, true);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_f64_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<FlatArray<'_, f64>>("SELECT ARRAY[1.0, 2.0, 3.0]::float8[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1.0, 2.0, 3.0]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_f32_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<FlatArray<'_, f32>>("SELECT ARRAY[1.0, 2.0, 3.0]::float4[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1.0, 2.0, 3.0]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_i64_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<FlatArray<'_, i64>>("SELECT ARRAY[1, 2, 3]::bigint[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1, 2, 3]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_i32_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<FlatArray<'_, i32>>("SELECT ARRAY[1, 2, 3]::integer[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1, 2, 3]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_i16_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let array = Spi::get_one::<FlatArray<'_, i16>>("SELECT ARRAY[1, 2, 3]::smallint[]")?
+            .expect("datum was null");
+        assert_eq!(array.as_slice()?, &[1, 2, 3]);
+        Ok(())
+    }
+
+    // #[pg_test]
+    // fn borrow_test_slice_with_null() -> Result<(), Box<dyn std::error::Error>> {
+    //     let array = Spi::get_one::<FlatArray<'_, i16>>("SELECT ARRAY[1, 2, 3, NULL]::smallint[]")?
+    //         .expect("datum was null");
+    //     assert_eq!(array.as_slice(), Err(FlatArraySliceError::ContainsNulls));
+    //     Ok(())
+    // }
+
+    #[pg_test]
+    fn borrow_test_array_of_points() -> Result<(), Box<dyn std::error::Error>> {
+        let points: &FlatArray<'_, pg_sys::Point> = Spi::get_one(
+            "SELECT ARRAY['(1,1)', '(2, 2)', '(3,3)', '(4,4)', NULL, '(5,5)']::point[]",
+        )?
+        .unwrap();
+        let points = points.into_iter().collect::<Vec<_>>();
+        let expected = vec![
+            Some(pg_sys::Point { x: 1.0, y: 1.0 }),
+            Some(pg_sys::Point { x: 2.0, y: 2.0 }),
+            Some(pg_sys::Point { x: 3.0, y: 3.0 }),
+            Some(pg_sys::Point { x: 4.0, y: 4.0 }),
+            None,
+            Some(pg_sys::Point { x: 5.0, y: 5.0 }),
+        ];
+
+        for (p, expected) in points.into_iter().zip(expected.into_iter()) {
+            match (p, expected) {
+                (Some(l), Some(r)) => {
+                    assert_eq!(l.x, r.x);
+                    assert_eq!(l.y, r.y);
+                }
+                (None, None) => (),
+                _ => panic!("points not equal"),
+            }
+        }
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_text_array_as_vec_string() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<FlatArray<'_, String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL")
+        .into_iter()
+        .collect::<Vec<_>>();
+        assert_eq!(a, vec![None, None, None, None, Some(String::from("the fifth element"))]);
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_text_array_iter() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<FlatArray<'_, String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL");
+
+        let mut iter = a.iter();
+
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(None));
+        assert_eq!(iter.next(), Some(Some(String::from("the fifth element"))));
+        assert_eq!(iter.next(), None);
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_text_array_via_getter() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<FlatArray<'_, String>>(
+            "SELECT ARRAY[NULL, NULL, NULL, NULL, 'the fifth element']::text[]",
+        )?
+        .expect("spi result was NULL");
+
+        assert_eq!(a.get(0), Some(None));
+        assert_eq!(a.get(1), Some(None));
+        assert_eq!(a.get(2), Some(None));
+        assert_eq!(a.get(3), Some(None));
+        assert_eq!(a.get(4), Some(Some(String::from("the fifth element"))));
+        assert_eq!(a.get(5), None);
+
+        Ok(())
+    }
+}

--- a/pgrx-tests/src/tests/array_borrowed.rs
+++ b/pgrx-tests/src/tests/array_borrowed.rs
@@ -159,27 +159,26 @@ fn borrow_arr_sort_uniq(arr: &FlatArray<'_, i32>) -> Vec<i32> {
 //     a.iter().cloned().collect()
 // }
 
-// FIXME: something about entity?
-// #[pg_extern]
-// fn borrow_validate_cstring_array(
-//     a: &FlatArray<'_, CStr>,
-// ) -> std::result::Result<bool, Box<dyn std::error::Error>> {
-//     assert_eq!(
-//         a.iter().map(|v| v.into_option()).collect::<Vec<_>>(),
-//         vec![
-//             Some(CStr::from_bytes_with_nul(b"one\0")?),
-//             Some(CStr::from_bytes_with_nul(b"two\0")?),
-//             None,
-//             Some(CStr::from_bytes_with_nul(b"four\0")?),
-//             Some(CStr::from_bytes_with_nul(b"five\0")?),
-//             None,
-//             Some(CStr::from_bytes_with_nul(b"seven\0")?),
-//             None,
-//             None
-//         ]
-//     );
-//     Ok(true)
-// }
+#[pg_extern]
+fn borrow_validate_cstring_array(
+    a: &FlatArray<'_, CStr>,
+) -> std::result::Result<bool, Box<dyn std::error::Error>> {
+    assert_eq!(
+        a.iter().map(|v| v.into_option()).collect::<Vec<_>>(),
+        vec![
+            Some(CStr::from_bytes_with_nul(b"one\0")?),
+            Some(CStr::from_bytes_with_nul(b"two\0")?),
+            None,
+            Some(CStr::from_bytes_with_nul(b"four\0")?),
+            Some(CStr::from_bytes_with_nul(b"five\0")?),
+            None,
+            Some(CStr::from_bytes_with_nul(b"seven\0")?),
+            None,
+            None
+        ]
+    );
+    Ok(true)
+}
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
@@ -377,12 +376,12 @@ mod tests {
         assert_eq!(result, Ok(Some(vec![1, 2, 3])));
     }
 
-    // #[pg_test]
-    // fn borrow_test_cstring_array() -> Result<(), pgrx::spi::Error> {
-    //     let strings = Spi::get_one::<bool>("SELECT borrow_validate_cstring_array(ARRAY['one', 'two', NULL, 'four', 'five', NULL, 'seven', NULL, NULL]::cstring[])")?.expect("datum was NULL");
-    //     assert_eq!(strings, true);
-    //     Ok(())
-    // }
+    #[pg_test]
+    fn borrow_test_cstring_array() -> Result<(), pgrx::spi::Error> {
+        let strings = Spi::get_one::<bool>("SELECT borrow_validate_cstring_array(ARRAY['one', 'two', NULL, 'four', 'five', NULL, 'seven', NULL, NULL]::cstring[])")?.expect("datum was NULL");
+        assert_eq!(strings, true);
+        Ok(())
+    }
 
     // FIXME: lol SPI
     // #[pg_test]

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -218,6 +218,7 @@ mod tests {
 
     #[pg_test(expected = "attempt to add with overflow")]
     fn test_sum_array_i32_overflow() -> Result<Option<i64>, pgrx::spi::Error> {
+        // Note that this test is calling a builtin, array_agg
         Spi::get_one::<i64>(
             "SELECT sum_array(a) FROM (SELECT array_agg(s) a FROM generate_series(1, 1000000) s) x;",
         )

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod aggregate_tests;
 mod anyarray_tests;
 mod anyelement_tests;
 mod anynumeric_tests;
+mod array_borrowed;
 mod array_tests;
 mod attributes_tests;
 mod bgworker_tests;

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -61,7 +61,7 @@ enum-map = "2.6.3"
 atomic-traits = "0.3.0" # PgAtomic and shmem init
 bitflags = "2.4.0" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
-bstr = "1.10"
+bstr = { version = "1.10", default-features = false}
 heapless = "0.8" # shmem and PgLwLock
 libc.workspace = true # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -61,6 +61,7 @@ enum-map = "2.6.3"
 atomic-traits = "0.3.0" # PgAtomic and shmem init
 bitflags = "2.4.0" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
+bstr = "1.10"
 heapless = "0.8" # shmem and PgLwLock
 libc.workspace = true # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -24,6 +24,8 @@ use core::{mem, slice};
 mod port;
 
 /// &FlatArray is akin to &ArrayType
+///
+/// `pgrx::datum::Array` is essentially `&FlatArray`
 #[repr(C)]
 pub struct FlatArray<'mcx, T: ?Sized> {
     scalar: PhantomData<&'mcx T>,
@@ -41,8 +43,7 @@ where
     pub fn nth(&self, index: usize) -> Option<&T> {
         // FIXME: consider nullability
         // FIXME: Become a dispatch to Iterator::nth
-        todo!()
-        // self.datum_at(index).map(|datum| unsafe { T::borrow_from(datum) })
+        self.ptr_to(index).map(|ptr| unsafe { &*T::point_from(ptr.cast_mut()) })
     }
 
     /// Mutably borrow the nth element.
@@ -51,24 +52,22 @@ where
     pub fn nth_mut(&mut self, index: usize) -> Option<&mut T> {
         // FIXME: consider nullability
         // FIXME: Become a dispatch to Iterator::nth
-        todo!();
-        // unsafe { self.datum_mut_at(index).map(|datum| unsafe { T::borrow_mut_from(datum) }) }
+        self.ptr_mut_to(index).map(|ptr| unsafe { &mut *T::point_from(ptr) })
     }
 
-    fn datum_at(&self, index: usize) -> Option<&Datum<'mcx>> {
+    // Obtain a pointer with read-only permissions to the type at this index
+    #[inline]
+    fn ptr_to(&self, index: usize) -> Option<*const u8> {
         let data_ptr = unsafe { port::ARR_DATA_PTR(ptr::addr_of!(self.head).cast_mut()) };
-        todo!();
+        todo!()
         // FIXME: replace with actual impl instead of something that merely typechecks
     }
 
-    /// # Safety
-    /// This is an incredibly naughty function for arrays where *the scalar type is
-    /// smaller than Datum*. This is because when we return `&mut Datum`, that could overlap
-    /// with the next `&mut Datum`, so it must essentially always be converted before exposure.
-    /// Consider replacing this with raw pointers.
-    unsafe fn datum_mut_at(&mut self, index: usize) -> Option<&mut Datum<'mcx>> {
+    // Obtain a pointer with read-write permissions to the type at this index
+    #[inline]
+    fn ptr_mut_to(&mut self, index: usize) -> Option<*mut u8> {
         let data_ptr = unsafe { port::ARR_DATA_PTR(ptr::addr_of_mut!(self.head)) };
-        todo!();
+        todo!()
         // FIXME: replace with actual impl instead of something that merely typechecks
     }
 

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -50,7 +50,7 @@ where
     pub fn nth_mut(&mut self, index: usize) -> Option<&mut T> {
         // FIXME: consider nullability
         // FIXME: Become a dispatch to Iterator::nth
-        self.datum_mut_at(index).map(|datum| unsafe { T::borrow_mut_from(datum) })
+        unsafe { self.datum_mut_at(index).map(|datum| unsafe { T::borrow_mut_from(datum) }) }
     }
 
     fn datum_at(&self, index: usize) -> Option<&Datum<'mcx>> {
@@ -63,7 +63,7 @@ where
     /// # Safety
     /// This is an incredibly naughty function for arrays where *the scalar type is
     /// smaller than Datum*. This is because when we return `&mut Datum`, that could overlap
-    /// with the next `&mut Datum`, so it must essentially always be converted.
+    /// with the next `&mut Datum`, so it must essentially always be converted before exposure.
     /// Consider replacing this with raw pointers.
     unsafe fn datum_mut_at(&mut self, index: usize) -> Option<&mut Datum<'mcx>> {
         let data_ptr = unsafe { port::ARR_DATA_PTR(ptr::addr_of_mut!(self.head)) };

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -45,18 +45,34 @@ where
         self.datum_mut_at(index).map(|datum| unsafe { T::borrow_mut_from(datum) })
     }
 
-    fn datum_at(&self, index: usize) -> Option<&Datum<'_>> {
+    fn datum_at(&self, index: usize) -> Option<&Datum<'mcx>> {
         let data_ptr = unsafe { ARR_DATA_PTR(ptr::addr_of!(self.head).cast_mut()) };
-        todo!();
+        // todo!();
         // FIXME: replace with actual impl instead of something that merely typechecks
-        Some(unsafe { &*(data_ptr as *const Datum<'_>) })
+        Some(unsafe { &*(data_ptr as *const Datum<'mcx>) })
     }
 
-    fn datum_mut_at(&mut self, index: usize) -> Option<&mut Datum<'_>> {
+    fn datum_mut_at(&mut self, index: usize) -> Option<&mut Datum<'mcx>> {
         let data_ptr = unsafe { ARR_DATA_PTR(ptr::addr_of_mut!(self.head)) };
-        todo!();
+        // todo!();
         // FIXME: replace with actual impl instead of something that merely typechecks
-        Some(unsafe { &mut *(data_ptr as *mut Datum<'_>) })
+        Some(unsafe { &mut *(data_ptr as *mut Datum<'mcx>) })
+    }
+
+    fn nullbitmap(&self) -> &[u8] {
+        todo!()
+    }
+
+    /// Obtain a mutable reference to the null bitmap.
+    /// # Safety
+    /// The items set to 1 in the null bitmap are treated as valid.
+    /// If the null bitmap covers any extent, then trailing bits must be set to 0 and
+    /// all elements that have a 1 marking them must be initialized. The null bitmap
+    /// is linear but the layout of elements may be nonlinear, so for some arrays
+    /// the positions of the null bits that must be set or unset cannot be directly
+    /// calculated from the positions of the elements in the array, and vice versa.
+    unsafe fn nullbitmap_mut(&mut self) -> &mut [u8] {
+        todo!()
     }
 }
 

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -41,7 +41,8 @@ where
     pub fn nth(&self, index: usize) -> Option<&T> {
         // FIXME: consider nullability
         // FIXME: Become a dispatch to Iterator::nth
-        self.datum_at(index).map(|datum| unsafe { T::borrow_from(datum) })
+        todo!()
+        // self.datum_at(index).map(|datum| unsafe { T::borrow_from(datum) })
     }
 
     /// Mutably borrow the nth element.
@@ -50,14 +51,14 @@ where
     pub fn nth_mut(&mut self, index: usize) -> Option<&mut T> {
         // FIXME: consider nullability
         // FIXME: Become a dispatch to Iterator::nth
-        unsafe { self.datum_mut_at(index).map(|datum| unsafe { T::borrow_mut_from(datum) }) }
+        todo!();
+        // unsafe { self.datum_mut_at(index).map(|datum| unsafe { T::borrow_mut_from(datum) }) }
     }
 
     fn datum_at(&self, index: usize) -> Option<&Datum<'mcx>> {
         let data_ptr = unsafe { port::ARR_DATA_PTR(ptr::addr_of!(self.head).cast_mut()) };
-        // todo!();
+        todo!();
         // FIXME: replace with actual impl instead of something that merely typechecks
-        Some(unsafe { &*(data_ptr as *const Datum<'mcx>) })
     }
 
     /// # Safety
@@ -67,9 +68,8 @@ where
     /// Consider replacing this with raw pointers.
     unsafe fn datum_mut_at(&mut self, index: usize) -> Option<&mut Datum<'mcx>> {
         let data_ptr = unsafe { port::ARR_DATA_PTR(ptr::addr_of_mut!(self.head)) };
-        // todo!();
+        todo!();
         // FIXME: replace with actual impl instead of something that merely typechecks
-        Some(unsafe { &mut *(data_ptr as *mut Datum<'mcx>) })
     }
 
     /// Number of elements in the Array
@@ -116,20 +116,11 @@ where
 }
 
 unsafe impl<T> BorrowDatum for FlatArray<'_, T> {
-    unsafe fn borrow_from<'dat>(datum: &'dat Datum<'_>) -> &'dat Self {
-        let ptr = datum as *const Datum<'_> as *const *const pg_sys::varlena;
+    const PASS: Option<layout::PassBy> = Some(layout::PassBy::Ref);
+    unsafe fn point_from(ptr: *mut u8) -> *mut Self {
         unsafe {
-            let ptr = *ptr;
-            let len = varlena::varsize_any(ptr) - mem::size_of::<pg_sys::ArrayType>();
-            &*(ptr::slice_from_raw_parts(ptr as *const u8, len) as *const Self)
-        }
-    }
-    unsafe fn borrow_mut_from<'dat>(datum: &'dat mut Datum<'_>) -> &'dat mut Self {
-        let ptr = datum as *mut Datum<'_> as *mut *mut pg_sys::varlena;
-        unsafe {
-            let ptr = *ptr;
-            let len = varlena::varsize_any(ptr) - mem::size_of::<pg_sys::ArrayType>();
-            &mut *(ptr::slice_from_raw_parts(ptr as *mut u8, len) as *mut Self)
+            let len = varlena::varsize_any(ptr.cast()) - mem::size_of::<pg_sys::ArrayType>();
+            ptr::slice_from_raw_parts_mut(ptr, len) as *mut Self
         }
     }
 }

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -60,7 +60,12 @@ where
         Some(unsafe { &*(data_ptr as *const Datum<'mcx>) })
     }
 
-    fn datum_mut_at(&mut self, index: usize) -> Option<&mut Datum<'mcx>> {
+    /// # Safety
+    /// This is an incredibly naughty function for arrays where *the scalar type is
+    /// smaller than Datum*. This is because when we return `&mut Datum`, that could overlap
+    /// with the next `&mut Datum`, so it must essentially always be converted.
+    /// Consider replacing this with raw pointers.
+    unsafe fn datum_mut_at(&mut self, index: usize) -> Option<&mut Datum<'mcx>> {
         let data_ptr = unsafe { ARR_DATA_PTR(ptr::addr_of_mut!(self.head)) };
         // todo!();
         // FIXME: replace with actual impl instead of something that merely typechecks

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -84,22 +84,6 @@ where
         todo!()
     }
 
-    // Obtain a pointer with read-only permissions to the type at this index
-    #[inline]
-    fn ptr_to(&self, index: usize) -> Option<*const u8> {
-        let data_ptr = unsafe { port::ARR_DATA_PTR(ptr::addr_of!(self.head).cast_mut()) };
-        todo!()
-        // FIXME: replace with actual impl instead of something that merely typechecks
-    }
-
-    // Obtain a pointer with read-write permissions to the type at this index
-    #[inline]
-    fn ptr_mut_to(&mut self, index: usize) -> Option<*mut u8> {
-        let data_ptr = unsafe { port::ARR_DATA_PTR(ptr::addr_of_mut!(self.head)) };
-        todo!()
-        // FIXME: replace with actual impl instead of something that merely typechecks
-    }
-
     /// Number of elements in the Array
     ///
     /// Note that for many Arrays, this doesn't have a linear relationship with array byte-len.

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -53,6 +53,8 @@ where
     /// Number of elements in the Array, including nulls
     ///
     /// Note that for many Arrays, this doesn't have a linear relationship with array byte-len.
+    #[doc(alias = "cardinality")]
+    #[doc(alias = "nelems")]
     pub fn count(&self) -> usize {
         self.as_raw().len()
     }
@@ -74,6 +76,7 @@ where
     T: ?Sized + BorrowDatum,
 {
     /// Iterate the array
+    #[doc(alias = "unnest")]
     pub fn iter(&self) -> ArrayIter<'_, T> {
         let nelems = self.count();
         let raw = self.as_raw();

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -9,6 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![allow(clippy::precedence)]
 #![allow(unused)]
+#![deny(unsafe_op_in_unsafe_fn)]
 use crate::datum::{Array, BorrowDatum, Datum};
 use crate::layout::{Align, Layout};
 use crate::nullable::Nullable;

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -36,7 +36,7 @@ pub struct FlatArray<'mcx, T: ?Sized> {
 
 impl<'mcx, T> FlatArray<'mcx, T>
 where
-    T: ?Sized + BorrowDatum,
+    T: ?Sized,
 {
     fn as_raw(&self) -> RawArray {
         unsafe {
@@ -45,6 +45,18 @@ where
         }
     }
 
+    /// Number of elements in the Array
+    ///
+    /// Note that for many Arrays, this doesn't have a linear relationship with array byte-len.
+    pub fn count(&self) -> usize {
+        self.as_raw().len()
+    }
+}
+
+impl<'mcx, T> FlatArray<'mcx, T>
+where
+    T: ?Sized + BorrowDatum,
+{
     /// Iterate the array
     // this lifetime seems wrong
     pub fn iter(&'mcx self) -> ArrayIter<'mcx, T> {
@@ -92,13 +104,6 @@ where
     }
     */
 
-    /// Number of elements in the Array
-    ///
-    /// Note that for many Arrays, this doesn't have a linear relationship with array byte-len.
-    pub fn count(&self) -> usize {
-        self.as_raw().len()
-    }
-
     pub fn nulls(&self) -> Option<&[u8]> {
         let len = self.count() + 7 >> 3; // Obtains 0 if len was 0.
 
@@ -133,7 +138,7 @@ where
     }
 }
 
-unsafe impl<T> BorrowDatum for FlatArray<'_, T> {
+unsafe impl<T: ?Sized> BorrowDatum for FlatArray<'_, T> {
     const PASS: Option<layout::PassBy> = Some(layout::PassBy::Ref);
     unsafe fn point_from(ptr: *mut u8) -> *mut Self {
         unsafe {

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -116,7 +116,8 @@ where
     }
 
     /**
-    Oxidized form of [ARR_NULLBITMAP(ArrayType*)][ARR_NULLBITMAP]
+    Oxidized form of [ARR_NULLBITMAP(ArrayType*)][arr_nullbitmap]
+
     If this returns None, the array *cannot* have nulls.
     Note that unlike the `is_null: bool` that appears elsewhere, 1 is "valid" and 0 is "null".
 
@@ -124,6 +125,7 @@ where
     Trailing bits must be set to 0, and all elements marked with 1 must be initialized.
     The null bitmap is linear but the layout of elements may be nonlinear, so for some arrays
     these cannot be calculated directly from each other.
+
     [ARR_NULLBITMAP]: <https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/utils/array.h;h=4ae6c3be2f8b57afa38c19af2779f67c782e4efc;hb=278273ccbad27a8834dfdf11895da9cd91de4114#l293>
     */
     pub unsafe fn nulls_mut(&mut self) -> Option<&mut [u8]> {

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -72,9 +72,7 @@ where
     /// `FlatArray::nth` may have to iterate the array, thus it is named for `Iterator::nth`,
     /// as opposed to a constant-time `get`.
     pub fn nth(&self, index: usize) -> Option<Nullable<&T>> {
-        // FIXME: consider nullability
-        // FIXME: Become a dispatch to Iterator::nth
-        todo!()
+        self.iter().nth(index)
     }
 
     /// Mutably borrow the nth element.
@@ -177,7 +175,7 @@ fn is_null(p: Option<NonNull<u8>>) -> bool {
 
 impl<'arr, T> Iterator for ArrayIter<'arr, T>
 where
-    T: BorrowDatum,
+    T: ?Sized + BorrowDatum,
 {
     type Item = Nullable<&'arr T>;
 

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -58,8 +58,7 @@ where
     T: ?Sized + BorrowDatum,
 {
     /// Iterate the array
-    // this lifetime seems wrong
-    pub fn iter(&'mcx self) -> ArrayIter<'mcx, T> {
+    pub fn iter(&self) -> ArrayIter<'_, T> {
         let nelems = self.count();
         let raw = self.as_raw();
         let nulls =

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -46,19 +46,27 @@ where
     }
 
     /// Iterate the array
-    pub fn iter(&self) -> ArrayIter<'mcx, T> {
-        let nulls = self.nulls();
+    // this lifetime seems wrong
+    pub fn iter(&'mcx self) -> ArrayIter<'mcx, T> {
+        let nulls = self
+            .nulls()
+            .map(|p| unsafe { NonNull::new_unchecked(ptr::from_ref(p).cast_mut().cast()) });
         let nelems = self.count();
         let raw = self.as_raw();
 
-        let data_ptr = raw.data_ptr();
+        let data = raw.data_ptr();
+        let arr = self;
+        let index = 0;
+        let offset = 0;
 
-        /* ArrayIter {
-
-        } */
-        todo!()
+        ArrayIter { data, nulls, nelems, arr, index, offset }
     }
 
+    /*
+    pub fn iter_mut(&mut self) -> ArrayIterMut<'mcx, T> {
+        ???
+    }
+    */
     /// Borrow the nth element.
     ///
     /// `FlatArray::nth` may have to iterate the array, thus it is named for `Iterator::nth`,
@@ -153,11 +161,18 @@ where
 {
     arr: &'arr FlatArray<'arr, T>,
     data: *const u8,
-    nulls: *const u8,
+    nulls: Option<NonNull<u8>>,
+    nelems: usize,
+    index: usize,
+    offset: usize,
 }
 
-fn is_null(p: *const u8) -> bool {
-    todo!()
+fn is_null(p: Option<NonNull<u8>>) -> bool {
+    if let Some(p) = p {
+        todo!()
+    } else {
+        false
+    }
 }
 
 impl<'arr, T> Iterator for ArrayIter<'arr, T>

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -72,6 +72,10 @@ where
         ArrayIter { data, nulls, nelems, arr, index, offset }
     }
 
+    pub fn iter_non_null(&self) -> impl Iterator<Item = &T> {
+        self.iter().filter_map(|elem| elem.into_option())
+    }
+
     /*
     /**
     Some problems with the design of an iter_mut for FlatArray:

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -241,9 +241,7 @@ where
             // note that we do NOT offset when the value is a null!
             Some(Nullable::Null)
         } else {
-            let borrow = unsafe {
-                &*<T as BorrowDatum>::point_from(self.data.byte_add(self.offset).cast_mut())
-            };
+            let borrow = unsafe { T::borrow_unchecked(self.data.add(self.offset)) };
             // As we always have a borrow, we just ask Rust what the array element's size is
             self.offset += self.align.pad(mem::size_of_val(borrow));
             Some(Nullable::Valid(borrow))

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -74,14 +74,14 @@ where
     /// Number of elements in the Array
     ///
     /// Note that for many Arrays, this doesn't have a linear relationship with array byte-len.
-    fn len(&self) -> usize {
+    pub fn count(&self) -> usize {
         let ndims = self.head.ndim as usize;
         let dims_ptr = unsafe { port::ARR_DIMS(ptr::addr_of!(self.head).cast_mut()) };
         unsafe { slice::from_raw_parts(dims_ptr, ndims).into_iter().sum::<i32>() as usize }
     }
 
     pub fn nulls(&self) -> Option<&[u8]> {
-        let len = self.len() + 7 >> 3; // Obtains 0 if len was 0.
+        let len = self.count() + 7 >> 3; // Obtains 0 if len was 0.
 
         // SAFETY: This obtains the nulls pointer from a function that must either
         // return a null pointer or a pointer to a valid null bitmap.
@@ -103,7 +103,7 @@ where
     [ARR_NULLBITMAP]: <https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/utils/array.h;h=4ae6c3be2f8b57afa38c19af2779f67c782e4efc;hb=278273ccbad27a8834dfdf11895da9cd91de4114#l293>
     */
     pub unsafe fn nulls_mut(&mut self) -> Option<&mut [u8]> {
-        let len = self.len() + 7 >> 3; // Obtains 0 if len was 0.
+        let len = self.count() + 7 >> 3; // Obtains 0 if len was 0.
 
         // SAFETY: This obtains the nulls pointer from a function that must either
         // return a null pointer or a pointer to a valid null bitmap.

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -17,9 +17,9 @@ use crate::toast::{Toast, Toasty};
 use crate::{layout, pg_sys, varlena};
 use bitvec::ptr::{self as bitptr, BitPtr, BitPtrError, Mut};
 use bitvec::slice::BitSlice;
-use core::ptr::{self, NonNull};
-use core::{slice, mem};
 use core::marker::PhantomData;
+use core::ptr::{self, NonNull};
+use core::{mem, slice};
 
 mod port;
 

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -141,7 +141,7 @@ where
 }
 
 unsafe impl<T: ?Sized> BorrowDatum for FlatArray<'_, T> {
-    const PASS: Option<layout::PassBy> = Some(layout::PassBy::Ref);
+    const PASS: layout::PassBy = layout::PassBy::Ref;
     unsafe fn point_from(ptr: *mut u8) -> *mut Self {
         unsafe {
             let len = varlena::varsize_any(ptr.cast()) - mem::size_of::<pg_sys::ArrayType>();

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -75,6 +75,7 @@ where
         self.iter().nth(index)
     }
 
+    /*
     /// Mutably borrow the nth element.
     ///
     /// `FlatArray::nth_mut` may have to iterate the array, thus it is named for `Iterator::nth`.
@@ -83,6 +84,7 @@ where
         // FIXME: Become a dispatch to Iterator::nth
         todo!()
     }
+    */
 
     /// Number of elements in the Array
     ///
@@ -164,7 +166,7 @@ where
     type Item = Nullable<&'arr T>;
 
     fn next(&mut self) -> Option<Nullable<&'arr T>> {
-        if is_null(self.nulls) {
+        if todo!() {
             Some(Nullable::Null)
         } else {
             unsafe {

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -194,15 +194,6 @@ where
     offset: usize,
 }
 
-fn is_null(p: Option<NonNull<u8>>) -> bool {
-    // TODO: this
-    if let Some(p) = p {
-        todo!()
-    } else {
-        false
-    }
-}
-
 impl<'arr, T> Iterator for ArrayIter<'arr, T>
 where
     T: ?Sized + BorrowDatum,
@@ -210,12 +201,23 @@ where
     type Item = Nullable<&'arr T>;
 
     fn next(&mut self) -> Option<Nullable<&'arr T>> {
-        // TODO: iteration
-        if todo!() {
+        if self.index >= self.nelems {
+            return None;
+        }
+        let is_null = match self.nulls {
+            Some(nulls) => !nulls.get(index).unwrap(),
+            None => false,
+        };
+        // note the index freezes when we reach the end of the null bitslice, fusing the iterator
+        self.index += 1;
+
+        if is_null {
             Some(Nullable::Null)
         } else {
             unsafe {
-                let ptr = <T as BorrowDatum>::point_from(self.data.cast_mut());
+                let ptr = <T as BorrowDatum>::point_from(self.data.add(self.offset).cast_mut());
+                // need some way of determining size using BorrowDatum...
+                self.offset += todo!();
                 Some(Nullable::Valid(&*ptr))
             }
         }

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -195,6 +195,7 @@ where
 }
 
 fn is_null(p: Option<NonNull<u8>>) -> bool {
+    // TODO: this
     if let Some(p) = p {
         todo!()
     } else {
@@ -209,6 +210,7 @@ where
     type Item = Nullable<&'arr T>;
 
     fn next(&mut self) -> Option<Nullable<&'arr T>> {
+        // TODO: iteration
         if todo!() {
             Some(Nullable::Null)
         } else {

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -62,6 +62,13 @@ where
     }
 
     /*
+    /**
+    Some problems with the design of an iter_mut for FlatArray:
+    In order to traverse the array, we need to assume well-formedness of e.g. cstring/varlena elements,
+    but &mut would allow safely updating varlenas within their span, e.g. injecting \0 into cstrings.
+    making it so that nothing allows making an ill-formed varlena via &mut seems untenable, also?
+    probably only viable to expose &mut for fixed-size types, then
+    */
     pub fn iter_mut(&mut self) -> ArrayIterMut<'mcx, T> {
         ???
     }

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -158,7 +158,7 @@ unsafe impl<T: ?Sized> BorrowDatum for FlatArray<'_, T> {
 
 unsafe impl<T> SqlTranslatable for &FlatArray<'_, T>
 where
-    T: SqlTranslatable,
+    T: ?Sized + SqlTranslatable,
 {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         match T::argument_sql()? {

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -216,7 +216,7 @@ impl<'arr> Dimensions<'arr> {
 
 /// Iterator for arrays
 #[derive(Clone)]
-struct ArrayIter<'arr, T>
+pub struct ArrayIter<'arr, T>
 where
     T: ?Sized + BorrowDatum,
 {

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -20,6 +20,7 @@ use crate::toast::{Toast, Toasty};
 use crate::{layout, pg_sys, varlena};
 use bitvec::ptr::{self as bitptr, BitPtr, BitPtrError, Const, Mut};
 use bitvec::slice::{self as bitslice, BitSlice};
+use core::iter::{ExactSizeIterator, FusedIterator};
 use core::marker::PhantomData;
 use core::ptr::{self, NonNull};
 use core::{ffi, mem, slice};
@@ -256,6 +257,20 @@ where
         }
     }
 }
+
+impl<'arr, 'mcx, T> IntoIterator for &'arr FlatArray<'mcx, T>
+where
+    T: ?Sized + BorrowDatum,
+{
+    type IntoIter = ArrayIter<'arr, T>;
+    type Item = Nullable<&'arr T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'arr, T> ExactSizeIterator for ArrayIter<'arr, T> where T: ?Sized + BorrowDatum {}
+impl<'arr, T> FusedIterator for ArrayIter<'arr, T> where T: ?Sized + BorrowDatum {}
 
 /**
 An aligned, dereferenceable `NonNull<ArrayType>` with low-level accessors.

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -73,6 +73,7 @@ pub mod spi;
 #[cfg(feature = "cshim")]
 pub mod spinlock;
 pub mod stringinfo;
+pub mod text;
 pub mod trigger_support;
 pub mod tupdesc;
 pub mod varlena;

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -36,7 +36,7 @@ impl DerefMut for Text {
 }
 
 unsafe impl BorrowDatum for Text {
-    const PASS: Option<PassBy> = Some(PassBy::Ref);
+    const PASS: PassBy = PassBy::Ref;
     unsafe fn point_from(ptr: *mut u8) -> *mut Self {
         unsafe {
             let len = varlena::varsize_any(ptr.cast());

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -1,0 +1,63 @@
+use crate::datum::{BorrowDatum, Datum};
+use crate::pgrx_sql_entity_graph::metadata::{
+    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+};
+use crate::{pg_sys, varlena};
+use core::ops::{Deref, DerefMut};
+use core::ptr;
+
+/// A more strongly-typed representation of a Postgres string, AKA `TEXT`.
+/// A pointer to this points to a byte array, which includes a variable-length header
+/// and an unsized data field which is... often but not always UTF-8.
+#[repr(transparent)]
+pub struct Text([u8]);
+
+// TODO(0.12.0): strip this and make Text forward its impl to BStr fn instead
+impl Deref for Text {
+    type Target = str;
+    fn deref(&self) -> &str {
+        let self_ptr = self as *const Text as *const pg_sys::varlena;
+        unsafe { varlena::text_to_rust_str(self_ptr).unwrap() }
+    }
+}
+
+// TODO(0.12.0): strip this and make Text forward its impl to BStr fn instead
+impl DerefMut for Text {
+    fn deref_mut(&mut self) -> &mut str {
+        let self_ptr = self as *mut Text as *mut pg_sys::varlena;
+        unsafe {
+            let len = varlena::varsize_any_exhdr(self_ptr);
+            let data = varlena::vardata_any(self_ptr);
+
+            &mut *(ptr::slice_from_raw_parts_mut(data as *mut u8, len) as *mut str)
+        }
+    }
+}
+
+unsafe impl BorrowDatum for Text {
+    unsafe fn borrow_from<'dat>(datum: &'dat Datum<'_>) -> &'dat Self {
+        let ptr = datum as *const Datum<'_> as *const *const pg_sys::varlena;
+        unsafe {
+            let ptr = *ptr;
+            let len = varlena::varsize_any(ptr);
+            &*(ptr::slice_from_raw_parts(ptr as *const u8, len) as *const Text)
+        }
+    }
+    unsafe fn borrow_mut_from<'dat>(datum: &'dat mut Datum<'_>) -> &'dat mut Self {
+        let ptr = datum as *mut Datum<'_> as *mut *mut pg_sys::varlena;
+        unsafe {
+            let ptr = *ptr;
+            let len = varlena::varsize_any(ptr);
+            &mut *(ptr::slice_from_raw_parts(ptr as *mut u8, len) as *mut Text)
+        }
+    }
+}
+
+unsafe impl<'dat> SqlTranslatable for &'dat Text {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("TEXT"))
+    }
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("TEXT")))
+    }
+}

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -102,7 +102,7 @@ impl TextData {
 
 impl Text {
     /// Length of the entire varlena in bytes
-    pub fn va_len(&self) -> usize {
+    pub fn vl_len(&self) -> usize {
         self.0.len()
     }
 }

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -115,10 +115,12 @@ impl Text {
 
 unsafe impl BorrowDatum for Text {
     const PASS: PassBy = PassBy::Ref;
-    unsafe fn point_from(ptr: *mut u8) -> *mut Self {
+    unsafe fn point_from(ptr: ptr::NonNull<u8>) -> ptr::NonNull<Self> {
         unsafe {
-            let len = varlena::varsize_any(ptr.cast());
-            ptr::slice_from_raw_parts_mut(ptr, len) as *mut Text
+            let len = varlena::varsize_any(ptr.as_ptr().cast());
+            ptr::NonNull::new_unchecked(
+                ptr::slice_from_raw_parts_mut(ptr.as_ptr(), len) as *mut Text
+            )
         }
     }
 }

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -21,11 +21,12 @@ pub use core::str::{Utf8Chunks, Utf8Error};
 /// A Postgres string, AKA `TEXT`.
 ///
 /// This is a varlena: a reference to a variable-length header followed by a slice of bytes.
-/// Usually this will be UTF-8, but this is not always strictly enforced by PostgreSQL.
 #[repr(transparent)]
 pub struct Text([u8]);
 
 /// Data field of a TEXT varlena
+///
+/// Usually this will be UTF-8, but this is not always strictly enforced by PostgreSQL.
 #[repr(transparent)]
 pub struct TextData([u8]);
 

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_op_in_unsafe_fn)]
 use crate::datum::BorrowDatum;
 use crate::layout::PassBy;
 use crate::pgrx_sql_entity_graph::metadata::{

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -7,9 +7,10 @@ use crate::{pg_sys, varlena};
 use core::ops::{Deref, DerefMut};
 use core::ptr;
 
-/// A more strongly-typed representation of a Postgres string, AKA `TEXT`.
-/// A pointer to this points to a byte array, which includes a variable-length header
-/// and an unsized data field which is... often but not always UTF-8.
+/// A Postgres string, AKA `TEXT`.
+///
+/// This is a varlena: a reference to a variable-length header followed by a slice of bytes.
+/// Usually this will be UTF-8, but this is not always strictly enforced by PostgreSQL.
 #[repr(transparent)]
 pub struct Text([u8]);
 

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -1,11 +1,18 @@
-use crate::datum::{BorrowDatum, Datum};
+use crate::datum::BorrowDatum;
 use crate::layout::PassBy;
 use crate::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
 use crate::{pg_sys, varlena};
-use core::ops::{Deref, DerefMut};
-use core::ptr;
+use core::borrow::Borrow;
+use core::{ptr, slice, str};
+
+use bstr::{BStr, ByteSlice};
+
+// We reexport these types so people don't have to care whether they're pulled from BStr or std,
+// they just use the ones from pgrx::text::*
+pub use bstr::{Bytes, Chars};
+pub use core::str::{Utf8Chunks, Utf8Error};
 
 /// A Postgres string, AKA `TEXT`.
 ///
@@ -14,25 +21,55 @@ use core::ptr;
 #[repr(transparent)]
 pub struct Text([u8]);
 
-// TODO(0.12.0): strip this and make Text forward its impl to BStr fn instead
-impl Deref for Text {
-    type Target = str;
-    fn deref(&self) -> &str {
+impl Text {
+    pub fn as_bytes(&self) -> &[u8] {
         let self_ptr = self as *const Text as *const pg_sys::varlena;
-        unsafe { varlena::text_to_rust_str(self_ptr).unwrap() }
-    }
-}
+        unsafe {
+            let len = varlena::varsize_any_exhdr(self_ptr);
+            let data = varlena::vardata_any(self_ptr);
 
-// TODO(0.12.0): strip this and make Text forward its impl to BStr fn instead
-impl DerefMut for Text {
-    fn deref_mut(&mut self) -> &mut str {
+            slice::from_raw_parts(data.cast::<u8>(), len)
+        }
+    }
+
+    /// Manipulate Text as its byte repr
+    ///
+    /// # Safety
+    /// Like [`str::as_bytes_mut`], this can cause problems if you change Text in a way that
+    /// your database is not specified to support, so the caller must assure that it remains in
+    /// a valid encoding for the database.
+    pub unsafe fn as_bytes_mut(&mut self) -> &mut [u8] {
         let self_ptr = self as *mut Text as *mut pg_sys::varlena;
         unsafe {
             let len = varlena::varsize_any_exhdr(self_ptr);
             let data = varlena::vardata_any(self_ptr);
 
-            &mut *(ptr::slice_from_raw_parts_mut(data as *mut u8, len) as *mut str)
+            slice::from_raw_parts_mut(data.cast::<u8>().cast_mut(), len)
         }
+    }
+
+    /// Reborrow `&Text as `&BStr`
+    ///
+    /// We do not implement Deref to BStr or [u8] because we'd like to expose a more selective API.
+    /// Several fn that [u8] implements are implemented very differently on str!
+    fn as_bstr(&self) -> &BStr {
+        self.as_bytes().borrow()
+    }
+
+    pub fn chars(&self) -> Chars<'_> {
+        self.as_bstr().chars()
+    }
+
+    pub fn bytes(&self) -> Bytes<'_> {
+        self.as_bstr().bytes()
+    }
+
+    pub fn to_str(&self) -> Result<&str, Utf8Error> {
+        str::from_utf8(self.as_bytes())
+    }
+
+    pub fn utf8_chunks(&self) -> Utf8Chunks {
+        self.as_bytes().utf8_chunks()
     }
 }
 

--- a/pgrx/src/text.rs
+++ b/pgrx/src/text.rs
@@ -4,6 +4,8 @@ use crate::pgrx_sql_entity_graph::metadata::{
     ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
 };
 use crate::{pg_sys, varlena};
+use alloc::borrow::Cow;
+use alloc::string::String;
 use core::borrow::Borrow;
 use core::{ptr, slice, str};
 
@@ -96,6 +98,13 @@ impl Text {
     /// Obtain a reference to the varlena data if it is a UTF-8 str
     pub fn to_str(&self) -> Result<&str, Utf8Error> {
         str::from_utf8(self.as_bytes())
+    }
+
+    /// You have two cows. Both are UTF-8 data.
+    ///
+    /// One is completely UTF-8, but the other is allocated and non-UTF-8 is patched over with �.
+    pub fn to_str_lossy(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(self.as_bytes())
     }
 
     /// Iterate over the UTF-8 chunks of the Text's data


### PR DESCRIPTION
Introduce a new Rust type that serves as a definition of what Postgres ArrayTypes "really are", called FlatArray. This is meant to be manipulated via `&FlatArray<'_, T>`... it is an "unsized type". It uses BorrowDatum to power its simplicity in iteration, compared to the incredibly jank implementation in `pgrx/src/datum/array.rs`! I should know it's jank, because I wrote it!

The cost is that it is much more nitpicky about what it can work with, as for a given `FlatArray<'_, T>`, we also require `BorrowDatum` in order to do anything useful with it! This means FlatArray can't be, say, `FlatArray<'mcx, String>`, and implicitly unbox elements into allocated types. You can still just use `.iter().map()`, of course, and the good news is this means all FlatArrays must truly be "zero-copy", as the type definition doesn't allow anything else.

As part of this compromise, we introduce a new Text type so that it is still possible to work with common array needs like strings.

Together, these are effectively the first varlena types that allow directly interacting with the data in their varlena header instead of "forgetting" it.