### PR TITLE
Teach `#[pg_cast]` how to pass down arguments useful to `#[pg_extern]`

### DIFF
--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -163,6 +163,9 @@ By default if no attribute is specified, the cast function can only be used in a
 Functions MUST accept and return exactly one value whose type MUST be a `pgrx` supported type. `pgrx` supports many PostgreSQL types by default.
 New types can be defined via [`macro@PostgresType`] or [`macro@PostgresEnum`].
 
+`#[pg_cast]` also supports all the attributes supported by the [`macro@pg_extern]` macro, which are
+passed down to the underlying function.
+
 Example usage:
 ```rust,ignore
 use pgrx::*;
@@ -173,31 +176,36 @@ fn cast_json_to_int(input: Json) -> i32 { todo!() }
 pub fn pg_cast(attr: TokenStream, item: TokenStream) -> TokenStream {
     fn wrapped(attr: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Error> {
         use syn::parse::Parser;
+        use syn::punctuated::Punctuated;
+
         let mut cast = PgCast::Default;
-        match syn::punctuated::Punctuated::<syn::Path, syn::Token![,]>::parse_terminated.parse(attr)
-        {
+        let mut pg_extern_attrs = proc_macro2::TokenStream::new();
+
+        // look for the attributes `#[pg_cast]` directly understands
+        match Punctuated::<syn::Path, syn::Token![,]>::parse_terminated.parse(attr) {
             Ok(paths) => {
-                if paths.len() > 1 {
-                    panic!(
-                        "pg_cast must take either 0 or 1 attribute. Found {}: {}",
-                        paths.len(),
-                        paths.to_token_stream()
-                    )
-                } else if paths.len() == 1 {
-                    match paths.first().unwrap().segments.last().unwrap().ident.to_string().as_str()
-                    {
-                        "implicit" => cast = PgCast::Implicit,
-                        "assignment" => cast = PgCast::Assignment,
-                        other => panic!("Unrecognized pg_cast option: {other}. "),
+                let mut new_paths = Punctuated::<syn::Path, syn::Token![,]>::new();
+                for path in paths {
+                    if path.is_ident("implicit") {
+                        cast = PgCast::Implicit
+                    } else if path.is_ident("assignment") {
+                        cast = PgCast::Assignment
+                    } else {
+                        // ... and anything it doesn't understand is blindly passed through to the
+                        // underlying `#[pg_extern]` function that gets created, which will ultimately
+                        // decide what's naughty and what's nice
+                        new_paths.push(path);
                     }
                 }
+
+                pg_extern_attrs.extend(new_paths.into_token_stream());
             }
             Err(err) => {
                 panic!("Failed to parse attribute to pg_cast: {err}")
             }
         }
-        // `pg_cast` does not support other `pg_extern` attributes for now, pass an empty attribute token stream.
-        let pg_extern = PgExtern::new(TokenStream::new().into(), item.clone().into())?.0;
+
+        let pg_extern = PgExtern::new(pg_extern_attrs.into(), item.clone().into())?.0;
         Ok(CodeEnrichment(pg_extern.as_cast(cast)).to_token_stream().into())
     }
 

--- a/pgrx-sql-entity-graph/src/pg_extern/cast.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/cast.rs
@@ -21,8 +21,9 @@ use quote::{quote, ToTokens, TokenStreamExt};
 /// A parsed `#[pg_cast]` operator.
 ///
 /// It is created during [`PgExtern`](crate::PgExtern) parsing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum PgCast {
+    #[default]
     Default,
     Assignment,
     Implicit,

--- a/pgrx-sql-entity-graph/src/pg_extern/cast.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/cast.rs
@@ -17,6 +17,7 @@
 */
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
+use syn::Path;
 
 /// A parsed `#[pg_cast]` operator.
 ///
@@ -27,6 +28,22 @@ pub enum PgCast {
     Default,
     Assignment,
     Implicit,
+}
+
+pub type InvalidCastStyle = Path;
+
+impl TryFrom<Path> for PgCast {
+    type Error = InvalidCastStyle;
+
+    fn try_from(path: Path) -> Result<Self, Self::Error> {
+        if path.is_ident("implicit") {
+            Ok(Self::Implicit)
+        } else if path.is_ident("assignment") {
+            Ok(Self::Assignment)
+        } else {
+            Err(path)
+        }
+    }
 }
 
 impl ToTokens for PgCast {

--- a/pgrx-tests/tests/compile-fail/invalid_pgcast_options.stderr
+++ b/pgrx-tests/tests/compile-fail/invalid_pgcast_options.stderr
@@ -1,7 +1,11 @@
-error: custom attribute panicked
- --> tests/compile-fail/invalid_pgcast_options.rs:3:1
+error: Invalid option `invalid_opt` inside `invalid_opt `
+ --> tests/compile-fail/invalid_pgcast_options.rs:3:11
   |
 3 | #[pg_cast(invalid_opt)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^
+  |           ^^^^^^^^^^^
+
+error: failed parsing pg_extern arguments
+ --> tests/compile-fail/invalid_pgcast_options.rs:3:11
   |
-  = help: message: Unrecognized pg_cast option: invalid_opt.
+3 | #[pg_cast(invalid_opt)]
+  |           ^^^^^^^^^^^

--- a/pgrx-tests/tests/compile-fail/too_many_cast_options.rs
+++ b/pgrx-tests/tests/compile-fail/too_many_cast_options.rs
@@ -1,0 +1,8 @@
+use pgrx::prelude::*;
+
+#[pg_cast(implicit, assignment)]
+pub fn cast_function(foo: i32) -> i32 {
+    foo
+}
+
+fn main() {}

--- a/pgrx-tests/tests/compile-fail/too_many_cast_options.stderr
+++ b/pgrx-tests/tests/compile-fail/too_many_cast_options.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> tests/compile-fail/too_many_cast_options.rs:3:1
+  |
+3 | #[pg_cast(implicit, assignment)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: The cast type has already been set to `Implicit`


### PR DESCRIPTION
The `#[pg_cast]` macro does two things.  It creates a regular UDF and it then generates the appropriate `CREATE CAST` sql.

Ultimately, the cast is just a function so we should support all the attibutes that `#[pg_extern]` supports.