### PR TITLE
fix(pgrx-bindgen): remove anonymous enum deprecation

### DIFF
--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -114,7 +114,7 @@ impl bindgen::callbacks::ParseCallbacks for BindingOverride {
         enum_name.inspect(|name| match name.strip_prefix("enum").unwrap_or(name).trim() {
             // specifically overridden enum
             "NodeTag" => return,
-            name if name.contains("unnamed at") => return,
+            name if name.contains("unnamed at") || name.contains("anonymous at") => return,
             // to prevent problems with BuiltinOid
             _ if variant_name.contains("OID") => return,
             name => self


### PR DESCRIPTION
This PR is to exclude anonymous enum deprecation from bindgen. Fix #1822.

On Ubuntu 20.04.6 LTS, the anonymous enum like below (from Postgres source code `src/pl/plpgsql/src/plpgsql.h`):

```c
enum
{
	PLPGSQL_RC_OK,
	PLPGSQL_RC_EXIT,
	PLPGSQL_RC_RETURN,
	PLPGSQL_RC_CONTINUE,
};
```

will be generated Rust code with module name for enum like this:

```rust
#[deprecated(since = "0.12.0", note = "you want pg_sys::(anonymous at /home/bo/.pgrx/15.8/pgrx-install/include/postgresql/server/plpgsql.h:136:1)::PLPGSQL_RC_OK")]
pub const (anonymous at /home/bo/.pgrx/15.8/pgrx-install/include/postgresql/server/plpgsql.h:136:1)_PLPGSQL_RC_OK: u32 = 0;
```

This generated Rust code is invalid because the anonymous enum name is set to `(anonymous at /home/bo/.pgrx/15.8/pgrx-install/include/postgresql/server/plpgsql.h:136:1)`, which cannot be used as module name. So we need to exclude anonymous enum like that.

Note: This issue doesn't happen on Ubuntu 22.04.4 LTS and above.