### PR TITLE
Trait TypmodInOutFuncs for input(input, oid, typmod) function

### DIFF
--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -969,7 +969,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         stream.extend(quote! {
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable,parallel_safe)]
-            pub fn #funcname_in #generics(input: Option<&::core::ffi::CStr>, oid: Option<i32>, typmod: Option<i32>) -> Option<#name #generics> {
+            pub fn #funcname_in #generics(input: Option<&::core::ffi::CStr>, oid: pgrx::pg_sys::Oid, typmod: i32) -> Option<#name #generics> {
                 input.map_or_else(|| {
                     for m in <#name as ::pgrx::inoutfuncs::TypmodInOutFuncs>::NULL_ERROR_MESSAGE {
                         ::pgrx::pg_sys::error!("{m}");

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -239,6 +239,8 @@ impl ToSql for SqlGraphEntity {
                             in_fn_module_path,
                             out_fn,
                             out_fn_module_path,
+                            typmod_in_fn,
+                            typmod_in_fn_module_path,
                             ..
                         }) = &context.graph[neighbor]
                         else {
@@ -249,7 +251,9 @@ impl ToSql for SqlGraphEntity {
                             && item.full_path.ends_with(in_fn);
                         let is_out_fn = item.full_path.starts_with(out_fn_module_path)
                             && item.full_path.ends_with(out_fn);
-                        is_in_fn || is_out_fn
+                        let is_typmod_in_fn = item.full_path.starts_with(typmod_in_fn_module_path)
+                            && item.full_path.ends_with(typmod_in_fn);
+                        is_in_fn || is_out_fn || is_typmod_in_fn
                     })
                 {
                     Ok(String::default())

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -232,7 +232,7 @@ impl ToSql for SqlGraphEntity {
                     result
                 } else if context
                     .graph
-                    .neighbors_undirected(*context.externs.get(item).unwrap())
+                    .neighbors_undirected(context.graph_root/* *context.externs.get(item).unwrap()*/)
                     .any(|neighbor| {
                         let SqlGraphEntity::Type(PostgresTypeEntity {
                             in_fn,

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -54,6 +54,7 @@ pub struct PostgresTypeDerive {
     generics: Generics,
     in_fn: Ident,
     out_fn: Ident,
+    typmod_in_fn: Ident,
     to_sql_config: ToSqlConfig,
 }
 
@@ -63,12 +64,13 @@ impl PostgresTypeDerive {
         generics: Generics,
         in_fn: Ident,
         out_fn: Ident,
+        typmod_in_fn: Ident,
         to_sql_config: ToSqlConfig,
     ) -> Result<CodeEnrichment<Self>, syn::Error> {
         if !to_sql_config.overrides_default() {
             crate::ident_is_acceptable_to_postgres(&name)?;
         }
-        Ok(CodeEnrichment(Self { generics, name, in_fn, out_fn, to_sql_config }))
+        Ok(CodeEnrichment(Self { generics, name, in_fn, out_fn, typmod_in_fn, to_sql_config }))
     }
 
     pub fn from_derive_input(
@@ -90,11 +92,16 @@ impl PostgresTypeDerive {
             &format!("{}_out", derive_input.ident).to_lowercase(),
             derive_input.ident.span(),
         );
+        let funcname_typmod_in = Ident::new(
+            &format!("{}_typmod_in", derive_input.ident).to_lowercase(),
+            derive_input.ident.span(),
+        );
         Self::new(
             derive_input.ident,
             derive_input.generics,
             funcname_in,
             funcname_out,
+            funcname_typmod_in,
             to_sql_config,
         )
     }
@@ -124,6 +131,7 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
 
         let in_fn = &self.in_fn;
         let out_fn = &self.out_fn;
+        let typmod_in_fn = &self.typmod_in_fn;
 
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_type_{}", self.name);
 
@@ -189,6 +197,13 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
                     },
+                    typmod_in_fn: stringify!(#typmod_in_fn),
+                    typmod_in_fn_module_path: {
+                        let typmod_in_fn = stringify!(#typmod_in_fn);
+                        let mut path_items: Vec<_> = typmod_in_fn.split("::").collect();
+                        let _ = path_items.pop(); // Drop the one we don't want.
+                        path_items.join("::")
+                    },
                     to_sql_config: #to_sql_config,
                 };
                 ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity::Type(submission)
@@ -205,6 +220,7 @@ impl Parse for CodeEnrichment<PostgresTypeDerive> {
         let to_sql_config = ToSqlConfig::from_attributes(attrs.as_slice())?.unwrap_or_default();
         let in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
         let out_fn = Ident::new(&format!("{}_out", ident).to_lowercase(), ident.span());
-        PostgresTypeDerive::new(ident, generics, in_fn, out_fn, to_sql_config)
+        let typmod_in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
+        PostgresTypeDerive::new(ident, generics, in_fn, out_fn, typmod_in_fn, to_sql_config)
     }
 }

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -220,7 +220,7 @@ impl Parse for CodeEnrichment<PostgresTypeDerive> {
         let to_sql_config = ToSqlConfig::from_attributes(attrs.as_slice())?.unwrap_or_default();
         let in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
         let out_fn = Ident::new(&format!("{}_out", ident).to_lowercase(), ident.span());
-        let typmod_in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
+        let typmod_in_fn = Ident::new(&format!("{}_typmod_in", ident).to_lowercase(), ident.span());
         PostgresTypeDerive::new(ident, generics, in_fn, out_fn, typmod_in_fn, to_sql_config)
     }
 }

--- a/pgrx/src/inoutfuncs.rs
+++ b/pgrx/src/inoutfuncs.rs
@@ -18,6 +18,7 @@ use crate::*;
 #[doc(hidden)]
 pub use serde_json::{from_slice as json_from_slice, to_vec as json_to_vec};
 use crate::pg_sys::Oid;
+use core::ffi::CStr;
 
 /// `#[derive(Copy, Clone, PostgresType)]` types need to implement this trait to provide the text
 /// input/output functions for that type
@@ -68,6 +69,10 @@ pub trait TypmodInOutFuncs {
 
     /// Convert `Self` into text by writing to the supplied `StringInfo` buffer
     fn output(&self, buffer: &mut StringInfo);
+
+    /// The type_modifier_input_function is passed the declared modifier(s) in the form of a cstring array. It must check the values for validity (throwing an error if they are wrong), and if they are correct, return a single non-negative integer value that will be stored as the column “typmod”. 
+    fn typmod_in(input: Array<&CStr>) -> i32 ;
+
 
     /// If PostgreSQL calls the conversion function with NULL as an argument, what
     /// error message should be generated?

--- a/pgrx/src/inoutfuncs.rs
+++ b/pgrx/src/inoutfuncs.rs
@@ -62,7 +62,7 @@ pub trait TypmodInOutFuncs {
     /// Given a string representation of `Self`, parse it into `Self`.
     ///
     /// It is expected that malformed input will raise an `error!()` or `panic!()`
-    fn input(input: &core::ffi::CStr, oid: Option<i32>, typmod: Option<i32>) -> Self
+    fn input(input: &core::ffi::CStr, oid: Oid, typmod: i32) -> Self
     where
         Self: Sized;
 

--- a/pgrx/src/prelude.rs
+++ b/pgrx/src/prelude.rs
@@ -34,7 +34,7 @@ pub use crate::datum::{
     Numeric, PgVarlena, PostgresType, Range, RangeBound, RangeSubType, Time, TimeWithTimeZone,
     Timestamp, TimestampWithTimeZone, VariadicArray,
 };
-pub use crate::inoutfuncs::{InOutFuncs, PgVarlenaInOutFuncs};
+pub use crate::inoutfuncs::{InOutFuncs, TypmodInOutFuncs, PgVarlenaInOutFuncs};
 
 // Trigger support
 pub use crate::trigger_support::{


### PR DESCRIPTION
https://www.postgresql.org/docs/current/sql-createtype.html
> The input function can be declared as taking one argument of type cstring, or as taking three arguments of types cstring, oid, integer. The first argument is the input text as a C string, the second argument is the type's own OID (except for array types, which instead receive their element type's OID), and the third is the typmod of the destination column, if known (-1 will be passed if not). 

This trait allows for the input function to take three arguments...