### PR TITLE
Lint cleanups, based on #2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ It is currently expected to work on other "Unix" OS with possible small changes,
  ‡ A local PostgreSQL server installation is not required. On Linux and MacOS, `cargo pgrx` can download and compile PostgreSQL versions on its own. On Windows, `cargo pgrx` downloads precompiled PostgreSQL versions from EnterpriseDB.
 
  ⹋ PGRX has not been tested to work on 32-bit, but the library attempts to handle conversion of `pg_sys::Datum`
-to and from `int8` and `double` types. Use it only for your own risk. We do not plan to add offical support
+to and from `int8` and `double` types. Use it only for your own risk. We do not plan to add official support
 without considerable ongoing technical and financial contributions.
 
 ### macOS

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -81,3 +81,4 @@ rustls = [
 
 [lints.clippy]
 or-fun-call = "allow" # kinda sus lint imo
+too_many_arguments = "allow"

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -416,7 +416,7 @@ fn copy_sql_files(
 pub(crate) fn find_library_file(
     manifest: &Manifest,
     manifest_path: &Path,
-    build_command_messages: &Vec<CargoMessage>,
+    build_command_messages: &[CargoMessage],
 ) -> eyre::Result<PathBuf> {
     use std::env::consts::{DLL_EXTENSION, DLL_SUFFIX};
 
@@ -430,7 +430,7 @@ pub(crate) fn find_library_file(
     // you might think this is being silly but they do periodically change outputs. these changes
     // often seem to be unintentional, but they're real, so...
     let library_file = build_command_messages
-        .into_iter()
+        .iter()
         .filter_map(|msg| match msg {
             CargoMessage::CompilerArtifact(artifact) => Some(artifact),
             _ => None,

--- a/cargo-pgrx/src/command/new.rs
+++ b/cargo-pgrx/src/command/new.rs
@@ -143,7 +143,7 @@ fn create_git_ignore(mut filename: PathBuf, _name: &str) -> Result<(), std::io::
 fn create_pgrx_embed_rs(mut filename: PathBuf) -> Result<(), std::io::Error> {
     filename.push("src");
     filename.push("bin");
-    filename.push(format!("pgrx_embed.rs"));
+    filename.push("pgrx_embed.rs");
     let mut file = std::fs::File::create(filename)?;
     file.write_all(include_bytes!("../templates/pgrx_embed_rs"))?;
     Ok(())

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -342,7 +342,7 @@ fn first_build(
     }
 
     command.arg("--package");
-    command.arg(format!("{package_name}"));
+    command.arg(package_name);
 
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");
@@ -507,7 +507,7 @@ fn second_build(
     command.arg(format!("pgrx_embed_{package_name}"));
 
     command.arg("--package");
-    command.arg(format!("{package_name}"));
+    command.arg(package_name);
 
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");

--- a/cargo-pgrx/src/command/upgrade.rs
+++ b/cargo-pgrx/src/command/upgrade.rs
@@ -224,14 +224,14 @@ impl Upgrade {
                 if let Some((key, dep)) = dep_table.get_key_value_mut(dep_name) {
                     self.update_dep(path, key, dep)?;
                     // Workaround since update_toml() doesn't preserve comments
-                    dep_table.key_decor_mut(dep_name).map(|dec| {
+                    if let Some(dec) = dep_table.key_decor_mut(dep_name) {
                         if let Some(prefix) = decor.as_ref().and_then(|val| val.prefix().cloned()) {
                             dec.set_prefix(prefix)
                         }
                         if let Some(suffix) = decor.as_ref().and_then(|val| val.suffix().cloned()) {
                             dec.set_suffix(suffix)
                         }
-                    });
+                    }
                 } else {
                     debug!(
                         "Manifest does not contain a dependency entry for \

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -125,15 +125,15 @@ impl bindgen::callbacks::ParseCallbacks for BindingOverride {
     ) -> Option<bindgen::callbacks::EnumVariantCustomBehavior> {
         enum_name.inspect(|name| match name.strip_prefix("enum").unwrap_or(name).trim() {
             // specifically overridden enum
-            "NodeTag" => return,
-            name if name.contains("unnamed at") || name.contains("anonymous at") => return,
+            "NodeTag" => (),
+            name if name.contains("unnamed at") || name.contains("anonymous at") => (),
             // to prevent problems with BuiltinOid
-            _ if variant_name.contains("OID") => return,
+            _ if variant_name.contains("OID") => (),
             name => self
                 .enum_names
                 .borrow_mut()
                 .entry(name.to_string())
-                .or_insert(Vec::new())
+                .or_default()
                 .push((variant_name.to_string(), variant_value)),
         });
         None
@@ -1020,7 +1020,7 @@ fn build_shim(
         build.flag("/Gw");
     }
     for pg_target_include in pg_target_includes(major_version, pg_config)?.iter() {
-        build.flag(&format!("-I{pg_target_include}"));
+        build.flag(format!("-I{pg_target_include}"));
     }
     for flag in extra_bindgen_clang_args(pg_config)? {
         build.flag(&flag);
@@ -1202,7 +1202,7 @@ fn rust_fmt(path: &Path) -> eyre::Result<()> {
     // in case we probably should respect RUSTFMT.
     let rustfmt = env_tracked("RUSTFMT").unwrap_or_else(|| "rustfmt".into());
     let mut command = Command::new(rustfmt);
-    command.arg(path).args(&["--edition", "2021"]).current_dir(".");
+    command.arg(path).args(["--edition", "2021"]).current_dir(".");
 
     let out = run_command(&mut command, "[bindings_diff]");
     match out {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -208,7 +208,7 @@ pub fn pg_cast(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
 
-        let pg_extern = PgExtern::new(pg_extern_attrs.into(), item.clone().into())?.0;
+        let pg_extern = PgExtern::new(pg_extern_attrs, item.clone().into())?.0;
         Ok(CodeEnrichment(pg_extern.as_cast(cast.unwrap_or_default())).to_token_stream().into())
     }
 

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -47,7 +47,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     let attrs = mem::take(&mut func.attrs);
     let generics = func.sig.generics.clone();
 
-    if !sig.abi.clone().and_then(|abi| abi.name).is_some_and(|name| name.value() == "C-unwind") {
+    if sig.abi.clone().and_then(|abi| abi.name).is_none_or(|name| name.value() != "C-unwind") {
         panic!("#[pg_guard] must be combined with extern \"C-unwind\"");
     }
 

--- a/pgrx-sql-entity-graph/src/schema/mod.rs
+++ b/pgrx-sql-entity-graph/src/schema/mod.rs
@@ -18,7 +18,7 @@
 pub mod entity;
 
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote, ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::parse::{Parse, ParseStream};
 use syn::ItemMod;
 
@@ -78,7 +78,7 @@ impl Schema {
         };
 
         let sql_graph_entity_fn_name =
-            format_ident!("__pgrx_internals_schema_{}_{}", ident, postfix);
+            quote::format_ident!("__pgrx_internals_schema_{ident}_{postfix}");
         quote! {
             #[no_mangle]
             #[doc(hidden)]

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -568,16 +568,17 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
         None
     };
 
-    let mut postmaster_args = Vec::new();
-    postmaster_args.push("-i".into());
-    postmaster_args.push("-p".into());
-    postmaster_args.push(pg_config.test_port().expect("unable to determine test port").to_string());
-    postmaster_args.push("-h".into());
-    postmaster_args.push(pg_config.host().into());
-    postmaster_args.push("-c".into());
-    postmaster_args.push("log_destination=stderr".into());
-    postmaster_args.push("-c".into());
-    postmaster_args.push("logging_collector=off".into());
+    let postmaster_args = vec![
+        "-i".into(),
+        "-p".into(),
+        pg_config.test_port().expect("unable to determine test port").to_string(),
+        "-h".into(),
+        pg_config.host().into(),
+        "-c".into(),
+        "log_destination=stderr".into(),
+        "-c".into(),
+        "logging_collector=off".into(),
+    ];
 
     let mut command = if let Some(runas) = get_runas() {
         #[inline]
@@ -711,7 +712,7 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
 
             if line.contains("database system is ready to accept connections") {
                 // Postgres says it's ready to go
-                if let Err(_) = sender.send(session_id.clone()) {
+                if sender.send(session_id.clone()).is_err() {
                     // The channel is closed.  This is really early in the startup process
                     // and likely indicates that a test crashed Postgres
                     panic!("{}: `monitor_pg()`:  failed to send back session_id `{session_id}`.  Did Postgres crash?", "ERROR".red().bold());
@@ -850,9 +851,8 @@ fn get_extension_name() -> eyre::Result<String> {
 fn get_pgdata_path() -> eyre::Result<PathBuf> {
     // Note that this path is turned into an entry in the unix_socket_directories config.
     // Each path has a low limit in maximum bytes, so we should avoid adding needless characters.
-    let mut pgdata_base = std::env::var("CARGO_PGRX_TEST_PGDATA")
-        .map(|path| PathBuf::from(path))
-        .unwrap_or_else(|_| {
+    let mut pgdata_base =
+        std::env::var("CARGO_PGRX_TEST_PGDATA").map(PathBuf::from).unwrap_or_else(|_| {
             let mut target_dir = get_target_dir()
                 .unwrap_or_else(|e| panic!("Failed to determine the crate target directory: {e}"));
             // ./test-data or ./pgdata both seem too cryptic
@@ -861,7 +861,7 @@ fn get_pgdata_path() -> eyre::Result<PathBuf> {
         });
 
     // append the postgres version number
-    pgdata_base.push(&format!("{}", pg_sys::get_pg_major_version_num()));
+    pgdata_base.push(format!("{}", pg_sys::get_pg_major_version_num()));
     Ok(pgdata_base)
 }
 
@@ -966,12 +966,7 @@ fn get_cargo_args() -> Vec<String> {
                 && !process.cmd().iter().any(|arg| arg == "pgrx")
             {
                 // ... do we want its args
-                return process
-                    .cmd()
-                    .to_vec()
-                    .into_iter()
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .collect();
+                return process.cmd().iter().map(|s| s.to_string_lossy().into_owned()).collect();
             }
         }
 
@@ -1011,7 +1006,7 @@ fn find_on_path(program: &str) -> Option<PathBuf> {
 }
 
 fn use_valgrind() -> bool {
-    std::env::var_os("USE_VALGRIND").is_some_and(|s| s.len() > 0)
+    std::env::var_os("USE_VALGRIND").is_some_and(|s| !s.is_empty())
 }
 
 /// Create a [`Command`] pre-configured to what the caller decides using `sudo`

--- a/pgrx-tests/src/framework/shutdown.rs
+++ b/pgrx-tests/src/framework/shutdown.rs
@@ -16,10 +16,7 @@ use std::{any, mem, process};
 /// Note that shutdown hooks are only run on the client, so must be added from
 /// your `setup` function, not the `#[pg_test]` itself.
 #[track_caller]
-pub fn add_shutdown_hook<F: FnOnce()>(func: F)
-where
-    F: Send + 'static,
-{
+pub fn add_shutdown_hook<F: FnOnce() + Send + 'static>(func: F) {
     SHUTDOWN_HOOKS
         .lock()
         .unwrap_or_else(PoisonError::into_inner)

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -197,14 +197,14 @@ impl RawArray {
         // hoping that doesn't also overflow on multiplication.
         // Also integer promotion doesn't real, so bitcast negatives.
         let dims = self.dims();
-        if dims.len() == 0 {
+        if dims.is_empty() {
             0
         } else {
             // bindgen whiffs MaxArraySize AND MaxAllocSize!
             const MAX_ARRAY_SIZE: u32 = 0x3fffffff / 8;
-            dims.into_iter()
+            dims.iter()
                 .map(|i| *i as u32) // treat negatives as huge
-                .fold(Some(1u32), |prod, d| prod.and_then(|m| m.checked_mul(d)))
+                .try_fold(1u32, |prod, d| prod.checked_mul(d))
                 .filter(|prod| prod <= &MAX_ARRAY_SIZE)
                 .expect("product of array dimensions must be < 2.pow(27)") as usize
         }
@@ -321,6 +321,7 @@ impl RawArray {
     * non-null
     * aligned
     * **validly initialized**, except in the case of [MaybeUninit] types
+
     It is reasonable to assume data Postgres exposes logically to SQL is initialized,
     but it may be incorrect to assume data Postgres has marked "null"
     otherwise follows Rust-level initialization requirements.

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -65,7 +65,7 @@ pub unsafe trait ArgAbi<'fcx>: Sized {
     ///
     /// # Safety
     /// - The argument's datum must have the matching "logical type" that can be "unboxed" from the
-    /// datum's object type.
+    ///   datum's object type.
     /// - Calling this with a null argument and a non-null type is *undefined behavior*.
     unsafe fn unbox_arg_unchecked(arg: Arg<'_, 'fcx>) -> Self;
 
@@ -73,7 +73,7 @@ pub unsafe trait ArgAbi<'fcx>: Sized {
     ///
     /// # Safety
     /// - The argument's datum must have the matching "logical type" that can be "unboxed" from the
-    /// datum's object type.
+    ///   datum's object type.
     /// - Calling this with a null argument and a non-null type is *undefined behavior*.
     ///
     /// # Note to implementers
@@ -469,16 +469,14 @@ where
     }
 
     unsafe fn fill_fcinfo_fcx(&self, fcinfo: pg_sys::FunctionCallInfo) {
-        match self {
-            Ok(value) => unsafe { value.fill_fcinfo_fcx(fcinfo) },
-            Err(_) => (),
+        if let Ok(value) = self {
+            unsafe { value.fill_fcinfo_fcx(fcinfo) }
         }
     }
 
     unsafe fn move_into_fcinfo_fcx(self, fcinfo: pg_sys::FunctionCallInfo) {
-        match self {
-            Ok(value) => unsafe { value.move_into_fcinfo_fcx(fcinfo) },
-            Err(_) => (),
+        if let Ok(value) = self {
+            unsafe { value.move_into_fcinfo_fcx(fcinfo) }
         }
     }
 
@@ -806,7 +804,7 @@ impl<'fcx> FcInfo<'fcx> {
     pub unsafe fn init_multi_func_call(&mut self) -> &'fcx mut pg_sys::FuncCallContext {
         unsafe {
             let fcx: *mut pg_sys::FuncCallContext = pg_sys::init_MultiFuncCall(self.0);
-            debug_assert!(fcx.is_null() == false);
+            debug_assert!(!fcx.is_null());
             &mut *fcx
         }
     }
@@ -820,7 +818,7 @@ impl<'fcx> FcInfo<'fcx> {
     pub(crate) unsafe fn deref_fcx(&mut self) -> &'fcx mut pg_sys::FuncCallContext {
         unsafe {
             let fcx: *mut pg_sys::FuncCallContext = (*(*self.0).flinfo).fn_extra.cast();
-            debug_assert!(fcx.is_null() == false);
+            debug_assert!(!fcx.is_null());
             &mut *fcx
         }
     }
@@ -887,9 +885,9 @@ impl<'a, 'fcx> Arg<'a, 'fcx> {
 
     /// # Safety
     /// - The argument's datum must have the matching "logical type" that can be "unboxed" from the
-    /// datum's object type.
+    ///   datum's object type.
     /// - If `T` cannot represent null arguments, calling this if the next arg is null is
-    /// *undefined behavior*.
+    ///   *undefined behavior*.
     /// - If `T` is pass-by-reference, calling this if the next arg is null is *undefined behavior*.
     pub unsafe fn unbox_unchecked<T: ArgAbi<'fcx>>(self) -> T {
         unsafe { <T as ArgAbi<'fcx>>::unbox_arg_unchecked(self) }
@@ -925,9 +923,9 @@ impl<'a, 'fcx> Args<'a, 'fcx> {
 
     /// # Safety
     /// - The argument's datum must have the matching "logical type" that can be "unboxed" from the
-    /// datum's object type.
+    ///   datum's object type.
     /// - In particular, if `T` cannot represent null arguments, calling this if the next arg is null is
-    /// *undefined behavior*.
+    ///   *undefined behavior*.
     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
         if T::is_virtual_arg() {
             // SAFETY: trivial condition
@@ -940,7 +938,7 @@ impl<'a, 'fcx> Args<'a, 'fcx> {
 
     /// # Safety
     /// - The argument's datum must have the matching "logical type" that can be "unboxed" from the
-    /// datum's object type.
+    ///   datum's object type.
     pub unsafe fn next_arg<T: ArgAbi<'fcx>>(&mut self) -> Option<Nullable<T>> {
         if T::is_virtual_arg() {
             // SAFETY: trivial condition

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -229,11 +229,11 @@ impl<'mcx, T: UnboxDatum> Array<'mcx, T> {
         }
         match self.null_slice.get_inner().map(|v| (v, v.is_null(index))) {
             // No null_slice, strict array.
-            None => self.get_strict_inner(index).map(|elem| Some(elem)),
+            None => self.get_strict_inner(index).map(Some),
             // self.null_slice exists but index is not in bounds.
-            Some((_, None)) => return None,
+            Some((_, None)) => None,
             // Elem is null
-            Some((_, Some(true))) => return Some(None),
+            Some((_, Some(true))) => Some(None),
             // Elem is not null.
             Some((nulls, Some(false))) => self.get_nullable_inner(nulls, index),
         }

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -79,8 +79,7 @@ where
         // Ptr<Datum> derefs to Datum which to Ptr
         PassBy::Ref => unsafe {
             let datum = ptr.read();
-            let ptr = ptr::NonNull::new(datum.sans_lifetime().cast_mut_ptr());
-            ptr
+            ptr::NonNull::new(datum.sans_lifetime().cast_mut_ptr())
         },
     }
 }

--- a/pgrx/src/datum/datetime_support/mod.rs
+++ b/pgrx/src/datum/datetime_support/mod.rs
@@ -205,7 +205,7 @@ pub trait HasExtractableParts: Clone + IntoDatum + seal::DateTimeType {
             );
             // don't leak the TEXT datum we made
             pg_sys::pfree(field_datum.unwrap().cast_mut_ptr());
-            field_value.map(|v| v.try_into().unwrap())
+            field_value
         }
     }
 }
@@ -517,9 +517,7 @@ impl_wrappers!(
 /// if the `zone` is "CEST", which is GMT+2, then the result is `7200`.
 ///
 /// ## Errors
-///
 /// Returns a [`DateTimeConversionError`] if the specified timezone is unknown to Postgres
-
 #[cfg(any(feature = "pg16", feature = "pg17"))]
 pub fn get_timezone_offset<Tz: AsRef<str>>(zone: Tz) -> Result<i32, DateTimeConversionError> {
     let zone = zone.as_ref();

--- a/pgrx/src/datum/datetime_support/mod.rs
+++ b/pgrx/src/datum/datetime_support/mod.rs
@@ -205,7 +205,7 @@ pub trait HasExtractableParts: Clone + IntoDatum + seal::DateTimeType {
             );
             // don't leak the TEXT datum we made
             pg_sys::pfree(field_datum.unwrap().cast_mut_ptr());
-            field_value
+            field_value.map(|v| v.try_into().unwrap())
         }
     }
 }

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -447,7 +447,7 @@ impl FromDatum for String {
         _typoid: pg_sys::Oid,
     ) -> Option<String> {
         if is_null || datum.is_null() {
-            return None;
+            None
         } else {
             let varlena = pg_sys::pg_detoast_datum_packed(datum.cast_mut_ptr());
             let converted_varlena = convert_varlena_to_str_memoized(varlena);

--- a/pgrx/src/datum/uuid.rs
+++ b/pgrx/src/datum/uuid.rs
@@ -52,11 +52,7 @@ impl FromDatum for Uuid {
         } else {
             let bytes =
                 std::slice::from_raw_parts(datum.cast_mut_ptr::<u8>() as *const u8, UUID_BYTES_LEN);
-            if let Ok(uuid) = Uuid::from_slice(bytes) {
-                Some(uuid)
-            } else {
-                None
-            }
+            Uuid::from_slice(bytes).ok()
         }
     }
 }

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -252,7 +252,7 @@ impl<'mcx> PgHeapTuple<'mcx, AllocatedByRust> {
     ///
     /// ## Errors
     /// - [PgHeapTupleError::IncorrectAttributeCount] if the number of items in the iterator
-    /// does not match the number of attributes in the [PgTupleDesc].
+    ///   does not match the number of attributes in the [PgTupleDesc].
     ///
     /// # Safety
     ///
@@ -320,7 +320,7 @@ impl<'mcx> PgHeapTuple<'mcx, AllocatedByRust> {
     ///
     /// - return [TryFromDatumError::NoSuchAttributeName] if the attribute does not exist
     /// - return [TryFromDatumError::IncompatibleTypes] if the Rust type of the `value` is not
-    /// compatible with the attribute's Postgres type
+    ///   compatible with the attribute's Postgres type
     pub fn set_by_name<T: IntoDatum>(
         &mut self,
         attname: &str,
@@ -339,7 +339,7 @@ impl<'mcx> PgHeapTuple<'mcx, AllocatedByRust> {
     /// ## Errors
     /// - return [TryFromDatumError::NoSuchAttributeNumber] if the attribute does not exist
     /// - return [TryFromDatumError::IncompatibleTypes] if the Rust type of the `value` is not
-    /// compatible with the attribute's Postgres type
+    ///   compatible with the attribute's Postgres type
     pub fn set_by_index<T: IntoDatum>(
         &mut self,
         attno: NonZeroUsize,
@@ -527,7 +527,7 @@ impl<'mcx, AllocatedBy: WhoAllocated> PgHeapTuple<'mcx, AllocatedBy> {
     /// ## Errors
     /// - return [`TryFromDatumError::NoSuchAttributeName`] if the attribute does not exist
     /// - return [`TryFromDatumError::IncompatibleTypes`] if the Rust type of the `value` is not
-    /// compatible with the attribute's Postgres type
+    ///   compatible with the attribute's Postgres type
     pub fn get_by_name<'tup, T>(&'tup self, attname: &str) -> Result<Option<T>, TryFromDatumError>
     where
         T: FromDatum + IntoDatum + UnboxDatum<As<'tup> = T> + 'tup,
@@ -551,7 +551,7 @@ impl<'mcx, AllocatedBy: WhoAllocated> PgHeapTuple<'mcx, AllocatedBy> {
     /// ## Errors
     /// - return [`TryFromDatumError::NoSuchAttributeNumber`] if the attribute does not exist
     /// - return [`TryFromDatumError::IncompatibleTypes`] if the Rust type of the `value` is not
-    /// compatible with the attribute's Postgres type
+    ///   compatible with the attribute's Postgres type
     pub fn get_by_index<'tup, T>(
         &'tup self,
         attno: NonZeroUsize,

--- a/pgrx/src/nullable.rs
+++ b/pgrx/src/nullable.rs
@@ -121,7 +121,7 @@ impl<T> Nullable<T> {
     where
         &'a A: Into<Cow<'a, str>>,
     {
-        self.into_option().expect(msg.into().as_ref())
+        self.into_option().unwrap_or_else(|| panic!("{}", msg.into().as_ref()))
     }
     /// Convert to a result, returning `err` if this enum is `Null`.
     #[inline]
@@ -372,7 +372,7 @@ pub struct MaybeStrictNulls<Inner: NullLayout<usize>> {
     pub inner: Option<Inner>,
 }
 
-impl<'mcx, Inner> MaybeStrictNulls<Inner>
+impl<Inner> MaybeStrictNulls<Inner>
 where
     Inner: NullLayout<usize>,
 {
@@ -382,10 +382,7 @@ where
     }
     #[inline]
     pub fn is_strict(&self) -> bool {
-        match self.inner {
-            Some(_) => false,
-            None => true,
-        }
+        self.inner.is_none()
     }
     #[inline]
     pub fn get_inner(&self) -> Option<&Inner> {

--- a/pgrx/src/rel.rs
+++ b/pgrx/src/rel.rs
@@ -20,15 +20,16 @@ use std::os::raw::c_char;
 macro_rules! pgstat_count_impl {
     ($name:ident, $new_field:ident, $old_field:ident) => {
         pub fn $name(&mut self) {
-            let info = self.pgstat_info;
-            unsafe {
+            #[cfg(not(feature = "pg12"))]
+            if self.should_count_relation() {
+                let info = self.pgstat_info;
+
                 #[cfg(any(feature = "pg16", feature = "pg17"))]
-                if self.should_count_relation() {
+                unsafe {
                     (*info).counts.$new_field += 1;
                 }
-
                 #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
-                if self.should_count_relation() {
+                unsafe {
                     (*info).t_counts.$old_field += 1;
                 }
             }
@@ -311,6 +312,7 @@ impl PgRelation {
     }
 
     #[inline(always)]
+    #[cfg(not(feature = "pg12"))]
     fn should_count_relation(&mut self) -> bool {
         if !self.pgstat_info.is_null() {
             return true;
@@ -335,16 +337,19 @@ impl PgRelation {
     pgstat_count_impl!(count_buffer_read, blocks_fetched, t_blocks_fetched);
     pgstat_count_impl!(count_buffer_hit, blocks_hit, t_blocks_hit);
 
-    pub fn count_index_tuples(&mut self, n: i64) {
-        let info = self.pgstat_info;
-        unsafe {
+    pub fn count_index_tuples(
+        &mut self,
+        #[cfg_attr(feature = "pg12", allow(unused_variables))] n: i64,
+    ) {
+        #[cfg(not(feature = "pg12"))]
+        if self.should_count_relation() {
+            let info = self.pgstat_info;
             #[cfg(any(feature = "pg16", feature = "pg17"))]
-            if self.should_count_relation() {
+            unsafe {
                 (*info).counts.tuples_returned += n;
             }
-
             #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
-            if self.should_count_relation() {
+            unsafe {
                 (*info).t_counts.t_tuples_returned += n;
             }
         }

--- a/pgrx/src/rel.rs
+++ b/pgrx/src/rel.rs
@@ -20,7 +20,6 @@ use std::os::raw::c_char;
 macro_rules! pgstat_count_impl {
     ($name:ident, $new_field:ident, $old_field:ident) => {
         pub fn $name(&mut self) {
-            #[cfg(not(feature = "pg12"))]
             if self.should_count_relation() {
                 let info = self.pgstat_info;
 
@@ -312,7 +311,6 @@ impl PgRelation {
     }
 
     #[inline(always)]
-    #[cfg(not(feature = "pg12"))]
     fn should_count_relation(&mut self) -> bool {
         if !self.pgstat_info.is_null() {
             return true;
@@ -337,11 +335,7 @@ impl PgRelation {
     pgstat_count_impl!(count_buffer_read, blocks_fetched, t_blocks_fetched);
     pgstat_count_impl!(count_buffer_hit, blocks_hit, t_blocks_hit);
 
-    pub fn count_index_tuples(
-        &mut self,
-        #[cfg_attr(feature = "pg12", allow(unused_variables))] n: i64,
-    ) {
-        #[cfg(not(feature = "pg12"))]
+    pub fn count_index_tuples(&mut self, n: i64) {
         if self.should_count_relation() {
             let info = self.pgstat_info;
             #[cfg(any(feature = "pg16", feature = "pg17"))]

--- a/pgrx/src/spi/query.rs
+++ b/pgrx/src/spi/query.rs
@@ -160,7 +160,7 @@ fn prepare<'conn>(
         pg_sys::SPI_prepare(
             cmd.as_ptr(),
             args.len() as i32,
-            args.into_iter().map(|arg| arg.value()).collect::<Vec<_>>().as_mut_ptr(),
+            args.iter().map(|arg| arg.value()).collect::<Vec<_>>().as_mut_ptr(),
         )
     };
     Ok(PreparedStatement {
@@ -325,7 +325,7 @@ impl<'conn> PreparedStatement<'conn> {
         let expected = unsafe { pg_sys::SPI_getargcount(self.plan.as_ptr()) } as usize;
 
         if expected == actual {
-            Ok(args.into_iter().map(prepare_datum).unzip())
+            Ok(args.iter().map(prepare_datum).unzip())
         } else {
             Err(SpiError::PreparedStatementArgumentMismatch { expected, got: actual })
         }

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -109,7 +109,6 @@ pub unsafe fn vartag_size(tag: pg_sys::vartag_external::Type) -> usize {
 /// #define VARSIZE_4B(PTR) \
 /// ((((varattrib_4b *) (PTR))->va_4byte.va_header >> 2) & 0x3FFFFFFF)
 /// ```
-
 #[allow(clippy::cast_ptr_alignment)]
 #[inline]
 pub unsafe fn varsize_4b(ptr: *const pg_sys::varlena) -> usize {
@@ -156,7 +155,6 @@ pub unsafe fn varatt_is_4b(ptr: *const pg_sys::varlena) -> bool {
 /// #define VARATT_IS_4B_U(PTR) \
 /// ((((varattrib_1b *) (PTR))->va_header & 0x03) == 0x00)
 /// ```
-
 #[allow(clippy::verbose_bit_mask)]
 #[inline]
 pub unsafe fn varatt_is_4b_u(ptr: *const pg_sys::varlena) -> bool {


### PR DESCRIPTION
This is a rebase of #2026 that removes the last pg12 references.