### PR TITLE
--install-only option for cargo pgrx run command

### DIFF
--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -329,6 +329,9 @@ When you exit `psql`, the Postgres instance continues to run in the background.
 
 For Postgres installations which are already on your computer, `cargo pgrx run` will need write permissions to the directories described by `pg_config --pkglibdir` and `pg_config --sharedir`. It's up to you to decide how to make that happen. While a single Postgres installation can be started multiple times on different ports and different data directories, it does not support multiple "extension library directories".
 
+With the `--install-only` option, `pgrx` will compile and install your extension but will skip all subsequent steps. This might be useful if you have an alternative
+testing approach and don't need an interactive shell.
+
 ```console
 $ cargo pgrx run --help
 Compile/install extension to a pgrx-managed Postgres instance and start psql
@@ -349,6 +352,7 @@ Options:
       --no-default-features            Do not activate the `default` feature
   -F, --features <FEATURES>            Space-separated list of features to activate
       --pgcli                          Use an existing `pgcli` on the $PATH [env: PGRX_PGCLI=]
+      --install-only                   Install without running
   -h, --help                           Print help
   -V, --version                        Print version
 ```

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -48,6 +48,9 @@ pub(crate) struct Run {
     /// Use an existing `pgcli` on the $PATH.
     #[clap(env = "PGRX_PGCLI", long)]
     pgcli: bool,
+    /// Install without running
+    #[clap(long)]
+    install_only: bool,
 }
 
 impl CommandExecute for Run {
@@ -86,6 +89,7 @@ impl CommandExecute for Run {
             &profile,
             self.pgcli,
             &self.features,
+            self.install_only,
         )
     }
 }
@@ -104,6 +108,7 @@ pub(crate) fn run(
     profile: &CargoProfile,
     pgcli: bool,
     features: &clap_cargo::Features,
+    install_only: bool,
 ) -> eyre::Result<()> {
     // stop postgres
     stop_postgres(pg_config)?;
@@ -119,6 +124,10 @@ pub(crate) fn run(
         None,
         features,
     )?;
+
+    if install_only {
+        return Ok(());
+    }
 
     // restart postgres
     start_postgres(pg_config)?;


### PR DESCRIPTION
This PR closes issue #1977 

We allow the user to install an extension into a pgrx-managed Postgres instance without starting the instance or spawning a PSQL shell.