### PR TITLE
Implement SqlTranslatable for TableAmRoutine

### DIFF
--- a/pgrx-pg-sys/src/submodules/sql_translatable.rs
+++ b/pgrx-pg-sys/src/submodules/sql_translatable.rs
@@ -45,6 +45,16 @@ unsafe impl SqlTranslatable for crate::IndexAmRoutine {
         Ok(Returns::One(SqlMapping::literal("internal")))
     }
 }
+
+unsafe impl SqlTranslatable for crate::TableAmRoutine {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("internal"))
+    }
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("internal")))
+    }
+}
+
 unsafe impl SqlTranslatable for crate::FdwRoutine {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("fdw_handler"))


### PR DESCRIPTION
Currently
```rust
#[pg_extern(sql = "
CREATE FUNCTION xxx_handler(internal) RETURNS table_am_handler LANGUAGE C STRICT AS 'MODULE_PATHNAME';
CREATE ACCESS METHOD xxx TYPE TABLE HANDLER xxx_handler;
")]
fn xxx_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::TableAmRoutine> {
    let mut amroutine =
        unsafe { PgBox::<pg_sys::TableAmRoutine>::alloc_node(pg_sys::NodeTag::T_TableAmRoutine) };

    ...

    amroutine.into_pg_boxed()
}

```
throws error saying that `SqlTranslatable` is not implemented for `TableAmRoutine`