### PR TITLE
Search for sql upgrade scripts relative to the package manifest

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -386,7 +386,7 @@ fn copy_sql_files(
     )?;
 
     // now copy all the version upgrade files too
-    if let Ok(dir) = fs::read_dir("sql/") {
+    if let Ok(dir) = fs::read_dir(package_manifest_path.as_ref().parent().unwrap().join("sql/")) {
         for sql in dir.flatten() {
             let filename = sql.file_name().into_string().unwrap();
 


### PR DESCRIPTION
Take ParadeDB[0] as an example. There repository is a Cargo workspace with the Postgres extension located in the pg_search directory.

Say you were to run `cargo pgrx install --package pg_search` from the root of the ParadeDB repository. cargo-pgrx would look for sql upgrade scripts relative to the current working directory instead of within the specified package directory.

Link: https://github.com/paradedb/paradedb [0]