### PR TITLE
Update version to 0.12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "bzip2",
  "cargo-edit",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "atomic-traits",
  "bitflags 2.4.2",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "bindgen",
  "clang-sys",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "cee-scape",
  "libc",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "clap-cargo 0.14.0",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,11 @@ exclude = [
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-macros = { path = "./pgrx-macros", version = "=0.12.3" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.3" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.3" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.12.3" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "0.12.3" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.12.4" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.12.4" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.12.4" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.12.4" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "0.12.4" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "0.12.2" # format-preserving edits to cargo.toml

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "cargo-pgrx"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -21,10 +21,10 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.12.3"
+pgrx = "=0.12.4"
 
 [dev-dependencies]
-pgrx-tests = "=0.12.3"
+pgrx-tests = "=0.12.4"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -36492,7 +36492,6 @@ extern "C" {
     pub fn MemoryContextDeleteChildren(context: MemoryContext);
     pub fn MemoryContextSetIdentifier(context: MemoryContext, id: *const ::core::ffi::c_char);
     pub fn MemoryContextSetParent(context: MemoryContext, new_parent: MemoryContext);
-    pub fn GetMemoryChunkContext(pointer: *mut ::core::ffi::c_void) -> MemoryContext;
     pub fn GetMemoryChunkSpace(pointer: *mut ::core::ffi::c_void) -> Size;
     pub fn MemoryContextGetParent(context: MemoryContext) -> MemoryContext;
     pub fn MemoryContextIsEmpty(context: MemoryContext) -> bool;

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -38075,7 +38075,6 @@ extern "C" {
     pub fn MemoryContextDeleteChildren(context: MemoryContext);
     pub fn MemoryContextSetIdentifier(context: MemoryContext, id: *const ::core::ffi::c_char);
     pub fn MemoryContextSetParent(context: MemoryContext, new_parent: MemoryContext);
-    pub fn GetMemoryChunkContext(pointer: *mut ::core::ffi::c_void) -> MemoryContext;
     pub fn GetMemoryChunkSpace(pointer: *mut ::core::ffi::c_void) -> Size;
     pub fn MemoryContextGetParent(context: MemoryContext) -> MemoryContext;
     pub fn MemoryContextIsEmpty(context: MemoryContext) -> bool;

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -72,7 +72,7 @@ rand = "0.8.5"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.12.3"
+version = "=0.12.4"
 
 [dev-dependencies]
 eyre.workspace = true # testing functions that return `eyre::Result`

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"


### PR DESCRIPTION
Welcome to pgrx v0.12.4.

First, and most importantly, it fixes a segfault when converting a NULL `pg_sys::Datum` into a Rust `String`.  It seems you'd need to go out of your way to cause the segfault, but nonetheless, it shouldn't happen.  A NULL Datum should convert to `Option::None` in all situations.

Secondly, @aykut-bozkurt has properly defined microseconds, which is critical for proper Time conversions.

From there, @usamoi enhanced our bindings generation such that we now auto-generate wrappers for any of Postgres' `static inline` functions in the included headers.  This is great as it eliminates our need to manually write these wrappers and it automatically exposes a lot more.

And thanks to @YohDeadfall `AnyArray` is now iterable!

As always, please upgrade using `cargo install cargo-pgrx --version 0.12.4 --locked`.  Then you can use `cargo pgrx upgrade` to update the dependencies in your extension crates.

## What's Changed

* use bindgen to generate wrappers of static inline functions by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/1844
* Unified argument names of Query methods by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/1848
* Fixes wrong value for microsecs in a day by @aykut-bozkurt in https://github.com/pgcentralfoundation/pgrx/pull/1849
* fix segfault converting a null `pg_sys::Datum` to a `String` by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/1853
* Added into_iter for anyarray by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/1851


**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.12.3...v0.12.4