### PR TITLE
Address elided lifetimes lints

### DIFF
--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -676,7 +676,7 @@ impl<'a> From<&'a [syn::Item]> for StructGraph<'a> {
 
 impl<'a> StructDescriptor<'a> {
     /// children returns an iterator over the children of this node in the graph
-    fn children(&'a self, graph: &'a StructGraph) -> StructDescriptorChildren {
+    fn children(&'a self, graph: &'a StructGraph) -> StructDescriptorChildren<'a> {
         StructDescriptorChildren { offset: 0, descriptor: self, graph }
     }
 }

--- a/pgrx-tests/src/tests/lifetime_tests.rs
+++ b/pgrx-tests/src/tests/lifetime_tests.rs
@@ -41,11 +41,11 @@ fn returns_option_ref_with_lifetime() -> Option<&'static str> {
 #[pg_extern]
 fn returns_tuple_with_lifetime<'a>(
     value: &'a str,
-) -> TableIterator<(name!(a, &'a str), name!(b, Option<&'a str>))> {
+) -> TableIterator<'a, (name!(a, &'a str), name!(b, Option<&'a str>))> {
     TableIterator::once((value, Some(value)))
 }
 
 #[pg_extern]
-fn returns_iterator_with_lifetime<'a>(value: &'a str) -> SetOfIterator<&'a str> {
+fn returns_iterator_with_lifetime<'a>(value: &'a str) -> SetOfIterator<'a, &'a str> {
     SetOfIterator::new(value.split_whitespace().into_iter())
 }

--- a/pgrx-tests/src/tests/trigger_tests.rs
+++ b/pgrx-tests/src/tests/trigger_tests.rs
@@ -96,7 +96,7 @@ mod tests {
     #[pg_trigger]
     fn field_species_fox_to_bear<'a>(
         trigger: &'a pgrx::PgTrigger<'a>,
-    ) -> Result<Option<PgHeapTuple<'_, impl WhoAllocated>>, TriggerError> {
+    ) -> Result<Option<PgHeapTuple<'a, impl WhoAllocated>>, TriggerError> {
         let mut new = trigger.new().ok_or(TriggerError::NullTriggerTuple)?.into_owned();
 
         let field = "species";

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -393,7 +393,7 @@ impl<'mcx, T: UnboxDatum> NullableContainer<'mcx, usize, <T as unbox::UnboxDatum
     }
 
     #[inline]
-    unsafe fn get_raw(&'mcx self, idx: usize) -> <T as unbox::UnboxDatum>::As<'_> {
+    unsafe fn get_raw(&'mcx self, idx: usize) -> <T as unbox::UnboxDatum>::As<'mcx> {
         self.get_strict_inner(idx).expect(
             "get_raw() called with an invalid index, bounds-checking\
             *should* occur before calling this method.",


### PR DESCRIPTION
Not writing a lifetime in these positions triggers some recent nightly lints. Seems harmless to just fix them.