### PR TITLE
fix segfault with empty `numrange` during `from_datum()`

### DIFF
--- a/.github/workflows/package-test.yaml
+++ b/.github/workflows/package-test.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/package-test.yaml
+++ b/.github/workflows/package-test.yaml
@@ -2,9 +2,9 @@ name: verify package can build
 
 on:
   push:
-    branches: [develop]
+    branches: [ develop ]
   pull_request:
-    branches: [develop]
+    branches: [ develop ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,7 +14,7 @@ env:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -2,9 +2,9 @@ name: cargo pgrx test --runas
 
 on:
   push:
-    branches: [develop]
+    branches: [ develop ]
   pull_request:
-    branches: [develop]
+    branches: [ develop ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,7 +12,7 @@ env:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
           echo ""
           
           echo "----- Remove old postgres -----"
-          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*'
           echo ""
           
           echo "----- Install system dependencies -----"
@@ -395,7 +395,7 @@ jobs:
           echo ""
           
           echo "----- Remove old postgres -----"
-          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*'
           echo ""
           
           echo "----- Install system dependencies -----"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,6 @@ jobs:
           echo "----- Install system dependencies -----"
           sudo apt-get install -y \
             build-essential \
-            llvm-14-dev libclang-14-dev clang-14 \
             gcc \
             libssl-dev \
             libz-dev \
@@ -401,7 +400,6 @@ jobs:
           echo "----- Install system dependencies -----"
           sudo apt-get install -y \
             build-essential \
-            llvm-14-dev libclang-14-dev clang-14 \
             gcc \
             libssl-dev \
             libz-dev \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   lintck:
     name: rustfmt, clippy, et al.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
       RUSTC_WRAPPER: sccache
@@ -97,7 +97,7 @@ jobs:
   pgrx_tests:
     name: Linux tests & examples
     needs: lintck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
       RUSTC_WRAPPER: sccache
@@ -363,7 +363,7 @@ jobs:
 
   cargo_pgrx_init:
     name: cargo pgrx init
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   lintck:
     name: rustfmt, clippy, et al.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
       RUSTC_WRAPPER: sccache
@@ -97,7 +97,7 @@ jobs:
   pgrx_tests:
     name: Linux tests & examples
     needs: lintck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
       RUSTC_WRAPPER: sccache
@@ -134,12 +134,13 @@ jobs:
           echo ""
           
           echo "----- Remove old postgres -----"
-          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*'
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
           echo ""
           
           echo "----- Install system dependencies -----"
           sudo apt-get install -y \
             build-essential \
+            llvm-14-dev libclang-14-dev clang-14 \
             gcc \
             libssl-dev \
             libz-dev \
@@ -362,7 +363,7 @@ jobs:
 
   cargo_pgrx_init:
     name: cargo pgrx init
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, 'nogha')"
     env:
       RUSTC_WRAPPER: sccache
@@ -394,12 +395,13 @@ jobs:
           echo ""
           
           echo "----- Remove old postgres -----"
-          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*'
+          sudo apt remove -y '^postgres.*' '^libpq.*' '^clang.*' '^llvm.*' '^libclang.*' '^libllvm.*' '^mono-llvm.*'
           echo ""
           
           echo "----- Install system dependencies -----"
           sudo apt-get install -y \
             build-essential \
+            llvm-14-dev libclang-14-dev clang-14 \
             gcc \
             libssl-dev \
             libz-dev \

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   distro_tests:
     name: Distro tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:
@@ -36,7 +36,7 @@ jobs:
 
   cargo_unlocked_tests:
     name: Cargo unlocked tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   distro_tests:
     name: Distro tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:
@@ -36,7 +36,7 @@ jobs:
 
   cargo_unlocked_tests:
     name: Cargo unlocked tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:

--- a/pgrx-tests/src/tests/range_tests.rs
+++ b/pgrx-tests/src/tests/range_tests.rs
@@ -142,6 +142,14 @@ mod tests {
     }
 
     #[pg_test]
+    fn test_empty_anynumeric_range() {
+        let matched = Spi::get_one::<Range<AnyNumeric>>(
+            "SELECT accept_range_numeric('[10.5, 10.5)'::numrange)",
+        );
+        assert_eq!(matched, Ok(Some(Range::empty())));
+    }
+
+    #[pg_test]
     fn test_accept_range_date() {
         let matched =
             Spi::get_one::<bool>("SELECT accept_range_date(daterange'[2000-01-01,2022-01-01)') = daterange'[2000-01-01,2022-01-01)'");


### PR DESCRIPTION
An empty `numrange` such as `'[10.5, 10.5)'::numrange` would lead to a segfault during a `Range<AnyNumeric>::from_datum()`.

This also hardcodes CI to `runs-on: ubuntu-22.04` due to the upgrade in -latest (https://github.com/actions/runner-images/issues/10636) that I don't have the patience to work out today.