### PR TITLE
Added `oids_of!` macro

### DIFF
--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -217,7 +217,10 @@ pub trait PostgresType {}
 /// ```
 #[macro_export]
 macro_rules! oids_of {
-    ($($t:path),* $(,)?) => ({
-        [$(::pgrx::pg_sys::PgOid::from(<$t>::type_oid())),*]
-    });
+    () =>(
+        [$crate::pg_sys::PgOid::Invalid; 0]
+    );
+    ($($t:path),+ $(,)?) => (
+        [$($crate::pg_sys::PgOid::from(<$t>::type_oid())),*]
+    );
 }

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -204,3 +204,20 @@ impl<'src, T: IntoDatum> From<T> for DatumWithOid<'src> {
 /// A tagging trait to indicate a user type is also meant to be used by Postgres
 /// Implemented automatically by `#[derive(PostgresType)]`
 pub trait PostgresType {}
+
+/// Creates a [`Vec<pg_sys::Oid>`] containing identifiers of the provded types.
+///
+/// # Examples
+///
+/// ```
+/// use pgrx::{oids_of, datum::IntoDatum};
+/// let v = oids_of![i32, f64];
+/// assert_eq!(v[0], i32::type_oid().into());
+/// assert_eq!(v[1], f64::type_oid().into());
+/// ```
+#[macro_export]
+macro_rules! oids_of {
+    ($($t:path),* $(,)?) => ({
+        [$(::pgrx::pg_sys::PgOid::from(<$t>::type_oid())),*]
+    });
+}

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -205,12 +205,13 @@ impl<'src, T: IntoDatum> From<T> for DatumWithOid<'src> {
 /// Implemented automatically by `#[derive(PostgresType)]`
 pub trait PostgresType {}
 
-/// Creates a [`Vec<pg_sys::Oid>`] containing identifiers of the provded types.
+/// Creates an array of [`pg_sys::Oid`] with the OID of each provided type
 ///
 /// # Examples
 ///
 /// ```
 /// use pgrx::{oids_of, datum::IntoDatum};
+///
 /// let oids = oids_of![i32, f64];
 /// assert_eq!(oids[0], i32::type_oid().into());
 /// assert_eq!(oids[1], f64::type_oid().into());
@@ -223,6 +224,7 @@ pub trait PostgresType {}
 #[macro_export]
 macro_rules! oids_of {
     () =>(
+        // avoid coercions to an ambiguously-typed array or slice
         [$crate::pg_sys::PgOid::Invalid; 0]
     );
     ($($t:path),+ $(,)?) => (

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -211,9 +211,14 @@ pub trait PostgresType {}
 ///
 /// ```
 /// use pgrx::{oids_of, datum::IntoDatum};
-/// let v = oids_of![i32, f64];
-/// assert_eq!(v[0], i32::type_oid().into());
-/// assert_eq!(v[1], f64::type_oid().into());
+/// let oids = oids_of![i32, f64];
+/// assert_eq!(oids[0], i32::type_oid().into());
+/// assert_eq!(oids[1], f64::type_oid().into());
+///
+/// // the usual conversions or coercions are available
+/// let oid_vec = oids_of![i8, i16].to_vec();
+/// let no_oid = &oids_of![];
+/// assert_eq!(no_oid.len(), 0);
 /// ```
 #[macro_export]
 macro_rules! oids_of {

--- a/pgrx/src/prelude.rs
+++ b/pgrx/src/prelude.rs
@@ -29,12 +29,15 @@ pub use crate::pgbox::{AllocatedByPostgres, AllocatedByRust, PgBox, WhoAllocated
 // These could be factored into a temporal type module that could be easily imported for code which works with them.
 // However, reexporting them seems fine for now.
 
-pub use crate::datum::{
-    datetime_support::*, AnyNumeric, Array, ArraySliceError, Date, FromDatum, Interval, IntoDatum,
-    Numeric, PgVarlena, PostgresType, Range, RangeBound, RangeSubType, Time, TimeWithTimeZone,
-    Timestamp, TimestampWithTimeZone, VariadicArray,
-};
 pub use crate::inoutfuncs::{InOutFuncs, PgVarlenaInOutFuncs};
+pub use crate::{
+    datum::{
+        datetime_support::*, AnyNumeric, Array, ArraySliceError, Date, FromDatum, Interval,
+        IntoDatum, Numeric, PgVarlena, PostgresType, Range, RangeBound, RangeSubType, Time,
+        TimeWithTimeZone, Timestamp, TimestampWithTimeZone, VariadicArray,
+    },
+    oids_of,
+};
 
 // Trigger support
 pub use crate::trigger_support::{


### PR DESCRIPTION
That's an improvement for SPI making it less cumbersome. Just to feel the difference look at the tests. Who would really want to write something like `PgBuiltInOids::INT4OID.oid()` instead of just telling a Rust type?

I will change the behavior of this macro a bit when you will be ready for shipping `0.13`, so it won't produce any vector but a slice.