### PR TITLE
refactor: more CStr literals

### DIFF
--- a/pgrx-tests/src/tests/roundtrip_tests.rs
+++ b/pgrx-tests/src/tests/roundtrip_tests.rs
@@ -214,10 +214,10 @@ mod tests {
     //     Vec<Option<&'static CStr>>,
     //     vec![
     //         None,
-    //         Some(unsafe { CStr::from_bytes_with_nul_unchecked(b"&one\0") }),
-    //         Some(unsafe { CStr::from_bytes_with_nul_unchecked(b"&two\0") }),
+    //         Some(unsafe { c"&one" }),
+    //         Some(unsafe { c"&two" }),
     //         None,
-    //         Some(unsafe { CStr::from_bytes_with_nul_unchecked(b"&three\0") }),
+    //         Some(unsafe { c"&three" }),
     //         None,
     //     ]
     // );

--- a/pgrx-tests/src/tests/roundtrip_tests.rs
+++ b/pgrx-tests/src/tests/roundtrip_tests.rs
@@ -214,10 +214,10 @@ mod tests {
     //     Vec<Option<&'static CStr>>,
     //     vec![
     //         None,
-    //         Some(unsafe { c"&one" }),
-    //         Some(unsafe { c"&two" }),
+    //         Some( c"&one" ),
+    //         Some( c"&two" ),
     //         None,
-    //         Some(unsafe { c"&three" }),
+    //         Some( c"&three" ),
     //         None,
     //     ]
     // );

--- a/pgrx-tests/tests/todo/roundtrip-tests.rs
+++ b/pgrx-tests/tests/todo/roundtrip-tests.rs
@@ -76,10 +76,10 @@ mod tests {
         Vec<Option<&'static CStr>>,
         vec![
             None,
-            Some(unsafe { CStr::from_bytes_with_nul_unchecked(b"&one\0") }),
-            Some(unsafe { CStr::from_bytes_with_nul_unchecked(b"&two\0") }),
+            Some(unsafe { c"&one" }),
+            Some(unsafe { c"&two" }),
             None,
-            Some(unsafe { CStr::from_bytes_with_nul_unchecked(b"&three\0") }),
+            Some(unsafe { "&three" }),
             None,
         ]
     );

--- a/pgrx-tests/tests/todo/roundtrip-tests.rs
+++ b/pgrx-tests/tests/todo/roundtrip-tests.rs
@@ -76,10 +76,10 @@ mod tests {
         Vec<Option<&'static CStr>>,
         vec![
             None,
-            Some(unsafe { c"&one" }),
-            Some(unsafe { c"&two" }),
+            Some( c"&one" ),
+            Some( c"&two" ),
             None,
-            Some(unsafe { "&three" }),
+            Some( c"&three" ),
             None,
         ]
     );


### PR DESCRIPTION
### What does this PR do

A PR that follows #1898, uses more CStr literal syntax. All the `CStr::from_bytes_with_nul_xxx`s will be cleared after this PR. 