### PR TITLE
force using extern "C-unwind" for functions marked with #[pg_guard]

### DIFF
--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -47,6 +47,10 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     let attrs = mem::take(&mut func.attrs);
     let generics = func.sig.generics.clone();
 
+    if !sig.abi.clone().and_then(|abi| abi.name).is_some_and(|name| name.value() == "C-unwind") {
+        panic!("#[pg_guard] must be combined with extern \"C-unwind\"");
+    }
+
     if attrs.iter().any(|attr| attr.path().is_ident("no_mangle"))
         && generics.params.iter().any(|p| match p {
             GenericParam::Type(_) => true,

--- a/pgrx/src/datum/datetime_support/mod.rs
+++ b/pgrx/src/datum/datetime_support/mod.rs
@@ -401,10 +401,8 @@ const DATE_EXTRACT: unsafe fn(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum
 
 #[cfg(any(feature = "pg12", feature = "pg13"))]
 mod pg12_13 {
-    use crate as pgrx; // for [pg_guard]
     use crate::prelude::*;
 
-    #[pg_guard]
     pub(super) unsafe fn date_part(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
         // we need to first convert the `date` value into a `timestamp` value
         // then call the `timestamp_part` function.


### PR DESCRIPTION
`pgrx` is switched from "C" to "C-unwind" in #1934 so it's fine to emit an error here

Without this error, someone who updates dependencies without reading changelog, would break extensions silently, if their only usage of `#[pg_guard]` is `_PG_init`. It's bad.