### PR TITLE
Add `xid8` feature to support 64-bit `TransactionId`

### DIFF
--- a/pgrx-pg-sys/src/submodules/htup.rs
+++ b/pgrx-pg-sys/src/submodules/htup.rs
@@ -125,7 +125,7 @@ pub unsafe fn HeapTupleHeaderGetRawXmin(tup: *const HeapTupleHeaderData) -> Tran
     // )
     unsafe {
         // SAFETY:  caller has asserted `tup` is a valid HeapTupleHeader pointer
-        (*tup).t_choice.t_heap.t_xmin
+        (*tup).t_choice.t_heap.t_xmin as _
     }
 }
 

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -35,14 +35,10 @@ pg14 = ["pgrx-pg-sys/pg14"]
 pg15 = ["pgrx-pg-sys/pg15"]
 pg16 = ["pgrx-pg-sys/pg16"]
 pg17 = ["pgrx-pg-sys/pg17"]
-no-schema-generation = [
-    "pgrx-macros/no-schema-generation",
-    "pgrx-sql-entity-graph/no-schema-generation",
-]
-unsafe-postgres = [
-] # when trying to compile against something that looks like Postgres but claims to be different
-nightly = [
-] # For features and functionality which require nightly Rust - for example, std::mem::allocator.
+no-schema-generation = ["pgrx-macros/no-schema-generation", "pgrx-sql-entity-graph/no-schema-generation"]
+unsafe-postgres = []     # when trying to compile against something that looks like Postgres but claims to be different
+nightly = []    # For features and functionality which require nightly Rust - for example, std::mem::allocator.
+xid8 = []     # For forks of official Postgres that use 64-bit TransactionId by default
 
 [package.metadata.docs.rs]
 features = ["pg14", "cshim"]
@@ -58,23 +54,20 @@ pgrx-sql-entity-graph.workspace = true
 thiserror.workspace = true # error handling and logging
 
 # used to internally impl things
-once_cell = "1.20.3"                             # polyfill until std::lazy::OnceCell stabilizes
+once_cell = "1.20.3" # polyfill until std::lazy::OnceCell stabilizes
 uuid = { version = "1.14.0", features = ["v4"] } # PgLwLock and shmem
 enum-map = "2.7.3"
 
 # exposed in public API
-atomic-traits = "0.4.0"     # PgAtomic and shmem init
-bitflags = "2.8.0"          # BackgroundWorker
-bitvec = "1.0"              # processing array nullbitmaps
-heapless = "0.8"            # shmem and PgLwLock
-libc.workspace = true       # FFI type compat
-seahash = "4.1.0"           # derive(PostgresHash)
-serde.workspace = true      # impls on pub types
-serde_cbor = "0.11.2"       # derive(PostgresType)
+atomic-traits = "0.4.0" # PgAtomic and shmem init
+bitflags = "2.8.0" # BackgroundWorker
+bitvec = "1.0" # processing array nullbitmaps
+heapless = "0.8" # shmem and PgLwLock
+libc.workspace = true # FFI type compat
+seahash = "4.1.0" # derive(PostgresHash)
+serde.workspace = true # impls on pub types
+serde_cbor = "0.11.2" # derive(PostgresType)
 serde_json.workspace = true # everything JSON
-
-[build-dependencies]
-pgrx-pg-sys.workspace = true
 
 [lints]
 clippy.cast_ptr_alignment = "allow"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -35,9 +35,14 @@ pg14 = ["pgrx-pg-sys/pg14"]
 pg15 = ["pgrx-pg-sys/pg15"]
 pg16 = ["pgrx-pg-sys/pg16"]
 pg17 = ["pgrx-pg-sys/pg17"]
-no-schema-generation = ["pgrx-macros/no-schema-generation", "pgrx-sql-entity-graph/no-schema-generation"]
-unsafe-postgres = []     # when trying to compile against something that looks like Postgres but claims to be different
-nightly = []    # For features and functionality which require nightly Rust - for example, std::mem::allocator.
+no-schema-generation = [
+    "pgrx-macros/no-schema-generation",
+    "pgrx-sql-entity-graph/no-schema-generation",
+]
+unsafe-postgres = [
+] # when trying to compile against something that looks like Postgres but claims to be different
+nightly = [
+] # For features and functionality which require nightly Rust - for example, std::mem::allocator.
 
 [package.metadata.docs.rs]
 features = ["pg14", "cshim"]
@@ -53,20 +58,23 @@ pgrx-sql-entity-graph.workspace = true
 thiserror.workspace = true # error handling and logging
 
 # used to internally impl things
