### PR TITLE
fix cargo-pgrx and pgrx-tests on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,6 @@ r = "run --features"
 [target.'cfg(target_os="macos")']
 # Postgres symbols won't be available until runtime
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
+
+[target.'cfg(target_env="msvc")']
+linker = "lld-link"

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -93,4 +93,6 @@ jobs:
         run: cargo pgrx init --pg14=$(which pg_config)
 
       - name: Test cargo pgrx test --runas
-        run: cd pgrx-examples/arrays && cargo pgrx test pg14 --runas postgres --pgdata=/tmp/pgdata
+        run: |
+          echo 0 | sudo tee /proc/sys/fs/protected_fifos
+          cd pgrx-examples/arrays && cargo pgrx test pg14 --runas postgres --pgdata=/tmp/pgdata

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -579,3 +579,78 @@ jobs:
 
       - name: Stop sccache server
         run: sccache --stop-server || true
+
+  build_windows:
+    name: Windows build & test
+    needs: lintck
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'nogha')"
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: C:\Users\runneradmin\sccache
+      SCCACHE_IDLE_TIMEOUT: 0
+      PG_VER: ${{ matrix.postgresql }}
+
+    strategy:
+      matrix:
+        os: [ "windows-2022" ]
+        postgresql: [ 13, 17 ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up prerequisites and environment
+        run: |
+          Write-Output ""
+
+          echo "----- Install sccache -----"
+          Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-pc-windows-msvc.tar.gz" -OutFile "sccache.tar.gz"
+          tar -xzvf sccache.tar.gz
+          Move-Item -Force "sccache-v0.5.4-x86_64-pc-windows-msvc\sccache.exe" -Destination "C:\Windows\System32"
+          New-Item -ItemType Directory -Force -Path $env:SCCACHE_DIR | Out-Null
+          sccache --version
+
+          rustup update
+
+          Write-Output "----- Outputting env -----"
+          Get-ChildItem Env:
+          Write-Output ""
+
+
+      - name: Cache sccache directory
+        uses: actions/cache@v4
+        continue-on-error: false
+        with:
+          path: C:\Users\runneradmin\sccache
+          key: pgrx-sccache-${{matrix.os}}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
+
+      - name: Cache cargo directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo
+          key: pgrx-cargo-${{matrix.os}}-tests-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml', '.cargo/config.toml') }}
+
+      - name: Start sccache server
+        run: sccache --start-server
+
+      - name: Print sccache stats
+        run: sccache --show-stats
+
+      - name: Install cargo-pgrx
+        run: cargo install --path cargo-pgrx/ --debug --force
+
+      - name: Print sccache stats
+        run: sccache --show-stats
+
+      - name: Run 'cargo pgrx init'
+        run: cargo pgrx init --pg$env:PG_VER=download
+
+      - name: Run tests
+        run: cargo test --all --no-default-features --features "pg$env:PG_VER pg_test cshim proptest" --all-targets
+
+      - name: Print sccache stats
+        run: sccache --show-stats
+
+      - name: Stop sccache server
+        run: sccache --stop-server || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +108,15 @@ name = "anyhow"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-compression"
@@ -302,6 +322,16 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b89e7c29231c673a61a46e722602bcd138298f6b9e81e71119693534585f5c"
@@ -359,7 +389,7 @@ dependencies = [
 name = "cargo-pgrx"
 version = "0.13.1"
 dependencies = [
- "bzip2",
+ "bzip2 0.5.1",
  "cargo-edit",
  "cargo_metadata 0.18.1",
  "cargo_toml",
@@ -389,6 +419,7 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "url",
+ "zip-extract",
 ]
 
 [[package]]
@@ -444,6 +475,8 @@ version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -477,6 +510,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clang-sys"
@@ -602,6 +645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad159cc964ac8f9d407cbc0aa44b02436c054b541f2b4b5f06972e1efdc54bc7"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +693,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -699,6 +763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +785,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1362,6 +1443,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1494,15 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jobslot"
@@ -1491,10 +1590,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
 
 [[package]]
 name = "matchers"
@@ -1759,6 +1874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +1941,7 @@ dependencies = [
  "pgrx-pg-config",
  "proc-macro2",
  "quote",
+ "regex",
  "shlex",
  "syn",
  "walkdir",
@@ -1897,8 +2023,10 @@ dependencies = [
  "serde_json",
  "shlex",
  "sysinfo",
+ "tempfile",
  "thiserror 2.0.11",
  "trybuild",
+ "winapi",
 ]
 
 [[package]]
@@ -2589,6 +2717,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,6 +2752,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
@@ -3875,6 +4020,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerovec"
@@ -3896,4 +4055,86 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2 0.4.4",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 2.0.11",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zip-extract"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a8c9e90f27d1435088a7b540b6cc8ae6ee525d992a695f16012d2f365b3d3c"
+dependencies = [
+ "log",
+ "thiserror 1.0.69",
+ "zip",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.14+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ regex = "1.11" # used for build/test
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shlex = "1.3" # shell lexing, also used by many of our deps
-syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
+syn = { version = "2", features = ["extra-traits", "full", "parsing", "visit-mut"] }
 toml = "0.8" # our config files
 toml_edit = "0.22.24" # format-preserving edits to toml files, used with cargo-edit
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
    + Safe access to Postgres' `MemoryContext` system via `pgrx::PgMemoryContexts`
    + Executor/planner/transaction/subtransaction hooks
    + Safely use Postgres-provided pointers with `pgrx::PgBox<T>` (akin to `alloc::boxed::Box<T>`)
-   + `#[pg_guard]` proc-macro for guarding `extern "C"` Rust functions that need to be passed into Postgres
+   + `#[pg_guard]` proc-macro for guarding `extern "C-unwind"` Rust functions that need to be passed into Postgres
    + Access Postgres' logging system through `eprintln!`-like macros
    + Direct `unsafe` access to large parts of Postgres internals via the `pgrx::pg_sys` module
    + New features added regularly!

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -57,6 +57,7 @@ serde-xml-rs = "0.6.0"
 tar = "0.4.44"
 ureq = { version = "3.0.6", default-features = false, features = ["gzip"] }
 url.workspace = true
+zip-extract = "0.2.1"
 
 # SQL schema generation
 proc-macro2.workspace = true

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -14,7 +14,7 @@ use bzip2::bufread::BzDecoder;
 use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use pgrx_pg_config::{
-    get_c_locale_flags, prefix_path, ConfigToml, PgConfig, PgConfigSelector, Pgrx, PgrxHomeError,
+    get_c_locale_flags, ConfigToml, PgConfig, PgConfigSelector, Pgrx, PgrxHomeError,
 };
 use tar::Archive;
 
@@ -23,9 +23,10 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::OnceLock;
 
+#[cfg(not(target_os = "windows"))]
 static PROCESS_ENV_DENYLIST: &[&str] = &[
     "DEBUG",
     "MAKEFLAGS",
@@ -289,8 +290,18 @@ fn untar(bytes: &[u8], pgrxdir: &Path, pg_config: &PgConfig, init: &Init) -> eyr
         pg_config.version()?,
         unpackdir.display()
     );
-    let mut tar_decoder = Archive::new(BzDecoder::new(bytes));
-    tar_decoder.unpack(&unpackdir)?;
+
+    if bytes.starts_with(b"PK\x03\x04")
+        || bytes.starts_with(b"PK\x05\x06")
+        || bytes.starts_with(b"PK\x07\x08")
+    {
+        // it's a zip download from EDB
+        use std::io::Cursor;
+        zip_extract::extract(Cursor::new(bytes), &unpackdir, false)?;
+    } else {
+        let mut tar_decoder = Archive::new(BzDecoder::new(bytes));
+        tar_decoder.unpack(&unpackdir)?;
+    }
 
     let mut pgdir = pgrxdir.to_path_buf();
     pgdir.push(&pg_config.version()?);
@@ -329,7 +340,9 @@ fn untar(bytes: &[u8], pgrxdir: &Path, pg_config: &PgConfig, init: &Init) -> eyr
     Ok(pgdir)
 }
 
-fn fixup_homebrew_for_icu(configure_cmd: &mut Command) {
+#[cfg(not(target_os = "windows"))]
+fn fixup_homebrew_for_icu(configure_cmd: &mut std::process::Command) {
+    use std::process::Command;
     // See if it's disabled via an argument
     if configure_cmd.get_args().any(|a| a == "--without-icu") {
         return;
@@ -401,7 +414,10 @@ fn fixup_homebrew_for_icu(configure_cmd: &mut Command) {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 fn configure_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::Result<()> {
+    use pgrx_pg_config::prefix_path;
+
     let _token = init.jobserver.get().unwrap().acquire().unwrap();
 
     println!("{} Postgres v{}", "  Configuring".bold().green(), pg_config.version()?);
@@ -465,6 +481,12 @@ fn configure_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::
     }
 }
 
+#[cfg(target_os = "windows")]
+fn configure_postgres(_pg_config: &PgConfig, _pgdir: &Path, _init: &Init) -> eyre::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
 fn make_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::Result<()> {
     println!("{} Postgres v{}", "    Compiling".bold().green(), pg_config.version()?);
     let mut command = std::process::Command::new("make");
@@ -498,6 +520,12 @@ fn make_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::Resul
     }
 }
 
+#[cfg(target_os = "windows")]
+fn make_postgres(_pg_config: &PgConfig, _pgdir: &Path, _init: &Init) -> eyre::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
 fn make_install_postgres(version: &PgConfig, pgdir: &Path, init: &Init) -> eyre::Result<PgConfig> {
     println!(
         "{} Postgres v{} to {}",
@@ -536,6 +564,18 @@ fn make_install_postgres(version: &PgConfig, pgdir: &Path, init: &Init) -> eyre:
             String::from_utf8(output.stderr).unwrap()
         ))
     }
+}
+
+#[cfg(target_os = "windows")]
+fn make_install_postgres(
+    _version: &PgConfig,
+    pgdir: &Path,
+    _init: &Init,
+) -> eyre::Result<PgConfig> {
+    let mut pg_config = get_pg_installdir(pgdir);
+    pg_config.push("bin");
+    pg_config.push("pg_config.exe");
+    Ok(PgConfig::new_with_defaults(pg_config))
 }
 
 fn validate_pg_config(pg_config: &PgConfig) -> eyre::Result<()> {
@@ -577,10 +617,16 @@ fn write_config(pg_configs: &Vec<PgConfig>, init: &Init) -> eyre::Result<()> {
     Ok(())
 }
 
+#[cfg(not(target_os = "windows"))]
 fn get_pg_installdir(pgdir: &Path) -> PathBuf {
     let mut dir = pgdir.to_path_buf();
     dir.push("pgrx-install");
     dir
+}
+
+#[cfg(target_os = "windows")]
+fn get_pg_installdir(pgdir: &Path) -> PathBuf {
+    pgdir.to_path_buf()
 }
 
 #[cfg(unix)]
@@ -599,7 +645,11 @@ fn is_root_user() -> bool {
 
 pub(crate) fn initdb(bindir: &Path, datadir: &Path) -> eyre::Result<()> {
     println!(" {} data directory at {}", "Initializing".bold().green(), datadir.display());
-    let mut command = std::process::Command::new(format!("{}/initdb", bindir.display()));
+    #[cfg(not(target_os = "windows"))]
+    let initdb = bindir.join("initdb");
+    #[cfg(target_os = "windows")]
+    let initdb = bindir.join("initdb.exe");
+    let mut command = std::process::Command::new(initdb);
     command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -129,9 +129,6 @@ pub(crate) fn install_extension(
     features: &clap_cargo::Features,
 ) -> eyre::Result<Vec<PathBuf>> {
     let mut output_tracking = Vec::new();
-    let base_directory = base_directory.unwrap_or_else(|| PathBuf::from("/"));
-    tracing::Span::current()
-        .record("base_directory", tracing::field::display(&base_directory.display()));
 
     let manifest = Manifest::from_path(&package_manifest_path)?;
     let (control_file, extname) = find_control_file(&package_manifest_path)?;
@@ -147,18 +144,25 @@ pub(crate) fn install_extension(
         build_command_stream.collect::<Result<Vec<_>, std::io::Error>>()?;
 
     println!("{} extension", "  Installing".bold().green());
-    let pkgdir = make_relative(pg_config.pkglibdir()?);
-    let extdir = make_relative(pg_config.extension_dir()?);
     let shlibpath = find_library_file(&manifest, &build_command_messages)?;
 
+    let extdir = if let Some(base_directory) = base_directory.as_ref() {
+        base_directory.join(make_relative_extdir(pg_config.extension_dir()?))
+    } else {
+        pg_config.extension_dir()?
+    };
+
+    let pkglibdir = if let Some(base_directory) = base_directory.as_ref() {
+        base_directory.join(make_relative_pkglibdir(pg_config.pkglibdir()?))
+    } else {
+        pg_config.pkglibdir()?
+    };
+
     {
-        let mut dest = base_directory.clone();
-        dest.push(&extdir);
-        dest.push(
-            control_file
-                .file_name()
-                .ok_or_else(|| eyre!("Could not get filename for `{}`", control_file.display()))?,
-        );
+        let filename = control_file
+            .file_name()
+            .ok_or_else(|| eyre!("Could not get filename for `{}`", control_file.display()))?;
+        let dest = extdir.join(filename);
         copy_file(
             &control_file,
             dest,
@@ -171,9 +175,6 @@ pub(crate) fn install_extension(
     }
 
     {
-        let mut dest = base_directory.clone();
-        dest.push(&pkgdir);
-
         let so_name = if versioned_so {
             let extver = get_version(&package_manifest_path)?;
             // note: versioned so-name format must agree with pgrx-utils
@@ -183,13 +184,18 @@ pub(crate) fn install_extension(
         };
         // Since Postgres 16, the shared library extension on macOS is `dylib`, not `so`.
         // Ref https://github.com/postgres/postgres/commit/b55f62abb2c2e07dfae99e19a2b3d7ca9e58dc1a
-        let so_extension = if cfg!(target_os = "macos") && pg_config.major_version().unwrap() >= 16
-        {
-            "dylib"
-        } else {
+        let so_ext = 'e: {
+            if cfg!(target_os = "macos") {
+                break 'e if pg_config.major_version().unwrap() >= 16 { "dylib" } else { "so" };
+            }
+            if cfg!(target_os = "windows") {
+                break 'e "dll";
+            }
             "so"
         };
-        dest.push(format!("{so_name}.{so_extension}"));
+        let filename = format!("{so_name}.{so_ext}");
+
+        let dest = pkglibdir.join(filename);
 
         // Remove the existing shared libraries if present. This is a workaround for an
         // issue highlighted by the following apple documentation:
@@ -224,7 +230,6 @@ pub(crate) fn install_extension(
         is_test,
         features,
         &extdir,
-        &base_directory,
         true,
         &mut output_tracking,
     )?;
@@ -339,21 +344,6 @@ pub(crate) fn build_extension(
     }
 }
 
-fn get_target_sql_file(
-    manifest_path: impl AsRef<Path>,
-    extdir: &Path,
-    base_directory: PathBuf,
-) -> eyre::Result<PathBuf> {
-    let mut dest = base_directory;
-    dest.push(extdir);
-
-    let (_, extname) = find_control_file(&manifest_path)?;
-    let version = get_version(&manifest_path)?;
-    dest.push(format!("{extname}--{version}.sql"));
-
-    Ok(dest)
-}
-
 fn copy_sql_files(
     user_manifest_path: Option<impl AsRef<Path>>,
     user_package: Option<&String>,
@@ -363,27 +353,30 @@ fn copy_sql_files(
     is_test: bool,
     features: &clap_cargo::Features,
     extdir: &Path,
-    base_directory: &Path,
     skip_build: bool,
     output_tracking: &mut Vec<PathBuf>,
 ) -> eyre::Result<()> {
-    let dest = get_target_sql_file(&package_manifest_path, extdir, base_directory.to_path_buf())?;
     let (_, extname) = find_control_file(&package_manifest_path)?;
+    {
+        let version = get_version(&package_manifest_path)?;
+        let filename = format!("{extname}--{version}.sql");
+        let dest = extdir.join(filename);
 
-    crate::command::schema::generate_schema(
-        pg_config,
-        user_manifest_path,
-        user_package,
-        &package_manifest_path,
-        profile,
-        is_test,
-        features,
-        Some(&dest),
-        Option::<String>::None,
-        None,
-        skip_build,
-        output_tracking,
-    )?;
+        crate::command::schema::generate_schema(
+            pg_config,
+            user_manifest_path,
+            user_package,
+            &package_manifest_path,
+            profile,
+            is_test,
+            features,
+            Some(&dest),
+            Option::<String>::None,
+            None,
+            skip_build,
+            output_tracking,
+        )?;
+    }
 
     // now copy all the version upgrade files too
     if let Ok(dir) = fs::read_dir(package_manifest_path.as_ref().parent().unwrap().join("sql/")) {
@@ -395,13 +388,9 @@ fn copy_sql_files(
                 regex::Regex::new(&format!(r"^{extname}--.+--.+\.sql$")).unwrap();
 
             if re_update_script_name.is_match(filename.as_str()) {
-                let mut dest = base_directory.to_path_buf();
-                dest.push(extdir);
-                dest.push(filename);
-
                 copy_file(
                     &sql.path(),
-                    dest,
+                    extdir.join(filename),
                     "extension schema upgrade file",
                     true,
                     &package_manifest_path,
@@ -422,7 +411,15 @@ pub(crate) fn find_library_file(
     // cargo sometimes decides to change whether targets are kebab-case or snake_case in metadata,
     // so normalize away the difference
     let target_name = manifest.target_name()?.replace('-', "_");
-    let so_ext = if cfg!(target_os = "macos") { "dylib" } else { "so" };
+    let so_ext = 'so_ext: {
+        if cfg!(target_os = "macos") {
+            break 'so_ext "dylib";
+        }
+        if cfg!(target_os = "windows") {
+            break 'so_ext "dll";
+        }
+        "so"
+    };
 
     // no hard and fast rule for the lib.so output filename exists, so we implement this routine
     // which is essentially a cope for cargo's disinterest in writing down any docs so far.
@@ -511,17 +508,36 @@ fn get_git_hash(manifest_path: impl AsRef<Path>) -> eyre::Result<String> {
     }
 }
 
-fn make_relative(path: PathBuf) -> PathBuf {
+#[cfg(not(target_os = "windows"))]
+fn make_relative_pkglibdir(path: PathBuf) -> PathBuf {
+    use std::path::Component;
     if path.is_relative() {
         return path;
     }
-    let mut relative = PathBuf::new();
-    let mut components = path.components();
-    components.next(); // skip the root
-    for part in components {
-        relative.push(part)
+    path.components()
+        .skip_while(|x| matches!(x, Component::Prefix(_) | Component::RootDir))
+        .collect()
+}
+
+#[cfg(target_os = "windows")]
+fn make_relative_pkglibdir(_: PathBuf) -> PathBuf {
+    "lib".into()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn make_relative_extdir(path: PathBuf) -> PathBuf {
+    use std::path::Component;
+    if path.is_relative() {
+        return path;
     }
-    relative
+    path.components()
+        .skip_while(|x| matches!(x, Component::Prefix(_) | Component::RootDir))
+        .collect()
+}
+
+#[cfg(target_os = "windows")]
+fn make_relative_extdir(_: PathBuf) -> PathBuf {
+    "share/extension".into()
 }
 
 pub(crate) fn format_display_path(path: impl AsRef<Path>) -> eyre::Result<String> {

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -18,7 +18,6 @@ use eyre::eyre;
 use owo_colors::OwoColorize;
 use pgrx_pg_config::{createdb, PgConfig, Pgrx};
 use std::path::Path;
-use std::process::Command;
 
 /// Compile/install extension to a pgrx-managed Postgres instance and start psql
 #[derive(clap::Args, Debug)]
@@ -144,6 +143,7 @@ pub(crate) fn run(
 #[cfg(unix)]
 pub(crate) fn exec_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> eyre::Result<()> {
     use std::os::unix::process::CommandExt;
+    use std::process::Command;
     let mut command = Command::new(match pgcli {
         false => pg_config.psql_path()?.into_os_string(),
         true => "pgcli".to_string().into(),
@@ -165,5 +165,28 @@ pub(crate) fn exec_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> eyre
 
 #[cfg(not(unix))]
 pub(crate) fn exec_psql(pg_config: &PgConfig, dbname: &str, pgcli: bool) -> eyre::Result<()> {
-    panic!("Tried to exec on a platform that doesn't support exec!")
+    use std::process::Command;
+    use std::process::Stdio;
+    let mut command = Command::new(match pgcli {
+        false => pg_config.psql_path()?.into_os_string(),
+        true => "pgcli".to_string().into(),
+    });
+    command
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .env_remove("PGDATABASE")
+        .env_remove("PGHOST")
+        .env_remove("PGPORT")
+        .env_remove("PGUSER")
+        .arg("-h")
+        .arg(pg_config.host())
+        .arg("-p")
+        .arg(pg_config.port()?.to_string())
+        .arg(dbname);
+    let command_str = format!("{command:?}");
+    tracing::debug!(command = %command_str, "Running");
+    let output = command.output()?;
+    tracing::trace!(status_code = %output.status, command = %command_str, "Finished");
+    Ok(())
 }

--- a/cargo-pgrx/src/command/status.rs
+++ b/cargo-pgrx/src/command/status.rs
@@ -64,8 +64,7 @@ pub(crate) fn status_postgres(pg_config: &PgConfig) -> eyre::Result<bool> {
         return Ok(false);
     } // if Err, let the filesystem and OS handle our impending failure
 
-    let mut pg_ctl = pg_config.bin_dir()?;
-    pg_ctl.push("pg_ctl");
+    let pg_ctl = pg_config.pg_ctl_path()?;
     let mut command = process::Command::new(pg_ctl);
     command.stdout(Stdio::piped()).stderr(Stdio::piped()).arg("status").arg("-D").arg(&datadir);
     let command_str = format!("{command:?}");

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -126,6 +126,11 @@ pub fn test_extension(
     runas: Option<String>,
     pgdata: Option<PathBuf>,
 ) -> eyre::Result<()> {
+    #[cfg(target_os = "windows")]
+    if runas.is_some() {
+        eyre::bail!("`--runas` is not supported on Windows");
+    }
+
     if let Some(ref testname) = testname {
         tracing::Span::current().record("testname", tracing::field::display(&testname.as_ref()));
     }

--- a/cargo-pgrx/src/command/version.rs
+++ b/cargo-pgrx/src/command/version.rs
@@ -30,6 +30,16 @@ mod rss {
 
     use crate::command::build_agent_for_url;
 
+    #[cfg(not(target_os = "windows"))]
+    fn download_url(major: u16, minor: u16) -> String {
+        format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2")
+    }
+
+    #[cfg(target_os = "windows")]
+    fn download_url(major: u16, minor: u16) -> String {
+        format!("https://get.enterprisedb.com/postgresql/postgresql-{major}.{minor}-1-windows-x64-binaries.zip")
+    }
+
     pub(super) struct PostgreSQLVersionRss;
 
     impl PostgreSQLVersionRss {
@@ -69,9 +79,7 @@ mod rss {
                     if matches!(known_pgver.minor, PgMinorVersion::Latest) {
                         // fill in the latest minor version number and its url
                         known_pgver.minor = PgMinorVersion::Release(minor);
-                        known_pgver.url = Some(Url::parse(
-                                &format!("https://ftp.postgresql.org/pub/source/v{major}.{minor}/postgresql-{major}.{minor}.tar.bz2")
-                            )?);
+                        known_pgver.url = Some(Url::parse(&download_url(major, minor))?);
                     }
                 }
             }

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -96,7 +96,7 @@ pub(crate) fn modify_features_for_version(
         // that aren't valid for the manifest
         if test {
             features.features.retain(|flag| {
-                if manifest.features.contains_key(flag) {
+                if manifest.features.contains_key(flag) || flag == "pgrx/cshim" {
                     true
                 } else {
                     use owo_colors::OwoColorize;

--- a/cargo-pgrx/src/templates/bgworker_lib_rs
+++ b/cargo-pgrx/src/templates/bgworker_lib_rs
@@ -21,7 +21,7 @@ this background worker
 
 #[allow(non_snake_case)]
 #[pg_guard]
-pub extern "C" fn _PG_init() {{
+pub extern "C-unwind" fn _PG_init() {{
     BackgroundWorkerBuilder::new("{name}")
         .set_function("background_worker_main")
         .set_library("{name}")
@@ -32,7 +32,7 @@ pub extern "C" fn _PG_init() {{
 
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {{
+pub extern "C-unwind" fn background_worker_main(arg: pg_sys::Datum) {{
     let arg = unsafe {{ i32::from_datum(arg, false) }};
 
     // these are the signals we want to receive.  If we don't attach the SIGTERM handler, then

--- a/cargo-pgrx/src/templates/cargo_config_toml
+++ b/cargo-pgrx/src/templates/cargo_config_toml
@@ -1,3 +1,6 @@
 [target.'cfg(target_os="macos")']
 # Postgres symbols won't be available until runtime
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
+
+[target.'cfg(target_env="msvc")']
+linker = "lld-link"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -13,6 +13,7 @@ pgrx-pg-config.workspace = true
 
 eyre.workspace = true
 proc-macro2.workspace = true
+regex.workspace = true
 syn.workspace = true
 walkdir.workspace = true
 

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -897,6 +897,8 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
         .blocklist_function("varsize_any")
         // it's defined twice on Windows, so use PGERROR instead
         .blocklist_item("ERROR")
+        // it causes strange linker errors for PostgreSQL 14 on Windows
+        .blocklist_function("IsQueryIdEnabled")
 }
 
 fn add_allowlists<'a>(

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -829,6 +829,7 @@ fn run_bindgen(
         .wrap_static_fns(enable_cshim)
         .wrap_static_fns_path(out_path.join("pgrx-cshim-static"))
         .wrap_static_fns_suffix("__pgrx_cshim")
+        .override_abi(bindgen::Abi::CUnwind, ".*")
         .generate()
         .wrap_err_with(|| format!("Unable to generate bindings for pg{major_version}"))?;
     let mut binding_str = bindings.to_string();
@@ -866,7 +867,7 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
         .blocklist_var("CONFIGURE_ARGS") // configuration during build is hopefully irrelevant
         .blocklist_var("_*(?:HAVE|have)_.*") // header tracking metadata
         .blocklist_var("_[A-Z_]+_H") // more header metadata
-        // It's used by explict `extern "C"`
+        // It's used by explict `extern "C-unwind"`
         .blocklist_function("pg_re_throw")
         .blocklist_function("err(start|code|msg|detail|context_msg|hint|finish)")
         // These functions are already ported in Rust

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -331,7 +331,7 @@ fn generate_bindings(
         .wrap_err_with(|| format!("bindgen failed for pg{major_version}"))?;
 
     let oids = extract_oids(&bindgen_output);
-    let rewritten_items = rewrite_items(&bindgen_output, &oids)
+    let rewritten_items = rewrite_items(bindgen_output, &oids)
         .wrap_err_with(|| format!("failed to rewrite items for pg{major_version}"))?;
     let oids = format_builtin_oid_impl(oids);
 
@@ -438,9 +438,10 @@ fn write_rs_file(
 /// Given a token stream representing a file, apply a series of transformations to munge
 /// the bindgen generated code with some postgres specific enhancements
 fn rewrite_items(
-    file: &syn::File,
+    mut file: syn::File,
     oids: &BTreeMap<syn::Ident, Box<syn::Expr>>,
 ) -> eyre::Result<proc_macro2::TokenStream> {
+    rewrite_c_abi_to_c_unwind(&mut file);
     let items_vec = rewrite_oid_consts(&file.items, oids);
     let mut items = apply_pg_guard(&items_vec)?;
     let pgnode_impls = impl_pg_node(&items_vec)?;
@@ -829,7 +830,6 @@ fn run_bindgen(
         .wrap_static_fns(enable_cshim)
         .wrap_static_fns_path(out_path.join("pgrx-cshim-static"))
         .wrap_static_fns_suffix("__pgrx_cshim")
-        .override_abi(bindgen::Abi::CUnwind, ".*")
         .generate()
         .wrap_err_with(|| format!("Unable to generate bindings for pg{major_version}"))?;
     let mut binding_str = bindings.to_string();
@@ -1174,6 +1174,23 @@ fn apply_pg_guard(items: &Vec<syn::Item>) -> eyre::Result<proc_macro2::TokenStre
     }
 
     Ok(out)
+}
+
+fn rewrite_c_abi_to_c_unwind(file: &mut syn::File) {
+    use proc_macro2::Span;
+    use syn::visit_mut::VisitMut;
+    use syn::LitStr;
+    pub struct Visitor {}
+    impl VisitMut for Visitor {
+        fn visit_abi_mut(&mut self, abi: &mut syn::Abi) {
+            if let Some(name) = &mut abi.name {
+                if name.value() == "C" {
+                    *name = LitStr::new("C-unwind", Span::call_site());
+                }
+            }
+        }
+    }
+    Visitor {}.visit_file_mut(file);
 }
 
 fn rust_fmt(path: &Path) -> eyre::Result<()> {

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -794,13 +794,12 @@ fn run_bindgen(
     let configure = pg_config.configure()?;
     let preferred_clang: Option<&std::path::Path> = configure.get("CLANG").map(|s| s.as_ref());
     eprintln!("pg_config --configure CLANG = {preferred_clang:?}");
+    let pg_target_includes = pg_target_includes(major_version, pg_config)?;
+    eprintln!("pg_target_includes = {pg_target_includes:?}");
     let (autodetect, includes) = clang::detect_include_paths_for(preferred_clang);
     let mut binder = bindgen::Builder::default();
     binder = add_blocklists(binder);
-    binder = binder
-        .allowlist_file(format!("{}.*", pg_target_include(major_version, pg_config)?))
-        .allowlist_item("PGERROR")
-        .allowlist_item("SIG.*");
+    binder = add_allowlists(binder, pg_target_includes.iter().map(|x| x.as_str()));
     binder = add_derives(binder);
     if !autodetect {
         let builtin_includes = includes.iter().filter_map(|p| Some(format!("-I{}", p.to_str()?)));
@@ -812,7 +811,7 @@ fn run_bindgen(
     let bindings = binder
         .header(include_h.display().to_string())
         .clang_args(extra_bindgen_clang_args(pg_config)?)
-        .clang_arg(format!("-I{}", pg_target_include(major_version, pg_config)?))
+        .clang_args(pg_target_includes.iter().map(|x| format!("-I{x}")))
         .detect_include_paths(autodetect)
         .parse_callbacks(Box::new(overrides))
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
@@ -900,6 +899,16 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
         .blocklist_item("ERROR")
 }
 
+fn add_allowlists<'a>(
+    mut bind: bindgen::Builder,
+    pg_target_includes: impl Iterator<Item = &'a str>,
+) -> bindgen::Builder {
+    for pg_target_include in pg_target_includes {
+        bind = bind.allowlist_file(format!("{}.*", regex::escape(pg_target_include)))
+    }
+    bind.allowlist_item("PGERROR").allowlist_item("SIG.*")
+}
+
 fn add_derives(bind: bindgen::Builder) -> bindgen::Builder {
     bind.derive_debug(true)
         .derive_copy(true)
@@ -947,23 +956,44 @@ fn target_env_tracked(s: &str) -> Option<String> {
     env_tracked(&format!("{s}_{target}")).or_else(|| env_tracked(s))
 }
 
-fn pg_target_include(pg_version: u16, pg_config: &PgConfig) -> eyre::Result<String> {
-    let var = "PGRX_INCLUDEDIR_SERVER";
+fn find_include(
+    pg_version: u16,
+    var: &str,
+    default: impl Fn() -> eyre::Result<PathBuf>,
+) -> eyre::Result<String> {
     let value =
         target_env_tracked(&format!("{var}_PG{pg_version}")).or_else(|| target_env_tracked(var));
     let path = match value {
         // No configured value: ask `pg_config`.
-        None => pg_config.includedir_server()?,
+        None => default()?,
         // Configured to non-empty string: pass to bindgen
         Some(overridden) => Path::new(&overridden).to_path_buf(),
     };
     let path = std::fs::canonicalize(&path)
         .wrap_err(format!("cannot find {path:?} for C header files"))?
         .join("") // returning a `/`-ending path
-        .to_str()
-        .ok_or(eyre!("{path:?} is not valid UTF-8 string"))?
+        .display()
         .to_string();
-    Ok(path)
+    if let Some(path) = path.strip_prefix("\\\\?\\") {
+        Ok(path.to_string())
+    } else {
+        Ok(path)
+    }
+}
+
+fn pg_target_includes(pg_version: u16, pg_config: &PgConfig) -> eyre::Result<Vec<String>> {
+    let mut result =
+        vec![find_include(pg_version, "PGRX_INCLUDEDIR_SERVER", || pg_config.includedir_server())?];
+    if let Some("msvc") = env_tracked("CARGO_CFG_TARGET_ENV").as_deref() {
+        result.push(find_include(pg_version, "PGRX_PKGINCLUDEDIR", || pg_config.pkgincludedir())?);
+        result.push(find_include(pg_version, "PGRX_INCLUDEDIR_SERVER_PORT_WIN32", || {
+            pg_config.includedir_server_port_win32()
+        })?);
+        result.push(find_include(pg_version, "PGRX_INCLUDEDIR_SERVER_PORT_WIN32_MSVC", || {
+            pg_config.includedir_server_port_win32_msvc()
+        })?);
+    }
+    Ok(result)
 }
 
 fn build_shim(
@@ -976,7 +1006,15 @@ fn build_shim(
     std::fs::copy(shim_src, shim_dst).unwrap();
 
     let mut build = cc::Build::new();
-    build.flag(&format!("-I{}", pg_target_include(major_version, pg_config)?));
+    if let Some("msvc") = env_tracked("CARGO_CFG_TARGET_ENV").as_deref() {
+        // without this, pgrx_embed would be linked to postgres.lib
+        build.compiler("clang");
+        build.archiver("llvm-lib");
+        build.flag("-flto=thin");
+    }
+    for pg_target_include in pg_target_includes(major_version, pg_config)?.iter() {
+        build.flag(&format!("-I{pg_target_include}"));
+    }
     for flag in extra_bindgen_clang_args(pg_config)? {
         build.flag(&flag);
     }
@@ -988,9 +1026,13 @@ fn build_shim(
 fn extra_bindgen_clang_args(pg_config: &PgConfig) -> eyre::Result<Vec<String>> {
     let mut out = vec![];
     let flags = shlex::split(&pg_config.cppflags()?.to_string_lossy()).unwrap_or_default();
-    // Just give clang the full flag set, since presumably that's what we're
-    // getting when we build the C shim anyway.
-    out.extend(flags.iter().cloned());
+    if env_tracked("CARGO_CFG_TARGET_OS").as_deref() != Some("windows") {
+        // Just give clang the full flag set, since presumably that's what we're
+        // getting when we build the C shim anyway.
+        // Skip it on Windows, since clang is used to generate cshim but MSVC is
+        // used to compile PostgreSQL.
+        out.extend(flags.iter().cloned());
+    }
     if env_tracked("CARGO_CFG_TARGET_OS").as_deref() == Some("macos") {
         // Find the `-isysroot` flags so we can warn about them, so something
         // reasonable shows up if/when the build fails.

--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -114,9 +114,9 @@ fn random_abort() {
 }
 
 #[pg_guard]
-pub unsafe extern "C" fn _PG_init() {
+pub unsafe extern "C-unwind" fn _PG_init() {
     #[pg_guard]
-    extern "C" fn random_abort_callback(
+    extern "C-unwind" fn random_abort_callback(
         event: pg_sys::XactEvent::Type,
         _arg: *mut std::os::raw::c_void,
     ) {

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 ::pgrx::pg_module_magic!();
 
 #[pg_guard]
-pub extern "C" fn _PG_init() {
+pub extern "C-unwind" fn _PG_init() {
     BackgroundWorkerBuilder::new("Background Worker Example")
         .set_function("background_worker_main")
         .set_library("bgworker")
@@ -40,7 +40,7 @@ pub extern "C" fn _PG_init() {
 
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn background_worker_main(arg: pg_sys::Datum) {
+pub extern "C-unwind" fn background_worker_main(arg: pg_sys::Datum) {
     let arg = unsafe { i32::from_polymorphic_datum(arg, false, pg_sys::INT4OID) };
 
     // these are the signals we want to receive.  If we don't attach the SIGTERM handler, then

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -37,7 +37,7 @@ static PRIMITIVE: PgLwLock<i32> = PgLwLock::new(c"shmem_primtive");
 static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = PgAtomic::new(c"shmem_atomic");
 
 #[pg_guard]
-pub extern "C" fn _PG_init() {
+pub extern "C-unwind" fn _PG_init() {
     pg_shmem_init!(DEQUE);
     pg_shmem_init!(VEC);
     pg_shmem_init!(HASH);

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -29,12 +29,12 @@ pub struct Pgtest {
 
 unsafe impl PGRXSharedMemory for Pgtest {}
 
-static DEQUE: PgLwLock<heapless::Deque<Pgtest, 400>> = PgLwLock::new();
-static VEC: PgLwLock<heapless::Vec<Pgtest, 400>> = PgLwLock::new();
-static HASH: PgLwLock<heapless::FnvIndexMap<i32, i32, 4>> = PgLwLock::new();
-static STRUCT: PgLwLock<Pgtest> = PgLwLock::new();
-static PRIMITIVE: PgLwLock<i32> = PgLwLock::new();
-static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = PgAtomic::new();
+static DEQUE: PgLwLock<heapless::Deque<Pgtest, 400>> = PgLwLock::new(c"shmem_deque");
+static VEC: PgLwLock<heapless::Vec<Pgtest, 400>> = PgLwLock::new(c"shmem_vec");
+static HASH: PgLwLock<heapless::FnvIndexMap<i32, i32, 4>> = PgLwLock::new(c"shmem_hash");
+static STRUCT: PgLwLock<Pgtest> = PgLwLock::new(c"shmem_struct");
+static PRIMITIVE: PgLwLock<i32> = PgLwLock::new(c"shmem_primtive");
+static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = PgAtomic::new(c"shmem_atomic");
 
 #[pg_guard]
 pub extern "C" fn _PG_init() {

--- a/pgrx-examples/wal_decoder/src/lib.rs
+++ b/pgrx-examples/wal_decoder/src/lib.rs
@@ -191,7 +191,7 @@ impl Serialize for Tuple {
 #[allow(non_snake_case)]
 #[no_mangle]
 #[pg_guard]
-pub unsafe extern "C" fn _PG_output_plugin_init(cb_ptr: *mut pg_sys::OutputPluginCallbacks) {
+pub unsafe extern "C-unwind" fn _PG_output_plugin_init(cb_ptr: *mut pg_sys::OutputPluginCallbacks) {
     let mut callbacks = unsafe { PgBox::from_pg(cb_ptr) };
     callbacks.startup_cb = Some(pg_decode_startup);
     callbacks.begin_cb = Some(pg_decode_begin_txn);
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn _PG_output_plugin_init(cb_ptr: *mut pg_sys::OutputPlugi
 //
 
 #[pg_guard]
-unsafe extern "C" fn pg_decode_startup(
+unsafe extern "C-unwind" fn pg_decode_startup(
     ctx_ptr: *mut pg_sys::LogicalDecodingContext,
     options_ptr: *mut pg_sys::OutputPluginOptions,
     _is_init: bool,
@@ -229,7 +229,7 @@ unsafe extern "C" fn pg_decode_startup(
 }
 
 #[pg_guard]
-unsafe extern "C" fn pg_decode_begin_txn(
+unsafe extern "C-unwind" fn pg_decode_begin_txn(
     ctx_ptr: *mut pg_sys::LogicalDecodingContext,
     _txn_ptr: *mut pg_sys::ReorderBufferTXN,
 ) {
@@ -240,7 +240,7 @@ unsafe extern "C" fn pg_decode_begin_txn(
 }
 
 #[pg_guard]
-unsafe extern "C" fn pg_decode_commit_txn(
+unsafe extern "C-unwind" fn pg_decode_commit_txn(
     ctx_ptr: *mut pg_sys::LogicalDecodingContext,
     txn_ptr: *mut pg_sys::ReorderBufferTXN,
     _commit_lsn: pg_sys::XLogRecPtr,
@@ -252,7 +252,7 @@ unsafe extern "C" fn pg_decode_commit_txn(
 }
 
 #[pg_guard]
-unsafe extern "C" fn pg_decode_change(
+unsafe extern "C-unwind" fn pg_decode_change(
     ctx_ptr: *mut pg_sys::LogicalDecodingContext,
     _txn_ptr: *mut pg_sys::ReorderBufferTXN,
     relation: pg_sys::Relation,
@@ -269,7 +269,7 @@ unsafe extern "C" fn pg_decode_change(
 }
 
 #[pg_guard]
-unsafe extern "C" fn pg_decode_shutdown(ctx_ptr: *mut pg_sys::LogicalDecodingContext) {
+unsafe extern "C-unwind" fn pg_decode_shutdown(ctx_ptr: *mut pg_sys::LogicalDecodingContext) {
     let layout = Layout::new::<DecodingState>();
     let ctx = unsafe { PgBox::from_pg(ctx_ptr) };
     unsafe { dealloc(ctx.output_plugin_private as *mut u8, layout) };

--- a/pgrx-pg-config/src/cargo.rs
+++ b/pgrx-pg-config/src/cargo.rs
@@ -89,8 +89,16 @@ impl PgrxManifestExt for Manifest {
 
     fn lib_filename(&self) -> eyre::Result<String> {
         let lib_name = &self.lib_name()?;
-        let so_extension = if cfg!(target_os = "macos") { "dylib" } else { "so" };
-        Ok(format!("lib{}.{}", lib_name.replace('-', "_"), so_extension))
+        let (prefix, extension) = 'pe: {
+            if cfg!(target_os = "macos") {
+                break 'pe ("lib", "dylib");
+            }
+            if cfg!(target_os = "windows") {
+                break 'pe ("", "dll");
+            }
+            ("lib", "so")
+        };
+        Ok(format!("{prefix}{}.{}", lib_name.replace('-', "_"), extension))
     }
 }
 

--- a/pgrx-pg-config/src/cargo.rs
+++ b/pgrx-pg-config/src/cargo.rs
@@ -88,17 +88,9 @@ impl PgrxManifestExt for Manifest {
     }
 
     fn lib_filename(&self) -> eyre::Result<String> {
+        use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
         let lib_name = &self.lib_name()?;
-        let (prefix, extension) = 'pe: {
-            if cfg!(target_os = "macos") {
-                break 'pe ("lib", "dylib");
-            }
-            if cfg!(target_os = "windows") {
-                break 'pe ("", "dll");
-            }
-            ("lib", "so")
-        };
-        Ok(format!("{prefix}{}.{}", lib_name.replace('-', "_"), extension))
+        Ok(format!("{DLL_PREFIX}{}{DLL_SUFFIX}", lib_name.replace('-', "_")))
     }
 }
 

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -29,11 +29,7 @@ pub static BASE_POSTGRES_TESTING_PORT_NO: u16 = 32200;
 /// The flags to specify to get a "C.UTF-8" locale on this system, or "C" locale on systems without
 /// a "C.UTF-8" locale equivalent.
 pub fn get_c_locale_flags() -> &'static [&'static str] {
-    #[cfg(target_os = "macos")]
-    {
-        &["--locale=C", "--lc-ctype=UTF-8"]
-    }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(target_family = "unix", not(target_os = "macos")))]
     {
         match Command::new("locale").arg("-a").output() {
             Ok(cmd)
@@ -46,6 +42,14 @@ pub fn get_c_locale_flags() -> &'static [&'static str] {
             // fallback to C if we can't list locales or don't have C.UTF-8
             _ => &["--locale=C"],
         }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        &["--locale=C", "--lc-ctype=UTF-8"]
+    }
+    #[cfg(target_os = "windows")]
+    {
+        &["--locale=C"]
     }
 }
 
@@ -330,32 +334,55 @@ impl PgConfig {
 
     pub fn postmaster_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
+        #[cfg(not(target_os = "windows"))]
         path.push("postgres");
-
+        #[cfg(target_os = "windows")]
+        path.push("postgres.exe");
         Ok(path)
     }
 
     pub fn initdb_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
+        #[cfg(not(target_os = "windows"))]
         path.push("initdb");
+        #[cfg(target_os = "windows")]
+        path.push("initdb.exe");
         Ok(path)
     }
 
     pub fn createdb_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
+        #[cfg(not(target_os = "windows"))]
         path.push("createdb");
+        #[cfg(target_os = "windows")]
+        path.push("createdb.exe");
         Ok(path)
     }
 
     pub fn dropdb_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
+        #[cfg(not(target_os = "windows"))]
         path.push("dropdb");
+        #[cfg(target_os = "windows")]
+        path.push("dropdb.exe");
+        Ok(path)
+    }
+
+    pub fn pg_ctl_path(&self) -> eyre::Result<PathBuf> {
+        let mut path = self.bin_dir()?;
+        #[cfg(not(target_os = "windows"))]
+        path.push("pg_ctl");
+        #[cfg(target_os = "windows")]
+        path.push("pg_ctl.exe");
         Ok(path)
     }
 
     pub fn psql_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
+        #[cfg(not(target_os = "windows"))]
         path.push("psql");
+        #[cfg(target_os = "windows")]
+        path.push("psql.exe");
         Ok(path)
     }
 
@@ -385,8 +412,22 @@ impl PgConfig {
             .collect())
     }
 
+    pub fn pkgincludedir(&self) -> eyre::Result<PathBuf> {
+        Ok(self.run("--pkgincludedir")?.into())
+    }
+
     pub fn includedir_server(&self) -> eyre::Result<PathBuf> {
         Ok(self.run("--includedir-server")?.into())
+    }
+
+    pub fn includedir_server_port_win32(&self) -> eyre::Result<PathBuf> {
+        let includedir_server = self.includedir_server()?;
+        Ok(includedir_server.join("port").join("win32"))
+    }
+
+    pub fn includedir_server_port_win32_msvc(&self) -> eyre::Result<PathBuf> {
+        let includedir_server = self.includedir_server()?;
+        Ok(includedir_server.join("port").join("win32_msvc"))
     }
 
     pub fn pkglibdir(&self) -> eyre::Result<PathBuf> {

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -12,6 +12,7 @@ use eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+use std::env::consts::EXE_SUFFIX;
 use std::ffi::OsString;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io::ErrorKind;
@@ -334,55 +335,37 @@ impl PgConfig {
 
     pub fn postmaster_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
-        #[cfg(not(target_os = "windows"))]
-        path.push("postgres");
-        #[cfg(target_os = "windows")]
-        path.push("postgres.exe");
+        path.push(format!("postgres{EXE_SUFFIX}"));
         Ok(path)
     }
 
     pub fn initdb_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
-        #[cfg(not(target_os = "windows"))]
-        path.push("initdb");
-        #[cfg(target_os = "windows")]
-        path.push("initdb.exe");
+        path.push(format!("initdb{EXE_SUFFIX}"));
         Ok(path)
     }
 
     pub fn createdb_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
-        #[cfg(not(target_os = "windows"))]
-        path.push("createdb");
-        #[cfg(target_os = "windows")]
-        path.push("createdb.exe");
+        path.push(format!("createdb{EXE_SUFFIX}"));
         Ok(path)
     }
 
     pub fn dropdb_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
-        #[cfg(not(target_os = "windows"))]
-        path.push("dropdb");
-        #[cfg(target_os = "windows")]
-        path.push("dropdb.exe");
+        path.push(format!("dropdb{EXE_SUFFIX}"));
         Ok(path)
     }
 
     pub fn pg_ctl_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
-        #[cfg(not(target_os = "windows"))]
-        path.push("pg_ctl");
-        #[cfg(target_os = "windows")]
-        path.push("pg_ctl.exe");
+        path.push(format!("pg_ctl{EXE_SUFFIX}"));
         Ok(path)
     }
 
     pub fn psql_path(&self) -> eyre::Result<PathBuf> {
         let mut path = self.bin_dir()?;
-        #[cfg(not(target_os = "windows"))]
-        path.push("psql");
-        #[cfg(target_os = "windows")]
-        path.push("psql.exe");
+        path.push(format!("psql{EXE_SUFFIX}"));
         Ok(path)
     }
 

--- a/pgrx-pg-sys/src/cshim.rs
+++ b/pgrx-pg-sys/src/cshim.rs
@@ -4,7 +4,7 @@
 use crate as pg_sys;
 
 #[pgrx_macros::pg_guard]
-extern "C" {
+extern "C-unwind" {
     #[link_name = "SpinLockInit__pgrx_cshim"]
     pub fn SpinLockInit(lock: *mut pg_sys::slock_t);
     #[link_name = "SpinLockAcquire__pgrx_cshim"]

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -106,7 +106,7 @@ pub unsafe fn GetMemoryChunkContext(pointer: *mut std::os::raw::c_void) -> pg_sy
     #[cfg(any(feature = "pg16", feature = "pg17"))]
     {
         #[pgrx_macros::pg_guard]
-        extern "C" {
+        extern "C-unwind" {
             #[link_name = "GetMemoryChunkContext"]
             pub fn extern_fn(pointer: *mut std::os::raw::c_void) -> pg_sys::MemoryContext;
         }
@@ -340,11 +340,11 @@ pub unsafe fn heap_tuple_get_struct<T>(htup: super::HeapTuple) -> *mut T {
 // and we route people to the old symbols they were using before on later ones.
 #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
 #[::pgrx_macros::pg_guard]
-extern "C" {
+extern "C-unwind" {
     pub fn planstate_tree_walker(
         planstate: *mut super::PlanState,
         walker: ::core::option::Option<
-            unsafe extern "C" fn(*mut super::PlanState, *mut ::core::ffi::c_void) -> bool,
+            unsafe extern "C-unwind" fn(*mut super::PlanState, *mut ::core::ffi::c_void) -> bool,
         >,
         context: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -352,7 +352,7 @@ extern "C" {
     pub fn query_tree_walker(
         query: *mut super::Query,
         walker: ::core::option::Option<
-            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+            unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
         >,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
@@ -361,7 +361,7 @@ extern "C" {
     pub fn query_or_expression_tree_walker(
         node: *mut super::Node,
         walker: ::core::option::Option<
-            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+            unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
         >,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
@@ -370,7 +370,7 @@ extern "C" {
     pub fn range_table_entry_walker(
         rte: *mut super::RangeTblEntry,
         walker: ::core::option::Option<
-            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+            unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
         >,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
@@ -379,7 +379,7 @@ extern "C" {
     pub fn range_table_walker(
         rtable: *mut super::List,
         walker: ::core::option::Option<
-            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+            unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
         >,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
@@ -388,7 +388,7 @@ extern "C" {
     pub fn expression_tree_walker(
         node: *mut super::Node,
         walker: ::core::option::Option<
-            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+            unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
         >,
         context: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -396,7 +396,7 @@ extern "C" {
     pub fn raw_expression_tree_walker(
         node: *mut super::Node,
         walker: ::core::option::Option<
-            unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+            unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
         >,
         context: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -406,7 +406,7 @@ extern "C" {
 pub unsafe fn planstate_tree_walker(
     planstate: *mut super::PlanState,
     walker: ::core::option::Option<
-        unsafe extern "C" fn(*mut super::PlanState, *mut ::core::ffi::c_void) -> bool,
+        unsafe extern "C-unwind" fn(*mut super::PlanState, *mut ::core::ffi::c_void) -> bool,
     >,
     context: *mut ::core::ffi::c_void,
 ) -> bool {
@@ -417,7 +417,7 @@ pub unsafe fn planstate_tree_walker(
 pub unsafe fn query_tree_walker(
     query: *mut super::Query,
     walker: ::core::option::Option<
-        unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+        unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
     >,
     context: *mut ::core::ffi::c_void,
     flags: ::core::ffi::c_int,
@@ -429,7 +429,7 @@ pub unsafe fn query_tree_walker(
 pub unsafe fn query_or_expression_tree_walker(
     node: *mut super::Node,
     walker: ::core::option::Option<
-        unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+        unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
     >,
     context: *mut ::core::ffi::c_void,
     flags: ::core::ffi::c_int,
@@ -440,7 +440,7 @@ pub unsafe fn query_or_expression_tree_walker(
 #[cfg(any(feature = "pg16", feature = "pg17"))]
 pub unsafe fn expression_tree_walker(
     node: *mut crate::Node,
-    walker: Option<unsafe extern "C" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
+    walker: Option<unsafe extern "C-unwind" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
     context: *mut ::core::ffi::c_void,
 ) -> bool {
     crate::expression_tree_walker_impl(node, walker, context)
@@ -450,7 +450,7 @@ pub unsafe fn expression_tree_walker(
 pub unsafe fn range_table_entry_walker(
     rte: *mut super::RangeTblEntry,
     walker: ::core::option::Option<
-        unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+        unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
     >,
     context: *mut ::core::ffi::c_void,
     flags: ::core::ffi::c_int,
@@ -462,7 +462,7 @@ pub unsafe fn range_table_entry_walker(
 pub unsafe fn range_table_walker(
     rtable: *mut super::List,
     walker: ::core::option::Option<
-        unsafe extern "C" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
+        unsafe extern "C-unwind" fn(*mut super::Node, *mut ::core::ffi::c_void) -> bool,
     >,
     context: *mut ::core::ffi::c_void,
     flags: ::core::ffi::c_int,
@@ -473,7 +473,7 @@ pub unsafe fn range_table_walker(
 #[cfg(any(feature = "pg16", feature = "pg17"))]
 pub unsafe fn raw_expression_tree_walker(
     node: *mut crate::Node,
-    walker: Option<unsafe extern "C" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
+    walker: Option<unsafe extern "C-unwind" fn(*mut crate::Node, *mut ::core::ffi::c_void) -> bool>,
     context: *mut ::core::ffi::c_void,
 ) -> bool {
     crate::raw_expression_tree_walker_impl(node, walker, context)

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -33,7 +33,7 @@ pub fn finfo_v1_extern_c(
     let tokens = quote_spanned! { synthetic =>
         #[no_mangle]
         #[doc(hidden)]
-        pub unsafe extern "C" fn #wrapper_symbol(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
+        pub unsafe extern "C-unwind" fn #wrapper_symbol(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
             #contents
         }
     };

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -39,7 +39,10 @@ pg17 = ["pgrx/pg17"]
 pg_test = []
 proptest = ["dep:proptest"]
 cshim = ["pgrx/cshim"]
-no-schema-generation = ["pgrx/no-schema-generation", "pgrx-macros/no-schema-generation"]
+no-schema-generation = [
+    "pgrx/no-schema-generation",
+    "pgrx-macros/no-schema-generation",
+]
 nightly = ["pgrx/nightly"]
 
 [package.metadata.docs.rs]
@@ -67,6 +70,7 @@ thiserror.workspace = true
 paste = "1"
 postgres = "0.19.10"
 proptest = { version = "1", optional = true }
+tempfile = "3.13.0"
 sysinfo = "0.33.1"
 rand = "0.9.0"
 
@@ -74,6 +78,16 @@ rand = "0.9.0"
 path = "../pgrx"
 default-features = false
 version = "=0.13.1"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.9", features = [
+    "securitybaseapi",
+    "minwinbase",
+    "namedpipeapi",
+    "winbase",
+    "winerror",
+    "winnt",
+] }
 
 [dev-dependencies]
 eyre.workspace = true # testing functions that return `eyre::Result`

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -114,7 +114,7 @@ pub fn run_test(
         );
         return Ok(());
     }
-    let (loglines, system_session_id) = initialize_test_framework(postgresql_conf)?;
+    let (loglines, system_session_id) = get_test_framework(postgresql_conf)?;
 
     let (mut client, session_id) = client()?;
 
@@ -190,9 +190,7 @@ fn format_loglines(session_id: &str, loglines: &LogLines) -> String {
     result
 }
 
-fn initialize_test_framework(
-    postgresql_conf: Vec<&'static str>,
-) -> eyre::Result<(LogLines, String)> {
+fn get_test_framework(postgresql_conf: Vec<&'static str>) -> eyre::Result<(LogLines, String)> {
     let mut state = TEST_MUTEX
         .get_or_init(|| {
             Mutex::new(SetupState {
@@ -212,20 +210,29 @@ fn initialize_test_framework(
         });
 
     if !state.installed {
-        shutdown::register_shutdown_hook();
-        install_extension()?;
-        initdb(postgresql_conf)?;
-
-        let system_session_id = start_pg(state.loglines.clone())?;
-        let pg_config = get_pg_config()?;
-        dropdb()?;
-        createdb(&pg_config, get_pg_dbname(), true, false, get_runas())?;
-        create_extension()?;
-        state.installed = true;
-        state.system_session_id = system_session_id;
+        initialize_test_framework(&mut state, postgresql_conf)
+            .expect("Could not initialize test framework");
     }
 
     Ok((state.loglines.clone(), state.system_session_id.clone()))
+}
+
+fn initialize_test_framework(
+    state: &mut SetupState,
+    postgresql_conf: Vec<&'static str>,
+) -> eyre::Result<()> {
+    shutdown::register_shutdown_hook();
+    install_extension()?;
+    initdb(postgresql_conf)?;
+
+    let system_session_id = start_pg(state.loglines.clone())?;
+    let pg_config = get_pg_config()?;
+    dropdb()?;
+    createdb(&pg_config, get_pg_dbname(), true, false, get_runas())?;
+    create_extension()?;
+    state.installed = true;
+    state.system_session_id = system_session_id;
+    Ok(())
 }
 
 fn get_pg_config() -> eyre::Result<PgConfig> {
@@ -418,7 +425,7 @@ fn maybe_make_pgdata<P: AsRef<Path>>(pgdata: P) -> eyre::Result<bool> {
     } else {
         // if the directory doesn't exist, make it. If it does, then we reuse it
         if !pgdata.exists() {
-            std::fs::create_dir_all(&pgdata)?;
+            std::fs::create_dir_all(pgdata.parent().unwrap())?;
 
             // which is the only time we need to `initdb` it.
             need_initdb = true;
@@ -446,25 +453,20 @@ fn initdb(postgresql_conf: Vec<&'static str>) -> eyre::Result<()> {
         };
 
         command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .current_dir(pgdata.parent().unwrap())
             .args(get_c_locale_flags())
             .arg("-D")
-            .arg(&pgdata)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .arg(&pgdata);
 
         let command_str = format!("{command:?}");
 
         println!("{} {}", "     Running".bold().green(), command_str);
-        let child = command.spawn().wrap_err_with(|| {
+
+        let output = command.output().wrap_err_with(|| {
             format!(
                 "Failed to spawn process for initializing database using command: '{command_str}': "
-            )
-        })?;
-
-        let output = child.wait_with_output().wrap_err_with(|| {
-            format!(
-                "Failed waiting for spawned process attempting to initialize database using command: '{command_str}': "
             )
         })?;
 
@@ -476,6 +478,8 @@ fn initdb(postgresql_conf: Vec<&'static str>) -> eyre::Result<()> {
                 String::from_utf8(output.stderr).unwrap()
             ));
         }
+
+        println!("{} initializing database", "    Finished".bold().green());
     }
 
     modify_postgresql_conf(pgdata, postgresql_conf)
@@ -485,8 +489,10 @@ fn modify_postgresql_conf(pgdata: PathBuf, postgresql_conf: Vec<&'static str>) -
     let mut contents = String::new();
 
     contents.push_str("log_line_prefix='[%m] [%p] [%c]: '\n");
-    contents
-        .push_str(&format!("unix_socket_directories = '{}'\n", pgdata.parent().unwrap().display()));
+    contents.push_str(&format!(
+        "unix_socket_directories = '{}'\n",
+        pgdata.parent().unwrap().display().to_string().replace("\\", "\\\\")
+    ));
     for setting in postgresql_conf {
         contents.push_str(&format!("{setting}\n"));
     }
@@ -522,30 +528,58 @@ fn modify_postgresql_conf(pgdata: PathBuf, postgresql_conf: Vec<&'static str>) -
 fn start_pg(loglines: LogLines) -> eyre::Result<String> {
     wait_for_pidfile()?;
 
-    let pg_config = get_pg_config()?;
-    let postmaster_path =
-        pg_config.postmaster_path().wrap_err("unable to determine postmaster path")?;
+    #[cfg(target_family = "unix")]
+    let pipe = pipe::UnixFifo::create()?;
+    #[cfg(target_family = "unix")]
+    let make_pipe_opened_without_blocking = pipe.full()?;
+    #[cfg(target_os = "windows")]
+    let mut pipe = pipe::WindowsNamedPipe::create()?;
 
-    let mut command = if use_valgrind() {
-        let mut cmd = Command::new("valgrind");
-        cmd.args([
-            "--leak-check=no",
-            "--gen-suppressions=all",
-            "--time-stamp=yes",
-            "--error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END",
-            "--trace-children=yes",
-        ]);
-        // Try to provide a suppressions file, we'll likely get false positives
-        // if we can't, but that might be better than nothing.
+    let pg_config = get_pg_config()?;
+    let pg_ctl = pg_config.pg_ctl_path()?;
+
+    let postmaster_path = if use_valgrind() {
+        #[allow(unused_mut)]
+        let mut builder = tempfile::Builder::new();
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let permission = std::fs::Permissions::from_mode(0o700);
+            builder.permissions(permission);
+        }
+        let mut file = builder.tempfile()?;
+        file.write_all(b"#!/usr/bin/sh\n")?;
+        let mut command = Command::new("valgrind");
+        command.arg("--leak-check=no");
+        command.arg("--gen-suppressions=all");
+        command.arg("--time-stamp=yes");
+        command.arg("--error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END");
+        command.arg("--trace-children=yes");
         if let Ok(path) = valgrind_suppressions_path(&pg_config) {
-            if path.exists() {
-                cmd.arg(format!("--suppressions={}", path.display()));
+            if let Ok(true) = std::fs::exists(&path) {
+                command.arg(format!("--suppressions={}", path.display()));
             }
         }
+        command.arg(pg_config.postmaster_path()?.display().to_string());
+        file.write_all(format!("{command:?}").as_bytes())?;
+        file.write_all(b" \"$@\"\n")?;
+        Some(file.into_temp_path())
+    } else {
+        None
+    };
 
-        cmd.arg(postmaster_path);
-        cmd
-    } else if let Some(runas) = get_runas() {
+    let mut postmaster_args = Vec::new();
+    postmaster_args.push("-i".into());
+    postmaster_args.push("-p".into());
+    postmaster_args.push(pg_config.test_port().expect("unable to determine test port").to_string());
+    postmaster_args.push("-h".into());
+    postmaster_args.push(pg_config.host().into());
+    postmaster_args.push("-c".into());
+    postmaster_args.push("log_destination=stderr".into());
+    postmaster_args.push("-c".into());
+    postmaster_args.push("logging_collector=off".into());
+
+    let mut command = if let Some(runas) = get_runas() {
         #[inline]
         fn accept_envar(var: &str) -> bool {
             // taken from https://doc.rust-lang.org/cargo/reference/environment-variables.html
@@ -555,9 +589,7 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
                 || ["OUT_DIR", "TARGET", "HOST", "NUM_JOBS", "OPT_LEVEL", "DEBUG", "PROFILE"]
                     .contains(&var)
         }
-
         let mut cmd = sudo_command(runas);
-
         // when running the `postmaster` process via `sudo`, we need to copy the cargo/rust-related
         // environment variables and pass as arguments to sudo, ahead of the `postmaster` command itself
         //
@@ -568,98 +600,108 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
                 cmd.arg(env_as_arg);
             }
         }
-
-        // now we can add the `postmaster` as the command for `sudo` to execute
-        cmd.arg(postmaster_path);
+        // now we can add the `pg_ctl` as the command for `sudo` to execute
+        cmd.arg(pg_ctl);
         cmd
     } else {
-        Command::new(postmaster_path)
+        Command::new(pg_ctl)
     };
     command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("start")
+        .arg("-o")
+        .arg(postmaster_args.join(" "))
         .arg("-D")
         .arg(get_pgdata_path()?.to_str().unwrap())
-        .arg("-h")
-        .arg(pg_config.host())
-        .arg("-p")
-        .arg(pg_config.test_port().expect("unable to determine test port").to_string())
-        // Redirecting logs to files can hang the test framework, override it
-        .args(["-c", "log_destination=stderr", "-c", "logging_collector=off"])
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::piped());
+        .arg("-l")
+        .arg(pipe.path());
+    if let Some(postmaster_path) = postmaster_path.as_ref() {
+        command
+            .arg("-W") // pg_ctl cannot detect if postmaster starts
+            .arg("-p")
+            .arg(postmaster_path);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // on windows, created pipes are leaked, so that the command hangs
+        command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    }
 
     let command_str = format!("{command:?}");
 
-    // start Postgres and monitor its stderr in the background
-    // also notify the main thread when it's ready to accept connections
-    let session_id = monitor_pg(command, command_str, loglines);
-
-    Ok(session_id)
-}
-
-fn valgrind_suppressions_path(pg_config: &PgConfig) -> Result<PathBuf, eyre::Report> {
-    let mut home = Pgrx::home()?;
-    home.push(pg_config.version()?);
-    home.push("src/tools/valgrind.supp");
-    Ok(home)
-}
-
-fn wait_for_pidfile() -> Result<(), eyre::Report> {
-    const MAX_PIDFILE_RETRIES: usize = 10;
-
-    let pidfile = get_pid_file()?;
-
-    let mut retries = 0;
-    while pidfile.exists() {
-        if retries > MAX_PIDFILE_RETRIES {
-            // break out and try to start postgres anyways, maybe it'll report a decent error about what's going on
-            eprintln!("`{}` has existed for ~10s.  There might be some problem with the pgrx testing Postgres instance", pidfile.display());
-            break;
-        }
-        eprintln!("`{}` still exists.  Waiting...", pidfile.display());
-        std::thread::sleep(Duration::from_secs(1));
-        retries += 1;
-    }
-    Ok(())
-}
-
-fn monitor_pg(mut command: Command, cmd_string: String, loglines: LogLines) -> String {
-    let (sender, receiver) = std::sync::mpsc::channel();
-
-    std::thread::spawn(move || {
-        let mut child = command.spawn().expect("postmaster didn't spawn");
-
-        let pid = child.id();
-        // Add a shutdown hook so we can terminate it when the test framework
-        // exits. TODO: Consider finding a way to handle cases where we fail to
-        // clean up due to a SIGNAL?
-        add_shutdown_hook(move || unsafe {
-            if let Some(_runas) = get_runas() {
-                sudo_command("root") // NB:  we must be "root" to kill the `sudo` process we spawned to start postgres
-                    .arg("kill")
-                    .arg("-s")
-                    .arg("SIGTERM")
-                    .arg(pid.to_string())
-                    .spawn()
-                    .expect("failed to spawn `sudo kill`")
-                    .wait()
-                    .expect("`sudo kill` didn't work");
-            } else {
-                libc::kill(pid as libc::pid_t, libc::SIGTERM);
-                let message_string = std::ffi::CString::new(
-                    format!("stopping postgres (pid={pid})\n").bold().blue().to_string(),
-                )
-                .unwrap();
-                // IMPORTANT: Rust string literals are not naturally null-terminated
-                libc::printf("%s\0".as_ptr().cast(), message_string.as_ptr());
-            }
+    #[cfg(target_family = "unix")]
+    let (output, mut pipe) = {
+        let output = command.output();
+        let pipe = pipe.read().expect("failed to connect to pipe");
+        drop(make_pipe_opened_without_blocking);
+        (output?, pipe)
+    };
+    #[cfg(target_os = "windows")]
+    let (output, mut pipe) = {
+        let (output, pipe) = std::thread::scope(|scope| {
+            let thread = scope.spawn(|| {
+                pipe.connect().expect("failed to connect to pg_ctl");
+                pipe.connect().expect("failed to connect to pipe")
+            });
+            (command.output(), thread.join().unwrap())
         });
+        (output?, pipe)
+    };
 
-        eprintln!("{cmd}\npid={p}", cmd = cmd_string.bold().blue(), p = pid.to_string().yellow());
-        eprintln!("{}", pg_sys::get_pg_version_string().bold().purple());
+    if !output.status.success() {
+        let log = {
+            use std::io::Read;
+            let mut buffer = vec![0u8; 4096];
+            let mut result = Vec::new();
+            if let Ok(n) = pipe.read(&mut buffer) {
+                if n > 0 {
+                    result.extend(&buffer[..n]);
+                }
+            }
+            result
+        };
+        panic!(
+            "problem running pg_ctl: {}\n\n{}\n\n{}",
+            command_str,
+            String::from_utf8(output.stderr).unwrap(),
+            String::from_utf8(log).unwrap()
+        );
+    }
 
-        // wait for the database to say its ready to start up
-        let reader = BufReader::new(child.stderr.take().expect("couldn't take postmaster stderr"));
+    add_shutdown_hook(|| {
+        let pg_config = get_pg_config().unwrap();
+        let pg_ctl = pg_config.pg_ctl_path().unwrap();
 
+        let mut command = if let Some(runas) = get_runas() {
+            let mut cmd = sudo_command(runas);
+            cmd.arg(pg_ctl);
+            cmd
+        } else {
+            Command::new(pg_ctl)
+        };
+        command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .arg("stop")
+            .arg("-D")
+            .arg(get_pgdata_path().unwrap().to_str().unwrap())
+            .arg("-m")
+            .arg("fast");
+        let command_str = format!("{command:?}");
+        let output = command.output().unwrap();
+        if !output.status.success() {
+            panic!(
+                "problem running pg_ctl: {}\n\n{}",
+                command_str,
+                String::from_utf8(output.stderr).unwrap()
+            );
+        }
+    });
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(pipe);
         let regex = regex::Regex::new(r"\[.*?\] \[.*?\] \[(?P<session_id>.*?)\]").unwrap();
         let mut is_started_yet = false;
         let mut lines = reader.lines();
@@ -699,21 +741,37 @@ fn monitor_pg(mut command: Command, cmd_string: String, loglines: LogLines) -> S
             let session_lines = loglines.entry(session_id).or_default();
             session_lines.push(line);
         }
-
-        // wait for Postgres to really finish
-        match child.try_wait() {
-            Ok(status) => {
-                if let Some(_status) = status {
-                    // we exited normally
-                }
-            }
-            Err(e) => panic!("was going to let Postgres finish, but errored this time:\n{e}"),
-        }
     });
 
     // wait for Postgres to indicate it's ready to accept connection
     // and return its pid when it is
-    receiver.recv().expect("Postgres failed to start")
+    Ok(receiver.recv().expect("Postgres failed to start"))
+}
+
+fn valgrind_suppressions_path(pg_config: &PgConfig) -> Result<PathBuf, eyre::Report> {
+    let mut home = Pgrx::home()?;
+    home.push(pg_config.version()?);
+    home.push("src/tools/valgrind.supp");
+    Ok(home)
+}
+
+fn wait_for_pidfile() -> Result<(), eyre::Report> {
+    const MAX_PIDFILE_RETRIES: usize = 10;
+
+    let pidfile = get_pid_file()?;
+
+    let mut retries = 0;
+    while pidfile.exists() {
+        if retries > MAX_PIDFILE_RETRIES {
+            // break out and try to start postgres anyways, maybe it'll report a decent error about what's going on
+            eprintln!("`{}` has existed for ~10s.  There might be some problem with the pgrx testing Postgres instance", pidfile.display());
+            break;
+        }
+        eprintln!("`{}` still exists.  Waiting...", pidfile.display());
+        std::thread::sleep(Duration::from_secs(1));
+        retries += 1;
+    }
+    Ok(())
 }
 
 fn dropdb() -> eyre::Result<()> {
@@ -819,8 +877,12 @@ pub(crate) fn get_pg_dbname() -> &'static str {
 }
 
 pub(crate) fn get_pg_user() -> String {
+    #[cfg(target_family = "unix")]
+    let varname = "USER";
+    #[cfg(target_os = "windows")]
+    let varname = "USERNAME";
     get_runas().unwrap_or_else(|| {
-        std::env::var("USER")
+        std::env::var(varname)
             .unwrap_or_else(|_| panic!("USER environment var is unset or invalid UTF-8"))
     })
 }
@@ -898,7 +960,7 @@ fn get_cargo_args() -> Vec<String> {
     while let Some(process) = system.process(pid) {
         // only if it's "cargo"... (This works for now, but just because `cargo`
         // is at the end of the path. How *should* this handle `CARGO`?)
-        if process.exe().is_some_and(|p| p.ends_with("cargo")) {
+        if process.exe().is_some_and(|p| p.ends_with("cargo") || p.ends_with("cargo.exe")) {
             // ... and only if it's "cargo test"...
             if process.cmd().iter().any(|arg| arg == "test")
                 && !process.cmd().iter().any(|arg| arg == "pgrx")
@@ -958,4 +1020,225 @@ fn sudo_command<U: AsRef<OsStr>>(user: U) -> Command {
     sudo.arg("-u");
     sudo.arg(user);
     sudo
+}
+
+pub mod pipe {
+    use rand::distr::Alphanumeric;
+    use rand::Rng;
+    use std::fs::File;
+    use std::io::Error;
+    use std::path::{Path, PathBuf};
+
+    #[cfg(target_family = "unix")]
+    pub struct UnixFifo {
+        path: PathBuf,
+    }
+
+    #[cfg(target_family = "unix")]
+    impl UnixFifo {
+        pub fn create() -> std::io::Result<Self> {
+            use std::ffi::CString;
+            let filename: String =
+                rand::rng().sample_iter(Alphanumeric).map(char::from).take(6).collect();
+            let path = format!(r"/tmp/{filename}");
+            let arg = CString::new(path.clone()).unwrap();
+            let mode = libc::S_IRUSR
+                | libc::S_IWUSR
+                | libc::S_IRGRP
+                | libc::S_IWGRP
+                | libc::S_IROTH
+                | libc::S_IWOTH;
+            let errno = unsafe { libc::mkfifo(arg.as_ptr(), mode) };
+            if errno < 0 {
+                return Err(Error::last_os_error());
+            }
+            let errno = unsafe { libc::chmod(arg.as_ptr(), mode) };
+            if errno < 0 {
+                return Err(Error::last_os_error());
+            }
+            Ok(UnixFifo { path: PathBuf::from(path) })
+        }
+        pub fn path(&self) -> &Path {
+            &self.path
+        }
+        pub fn read(&self) -> std::io::Result<File> {
+            use std::os::unix::fs::OpenOptionsExt;
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NOCTTY)
+                .open(&self.path)?;
+            Ok(file)
+        }
+        pub fn full(&self) -> std::io::Result<File> {
+            use std::os::unix::fs::OpenOptionsExt;
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_NOCTTY)
+                .open(&self.path)?;
+            Ok(file)
+        }
+    }
+
+    #[cfg(target_family = "unix")]
+    impl Drop for UnixFifo {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub struct WindowsNamedPipe {
+        path: PathBuf,
+        file: File,
+    }
+
+    #[cfg(target_os = "windows")]
+    impl WindowsNamedPipe {
+        pub fn create() -> std::io::Result<Self> {
+            let filename: String =
+                rand::thread_rng().sample_iter(Alphanumeric).map(char::from).take(6).collect();
+            let path = format!(r"\\.\pipe\{filename}");
+            let server = unsafe {
+                use std::os::windows::ffi::OsStrExt;
+                use std::os::windows::io::FromRawHandle;
+                let mut os_str = PathBuf::from(&path).as_os_str().to_os_string();
+                os_str.push("\0");
+                let arg = os_str.encode_wide().collect::<Vec<u16>>();
+                let mut sd = {
+                    let mut sd = std::mem::zeroed::<winapi::um::winnt::SECURITY_DESCRIPTOR>();
+                    let success = winapi::um::securitybaseapi::InitializeSecurityDescriptor(
+                        (&raw mut sd).cast(),
+                        winapi::um::winnt::SECURITY_DESCRIPTOR_REVISION,
+                    );
+                    if success == 0 {
+                        return Err(Error::last_os_error());
+                    }
+                    let success = winapi::um::securitybaseapi::SetSecurityDescriptorDacl(
+                        (&raw mut sd).cast(),
+                        1,
+                        std::ptr::null_mut(),
+                        0,
+                    );
+                    if success == 0 {
+                        return Err(Error::last_os_error());
+                    }
+                    let success = winapi::um::securitybaseapi::SetSecurityDescriptorControl(
+                        (&raw mut sd).cast(),
+                        winapi::um::winnt::SE_DACL_PROTECTED,
+                        winapi::um::winnt::SE_DACL_PROTECTED,
+                    );
+                    if success == 0 {
+                        return Err(Error::last_os_error());
+                    }
+                    sd
+                };
+                let mut sa = {
+                    let mut sa = std::mem::zeroed::<winapi::um::minwinbase::SECURITY_ATTRIBUTES>();
+                    sa.nLength = size_of::<winapi::um::minwinbase::SECURITY_ATTRIBUTES>() as _;
+                    sa.lpSecurityDescriptor = (&raw mut sd).cast();
+                    sa.bInheritHandle = 0;
+                    sa
+                };
+                let raw_handle = winapi::um::namedpipeapi::CreateNamedPipeW(
+                    arg.as_ptr().cast(),
+                    winapi::um::winbase::PIPE_ACCESS_DUPLEX
+                        | winapi::um::winbase::FILE_FLAG_FIRST_PIPE_INSTANCE,
+                    winapi::um::winbase::PIPE_TYPE_BYTE
+                        | winapi::um::winbase::PIPE_READMODE_BYTE
+                        | winapi::um::winbase::PIPE_WAIT,
+                    winapi::um::winbase::PIPE_UNLIMITED_INSTANCES,
+                    65536,
+                    65536,
+                    0,
+                    &raw mut sa,
+                );
+                if raw_handle == winapi::um::handleapi::INVALID_HANDLE_VALUE {
+                    return Err(Error::last_os_error());
+                }
+                File::from_raw_handle(raw_handle.cast())
+            };
+            Ok(WindowsNamedPipe { path: PathBuf::from(path), file: server })
+        }
+        pub fn path(&self) -> &Path {
+            &self.path
+        }
+        pub fn connect(&mut self) -> std::io::Result<File> {
+            use std::os::windows::io::AsRawHandle;
+            let ret = unsafe {
+                winapi::um::namedpipeapi::ConnectNamedPipe(
+                    self.file.as_raw_handle().cast(),
+                    std::ptr::null_mut(),
+                )
+            };
+            if ret == 0 {
+                let last_os_error = Error::last_os_error();
+                if last_os_error.raw_os_error()
+                    != Some(winapi::shared::winerror::ERROR_PIPE_CONNECTED as _)
+                {
+                    return Err(last_os_error);
+                }
+            }
+            let path = &self.path;
+            let server = unsafe {
+                use std::os::windows::ffi::OsStrExt;
+                use std::os::windows::io::FromRawHandle;
+                let mut os_str = PathBuf::from(&path).as_os_str().to_os_string();
+                os_str.push("\0");
+                let arg = os_str.encode_wide().collect::<Vec<u16>>();
+                let mut sd = {
+                    let mut sd = std::mem::zeroed::<winapi::um::winnt::SECURITY_DESCRIPTOR>();
+                    let success = winapi::um::securitybaseapi::InitializeSecurityDescriptor(
+                        (&raw mut sd).cast(),
+                        winapi::um::winnt::SECURITY_DESCRIPTOR_REVISION,
+                    );
+                    if success == 0 {
+                        return Err(Error::last_os_error());
+                    }
+                    let success = winapi::um::securitybaseapi::SetSecurityDescriptorDacl(
+                        (&raw mut sd).cast(),
+                        1,
+                        std::ptr::null_mut(),
+                        0,
+                    );
+                    if success == 0 {
+                        return Err(Error::last_os_error());
+                    }
+                    let success = winapi::um::securitybaseapi::SetSecurityDescriptorControl(
+                        (&raw mut sd).cast(),
+                        winapi::um::winnt::SE_DACL_PROTECTED,
+                        winapi::um::winnt::SE_DACL_PROTECTED,
+                    );
+                    if success == 0 {
+                        return Err(Error::last_os_error());
+                    }
+                    sd
+                };
+                let mut sa = {
+                    let mut sa = std::mem::zeroed::<winapi::um::minwinbase::SECURITY_ATTRIBUTES>();
+                    sa.nLength = size_of::<winapi::um::minwinbase::SECURITY_ATTRIBUTES>() as _;
+                    sa.lpSecurityDescriptor = (&raw mut sd).cast();
+                    sa.bInheritHandle = 0;
+                    sa
+                };
+                let raw_handle = winapi::um::namedpipeapi::CreateNamedPipeW(
+                    arg.as_ptr().cast(),
+                    winapi::um::winbase::PIPE_ACCESS_DUPLEX,
+                    winapi::um::winbase::PIPE_TYPE_BYTE
+                        | winapi::um::winbase::PIPE_READMODE_BYTE
+                        | winapi::um::winbase::PIPE_WAIT,
+                    winapi::um::winbase::PIPE_UNLIMITED_INSTANCES,
+                    65536,
+                    65536,
+                    0,
+                    &raw mut sa,
+                );
+                if raw_handle == winapi::um::handleapi::INVALID_HANDLE_VALUE {
+                    return Err(Error::last_os_error());
+                }
+                File::from_raw_handle(raw_handle.cast())
+            };
+            Ok(std::mem::replace(&mut self.file, server))
+        }
+    }
 }

--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -11,7 +11,7 @@ use pgrx::prelude::*;
 
 #[pg_guard]
 #[no_mangle]
-pub extern "C" fn bgworker(arg: pg_sys::Datum) {
+pub extern "C-unwind" fn bgworker(arg: pg_sys::Datum) {
     use pgrx::bgworkers::*;
     use std::time::Duration;
     BackgroundWorker::attach_signal_handlers(SignalWakeFlags::SIGHUP | SignalWakeFlags::SIGTERM);
@@ -43,7 +43,7 @@ pub extern "C" fn bgworker(arg: pg_sys::Datum) {
 #[pg_guard]
 #[no_mangle]
 /// Here we test that `BackgroundWorker::transaction` can return data from the closure
-pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
+pub extern "C-unwind" fn bgworker_return_value(arg: pg_sys::Datum) {
     use pgrx::bgworkers::*;
     use std::time::Duration;
     BackgroundWorker::attach_signal_handlers(SignalWakeFlags::SIGHUP | SignalWakeFlags::SIGTERM);
@@ -77,7 +77,7 @@ pub extern "C" fn bgworker_return_value(arg: pg_sys::Datum) {
 #[pg_guard]
 #[no_mangle]
 /// Simple background worker that waits to be terminated; used to test behaviour in case of worker slots exhaustion
-pub extern "C" fn bgworker_sleep() {
+pub extern "C-unwind" fn bgworker_sleep() {
     use pgrx::bgworkers::*;
     BackgroundWorker::attach_signal_handlers(SignalWakeFlags::SIGHUP | SignalWakeFlags::SIGTERM);
     while BackgroundWorker::wait_latch(None) {}

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -59,7 +59,6 @@ mod rel_tests;
 mod result_tests;
 mod roundtrip_tests;
 mod schema_tests;
-#[cfg(target_family = "unix")]
 mod shmem_tests;
 mod spi_tests;
 mod srf_tests;

--- a/pgrx-tests/src/tests/mod.rs
+++ b/pgrx-tests/src/tests/mod.rs
@@ -59,6 +59,7 @@ mod rel_tests;
 mod result_tests;
 mod roundtrip_tests;
 mod schema_tests;
+#[cfg(target_family = "unix")]
 mod shmem_tests;
 mod spi_tests;
 mod srf_tests;

--- a/pgrx-tests/src/tests/pg_guard_tests.rs
+++ b/pgrx-tests/src/tests/pg_guard_tests.rs
@@ -18,7 +18,7 @@ fn extern_func() -> bool {
 #[pg_guard]
 // Uncommenting the line below will make it fail to compile
 // #[no_mangle]
-extern "C" fn extern_func_impl<T>() -> bool {
+extern "C-unwind" fn extern_func_impl<T>() -> bool {
     true
 }
 
@@ -26,7 +26,7 @@ extern "C" fn extern_func_impl<T>() -> bool {
 // and [no_mangle]
 #[pg_guard]
 #[no_mangle]
-extern "C" fn extern_func_impl_1() -> bool {
+extern "C-unwind" fn extern_func_impl_1() -> bool {
     true
 }
 
@@ -35,7 +35,7 @@ extern "C" fn extern_func_impl_1() -> bool {
 #[pg_guard]
 #[no_mangle]
 #[allow(unused_lifetimes)]
-extern "C" fn extern_func_impl_2<'a>() -> bool {
+extern "C-unwind" fn extern_func_impl_2<'a>() -> bool {
     true
 }
 

--- a/pgrx-tests/src/tests/pg_try_tests.rs
+++ b/pgrx-tests/src/tests/pg_try_tests.rs
@@ -24,7 +24,7 @@ fn crash() {
 }
 
 #[pg_guard]
-extern "C" fn walker(_node: *mut pg_sys::Node, _void: *mut ::core::ffi::c_void) -> bool {
+extern "C-unwind" fn walker(_node: *mut pg_sys::Node, _void: *mut ::core::ffi::c_void) -> bool {
     panic!("panic in walker");
 }
 

--- a/pgrx-tests/src/tests/pgrx_module_qualification.rs
+++ b/pgrx-tests/src/tests/pgrx_module_qualification.rs
@@ -115,7 +115,7 @@ mod pgrx_modqual_tests {
 
     #[allow(dead_code)]
     #[pg_guard]
-    extern "C" fn extern_foo_func() {}
+    extern "C-unwind" fn extern_foo_func() {}
 
     #[pg_schema]
     mod foo_schema {}

--- a/pgrx-tests/src/tests/result_tests.rs
+++ b/pgrx-tests/src/tests/result_tests.rs
@@ -96,10 +96,13 @@ mod tests {
         Err(pgrx::spi::Error::InvalidPosition)
     }
 
-    #[pg_test(error = "No such file or directory (os error 2)")]
+    #[pg_test(error = "I am a platform-independent and locale-agnostic string")]
     fn test_return_io_error() -> Result<(), std::io::Error> {
-        std::fs::read("/tmp/i-sure-hope-this-doest-exist.pgrx-tests::test_result_result")
-            .map(|_| ())
+        use std::io::{Error, ErrorKind};
+        Err(Error::new(
+            ErrorKind::NotFound,
+            "I am a platform-independent and locale-agnostic string",
+        ))
     }
 
     #[pg_test]

--- a/pgrx-tests/src/tests/shmem_tests.rs
+++ b/pgrx-tests/src/tests/shmem_tests.rs
@@ -15,7 +15,7 @@ static ATOMIC: PgAtomic<AtomicBool> = PgAtomic::new(c"pgrx_tests_atomic");
 static LWLOCK: PgLwLock<bool> = PgLwLock::new(c"pgrx_tests_lwlock");
 
 #[pg_guard]
-pub extern "C" fn _PG_init() {
+pub extern "C-unwind" fn _PG_init() {
     // This ensures that this functionality works across PostgreSQL versions
     pg_shmem_init!(ATOMIC);
     pg_shmem_init!(LWLOCK);

--- a/pgrx-tests/src/tests/shmem_tests.rs
+++ b/pgrx-tests/src/tests/shmem_tests.rs
@@ -11,8 +11,8 @@ use pgrx::prelude::*;
 use pgrx::{pg_shmem_init, PgAtomic, PgLwLock, PgSharedMemoryInitialization};
 use std::sync::atomic::AtomicBool;
 
-static ATOMIC: PgAtomic<AtomicBool> = PgAtomic::new();
-static LWLOCK: PgLwLock<bool> = PgLwLock::new();
+static ATOMIC: PgAtomic<AtomicBool> = PgAtomic::new(c"pgrx_tests_atomic");
+static LWLOCK: PgLwLock<bool> = PgLwLock::new(c"pgrx_tests_lwlock");
 
 #[pg_guard]
 pub extern "C" fn _PG_init() {

--- a/pgrx/src/callbacks.rs
+++ b/pgrx/src/callbacks.rs
@@ -164,7 +164,7 @@ where
 
     // internal function that we register as an XactCallback
     #[pg_guard]
-    unsafe extern "C" fn callback(
+    unsafe extern "C-unwind" fn callback(
         event: pg_sys::XactEvent::Type,
         _arg: *mut ::std::os::raw::c_void,
     ) {
@@ -318,7 +318,7 @@ where
     static mut SUB_HOOKS: Option<SubCallbackMap> = None;
 
     #[pg_guard]
-    unsafe extern "C" fn callback(
+    unsafe extern "C-unwind" fn callback(
         event: pg_sys::SubXactEvent::Type,
         my_subid: pg_sys::SubTransactionId,
         parent_subid: pg_sys::SubTransactionId,

--- a/pgrx/src/fcinfo.rs
+++ b/pgrx/src/fcinfo.rs
@@ -313,7 +313,7 @@ pub unsafe fn direct_function_call<R: FromDatum>(
 ///
 /// This function is unsafe as the function you're calling is also unsafe
 pub unsafe fn direct_pg_extern_function_call<R: FromDatum>(
-    func: unsafe extern "C" fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum,
+    func: unsafe extern "C-unwind" fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum,
     args: &[Option<pg_sys::Datum>],
 ) -> Option<R> {
     direct_pg_extern_function_call_as_datum(func, args).and_then(|d| R::from_datum(d, false))
@@ -376,7 +376,7 @@ unsafe fn direct_function_call_as_datum_internal(
 ///
 /// This function is unsafe as the function you're calling is also unsafe
 pub unsafe fn direct_pg_extern_function_call_as_datum(
-    func: unsafe extern "C" fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum,
+    func: unsafe extern "C-unwind" fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum,
     args: &[Option<pg_sys::Datum>],
 ) -> Option<pg_sys::Datum> {
     direct_function_call_as_datum_internal(|fcinfo| func(fcinfo), args)

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -233,7 +233,7 @@ macro_rules! pg_magic_func {
         #[no_mangle]
         #[allow(non_snake_case, unexpected_cfgs)]
         #[doc(hidden)]
-        pub extern "C" fn Pg_magic_func() -> &'static ::pgrx::pg_sys::Pg_magic_struct {
+        pub extern "C-unwind" fn Pg_magic_func() -> &'static ::pgrx::pg_sys::Pg_magic_struct {
             static MY_MAGIC: ::pgrx::pg_sys::Pg_magic_struct = ::pgrx::pg_sys::Pg_magic_struct {
                 len: ::core::mem::size_of::<::pgrx::pg_sys::Pg_magic_struct>() as i32,
                 version: ::pgrx::pg_sys::PG_VERSION_NUM as i32 / 100,

--- a/pgrx/src/lwlock.rs
+++ b/pgrx/src/lwlock.rs
@@ -10,10 +10,8 @@
 #![allow(clippy::needless_borrow)]
 use crate::pg_sys;
 use core::ops::{Deref, DerefMut};
-use once_cell::sync::OnceCell;
 use std::cell::UnsafeCell;
-use std::fmt;
-use uuid::Uuid;
+use std::ffi::CStr;
 
 /// A Rust locking mechanism which uses a PostgreSQL LWLock to lock the data
 ///
@@ -33,8 +31,8 @@ use uuid::Uuid;
 /// This lock can not be poisoned from Rust. Panic and Abort are handled by
 /// PostgreSQL cleanly.
 pub struct PgLwLock<T> {
-    inner: UnsafeCell<PgLwLockInner<T>>,
-    name: OnceCell<&'static str>,
+    name: &'static CStr,
+    inner: UnsafeCell<*mut PgLwLockShared<T>>,
 }
 
 unsafe impl<T: Send> Send for PgLwLock<T> {}
@@ -43,94 +41,44 @@ unsafe impl<T: Send + Sync> Sync for PgLwLock<T> {}
 impl<T> PgLwLock<T> {
     /// Create an empty lock which can be created as a global with None as a
     /// sentinel value
-    pub const fn new() -> Self {
-        PgLwLock { inner: UnsafeCell::new(PgLwLockInner::empty()), name: OnceCell::new() }
-    }
-
-    /// Create a new lock for T by attaching a LWLock, which is looked up by name
-    pub fn from_named(input_name: &'static str, value: *mut T) -> Self {
-        let name = OnceCell::new();
-        let inner = UnsafeCell::new(PgLwLockInner::<T>::new(input_name, value));
-        name.set(input_name).unwrap();
-        PgLwLock { inner, name }
+    pub const fn new(name: &'static CStr) -> Self {
+        PgLwLock { name, inner: UnsafeCell::new(std::ptr::null_mut()) }
     }
 
     /// Get the name of the PgLwLock
-    pub fn get_name(&self) -> &'static str {
-        match self.name.get() {
-            None => {
-                let name = Box::leak(Uuid::new_v4().to_string().into_boxed_str());
-                self.name.set(name).unwrap();
-                name
-            }
-            Some(name) => name,
-        }
+    pub fn name(&self) -> &'static CStr {
+        self.name
     }
 
     /// Obtain a shared lock (which comes with `&T` access)
     pub fn share(&self) -> PgLwLockShareGuard<T> {
-        unsafe { self.inner.get().as_ref().unwrap().share() }
+        unsafe {
+            let shared = self.inner.get().read().as_ref().expect("PgLwLock was not initialized");
+            pg_sys::LWLockAcquire((*shared).lock_ptr, pg_sys::LWLockMode::LW_SHARED);
+            PgLwLockShareGuard { data: &*(*shared).data.get(), lock: (*shared).lock_ptr }
+        }
     }
 
     /// Obtain an exclusive lock (which comes with `&mut T` access)
     pub fn exclusive(&self) -> PgLwLockExclusiveGuard<T> {
-        unsafe { self.inner.get().as_ref().unwrap().exclusive() }
+        unsafe {
+            let shared = self.inner.get().read().as_ref().expect("PgLwLock was not initialized");
+            pg_sys::LWLockAcquire((*shared).lock_ptr, pg_sys::LWLockMode::LW_EXCLUSIVE);
+            PgLwLockExclusiveGuard { data: &mut *(*shared).data.get(), lock: (*shared).lock_ptr }
+        }
     }
 
     /// Attach an empty PgLwLock lock to a LWLock, and wrap T
     /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    pub unsafe fn attach(&self, value: *mut T) {
-        *self.inner.get() = PgLwLockInner::<T>::new(self.get_name(), value);
+    pub unsafe fn attach(&self, value: *mut PgLwLockShared<T>) {
+        *self.inner.get() = value;
     }
 }
 
-pub struct PgLwLockInner<T> {
-    lock_ptr: *mut pg_sys::LWLock,
-    data: *mut T,
-}
-
-impl<T> fmt::Debug for PgLwLockInner<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PgLwLockInner").finish()
-    }
-}
-
-impl<'a, T> PgLwLockInner<T> {
-    fn new(name: &'static str, data: *mut T) -> Self {
-        unsafe {
-            let lock = alloc::ffi::CString::new(name).expect("CString::new failed");
-            PgLwLockInner {
-                lock_ptr: &mut (*pg_sys::GetNamedLWLockTranche(lock.as_ptr())).lock,
-                data,
-            }
-        }
-    }
-
-    const fn empty() -> Self {
-        PgLwLockInner { lock_ptr: std::ptr::null_mut(), data: std::ptr::null_mut() }
-    }
-
-    fn share(&self) -> PgLwLockShareGuard<T> {
-        if self.lock_ptr.is_null() {
-            panic!("PgLwLock is not initialized");
-        }
-        unsafe {
-            pg_sys::LWLockAcquire(self.lock_ptr, pg_sys::LWLockMode::LW_SHARED);
-
-            PgLwLockShareGuard { data: self.data.as_ref().unwrap(), lock: self.lock_ptr }
-        }
-    }
-
-    fn exclusive(&self) -> PgLwLockExclusiveGuard<T> {
-        if self.lock_ptr.is_null() {
-            panic!("PgLwLock is not initialized");
-        }
-        unsafe {
-            pg_sys::LWLockAcquire(self.lock_ptr, pg_sys::LWLockMode::LW_EXCLUSIVE);
-
-            PgLwLockExclusiveGuard { data: self.data.as_mut().unwrap(), lock: self.lock_ptr }
-        }
-    }
+#[repr(C)]
+pub struct PgLwLockShared<T> {
+    pub data: UnsafeCell<T>,
+    pub lock_ptr: *mut pg_sys::LWLock,
 }
 
 pub struct PgLwLockShareGuard<'a, T> {

--- a/pgrx/src/memcxt.rs
+++ b/pgrx/src/memcxt.rs
@@ -557,7 +557,7 @@ impl PgMemoryContexts {
     pub fn leak_and_drop_on_delete<T>(&mut self, v: T) -> *mut T {
         use crate as pgrx;
         #[pgrx::pg_guard]
-        unsafe extern "C" fn drop_on_delete<T>(ptr: void_mut_ptr) {
+        unsafe extern "C-unwind" fn drop_on_delete<T>(ptr: void_mut_ptr) {
             let boxed = Box::from_raw(ptr as *mut T);
             drop(boxed);
         }

--- a/pgrx/src/shmem.rs
+++ b/pgrx/src/shmem.rs
@@ -44,7 +44,7 @@ pub unsafe trait PGRXSharedMemory {}
 /// static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = PgAtomic::new(c"atomic");
 ///
 /// #[pg_guard]
-/// pub extern "C" fn _PG_init() {
+/// pub extern "C-unwind" fn _PG_init() {
 ///     pg_shmem_init!(PRIMITIVE);
 ///     pg_shmem_init!(ATOMIC);
 /// }
@@ -56,12 +56,12 @@ macro_rules! pg_shmem_init {
         $thing.pg_init();
 
         unsafe {
-            static mut PREV_SHMEM_STARTUP_HOOK: Option<unsafe extern "C" fn()> = None;
+            static mut PREV_SHMEM_STARTUP_HOOK: Option<unsafe extern "C-unwind" fn()> = None;
             PREV_SHMEM_STARTUP_HOOK = pg_sys::shmem_startup_hook;
             pg_sys::shmem_startup_hook = Some(__pgrx_private_shmem_hook);
 
             #[pg_guard]
-            extern "C" fn __pgrx_private_shmem_hook() {
+            extern "C-unwind" fn __pgrx_private_shmem_hook() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_STARTUP_HOOK {
                         i();
@@ -78,12 +78,12 @@ macro_rules! pg_shmem_init {
 macro_rules! pg_shmem_init {
     ($thing:expr) => {
         unsafe {
-            static mut PREV_SHMEM_REQUEST_HOOK: Option<unsafe extern "C" fn()> = None;
+            static mut PREV_SHMEM_REQUEST_HOOK: Option<unsafe extern "C-unwind" fn()> = None;
             PREV_SHMEM_REQUEST_HOOK = pg_sys::shmem_request_hook;
             pg_sys::shmem_request_hook = Some(__pgrx_private_shmem_request_hook);
 
             #[pg_guard]
-            extern "C" fn __pgrx_private_shmem_request_hook() {
+            extern "C-unwind" fn __pgrx_private_shmem_request_hook() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_REQUEST_HOOK {
                         i();
@@ -94,12 +94,12 @@ macro_rules! pg_shmem_init {
         }
 
         unsafe {
-            static mut PREV_SHMEM_STARTUP_HOOK: Option<unsafe extern "C" fn()> = None;
+            static mut PREV_SHMEM_STARTUP_HOOK: Option<unsafe extern "C-unwind" fn()> = None;
             PREV_SHMEM_STARTUP_HOOK = pg_sys::shmem_startup_hook;
             pg_sys::shmem_startup_hook = Some(__pgrx_private_shmem_hook);
 
             #[pg_guard]
-            extern "C" fn __pgrx_private_shmem_hook() {
+            extern "C-unwind" fn __pgrx_private_shmem_hook() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_STARTUP_HOOK {
                         i();


### PR DESCRIPTION
Notes:
1. postgres must run without administrator privileges, so switch calling `postgres` directly to starting postgres by `pg_ctl` in testing
2. Windows CI is added
3. known issue: `pgrx-cshim.c` is compiled with `-flto`, because, without this flag, `pgrx_embed.exe` is linked to `postgres.exe`
4. known issue: `cargo-pgrx` downloads, instead of building, postgres binaries from EDB website
5. known issue: `cargo pgrx run` and `cargo pgrx test` always print logs for `pg_ctl start` on Windows (pipes generated by `std::process::Command` are leaked to postgres, a command with `Stdio::piped()` hangs, so we use `Stdio::inherit()` on Windows)
6. breaking change: this pull request fixes `PgLwLock` and `PgAtomic` but introduces a breaking change about `PgLwLock` and `PgAtomic`: name must be provided at `PgLwLock/PgAtomic::new`, `PgLwLock::from_named` is removed and a parameter of `PgLwLock::attach` changes
7. breaking change: this pull request makes everything `C-unwind` and it's necessary for downstream to switch from `C` to `C-unwind`
8. regression: `cargo-pgrx` users need to execute `sudo sysctl fs.protected_fifos=0` before using `--runas` on Linux