### PR TITLE
[Test] Add lifetime marker to make error message consistent.

### DIFF
--- a/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.rs
+++ b/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.rs
@@ -3,7 +3,7 @@ use pgrx::prelude::*;
 #[pg_extern]
 fn returns_tuple_with_lifetime(
     value: &'static str,
-) -> TableIterator<(name!(a, &'static str), name!(b, Option<&'static str>))> {
+) -> TableIterator<'static, (name!(a, &'static str), name!(b, Option<&'static str>))> {
     TableIterator::once((value, Some(value)))
 }
 

--- a/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.stderr
+++ b/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of function
- --> tests/compile-fail/table-iterators-arent-immortal.rs:6:78
+ --> tests/compile-fail/table-iterators-arent-immortal.rs:6:87
   |
 3 |   #[pg_extern]
   |   ------------
@@ -7,8 +7,8 @@ error[E0521]: borrowed data escapes outside of function
   |   lifetime `'fcx` defined here
   |   in this procedural macro expansion
 ...
-6 |   ) -> TableIterator<(name!(a, &'static str), name!(b, Option<&'static str>))> {
-  |  ______________________________________________________________________________^
+6 |   ) -> TableIterator<'static, (name!(a, &'static str), name!(b, Option<&'static str>))> {
+  |  _______________________________________________________________________________________^
 7 | |     TableIterator::once((value, Some(value)))
 8 | | }
   | | ^


### PR DESCRIPTION
This patch adds a lifetime marker to TableIterator to make error message consistent between different versions of rustc.