-once_cell = "1.20.3" # polyfill until std::lazy::OnceCell stabilizes
+once_cell = "1.20.3"                             # polyfill until std::lazy::OnceCell stabilizes
 uuid = { version = "1.14.0", features = ["v4"] } # PgLwLock and shmem
 enum-map = "2.7.3"
 
 # exposed in public API
-atomic-traits = "0.4.0" # PgAtomic and shmem init
-bitflags = "2.8.0" # BackgroundWorker
-bitvec = "1.0" # processing array nullbitmaps
-heapless = "0.8" # shmem and PgLwLock
-libc.workspace = true # FFI type compat
-seahash = "4.1.0" # derive(PostgresHash)
-serde.workspace = true # impls on pub types
-serde_cbor = "0.11.2" # derive(PostgresType)
+atomic-traits = "0.4.0"     # PgAtomic and shmem init
+bitflags = "2.8.0"          # BackgroundWorker
+bitvec = "1.0"              # processing array nullbitmaps
+heapless = "0.8"            # shmem and PgLwLock
+libc.workspace = true       # FFI type compat
+seahash = "4.1.0"           # derive(PostgresHash)
+serde.workspace = true      # impls on pub types
+serde_cbor = "0.11.2"       # derive(PostgresType)
 serde_json.workspace = true # everything JSON
+
+[build-dependencies]
+pgrx-pg-sys.workspace = true
 
 [lints]
 clippy.cast_ptr_alignment = "allow"

--- a/pgrx/build.rs
+++ b/pgrx/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if size_of::<pgrx_pg_sys::TransactionId>() == size_of::<u64>() {
+        println!("cargo:rustc-cfg=xid8");
+    }
+}

--- a/pgrx/build.rs
+++ b/pgrx/build.rs
@@ -1,5 +1,0 @@
-fn main() {
-    if size_of::<pgrx_pg_sys::TransactionId>() == size_of::<u64>() {
-        println!("cargo:rustc-cfg=xid8");
-    }
-}

--- a/pgrx/src/xid.rs
+++ b/pgrx/src/xid.rs
@@ -9,6 +9,13 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::pg_sys;
 
+#[cfg(all(xid8, feature = "unsafe-postgres"))]
+#[inline]
+pub fn xid_to_64bit(xid: pg_sys::TransactionId) -> u64 {
+    xid
+}
+
+#[cfg(not(xid8))]
 #[inline]
 pub fn xid_to_64bit(xid: pg_sys::TransactionId) -> u64 {
     let full_xid = unsafe { pg_sys::ReadNextFullTransactionId() };
@@ -19,6 +26,7 @@ pub fn xid_to_64bit(xid: pg_sys::TransactionId) -> u64 {
     convert_xid_common(xid, last_xid, epoch)
 }
 
+#[cfg(not(xid8))]
 #[inline]
 fn convert_xid_common(xid: pg_sys::TransactionId, last_xid: u32, epoch: u32) -> u64 {
     /* return special xid's as-is */

--- a/pgrx/src/xid.rs
+++ b/pgrx/src/xid.rs
@@ -9,13 +9,13 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::pg_sys;
 
-#[cfg(all(xid8, feature = "unsafe-postgres"))]
+#[cfg(all(feature = "xid8", feature = "unsafe-postgres"))]
 #[inline]
 pub fn xid_to_64bit(xid: pg_sys::TransactionId) -> u64 {
     xid
 }
 
-#[cfg(not(xid8))]
+#[cfg(not(feature = "xid8"))]
 #[inline]
 pub fn xid_to_64bit(xid: pg_sys::TransactionId) -> u64 {
     let full_xid = unsafe { pg_sys::ReadNextFullTransactionId() };
@@ -26,7 +26,7 @@ pub fn xid_to_64bit(xid: pg_sys::TransactionId) -> u64 {
     convert_xid_common(xid, last_xid, epoch)
 }
 
-#[cfg(not(xid8))]
+#[cfg(not(feature = "xid8"))]
 #[inline]
 fn convert_xid_common(xid: pg_sys::TransactionId, last_xid: u32, epoch: u32) -> u64 {
     /* return special xid's as-is */


### PR DESCRIPTION
This PR adds a new `xid8` feature to compile pgrx for Postgres forks where TransactionId is a 64-bit number.

I'm not sure if this should be in the main `pgrx` repository because this PR is aimed at supporting Postgres forks.

For example, in the PostgresPro Enterprise version, `TransactionId` is 64-bit by [default](https://postgrespro.com/docs/enterprise/16/transaction-id). Also, the PostgresPro developers have sent the [patch](https://www.postgresql.org/message-id/flat/CACG%3DezZe1NQSCnfHOr78AtAZxJZeCvxrts0ygrxYwe%3DpyyjVWA%40mail.gmail.com) to the original Postgres for review.

Fix #1997 