### PR TITLE
Use `petgraph::algo::tarjan_scc` to order the schema graph

### DIFF
--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -417,7 +417,11 @@ impl PgrxSql {
                 }
             }
 
-            full_sql.push_str(&inner_sql.join("\n\n"));
+            if !inner_sql.is_empty() {
+                full_sql.push_str("/* <begin connected objects> */\n");
+                full_sql.push_str(&inner_sql.join("\n\n"));
+                full_sql.push_str("/* </end connected objects> */\n\n");
+            }
         }
 
         Ok(full_sql)

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -406,7 +406,7 @@ impl PgrxSql {
 
         // NB:  A properly we'd *like* to maintain is that the schema generator outputs
         // consistent results from run-to-run when there are no changes to the schema.
-        // This is to improve change detecting using simple tools like `diff`.
+        // This is to improve change detection using simple tools like `diff`.
         //
         // Historically, we used [`petgraph::algo:toposort`] but its ordering is not at all
         // consistent.


### PR DESCRIPTION
This seems to give a consistent ordering of the schema through consecutive runs of `cargo pgrx schema`.

It also allows `diff` to produce nice diffs when the schema changes compared to a previous version.

Tossing this up here to see if CI blows up on any of the tests or examples due to the schema being out of order.

I've tested this ordering with the `pg_search` extension (which is quite large) and it still generates a perfectly usable schema.  The same one from run to run, even!

It also adds comment markers around each connected block of sql objects, just to help better visualize the connectedness of the schema.

Closes #1866 