### PR TITLE
fix: crash from drop impls that panic via `leak_and_drop_on_delete()`

### DIFF
--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -646,7 +646,11 @@ fn monitor_pg(mut command: Command, cmd_string: String, loglines: LogLines) -> S
 
             if line.contains("database system is ready to accept connections") {
                 // Postgres says it's ready to go
-                sender.send(session_id.clone()).unwrap();
+                if let Err(_) = sender.send(session_id.clone()) {
+                    // The channel is closed.  This is really early in the startup process
+                    // and likely indicates that a test crashed Postgres
+                    panic!("{}: `monitor_pg()`:  failed to send back session_id `{session_id}`.  Did Postgres crash?", "ERROR".red().bold());
+                }
                 is_started_yet = true;
             }
 

--- a/pgrx/src/memcxt.rs
+++ b/pgrx/src/memcxt.rs
@@ -555,6 +555,8 @@ impl PgMemoryContexts {
     /// this MemoryContext, the original instance of `T` will be resurrected and its `impl Drop`
     /// will be called.
     pub fn leak_and_drop_on_delete<T>(&mut self, v: T) -> *mut T {
+        use crate as pgrx;
+        #[pgrx::pg_guard]
         unsafe extern "C" fn drop_on_delete<T>(ptr: void_mut_ptr) {
             let boxed = Box::from_raw(ptr as *mut T);
             drop(boxed);


### PR DESCRIPTION
If `PgMemoryContexts::leak_and_drop_on_delete()` leaks a type that is `impl Drop`, and that implementation happens to panic, then Postgres will segfault because the callback function was not properly guarded.

As a drive-by, slightly cleanup error reporting in the test framework.