### PR TITLE
docs: update generic type name of TableIterator

### DIFF
--- a/pgrx/src/iter.rs
+++ b/pgrx/src/iter.rs
@@ -100,7 +100,7 @@ where
 ///
 /// [`TableIterator`] is typically used as the return type of a `#[pg_extern]`-style function,
 /// indicating that the function returns a table of named columns.  [`TableIterator`] is
-/// generic over `T`, but that `T` must be a Rust tuple containing one or more elements.  They
+/// generic over `Row`, but that `Row` must be a Rust tuple containing one or more elements.  They
 /// must also be "named" using pgrx's [`name!`][crate::name] macro.  See the examples below.
 ///
 /// It is a lightweight wrapper around an iterator, which you provide during construction.  The


### PR DESCRIPTION
### What does this PR do

Updates the doc of `TableIterator`, the generic type has been renamed in #1701 but the doc was not updated