### PR TITLE
feat: auto-generate type alignment (#[pgrx(alignment = "on")])

### DIFF
--- a/pgrx-examples/custom_types/src/alignment.rs
+++ b/pgrx-examples/custom_types/src/alignment.rs
@@ -1,0 +1,54 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::prelude::*;
+use serde::*;
+
+#[derive(PostgresType, Serialize, Deserialize)]
+#[pgrx(alignment = "on")]
+pub struct AlignedTo4Bytes {
+    v1: u32,
+    v2: [u32; 3],
+}
+
+#[derive(PostgresType, Serialize, Deserialize)]
+#[pgrx(alignment = "on")]
+pub struct AlignedTo8Bytes {
+    v1: u64,
+    v2: [u64; 3],
+}
+
+#[derive(PostgresType, Serialize, Deserialize)]
+#[pgrx(alignment = "off")]
+pub struct NotAlignedTo8Bytes {
+    v1: u64,
+    v2: [u64; 3],
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn test_alignment_is_correct() {
+        let val = Spi::get_one::<String>(r#"SELECT typalign::text FROM pg_type WHERE typname = 'alignedto4bytes'"#).unwrap().unwrap();
+
+        assert!(val == "i");
+
+        let val = Spi::get_one::<String>(r#"SELECT typalign::text FROM pg_type WHERE typname = 'alignedto8bytes'"#).unwrap().unwrap();
+
+        assert!(val == "d");
+
+        let val = Spi::get_one::<String>(r#"SELECT typalign::text FROM pg_type WHERE typname = 'notalignedto8bytes'"#).unwrap().unwrap();
+
+        assert!(val == "i");
+    }
+}

--- a/pgrx-examples/custom_types/src/lib.rs
+++ b/pgrx-examples/custom_types/src/lib.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+mod alignment;
 mod complex;
 mod fixed_size;
 mod generic_enum;

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -781,6 +781,7 @@ Optionally accepts the following attributes:
 
 * `inoutfuncs(some_in_fn, some_out_fn)`: Define custom in/out functions for the type.
 * `pgvarlena_inoutfuncs(some_in_fn, some_out_fn)`: Define custom in/out functions for the `PgVarlena` of this type.
+* `pgrx(alignment = "<align>")`: Derive Postgres alignment from Rust type. One of `"on"`, or `"off"`.
 * `sql`: Same arguments as [`#[pgrx(sql = ..)]`](macro@pgrx).
 */
 #[proc_macro_derive(

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -94,6 +94,8 @@ pub trait SqlGraphIdentifier {
     fn line(&self) -> Option<u32>;
 }
 
+pub use postgres_type::Alignment;
+
 /// An entity corresponding to some SQL required by the extension.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SqlGraphEntity {


### PR DESCRIPTION
Postgres allows for types to specify their alignment in the `CREATE TYPE` statement. This change adds the ability to derive Postgres' alignment configuration from the type's Rust alignment (`std::mem::align_of::<T>()`). This functionality is opt-in through the `#[pgrx(alignment = "on")]` attribute:

```
#[derive(PostgresType)]
#[pgrx(alignment = "on")]
struct AlignedTo8Bytes {
  v1: u64,
  v2: [u64; 3]
}
```