### PR TITLE
Dedup array `IntoDatum`, drop intermediate Vecs for `tuples`

### DIFF
--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -1019,6 +1019,7 @@ fn array_datum_from_iter<T: IntoDatum>(elements: impl Iterator<Item = T>) -> Opt
         pg_sys::initArrayResult(
             T::type_oid(),
             PgMemoryContexts::CurrentMemoryContext.value(),
+            // All elements use the same memory context
             false,
         )
     };
@@ -1037,14 +1038,10 @@ fn array_datum_from_iter<T: IntoDatum>(elements: impl Iterator<Item = T>) -> Opt
         }
     }
 
-    if state.is_null() {
-        // shouldn't happen
-        None
-    } else {
-        Some(unsafe {
-            pg_sys::makeArrayResult(state, PgMemoryContexts::CurrentMemoryContext.value())
-        })
-    }
+    // Should not happen: {init, accum}ArrayResult both return non-null pointers
+    assert!(!state.is_null());
+
+    Some(unsafe { pg_sys::makeArrayResult(state, PgMemoryContexts::CurrentMemoryContext.value()) })
 }
 
 impl<T> IntoDatum for Vec<T>

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -1012,41 +1012,47 @@ where
     }
 }
 
+#[inline]
+/// Converts an iterator into an array datum
+fn array_datum_from_iter<T: IntoDatum>(elements: impl Iterator<Item = T>) -> Option<pg_sys::Datum> {
+    let mut state = unsafe {
+        pg_sys::initArrayResult(
+            T::type_oid(),
+            PgMemoryContexts::CurrentMemoryContext.value(),
+            false,
+        )
+    };
+    for s in elements {
+        let datum = s.into_datum();
+        let isnull = datum.is_none();
+
+        unsafe {
+            state = pg_sys::accumArrayResult(
+                state,
+                datum.unwrap_or(0.into()),
+                isnull,
+                T::type_oid(),
+                PgMemoryContexts::CurrentMemoryContext.value(),
+            );
+        }
+    }
+
+    if state.is_null() {
+        // shouldn't happen
+        None
+    } else {
+        Some(unsafe {
+            pg_sys::makeArrayResult(state, PgMemoryContexts::CurrentMemoryContext.value())
+        })
+    }
+}
+
 impl<T> IntoDatum for Vec<T>
 where
     T: IntoDatum,
 {
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let mut state = unsafe {
-            pg_sys::initArrayResult(
-                T::type_oid(),
-                PgMemoryContexts::CurrentMemoryContext.value(),
-                false,
-            )
-        };
-        for s in self {
-            let datum = s.into_datum();
-            let isnull = datum.is_none();
-
-            unsafe {
-                state = pg_sys::accumArrayResult(
-                    state,
-                    datum.unwrap_or(0.into()),
-                    isnull,
-                    T::type_oid(),
-                    PgMemoryContexts::CurrentMemoryContext.value(),
-                );
-            }
-        }
-
-        if state.is_null() {
-            // shouldn't happen
-            None
-        } else {
-            Some(unsafe {
-                pg_sys::makeArrayResult(state, PgMemoryContexts::CurrentMemoryContext.value())
-            })
-        }
+        array_datum_from_iter(self.into_iter())
     }
 
     fn type_oid() -> pg_sys::Oid {
@@ -1073,36 +1079,7 @@ where
     T: IntoDatum + Copy + 'a,
 {
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let mut state = unsafe {
-            pg_sys::initArrayResult(
-                T::type_oid(),
-                PgMemoryContexts::CurrentMemoryContext.value(),
-                false,
-            )
-        };
-        for s in self {
-            let datum = s.into_datum();
-            let isnull = datum.is_none();
-
-            unsafe {
-                state = pg_sys::accumArrayResult(
-                    state,
-                    datum.unwrap_or(0.into()),
-                    isnull,
-                    T::type_oid(),
-                    PgMemoryContexts::CurrentMemoryContext.value(),
-                );
-            }
-        }
-
-        if state.is_null() {
-            // shouldn't happen
-            None
-        } else {
-            Some(unsafe {
-                pg_sys::makeArrayResult(state, PgMemoryContexts::CurrentMemoryContext.value())
-            })
-        }
+        array_datum_from_iter(self.into_iter().copied())
     }
 
     fn type_oid() -> pg_sys::Oid {

--- a/pgrx/src/datum/tuples.rs
+++ b/pgrx/src/datum/tuples.rs
@@ -15,8 +15,8 @@ where
     B: IntoDatum,
 {
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let vec = vec![self.0.into_datum(), self.1.into_datum()];
-        vec.into_datum()
+        let arr = [self.0.into_datum(), self.1.into_datum()];
+        arr.into_datum()
     }
 
     fn type_oid() -> pg_sys::Oid {
@@ -31,8 +31,8 @@ where
     C: IntoDatum,
 {
     fn into_datum(self) -> Option<pg_sys::Datum> {
-        let vec = vec![self.0.into_datum(), self.1.into_datum(), self.2.into_datum()];
-        vec.into_datum()
+        let arr = [self.0.into_datum(), self.1.into_datum(), self.2.into_datum()];
+        arr.into_datum()
     }
 
     fn type_oid() -> pg_sys::Oid {


### PR DESCRIPTION
Moves duplicated `IntoDatum` code from  for `&[T]` and `Vec<T>` into a single function, and makes tuple's `IntoDatum` not allocate intermediate Vecs