### PR TITLE
Always panic if len of varlena exceeds the maximum

### DIFF
--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -337,10 +337,12 @@ impl_into_datum_c_str!(&CStr);
 impl<'a> IntoDatum for &'a [u8] {
     /// # Panics
     ///
-    /// This function will panic if the string being converted to a datum is longer than a half of [`i32::MAX`].
+    /// This function will panic if the string being converted to a datum
+    //  is longer than 1 GiB including 4 bytes used for a header.
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let len = pg_sys::VARHDRSZ + self.len();
+        let len = self.len().saturating_add(pg_sys::VARHDRSZ);
+        assert!(len < (u32::MAX as usize >> 2));
         unsafe {
             // SAFETY:  palloc gives us a valid pointer and if there's not enough memory it'll raise an error
             let varlena = pg_sys::palloc(len) as *mut pg_sys::varlena;
@@ -351,10 +353,9 @@ impl<'a> IntoDatum for &'a [u8] {
                 &mut varlena.cast::<pg_sys::varattrib_4b>().as_mut().unwrap_unchecked().va_4byte;
 
             // This is the same as Postgres' `#define SET_VARSIZE_4B` (which have over in
-            // `pgrx/src/varlena.rs`), however we're asserting that the input string isn't too big
-            // for a Postgres varlena, since it's limited to 32bits -- in reality it's a quarter
-            // that length, but this is good enough
-            assert!(len < (u32::MAX as usize >> 2));
+            // `pgrx/src/varlena.rs`), however we're asserting above that the input string
+            // isn't too big for a Postgres varlena, since it's limited to 32 bits and,
+            // in reality, it's a quarter that length, but this is good enough
             set_varsize_4b(varlena, len as i32);
 
             // SAFETY: src and dest pointers are valid, exactly `self.len()` bytes long,

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -337,7 +337,7 @@ impl_into_datum_c_str!(&CStr);
 impl<'a> IntoDatum for &'a [u8] {
     /// # Panics
     ///
-    /// This function will panic if the string being converted to a datum is longer than a `u32`.
+    /// This function will panic if the string being converted to a datum is longer than a half of [`i32::MAX`].
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         let len = pg_sys::VARHDRSZ + self.len();
@@ -352,9 +352,9 @@ impl<'a> IntoDatum for &'a [u8] {
 
             // This is the same as Postgres' `#define SET_VARSIZE_4B` (which have over in
             // `pgrx/src/varlena.rs`), however we're asserting that the input string isn't too big
-            // for a Postgres varlena, since it's limited to 32bits -- in reality it's about half
+            // for a Postgres varlena, since it's limited to 32bits -- in reality it's a quarter
             // that length, but this is good enough
-            debug_assert!(len < (u32::MAX as usize >> 2));
+            assert!(len < (u32::MAX as usize >> 2));
             set_varsize_4b(varlena, len as i32);
 
             // SAFETY: src and dest pointers are valid, exactly `self.len()` bytes long,

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -15,7 +15,7 @@ use core::{ops::DerefMut, slice, str};
 /// # Safety
 ///
 /// The caller asserts the specified `ptr` really is a non-null, palloc'd [`pg_sys::varlena`] pointer
-/// that is aligned to 4 bytes.
+/// that is aligned to 4 bytes, and that the `len` is a half of [`i32::MAX`]
 #[inline(always)]
 pub unsafe fn set_varsize_4b(ptr: *mut pg_sys::varlena, len: i32) {
     // #define SET_VARSIZE_4B(PTR,len) \


### PR DESCRIPTION
The documentation is fixed due to being incorrect, `4294967295 >> 2` is division by `4`. And the reason of panicking is that it's promised too.