### PR TITLE
include `utils/spccache.h`

### DIFF
--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -191,6 +191,7 @@
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"
 #include "utils/sortsupport.h"
+#include "utils/spccache.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
 #include "utils/tuplestore.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -192,6 +192,7 @@
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"
 #include "utils/sortsupport.h"
+#include "utils/spccache.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
 #include "utils/tuplestore.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -193,6 +193,7 @@
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"
 #include "utils/sortsupport.h"
+#include "utils/spccache.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
 #include "utils/tuplestore.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -195,6 +195,7 @@
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"
 #include "utils/sortsupport.h"
+#include "utils/spccache.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
 #include "utils/tuplestore.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -194,6 +194,7 @@
 #include "utils/selfuncs.h"
 #include "utils/snapmgr.h"
 #include "utils/sortsupport.h"
+#include "utils/spccache.h"
 #include "utils/catcache.h"
 #include "utils/syscache.h"
 #include "utils/tuplestore.h"


### PR DESCRIPTION
https://github.com/postgres/postgres/blob/master/src/include/utils/spccache.h

It's used to get `spc_random_page_cost`, `spc_seq_page_cost`, `io_concurrency` and `maintenance_io_concurrency` for a table.