### PR TITLE
Fix "about" info for cross subcommand

### DIFF
--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -42,7 +42,7 @@ Commands:
   connect       Connect, via psql, to a Postgres instance
   test          Run the test suite for this crate
   get           Get a property from the extension control file
-  cross         Cargo subcommand for 'pgrx' to make Postgres extension development easy
+  cross         Commands having to do with cross-compilation. (Experimental)
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/cargo-pgrx/src/command/cross/mod.rs
+++ b/cargo-pgrx/src/command/cross/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod pgrx_target;
 
 /// Commands having to do with cross-compilation. (Experimental)
 #[derive(clap::Args, Debug)]
-#[clap(about, author)]
+#[clap(author)]
 pub(crate) struct Cross {
     #[command(subcommand)]
     pub(crate) subcommand: CargoPgrxCrossSubCommands,


### PR DESCRIPTION
The help text for "cross" currently displays incorrectly.  This is even reflected in the readme, see :

https://github.com/pgcentralfoundation/pgrx/blob/c944bdef8f2631f430584d5b50de070da17593fe/cargo-pgrx/README.md?plain=1#L45

This change fixes so it displays as expected, and also updates the README to match.