### PR TITLE
fix a deadlock in `cargo pgrx install` during `get_git_hash()`

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -494,7 +494,8 @@ static GIT_HASH: OnceLock<MemoizeKeyValue> = OnceLock::new();
 fn get_git_hash(manifest_path: impl AsRef<Path>) -> eyre::Result<String> {
     let path_string = manifest_path.as_ref().to_owned();
 
-    if let Some(hash) = GIT_HASH.get_or_init(Default::default).lock().unwrap().get(&path_string) {
+    let mut mutex = GIT_HASH.get_or_init(Default::default).lock().unwrap();
+    if let Some(hash) = mutex.get(&path_string) {
         Ok(hash.clone())
     } else {
         let hash = match get_property(manifest_path, "git_hash")? {
@@ -504,7 +505,7 @@ fn get_git_hash(manifest_path: impl AsRef<Path>) -> eyre::Result<String> {
             )),
         };
 
-        GIT_HASH.get_or_init(Default::default).lock().unwrap().insert(path_string, hash.clone());
+        mutex.insert(path_string, hash.clone());
 
         Ok(hash)
     }


### PR DESCRIPTION
I can't quite explain why, but this function was deadlocking with this backtrace:

```
* thread #1, name = 'cargo-pgrx', stop reason = signal SIGSTOP
  * frame #0: 0x00007fbe1eeb288d libc.so.6`syscall at syscall.S:38
    frame #1: 0x000055aee526c5d3 cargo-pgrx`std::sys::sync::mutex::futex::Mutex::lock_contended::h6389e2305b0b005c [inlined] std::sys::pal::unix::futex::futex_wait::h30abf43e2d55aa33 at futex.rs:67:21
    frame #2: 0x000055aee526c590 cargo-pgrx`std::sys::sync::mutex::futex::Mutex::lock_contended::h6389e2305b0b005c at futex.rs:57:13
    frame #3: 0x000055aee4157835 cargo-pgrx`std::sync::mutex::Mutex$LT$T$GT$::lock::h4d2bb65800cc6fd3 at futex.rs:29:13
    frame #4: 0x000055aee41577ed cargo-pgrx`std::sync::mutex::Mutex$LT$T$GT$::lock::h4d2bb65800cc6fd3(self=0x000055aee6926c20) at mutex.rs:317:24
    frame #5: 0x000055aee406c779 cargo-pgrx`cargo_pgrx::command::install::get_git_hash::ha84d504db9d1bba8(manifest_path=0x00007ffdc43b83b0) at install.rs:507:9
    frame #6: 0x000055aee406d6e9 cargo-pgrx`cargo_pgrx::command::install::filter_contents::h8c710847129ba6be(manifest_path=0x00007ffdc43b8d10, input=String @ 0x00007ffdc43b8940) at install.rs:541:46
```