### PR TITLE
fix warnings

### DIFF
--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -458,7 +458,7 @@ fn compute_codegen(
         out
     };
     Ok(quote::quote! {
-        fn main() {
+        pub fn main() {
             #inputs
             #build
             #outputs

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -16,7 +16,7 @@ use std::cell::Cell;
 use std::fmt::{Display, Formatter};
 use std::hint::unreachable_unchecked;
 use std::panic::{
-    catch_unwind, panic_any, resume_unwind, AssertUnwindSafe, Location, PanicInfo, UnwindSafe,
+    catch_unwind, panic_any, resume_unwind, AssertUnwindSafe, Location, PanicHookInfo, UnwindSafe,
 };
 
 use crate::elog::PgLogLevel;
@@ -112,8 +112,8 @@ impl From<&Location<'_>> for ErrorReportLocation {
     }
 }
 
-impl From<&PanicInfo<'_>> for ErrorReportLocation {
-    fn from(pi: &PanicInfo<'_>) -> Self {
+impl From<&PanicHookInfo<'_>> for ErrorReportLocation {
+    fn from(pi: &PanicHookInfo<'_>) -> Self {
         pi.location().map(|l| l.into()).unwrap_or_default()
     }
 }

--- a/pgrx/src/callbacks.rs
+++ b/pgrx/src/callbacks.rs
@@ -8,6 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Provides safe wrappers around Postgres' "Transaction" and "Sub Transaction" hook system
+#![allow(static_mut_refs)]
 
 use crate as pgrx; // for #[pg_guard] support from within ourself
 use crate::pg_sys;

--- a/pgrx/src/hooks.rs
+++ b/pgrx/src/hooks.rs
@@ -9,6 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! A trait and registration system for hooking Postgres internal operations such as its planner and executor
 #![allow(clippy::unit_arg)]
+#![allow(static_mut_refs)]
 #![deprecated(
     since = "0.12.1",
     note = "currently always UB, use FFI + pointers to `static UnsafeCell`"

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -231,7 +231,7 @@ macro_rules! pg_module_magic {
 macro_rules! pg_magic_func {
     () => {
         #[no_mangle]
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, unexpected_cfgs)]
         #[doc(hidden)]
         pub extern "C" fn Pg_magic_func() -> &'static ::pgrx::pg_sys::Pg_magic_struct {
             static MY_MAGIC: ::pgrx::pg_sys::Pg_magic_struct = ::pgrx::pg_sys::Pg_magic_struct {
@@ -306,11 +306,16 @@ pub(crate) enum Utf8Compat {
 #[macro_export]
 macro_rules! pgrx_embed {
     () => {
-        #[cfg(not(pgrx_embed))]
-        fn main() {
-            panic!("PGRX_EMBED was not set.");
+        mod pgrx_embed {
+            #![allow(unexpected_cfgs)]
+
+            #[cfg(not(pgrx_embed))]
+            pub fn main() {
+                panic!("PGRX_EMBED was not set.");
+            }
+            #[cfg(pgrx_embed)]
+            include!(env!("PGRX_EMBED"));
         }
-        #[cfg(pgrx_embed)]
-        include!(env!("PGRX_EMBED"));
+        pub use pgrx_embed::main;
     };
 }


### PR DESCRIPTION
1. `unexpected_cfgs` warnings are emitted for extension crates by latest nightly rustc, and it's annoying (`pgrx_embed` in `pgrx_embed`, and `Pg_magic_func` if extension does not support all postgres major versions)
2. `PanicInfo` warnings are emitted by latest stable rustc while using local pgrx as a patch
3. `static_mut_refs`  warnings are emitted by latest nightly rustc while using local pgrx as a patch
