### PR TITLE
Enable cross compiling extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ my_extension=# SELECT hello_my_extension();
 
 For more details on how to manage pgrx extensions see [Managing pgrx extensions](cargo-pgrx/README.md).
 
+## Cross-compiling
+
+So far, cross-compiling extensions with pgrx has only been demonstrated under [nix](https://nixos.org/).
+Proper support in nixpkgs is still in flux, so watch this space.
+
+In order to cross-compile outside of nix, you will need two ingredients:
+
+1) A sysroot for the cross architecture, with rust configured to invoke the linker with flags to link against this sysroot.
+2) A `pg_config` program that provides values associated with postgres compiled for the desired cross architecture.
+   This can be achieved by either emulating pg_config with qemu-user or similar, or replicating pg_config with a shell script.
+
+Then, modify the standard build process in the following ways:
+
+1) Pass `--no-run` to `cargo pgrx init`, since we cannot run postgres for the cross machine.
+2) Pass one of the `--pgXX` flags to `cargo pgrx init` with the aforementioned `pg_config`.
+3) Pass the `--pg-config` flag to `cargo pgrx package` with the aforementioned `pg_config`.
+4) Pass the `--target` flag to `cargo pgrx package` with the rust triple of the cross machine.
+
+`cargo pgrx run` will not not work.
+
 ## Upgrading
 
 As new Postgres versions are supported by `pgrx`, you can re-run the `pgrx init` process to download and compile them:

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -72,6 +72,9 @@ pub(crate) struct Init {
     base_testing_port: Option<u16>,
     #[clap(long, help = "Additional flags to pass to the configure script")]
     configure_flag: Vec<String>,
+    /// Do not attempt to run any compiled postgresql binaries. Useful for cross compiling.
+    #[clap(long)]
+    no_run: bool,
     /// Compile PostgreSQL with the necessary flags to detect a good amount of
     /// memory errors when run under Valgrind.
     ///
@@ -220,13 +223,15 @@ pub(crate) fn init_pgrx(pgrx: &Pgrx, init: &Init) -> eyre::Result<()> {
     for pg_config in output_configs.iter() {
         validate_pg_config(pg_config)?;
 
-        if is_root_user() {
-            println!("{} initdb as current user is root user", "   Skipping".bold().green());
-        } else {
-            let datadir = pg_config.data_dir()?;
-            let bindir = pg_config.bin_dir()?;
-            if !datadir.try_exists()? {
-                initdb(&bindir, &datadir)?;
+        if !init.no_run {
+            if is_root_user() {
+                println!("{} initdb as current user is root user", "   Skipping".bold().green());
+            } else {
+                let datadir = pg_config.data_dir()?;
+                let bindir = pg_config.bin_dir()?;
+                if !datadir.try_exists()? {
+                    initdb(&bindir, &datadir)?;
+                }
             }
         }
     }

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -55,6 +55,8 @@ pub(crate) struct Install {
     sudo: bool,
     #[clap(flatten)]
     pub(crate) features: clap_cargo::Features,
+    #[clap(long)]
+    pub(crate) target: Option<String>,
     #[clap(from_global, action = ArgAction::Count)]
     pub(crate) verbose: u8,
 }
@@ -106,6 +108,7 @@ impl CommandExecute for Install {
             self.test,
             None,
             &self.features,
+            self.target.as_ref().map(|x| x.as_str()),
         )?;
         Ok(())
     }
@@ -127,6 +130,7 @@ pub(crate) fn install_extension(
     is_test: bool,
     base_directory: Option<PathBuf>,
     features: &clap_cargo::Features,
+    target: Option<&str>,
 ) -> eyre::Result<Vec<PathBuf>> {
     let mut output_tracking = Vec::new();
 
@@ -136,7 +140,7 @@ pub(crate) fn install_extension(
     let versioned_so = get_property(&package_manifest_path, "module_pathname")?.is_none();
 
     let build_command_output =
-        build_extension(user_manifest_path.as_ref(), user_package, profile, features)?;
+        build_extension(user_manifest_path.as_ref(), user_package, profile, features, target)?;
     let build_command_bytes = build_command_output.stdout;
     let build_command_reader = BufReader::new(build_command_bytes.as_slice());
     let build_command_stream = CargoMessage::parse_stream(build_command_reader);
@@ -225,6 +229,7 @@ pub(crate) fn install_extension(
         profile,
         is_test,
         features,
+        target,
         &extdir,
         true,
         &mut output_tracking,
@@ -288,6 +293,7 @@ pub(crate) fn build_extension(
     user_package: Option<&String>,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
+    target: Option<&str>,
 ) -> eyre::Result<std::process::Output> {
     let flags = std::env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
 
@@ -326,6 +332,11 @@ pub(crate) fn build_extension(
         command.arg(arg);
     }
 
+    if let Some(target) = target {
+        command.arg("--target");
+        command.arg(target);
+    }
+
     let command = command.stderr(Stdio::inherit());
     let command_str = format!("{command:?}");
     println!("{} extension with features {}", "    Building".bold().green(), features_arg.cyan());
@@ -348,6 +359,7 @@ fn copy_sql_files(
     profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
+    target: Option<&str>,
     extdir: &Path,
     skip_build: bool,
     output_tracking: &mut Vec<PathBuf>,
@@ -366,6 +378,7 @@ fn copy_sql_files(
             profile,
             is_test,
             features,
+            target,
             Some(&dest),
             Option::<String>::None,
             None,

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -43,6 +43,8 @@ pub(crate) struct Package {
     pub(crate) out_dir: Option<PathBuf>,
     #[clap(flatten)]
     pub(crate) features: clap_cargo::Features,
+    #[clap(long)]
+    pub(crate) target: Option<String>,
     #[clap(from_global, action = ArgAction::Count)]
     pub(crate) verbose: u8,
 }
@@ -79,7 +81,7 @@ impl Package {
         let out_dir = if let Some(out_dir) = self.out_dir {
             out_dir
         } else {
-            build_base_path(&pg_config, &package_manifest_path, &profile)?
+            build_base_path(&pg_config, &package_manifest_path, &profile, self.target.as_ref().map(|x| x.as_str()))?
         };
 
         let output_files = package_extension(
@@ -91,6 +93,7 @@ impl Package {
             &profile,
             self.test,
             &self.features,
+            self.target.as_ref().map(|x| x.as_str()),
         )?;
 
         Ok((out_dir, output_files))
@@ -119,6 +122,7 @@ pub(crate) fn package_extension(
     profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
+    target: Option<&str>,
 ) -> eyre::Result<Vec<PathBuf>> {
     let out_dir_exists = out_dir.try_exists().wrap_err_with(|| {
         format!("failed to access {} while packaging extension", out_dir.display())
@@ -137,6 +141,7 @@ pub(crate) fn package_extension(
         is_test,
         Some(out_dir),
         features,
+        target,
     )
 }
 
@@ -144,11 +149,15 @@ pub(crate) fn build_base_path(
     pg_config: &PgConfig,
     manifest_path: impl AsRef<Path>,
     profile: &CargoProfile,
+    target: Option<&str>,
 ) -> eyre::Result<PathBuf> {
     let mut target_dir = get_target_dir()?;
     let pgver = pg_config.major_version()?;
     let extname = get_property(manifest_path, "extname")?
         .ok_or(eyre!("could not determine extension name"))?;
+    if let Some(target) = target {
+        target_dir.push(target);
+    }
     target_dir.push(profile.target_subdir());
     target_dir.push(format!("{extname}-pg{pgver}"));
     Ok(target_dir)

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -81,7 +81,12 @@ impl Package {
         let out_dir = if let Some(out_dir) = self.out_dir {
             out_dir
         } else {
-            build_base_path(&pg_config, &package_manifest_path, &profile, self.target.as_ref().map(|x| x.as_str()))?
+            build_base_path(
+                &pg_config,
+                &package_manifest_path,
+                &profile,
+                self.target.as_ref().map(|x| x.as_str()),
+            )?
         };
 
         let output_files = package_extension(

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -91,7 +91,7 @@ impl CommandExecute for Run {
             self.pgcli,
             &self.features,
             self.install_only,
-            self.target.as_ref().map(|x| x.as_str())
+            self.target.as_ref().map(|x| x.as_str()),
         )
     }
 }

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -42,6 +42,8 @@ pub(crate) struct Run {
     profile: Option<String>,
     #[clap(flatten)]
     features: clap_cargo::Features,
+    #[clap(long)]
+    target: Option<String>,
     #[clap(from_global, action = ArgAction::Count)]
     verbose: u8,
     /// Use an existing `pgcli` on the $PATH.
@@ -89,6 +91,7 @@ impl CommandExecute for Run {
             self.pgcli,
             &self.features,
             self.install_only,
+            self.target.as_ref().map(|x| x.as_str())
         )
     }
 }
@@ -108,6 +111,7 @@ pub(crate) fn run(
     pgcli: bool,
     features: &clap_cargo::Features,
     install_only: bool,
+    target: Option<&str>,
 ) -> eyre::Result<()> {
     // stop postgres
     stop_postgres(pg_config)?;
@@ -122,6 +126,7 @@ pub(crate) fn run(
         false,
         None,
         features,
+        target,
     )?;
 
     if install_only {

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -222,7 +222,11 @@ pub(crate) fn generate_schema(
     Ok(())
 }
 
-fn compute_symbols(profile: &CargoProfile, lib_filename: &str, target: Option<&str>) -> eyre::Result<Vec<String>> {
+fn compute_symbols(
+    profile: &CargoProfile,
+    lib_filename: &str,
+    target: Option<&str>,
+) -> eyre::Result<Vec<String>> {
     use object::Object;
     use std::collections::HashSet;
 

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -53,6 +53,8 @@ pub(crate) struct Schema {
     /// A path to output a produced GraphViz DOT file
     #[clap(long, short, value_parser)]
     dot: Option<PathBuf>,
+    #[clap(long)]
+    target: Option<String>,
     #[clap(from_global, action = ArgAction::Count)]
     verbose: u8,
     /// Skip building a fresh extension shared object.
@@ -101,6 +103,7 @@ impl CommandExecute for Schema {
             &profile,
             self.test,
             &self.features,
+            self.target.as_ref().map(|x| x.as_str()),
             self.out.as_ref(),
             self.dot,
             log_level,
@@ -126,6 +129,7 @@ pub(crate) fn generate_schema(
     profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
+    target: Option<&str>,
     path: Option<impl AsRef<std::path::Path>>,
     dot: Option<impl AsRef<std::path::Path>>,
     log_level: Option<String>,
@@ -157,11 +161,12 @@ pub(crate) fn generate_schema(
             is_test,
             &features_arg,
             &flags,
+            target,
             &package_name,
         )?;
     };
 
-    let symbols = compute_symbols(profile, &lib_filename)?;
+    let symbols = compute_symbols(profile, &lib_filename, target)?;
 
     let mut out_path = None;
     if let Some(path) = path.as_ref() {
@@ -217,12 +222,15 @@ pub(crate) fn generate_schema(
     Ok(())
 }
 
-fn compute_symbols(profile: &CargoProfile, lib_filename: &str) -> eyre::Result<Vec<String>> {
+fn compute_symbols(profile: &CargoProfile, lib_filename: &str, target: Option<&str>) -> eyre::Result<Vec<String>> {
     use object::Object;
     use std::collections::HashSet;
 
     // Inspect the symbol table for a list of `__pgrx_internals` we should have the generator call
     let mut lib_so = get_target_dir()?;
+    if let Some(target) = target {
+        lib_so.push(target);
+    }
     lib_so.push(profile.target_subdir());
     lib_so.push(lib_filename);
 
@@ -313,6 +321,7 @@ fn first_build(
     is_test: bool,
     features_arg: &str,
     flags: &str,
+    target: Option<&str>,
     package_name: &str,
 ) -> eyre::Result<()> {
     let mut command = crate::env::cargo();
@@ -357,6 +366,11 @@ fn first_build(
 
     for arg in flags.split_ascii_whitespace() {
         command.arg(arg);
+    }
+
+    if let Some(target) = target {
+        command.arg("--target");
+        command.arg(target);
     }
 
     let command_str = format!("{command:?}");

--- a/cargo-pgrx/src/command/sudo_install.rs
+++ b/cargo-pgrx/src/command/sudo_install.rs
@@ -18,6 +18,7 @@ pub(crate) struct SudoInstall {
     pg_config: Option<PathBuf>,
     out_dir: Option<PathBuf>,
     features: clap_cargo::Features,
+    target: Option<String>,
     verbose: u8,
 }
 
@@ -32,6 +33,7 @@ impl From<Install> for SudoInstall {
             pg_config: value.pg_config.map(PathBuf::from),
             out_dir: None,
             features: value.features,
+            target: value.target,
             verbose: value.verbose,
         }
     }
@@ -49,6 +51,7 @@ impl From<SudoInstall> for Package {
             out_dir: value.out_dir,
             features: value.features,
             verbose: value.verbose,
+            target: value.target,
         }
     }
 }


### PR DESCRIPTION
Two pieces here in order to enable my successful build of some pgrx extensions from x86_64-linux to x86_64-freebsd:

- `cargo pgrx init --no-run` does not attempt to run the discovered postgreses, since they could be for the target architecture or OS.
- `--target` flag to some other commands is passed along to cargo build invocations and injected into the calculation of the build directory path. The builds done in order to generate bindings (?) are still done native, since the result has to run at build time.

Note that I was doing this within nix and nixpkgs, but I think it should generalize pretty well to the normal rust cross toolchains.

Note also that I haven't actually tested this diff precisely, since I was working with something that pinned, of all things, 0.12.0-alpha1. The rebase was pretty straightforward but if you want to see the diff that I know for sure works, check [here](https://github.com/rhelmot/pgrx/tree/alpha-patched).