### PR TITLE
Implemented `Display` for `Oid`

### DIFF
--- a/pgrx-pg-sys/src/submodules/oids.rs
+++ b/pgrx-pg-sys/src/submodules/oids.rs
@@ -8,6 +8,8 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![allow(non_camel_case_types)]
+use std::fmt;
+
 use crate as pg_sys;
 use crate::BuiltinOid;
 use crate::Datum;
@@ -25,7 +27,7 @@ use pgrx_sql_entity_graph::metadata::{
 ///
 /// [pg_docs_oid]: https://www.postgresql.org/docs/current/datatype-oid.html
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct Oid(pub(crate) u32);
 
@@ -90,6 +92,18 @@ impl Oid {
 impl Default for Oid {
     fn default() -> Oid {
         Oid::INVALID
+    }
+}
+
+impl fmt::Debug for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
     }
 }
 

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -19,7 +19,7 @@ use std::num::NonZeroUsize;
 /// If converting a Datum to a Rust type fails, this is the set of possible reasons why.
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum TryFromDatumError {
-    #[error("Postgres type {datum_type} ({datum_oid:?}) is not compatible with the Rust type {rust_type} ({rust_oid:?})")]
+    #[error("Postgres type {datum_type} (Oid({datum_oid})) is not compatible with the Rust type {rust_type} (Oid({rust_oid}))")]
     IncompatibleTypes {
         rust_type: &'static str,
         rust_oid: pg_sys::Oid,


### PR DESCRIPTION
The purpose of this change is to forward `Debug` and `Display` implementations of the `Oid` type to its underlying field, so it's possible to use it for logging.