### PR TITLE
Changed args of prepare methods to be slices

### DIFF
--- a/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-prep-stmt.rs
+++ b/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-prep-stmt.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 fn issue1209_prepared_stmt(q: &str) -> Result<Option<String>, Box<dyn Error>> {
     use pgrx::spi::Query;
 
-    let prepared = { Spi::connect(|c| c.prepare(q, None))? };
+    let prepared = { Spi::connect(|c| c.prepare(q, &[]))? };
 
     Ok(Spi::connect(|c| prepared.execute(&c, Some(1), &[])?.first().get(1))?)
 }

--- a/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-prep-stmt.stderr
+++ b/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-prep-stmt.stderr
@@ -1,8 +1,8 @@
 error: lifetime may not live long enough
  --> tests/compile-fail/escaping-spiclient-1209-prep-stmt.rs:8:39
   |
-8 |     let prepared = { Spi::connect(|c| c.prepare(q, None))? };
-  |                                    -- ^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+8 |     let prepared = { Spi::connect(|c| c.prepare(q, &[]))? };
+  |                                    -- ^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
   |                                    ||
   |                                    |return type of closure is std::result::Result<pgrx::spi::PreparedStatement<'2>, pgrx::spi::SpiError>
   |                                    has type `SpiClient<'1>`

--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -17,7 +17,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn prepare<Q: PreparableQuery<'conn>>(
         &self,
         query: Q,
-        args: Option<Vec<PgOid>>,
+        args: &[PgOid],
     ) -> SpiResult<PreparedStatement<'conn>> {
         query.prepare(self, args)
     }
@@ -26,7 +26,7 @@ impl<'conn> SpiClient<'conn> {
     pub fn prepare_mut<Q: PreparableQuery<'conn>>(
         &self,
         query: Q,
-        args: Option<Vec<PgOid>>,
+        args: &[PgOid],
     ) -> SpiResult<PreparedStatement<'conn>> {
         query.prepare_mut(self, args)
     }


### PR DESCRIPTION
Since there's an opportunity to break more things for `0.13` I decided to improve the `prepare` and `prepare_mut` methods as well. The motivation for that is the same as for #1858, `&[]` requires no heap allocations on the heap if there's a fixed set of arguments.