### PR TITLE
Add `BorrowDatum` for unsizing borrows of datums

### DIFF
--- a/pgrx-tests/src/tests/borrow_datum.rs
+++ b/pgrx-tests/src/tests/borrow_datum.rs
@@ -1,0 +1,83 @@
+use pgrx::prelude::*;
+
+// BorrowDatum only describes something as a valid argument, but every &T has a U we CAN return,
+// going from &T as arg to T as ret type. We also don't necessarily have SPI support for each type.
+// Thus we don't *exactly* reuse the roundtrip test macro.
+
+macro_rules! clonetrip {
+    ($fname:ident, $tname:ident, &$lt:lifetime $rtype:ty, &$expected:expr) => {
+        #[pg_extern]
+        fn $fname<$lt>(i: &$lt $rtype) -> $rtype {
+            i.clone()
+        }
+
+        clonetrip_test!($fname, $tname, &'_ $rtype, $expected);
+    };
+    ($fname:ident, $tname:ident, &$lt:lifetime $ref_ty:ty => $own_ty:ty, $test:expr, $value:expr) => {
+        #[pg_extern]
+        fn $fname(i: &$ref_ty) -> $own_ty {
+            i.into()
+        }
+
+        clonetrip_test!($fname, $tname, &'_ $ref_ty => $own_ty, $test, $value);
+    };
+}
+
+macro_rules! clonetrip_test {
+    ($fname:ident, $tname:ident, &'_ $rtype:ty, $expected:expr) => {
+        #[pg_test]
+        fn $tname() -> Result<(), Box<dyn std::error::Error>> {
+            let expected: $rtype = $expected;
+            let result: $rtype = Spi::get_one_with_args(
+                &format!("SELECT {}($1)", stringify!(tests.$fname)),
+                vec![(PgOid::from(<$rtype>::type_oid()), expected.into_datum())],
+            )?
+            .unwrap();
+
+            assert_eq!(&$expected, &result);
+            Ok(())
+        }
+    };
+    ($fname:ident, $tname:ident, $ref_ty:ty => $own_ty:ty, $test:expr, $value:expr) => {
+        #[pg_test]
+        fn $tname() -> Result<(), Box<dyn std::error::Error>> {
+            let value: $own_ty = $value;
+            let result: $own_ty = Spi::get_one_with_args(
+                &format!("SELECT {}($1)", stringify!(tests.$fname)),
+                vec![(PgOid::from(<$ref_ty>::type_oid()), value.into_datum())],
+            )?
+            .unwrap();
+
+            assert_eq!($test, &*result);
+            Ok(())
+        }
+    };
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    #[allow(unused)]
+    use crate as pgrx_tests;
+
+    // Exercising BorrowDatum impls
+    clonetrip!(clone_bool, test_clone_bool, &'a bool, &false);
+    clonetrip!(clone_i8, test_clone_i8, &'a i8, &i8::MIN);
+    clonetrip!(clone_i16, test_clone_i16, &'a i16, &i16::MIN);
+    clonetrip!(clone_i32, test_clone_i32, &'a i32, &-1i32);
+    clonetrip!(clone_f64, test_clone_f64, &'a f64, &f64::NEG_INFINITY);
+    clonetrip!(
+        clone_point,
+        test_clone_point,
+        &'a pg_sys::Point,
+        &pg_sys::Point { x: -1.0, y: f64::INFINITY }
+    );
+    clonetrip!(clone_str, test_clone_str, &'a str => String, "string", String::from("string"));
+    clonetrip!(
+        clone_oid,
+        test_clone_oid,
+        &'a pg_sys::Oid,
+        &pg_sys::Oid::from(pg_sys::BuiltinOid::RECORDOID)
+    );
+}

--- a/pgrx-tests/src/tests/borrow_datum.rs
+++ b/pgrx-tests/src/tests/borrow_datum.rs
@@ -60,6 +60,7 @@ mod tests {
     use super::*;
     #[allow(unused)]
     use crate as pgrx_tests;
+    use std::ffi::{CStr, CString};
 
     // Exercising BorrowDatum impls
     clonetrip!(clone_bool, test_clone_bool, &'a bool, &false);
@@ -73,7 +74,7 @@ mod tests {
         &'a pg_sys::Point,
         &pg_sys::Point { x: -1.0, y: f64::INFINITY }
     );
-    clonetrip!(clone_str, test_clone_str, &'a str => String, "string", String::from("string"));
+    clonetrip!(clone_str, test_clone_str, &'a CStr => CString, c"cee string", CString::from(c"cee string"));
     clonetrip!(
         clone_oid,
         test_clone_oid,

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod attributes_tests;
 mod bgworker_tests;
 #[cfg(feature = "cshim")]
 mod bindings_of_inline_fn_tests;
+mod borrow_datum;
 mod bytea_tests;
 mod cfg_tests;
 mod complex;

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -266,11 +266,11 @@ argue_from_datum! { 'fcx; Date, Interval, Time, TimeWithTimeZone, Timestamp, Tim
 argue_from_datum! { 'fcx; AnyArray, AnyElement, AnyNumeric }
 argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid, PgRelation }
 argue_from_datum! { 'fcx; pg_sys::BOX, pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point }
-argue_from_datum! { 'fcx; &'fcx str, &'fcx CStr, &'fcx [u8] }
+argue_from_datum! { 'fcx; &'fcx str, &'fcx [u8] }
 
 unsafe impl<'fcx, T> ArgAbi<'fcx> for &'fcx T
 where
-    T: BorrowDatum,
+    T: ?Sized + BorrowDatum,
 {
     unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> &'fcx T {
         let ptr: *mut u8 = match T::PASS {

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -274,9 +274,8 @@ where
 {
     unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> &'fcx T {
         let ptr: *mut u8 = match T::PASS {
-            Some(PassBy::Ref) => arg.2.value.cast_mut_ptr(),
-            Some(PassBy::Value) => ptr::addr_of!(arg.0.raw_args()[arg.1].value).cast_mut().cast(),
-            _ => todo!(),
+            PassBy::Ref => arg.2.value.cast_mut_ptr(),
+            PassBy::Value => ptr::addr_of!(arg.0.raw_args()[arg.1].value).cast_mut().cast(),
         };
         unsafe { &*T::point_from(ptr) }
     }

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -277,7 +277,7 @@ where
             PassBy::Ref => arg.2.value.cast_mut_ptr(),
             PassBy::Value => ptr::addr_of!(arg.0.raw_args()[arg.1].value).cast_mut().cast(),
         };
-        unsafe { &*T::point_from(ptr) }
+        unsafe { T::borrow_unchecked(ptr) }
     }
 
     unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
@@ -288,7 +288,7 @@ where
         if arg.is_null() || ptr.is_null() {
             Nullable::Null
         } else {
-            unsafe { Nullable::Valid(&*T::point_from(ptr)) }
+            unsafe { Nullable::Valid(T::borrow_unchecked(ptr)) }
         }
     }
 }

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -279,6 +279,18 @@ where
         };
         unsafe { &*T::point_from(ptr) }
     }
+
+    unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
+        let ptr: *mut u8 = match T::PASS {
+            PassBy::Ref => arg.2.value.cast_mut_ptr(),
+            PassBy::Value => ptr::addr_of!(arg.0.raw_args()[arg.1].value).cast_mut().cast(),
+        };
+        if arg.is_null() || ptr.is_null() {
+            Nullable::Null
+        } else {
+            unsafe { Nullable::Valid(&*T::point_from(ptr)) }
+        }
+    }
 }
 
 /// How to return a value from Rust to Postgres

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -266,6 +266,10 @@ argue_from_datum! { 'fcx; Date, Interval, Time, TimeWithTimeZone, Timestamp, Tim
 argue_from_datum! { 'fcx; AnyArray, AnyElement, AnyNumeric }
 argue_from_datum! { 'fcx; Inet, Internal, Json, JsonB, Uuid, PgRelation }
 argue_from_datum! { 'fcx; pg_sys::BOX, pg_sys::ItemPointerData, pg_sys::Oid, pg_sys::Point }
+// We could use the upcoming impl of ArgAbi for `&'fcx T where T: ?Sized + BorrowDatum`
+// to support these types by implementing BorrowDatum for them also, but we reject this.
+// It would greatly complicate other users of BorrowDatum like FlatArray, which want all impls
+// of BorrowDatum to return a borrow of the entire pointee's len.
 argue_from_datum! { 'fcx; &'fcx str, &'fcx [u8] }
 
 unsafe impl<'fcx, T> ArgAbi<'fcx> for &'fcx T

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -14,14 +14,21 @@ use core::ffi;
 pub unsafe trait BorrowDatum {
     /// Lossless zero-unboxing reference conversion.
     ///
-    /// By calling this you assert the Datum is not an SQL Null and, for pass-by-reference types,
-    /// this Datum points to a valid instance of that type.
+    /// # Safety
+    /// * The Datum must not be an SQL Null.
+    /// * For pass-by-reference types, this Datum must point to a valid instance of that type.
     unsafe fn borrow_from<'dat>(datum: &'dat Datum<'_>) -> &'dat Self;
 
     /// Lossless zero-unboxing mutable reference conversion.
     ///
-    /// By calling this you assert the Datum is not an SQL Null and, for pass-by-reference types,
-    /// this Datum points to a valid instance of that type.
+    /// # Safety
+    /// * The Datum must not be an SQL Null.
+    /// * For pass-by-reference types, this Datum must point to a valid instance of that type.
+    ///
+    /// **Design Note:** For pass-by-value types, if you yield two successive `&mut Datum<'_>`,
+    /// and the underlying source is e.g. an ArrayType or one of the many Tuples of Postgres,
+    /// then merely yielding two `&mut Datum<'_>`s in a row is unsound. This is because the bytes
+    /// of one Datum can overlap with the next. Uh... whoops?
     unsafe fn borrow_mut_from<'dat>(datum: &'dat mut Datum<'_>) -> &'dat mut Self;
 }
 

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -1,0 +1,65 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+use super::*;
+use core::ffi;
+
+/// Converts `&Datum` to `&T`
+///
+/// Only for types which can be losslessly referenced from a borrow of a Datum, without unboxing.
+/// For instance, you may not borrow `&String` from `&Datum<'_>`: that just doesn't work as it
+/// requires a full unboxing to be performed. You may, however, claim `&str` from the datum.
+/// Implementers are expected to uphold this obligation.
+///
+/// Note that this is unaware of "detoasting".
+// TODO: Implement the DetoastDatum this is supposed to combine with.
+pub unsafe trait BorrowDatum {
+    /// Lossless zero-unboxing reference conversion.
+    ///
+    /// By calling this you assert the Datum is not an SQL Null and, for pass-by-reference types,
+    /// this Datum points to a valid instance of that type.
+    unsafe fn borrow_from<'dat>(datum: &'dat Datum<'_>) -> &'dat Self;
+
+    /// Lossless zero-unboxing mutable reference conversion.
+    ///
+    /// By calling this you assert the Datum is not an SQL Null and, for pass-by-reference types,
+    /// this Datum points to a valid instance of that type.
+    unsafe fn borrow_mut_from<'dat>(datum: &'dat mut Datum<'_>) -> &'dat mut Self;
+}
+
+macro_rules! borrow_by_value {
+    ($($value_ty:ty),*) => {
+        $(
+            unsafe impl BorrowDatum for $value_ty {
+                /// Directly cast `&Datum as &Self`
+                unsafe fn borrow_from<'dat>(datum: &'dat Datum<'_>) -> &'dat Self {
+                    unsafe { &*(datum as *const Datum<'_> as *const Self) }
+                }
+                /// Directly cast `&mut Datum as &mut Self`
+                unsafe fn borrow_mut_from<'dat>(datum: &'dat mut Datum<'_>) -> &'dat mut Self {
+                    unsafe { &mut *(datum as *mut Datum<'_> as *mut Self) }
+                }
+            }
+        )*
+    }
+}
+
+borrow_by_value! {
+    i8, i16, i32, i64, bool, f32, f64, pg_sys::Oid, Date, Time, Timestamp, TimestampWithTimeZone
+}
+
+/// It is rare to pass CStr via Datums, but not unheard of
+unsafe impl BorrowDatum for ffi::CStr {
+    /// Treat `&Datum` as `&*const ffi::c_char` and then deref-reborrow it,
+    /// with the same constraints as [`ffi::CStr::from_ptr`].
+    unsafe fn borrow_from<'dat>(datum: &'dat Datum<'_>) -> &'dat Self {
+        unsafe { ffi::CStr::from_ptr(*datum.0.cast_mut_ptr()) }
+    }
+
+    /// Treat `&mut Datum` as `&mut *mut ffi::c_char` and then deref-reborrow it,
+    /// with the same constraints as [`ffi::CStr::from_ptr`].
+    unsafe fn borrow_mut_from<'dat>(datum: &'dat mut Datum<'_>) -> &'dat mut Self {
+        let char_ptr: *mut ffi::c_char = datum.0.cast_mut_ptr();
+        let len = unsafe { ffi::CStr::from_ptr(char_ptr).to_bytes().len() };
+        let slice_ptr = core::ptr::slice_from_raw_parts_mut(char_ptr, len + 1);
+        unsafe { &mut *(slice_ptr as *mut ffi::CStr) }
+    }
+}

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -31,6 +31,7 @@ pub unsafe trait BorrowDatum {
     /// # Safety
     /// - This must be correctly invoked for the pointee type, as it may deref and read one or more
     ///   bytes in its implementation in order to read the inline metadata and unsize the type.
+    /// - This must be invoked with a pointee initialized for the dynamically specified length.
     ///
     /// ## For Implementers
     /// Reading the **first** byte pointed to is permitted if `T::PASS = PassBy::Ref`, assuming you

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -25,7 +25,7 @@ pub unsafe trait BorrowDatum {
     /// - `PassBy::Ref` means the pointee will occupy at least 1 byte for variable-sized types.
     ///
     /// Note that this means a zero-sized type is inappropriate for `BorrowDatum`.
-    const PASS: Option<PassBy>;
+    const PASS: PassBy;
 
     /// Cast a pointer to this blob of bytes to a pointer to this type.
     ///
@@ -62,10 +62,10 @@ macro_rules! borrow_by_value {
     ($($value_ty:ty),*) => {
         $(
             unsafe impl BorrowDatum for $value_ty {
-                const PASS: Option<PassBy> = if mem::size_of::<Self>() <= mem::size_of::<Datum>() {
-                    Some(PassBy::Value)
+                const PASS: PassBy = if mem::size_of::<Self>() <= mem::size_of::<Datum>() {
+                    PassBy::Value
                 } else {
-                    Some(PassBy::Ref)
+                    PassBy::Ref
                 };
 
                 unsafe fn point_from(ptr: *mut u8) -> *mut Self {
@@ -82,7 +82,7 @@ borrow_by_value! {
 
 /// It is rare to pass CStr via Datums, but not unheard of
 unsafe impl BorrowDatum for ffi::CStr {
-    const PASS: Option<PassBy> = Some(PassBy::Ref);
+    const PASS: PassBy = PassBy::Ref;
 
     unsafe fn point_from(ptr: *mut u8) -> *mut Self {
         let char_ptr: *mut ffi::c_char = ptr.cast();

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -9,8 +9,7 @@ use core::{ffi, mem, ptr};
 /// Despite its pleasant-sounding name, this implements a fairly low-level detail.
 /// It exists to allow other code to use that nice-sounding BorrowDatum bound.
 /// Outside of the pgrx library, it is probably incorrect to call and rely on this:
-/// instead use the convenience functions available in `pgrx::datum`.
-// TODO: implement those.
+/// instead use convenience functions `Datum::borrow_as`.
 ///
 /// Its behavior is trusted for ABI details, and it should not be implemented if any doubt
 /// exists of whether the type would be suitable for passing via Postgres.
@@ -104,6 +103,7 @@ macro_rules! impl_borrow_fixed_len {
     }
 }
 
+// FIXME: these value-based impls are not actually well-tested in argument position
 impl_borrow_fixed_len! {
     i8, i16, i32, i64, bool, f32, f64, pg_sys::Oid, Date, Time, Timestamp, TimestampWithTimeZone
 }

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -103,9 +103,10 @@ macro_rules! impl_borrow_fixed_len {
     }
 }
 
-// FIXME: these value-based impls are not actually well-tested in argument position
 impl_borrow_fixed_len! {
-    i8, i16, i32, i64, bool, f32, f64, pg_sys::Oid, Date, Time, Timestamp, TimestampWithTimeZone
+    i8, i16, i32, i64, bool, f32, f64,
+    pg_sys::Oid, pg_sys::Point,
+    Date, Time, Timestamp, TimestampWithTimeZone
 }
 
 /// It is rare to pass CStr via Datums, but not unheard of

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -94,4 +94,9 @@ unsafe impl BorrowDatum for ffi::CStr {
         let len = unsafe { ffi::CStr::from_ptr(char_ptr).to_bytes_with_nul().len() };
         ptr::slice_from_raw_parts_mut(char_ptr, len) as *mut Self
     }
+
+    unsafe fn borrow_unchecked<'dat>(ptr: *const u8) -> &'dat Self {
+        let char_ptr: *const ffi::c_char = ptr.cast();
+        unsafe { ffi::CStr::from_ptr(char_ptr) }
+    }
 }

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -55,12 +55,12 @@ pub unsafe trait BorrowDatum {
     /// - This must be 4-byte aligned!
     unsafe fn point_from_align4(ptr: ptr::NonNull<u32>) -> ptr::NonNull<Self> {
         debug_assert!(ptr.is_aligned());
-        unsafe { <Self as BorrowDatum>::point_from(ptr.cast()) }
+        unsafe { BorrowDatum::point_from(ptr.cast()) }
     }
 
     /// Optimization for borrowing the referent
     unsafe fn borrow_unchecked<'dat>(ptr: ptr::NonNull<u8>) -> &'dat Self {
-        unsafe { Self::point_from(ptr).as_ref() }
+        unsafe { BorrowDatum::point_from(ptr).as_ref() }
     }
 }
 

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -56,6 +56,11 @@ pub unsafe trait BorrowDatum {
         debug_assert!(ptr.is_aligned());
         unsafe { <Self as BorrowDatum>::point_from(ptr.cast()) }
     }
+
+    /// Optimization for borrowing the referent
+    unsafe fn borrow_unchecked<'dat>(ptr: *const u8) -> &'dat Self {
+        unsafe { &*Self::point_from(ptr.cast_mut()) }
+    }
 }
 
 macro_rules! borrow_by_value {

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -86,7 +86,7 @@ unsafe impl BorrowDatum for ffi::CStr {
 
     unsafe fn point_from(ptr: *mut u8) -> *mut Self {
         let char_ptr: *mut ffi::c_char = ptr.cast();
-        let len = unsafe { ffi::CStr::from_ptr(char_ptr).to_bytes().len() };
-        ptr::slice_from_raw_parts_mut(char_ptr, len + 1) as *mut Self
+        let len = unsafe { ffi::CStr::from_ptr(char_ptr).to_bytes_with_nul().len() };
+        ptr::slice_from_raw_parts_mut(char_ptr, len) as *mut Self
     }
 }

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -37,7 +37,7 @@ pub unsafe trait BorrowDatum {
     /// are implementing a varlena type. As the other dynamic length type, CStr also does this.
     /// This function
     /// - must NOT mutate the pointee
-    /// - must return a pointer with provenance to the entire allocation
+    /// - must point to the entire datum's length (`size_of_val` must not lose bytes)
     ///
     /// Do not attempt to handle pass-by-value versus pass-by-ref in this fn's body!
     /// A caller may be in a context where all types are handled by-reference, for instance.
@@ -63,7 +63,7 @@ pub unsafe trait BorrowDatum {
     }
 }
 
-macro_rules! borrow_by_value {
+macro_rules! impl_borrow_fixed_len {
     ($($value_ty:ty),*) => {
         $(
             unsafe impl BorrowDatum for $value_ty {
@@ -81,7 +81,7 @@ macro_rules! borrow_by_value {
     }
 }
 
-borrow_by_value! {
+impl_borrow_fixed_len! {
     i8, i16, i32, i64, bool, f32, f64, pg_sys::Oid, Date, Time, Timestamp, TimestampWithTimeZone
 }
 

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -9,7 +9,7 @@ use core::{ffi, mem, ptr};
 /// Despite its pleasant-sounding name, this implements a fairly low-level detail.
 /// It exists to allow other code to use that nice-sounding BorrowDatum bound.
 /// Outside of the pgrx library, it is probably incorrect to call and rely on this:
-/// instead use convenience functions `Datum::borrow_as`.
+/// instead use convenience functions like `Datum::borrow_as`.
 ///
 /// Its behavior is trusted for ABI details, and it should not be implemented if any doubt
 /// exists of whether the type would be suitable for passing via Postgres.

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -139,7 +139,7 @@ pub struct Datum<'src>(
 );
 
 impl<'src> Datum<'src> {
-    /// The Datum without its lifetime.
+    /// Strip a Datum of its lifetime for FFI purposes.
     pub fn sans_lifetime(self) -> pg_sys::Datum {
         self.0
     }

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -16,6 +16,7 @@
 mod anyarray;
 mod anyelement;
 mod array;
+mod borrow;
 mod date;
 pub mod datetime_support;
 mod from;
@@ -44,6 +45,7 @@ pub use self::uuid::*;
 pub use anyarray::*;
 pub use anyelement::*;
 pub use array::*;
+pub use borrow::*;
 pub use date::*;
 pub use datetime_support::*;
 pub use from::*;

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -35,7 +35,7 @@ pub(crate) struct Layout {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum PassBy {
+pub enum PassBy {
     Ref,
     Value,
 }

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -55,6 +55,7 @@ pub mod htup;
 pub mod inoutfuncs;
 pub mod itemptr;
 pub mod iter;
+pub mod layout;
 pub mod list;
 pub mod lwlock;
 pub mod memcx;
@@ -79,7 +80,6 @@ pub mod wrappers;
 pub mod xid;
 
 /// Not ready for public exposure.
-mod layout;
 mod ptr;
 mod slice;
 mod toast;


### PR DESCRIPTION
Add a trait that allows borrowing Datums from various places, like arguments and arrays, instead of always taking them by-value. This is most important for unsizing borrows, as the sized kind are a simple `.cast()` away.

The motivating rationale is to enable new APIs in the near future like FlatArray and Text. It also brings in some more uniformity because of the blanket-impl of ArgAbi for `&T`. This means that various types that _are_ pass-by-reference may now actually be taken by reference from their Datum, instead of copying them into the Rust function! This is more important for unsized types, but for various reasons, right now it only takes over the ArgAbi of one unsized type: CStr.