### PR TITLE
Fixed docker file for alpine

### DIFF
--- a/.github/docker/Dockerfile.alpine
+++ b/.github/docker/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # Example of how to build this container (ran from pgrx checkout directory):
-#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine_3.18 -t pgrx-alpine .
+#   docker build --build-arg PG_MAJOR_VER=14 -f .github/docker/Dockerfile.alpine_3.21 -t pgrx-alpine .
 #
 # Example of how to run this container with tests after building the image:
 #   docker run pgrx-alpine cargo test --no-default-features --features pg14 --locked
@@ -9,7 +9,7 @@
 
 ARG PG_MAJOR_VER
 # Use Postgres' official alpine version, it's just easier that way
-FROM postgres:${PG_MAJOR_VER}-alpine3.18
+FROM postgres:${PG_MAJOR_VER}-alpine3.21
 ENV PG_MAJOR_VER=${PG_MAJOR_VER}
 
 # Required for compiling Rust

--- a/.github/workflows/will-it-blend-develop.yml
+++ b/.github/workflows/will-it-blend-develop.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false # We want all of them to run, even if one fails
       matrix:
         pg_version: [ "pg12", "pg13", "pg14", "pg15", "pg16", "pg17" ]
-        container: [ "fedora", "debian_bullseye", "alpine_3.21" ]
+        container: [ "fedora", "debian_bullseye", "alpine" ]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Previously I made a pull request that should fix the CI, but I forgot to include changes of the docker file. So, now it includes the changes and in addition to that the file name doesn't include version anymore to make it a bit easier to maintain. Only the docker file needs to be updated and a newer version set in it.

The issue with the Fedora's part is quite simple. PostgreSQL 12 is dead and no more supported, that's why it doesn't exist in the repository and cannot be installed on Fedora with the current docker file.

See [my CI run](https://github.com/YohDeadfall/pgrx/actions/runs/14229043458) that verifies that the fix works.