### PR TITLE
add `pg_config --libdir` to linker search path

### DIFF
--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -343,6 +343,12 @@ fn generate_bindings(
             )
         })?;
     }
+
+    let lib_dir = pg_config.lib_dir()?;
+    println!(
+        "cargo:rustc-link-search={}",
+        lib_dir.to_str().ok_or(eyre!("{lib_dir:?} is not valid UTF-8 string"))?
+    );
     Ok(())
 }
 

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -323,6 +323,10 @@ impl PgConfig {
         Ok(self.run("--bindir")?.into())
     }
 
+    pub fn lib_dir(&self) -> eyre::Result<PathBuf> {
+        Ok(self.run("--libdir")?.into())
+    }
+
     pub fn postmaster_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
         path.push("postgres");


### PR DESCRIPTION
On Windows, the linker needs `postgres.lib` to link against. So add `pg_config --libdir` to linker search path.