### PR TITLE
Explicitly enable object Cargo features

### DIFF
--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -41,11 +41,6 @@ jobslot = "0.2.12" # as seen in gmake -j{N}
 semver = "1.0.20" # checking pgrx versions match
 tempfile = "3.8.0"
 
-# SQL schema generation
-object = { version = "0.32.1", default-features = false, features = [ "std" ] }
-proc-macro2.workspace = true
-quote.workspace = true
-
 # emit better diagnostics
 color-eyre = "0.6.2"
 eyre.workspace = true
@@ -62,6 +57,18 @@ serde-xml-rs = "0.6.0"
 tar = "0.4.40"
 ureq = { version = "2.8.0", default-features = false, features = [ "gzip" ] }
 url.workspace = true
+
+# SQL schema generation
+proc-macro2.workspace = true
+quote.workspace = true
+[dependencies.object]
+version = "0.32.2"
+default-features = false
+features = [
+    "read_core", "std", # we use object read-only and like having actual errors
+    "coff", "elf", "macho", "pe", "xcoff", # support all object formats to allow cross-builds
+]
+
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
cargo-pgrx only works if we enable a minimal set of Cargo features for for the object crate, that we implicitly enable despite having set object to be `default-features = false`!

The Cargo feature resolver has unified our "std" feature for object with the requested object features of our other dependencies that also depend on the object crate. However, these dependencies do so conditionally, based on the platform that they are compiling on. This means that if other dependencies stop using the object crate, or with less features, our enabled Cargo features for object will no longer be the correct set to build our own binary!

This also implies some platforms are simply unable to build cargo-pgrx. Even if we don't support these platforms explicitly, we have generally taken a "smoke 'em if you got 'em" approach for unsupported platforms. Thus, enable enough of object's Cargo features to prevent weird problems from surfacing in the future through unrelated dependency changes, and make the cargo-pgrx build effectively platform-invariant.

Whether it actually works on those platforms is a "them" problem, but now they should be able to actually get to debugging it a bit.