### PR TITLE
Disabled Will It Bend on forks

### DIFF
--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   distro_tests:
+    if: github.repository_owner == 'pgcentralfoundation'
     name: Distro tests
     runs-on: ubuntu-22.04
     strategy:
@@ -35,6 +36,7 @@ jobs:
         run: ./.github/docker/run-docker.sh "$PG_MAJOR_VER" ${{ matrix.container }}
 
   cargo_unlocked_tests:
+    if: github.repository_owner == 'pgcentralfoundation'
     name: Cargo unlocked tests
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
As Will It Bend is fixed now that change isn't important as should be no GitHub notifications about CI failures every week. Still. it's better to disable the workflow for forks as it's designed for maintainers to keep the project healthy.