### PR TITLE
Renamed Oid::as_u32 to to_u32

### DIFF
--- a/pgrx-pg-sys/src/submodules/oids.rs
+++ b/pgrx-pg-sys/src/submodules/oids.rs
@@ -82,7 +82,7 @@ impl Oid {
         }
     }
 
-    pub const fn as_u32(self) -> u32 {
+    pub const fn to_u32(self) -> u32 {
         self.0
     }
 }

--- a/pgrx-tests/src/tests/oid_tests.rs
+++ b/pgrx-tests/src/tests/oid_tests.rs
@@ -24,7 +24,7 @@ mod tests {
     fn test_reasonable_oid() -> spi::Result<()> {
         let oid = Spi::get_one::<pg_sys::Oid>("SELECT tests.oid_roundtrip(42)")?
             .expect("SPI result was null");
-        assert_eq!(oid.as_u32(), 42);
+        assert_eq!(oid.to_u32(), 42);
         Ok(())
     }
 
@@ -33,7 +33,7 @@ mod tests {
         // nb:  this stupid value is greater than i32::MAX
         let oid = Spi::get_one::<pg_sys::Oid>("SELECT tests.oid_roundtrip(2147483648)")?
             .expect("SPI result was null");
-        assert_eq!(oid.as_u32(), 2_147_483_648);
+        assert_eq!(oid.to_u32(), 2_147_483_648);
         Ok(())
     }
 }

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -746,7 +746,7 @@ impl<'fcx> FcInfo<'fcx> {
     pub fn get_collation(&self) -> Option<pg_sys::Oid> {
         // SAFETY: see FcInfo::from_ptr
         let fcinfo = unsafe { self.0.as_mut() }.unwrap();
-        (fcinfo.fncollation.as_u32() != 0).then_some(fcinfo.fncollation)
+        (fcinfo.fncollation.to_u32() != 0).then_some(fcinfo.fncollation)
     }
 
     /// Retrieve the type (as an Oid) of argument number `num`.

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -226,7 +226,7 @@ impl IntoDatum for pg_sys::Oid {
         if self == pg_sys::Oid::INVALID {
             None
         } else {
-            Some(pg_sys::Datum::from(self.as_u32()))
+            Some(pg_sys::Datum::from(self.to_u32()))
         }
     }
 


### PR DESCRIPTION
The reason behind that is that `as_*` methods doesn't consume `self` but a reference, and `to_*` methods do conversion by consuming `self`. 