### PR TITLE
include `storage/buf_internals.h`

### DIFF
--- a/pgrx-pg-sys/include/pg12.h
+++ b/pgrx-pg-sys/include/pg12.h
@@ -138,6 +138,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
 #include "storage/block.h"
+#include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "storage/buffile.h"
 #include "storage/bufpage.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -139,6 +139,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
 #include "storage/block.h"
+#include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "storage/buffile.h"
 #include "storage/bufpage.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -140,6 +140,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
 #include "storage/block.h"
+#include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "storage/buffile.h"
 #include "storage/bufpage.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -141,6 +141,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
 #include "storage/block.h"
+#include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "storage/buffile.h"
 #include "storage/bufpage.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -143,6 +143,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
 #include "storage/block.h"
+#include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "storage/buffile.h"
 #include "storage/bufpage.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -143,6 +143,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
 #include "storage/block.h"
+#include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "storage/buffile.h"
 #include "storage/bufpage.h"


### PR DESCRIPTION
Adds another header that's useful when working with Postgres' block storage.