### PR TITLE
Update version to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "bzip2",
  "cargo-edit",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "atomic-traits",
  "bitflags 2.9.0",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "cee-scape",
  "libc",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "clap-cargo 0.14.1",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ exclude = [
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-macros = { path = "./pgrx-macros", version = "=0.13.1" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.13.1" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.13.1" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.13.1" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.13.1" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.14.0" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.14.0" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.14.0" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.14.0" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.14.0" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "=0.13.2" # format-preserving edits to cargo.toml

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "cargo-pgrx"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -20,10 +20,10 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.13.1"
+pgrx = "=0.14.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.13.1"
+pgrx-tests = "=0.14.0"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -5,7 +5,7 @@ easy to reference on docs.rs. Bindings are regenerated for your
 build of pgrx, and the values of your Postgres version may differ.
 */
 use crate as pg_sys;
-use crate::{Datum, Oid, PgNode};
+use crate::{Datum, MultiXactId, Oid, PgNode, TransactionId};
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct __BindgenBitfieldUnit<Storage> {
@@ -2295,6 +2295,25 @@ pub const LOG_METAINFO_DATAFILE_TMP: &::core::ffi::CStr = c"current_logfiles.tmp
 pub const RBTXN_HAS_CATALOG_CHANGES: u32 = 1;
 pub const RBTXN_IS_SUBXACT: u32 = 2;
 pub const RBTXN_IS_SERIALIZED: u32 = 4;
+pub const BUF_REFCOUNT_ONE: u32 = 1;
+pub const BUF_REFCOUNT_MASK: u32 = 262143;
+pub const BUF_USAGECOUNT_MASK: u32 = 3932160;
+pub const BUF_USAGECOUNT_ONE: u32 = 262144;
+pub const BUF_USAGECOUNT_SHIFT: u32 = 18;
+pub const BUF_FLAG_MASK: u32 = 4290772992;
+pub const BM_LOCKED: u32 = 4194304;
+pub const BM_DIRTY: u32 = 8388608;
+pub const BM_VALID: u32 = 16777216;
+pub const BM_TAG_VALID: u32 = 33554432;
+pub const BM_IO_IN_PROGRESS: u32 = 67108864;
+pub const BM_IO_ERROR: u32 = 134217728;
+pub const BM_JUST_DIRTIED: u32 = 268435456;
+pub const BM_PIN_COUNT_WAITER: u32 = 536870912;
+pub const BM_CHECKPOINT_NEEDED: u32 = 1073741824;
+pub const BM_PERMANENT: u32 = 2147483648;
+pub const BM_MAX_USAGE_COUNT: u32 = 5;
+pub const FREENEXT_END_OF_LIST: i32 = -1;
+pub const FREENEXT_NOT_IN_LIST: i32 = -2;
 pub const XLOG_STANDBY_LOCK: u32 = 0;
 pub const XLOG_RUNNING_XACTS: u32 = 16;
 pub const XLOG_INVALIDATIONS: u32 = 32;
@@ -5122,7 +5141,7 @@ pub struct timespec {
     pub tv_sec: __time_t,
     pub tv_nsec: __syscall_slong_t,
 }
-pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C" fn()>;
+pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type Pointer = *mut ::core::ffi::c_char;
 pub type int8 = ::core::ffi::c_schar;
 pub type int16 = ::core::ffi::c_short;
@@ -5144,10 +5163,8 @@ pub type float4 = f32;
 pub type float8 = f64;
 pub type regproc = Oid;
 pub type RegProcedure = regproc;
-pub type TransactionId = uint32;
 pub type LocalTransactionId = uint32;
 pub type SubTransactionId = uint32;
-pub type MultiXactId = TransactionId;
 pub type MultiXactOffset = uint32;
 pub type CommandId = uint32;
 #[repr(C)]
@@ -5311,13 +5328,13 @@ impl Default for passwd {
 }
 pub type pgsocket = ::core::ffi::c_int;
 pub type qsort_arg_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
         arg: *mut ::core::ffi::c_void,
     ) -> ::core::ffi::c_int,
 >;
-pub type pqsigfunc = ::core::option::Option<unsafe extern "C" fn(signo: ::core::ffi::c_int)>;
+pub type pqsigfunc = ::core::option::Option<unsafe extern "C-unwind" fn(signo: ::core::ffi::c_int)>;
 pub type __jmp_buf = [::core::ffi::c_long; 8usize];
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5331,7 +5348,8 @@ pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[derive(Debug, Copy, Clone)]
 pub struct ErrorContextCallback {
     pub previous: *mut ErrorContextCallback,
-    pub callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub arg: *mut ::core::ffi::c_void,
 }
 impl Default for ErrorContextCallback {
@@ -5385,7 +5403,8 @@ impl Default for ErrorData {
         }
     }
 }
-pub type emit_log_hook_type = ::core::option::Option<unsafe extern "C" fn(edata: *mut ErrorData)>;
+pub type emit_log_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(edata: *mut ErrorData)>;
 pub mod PGErrorVerbosity {
     pub type Type = ::core::ffi::c_uint;
     pub const PGERROR_TERSE: Type = 0;
@@ -5394,7 +5413,7 @@ pub mod PGErrorVerbosity {
 }
 pub type MemoryContext = *mut MemoryContextData;
 pub type MemoryContextCallbackFunction =
-    ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryContextCallback {
@@ -6191,7 +6210,7 @@ impl Default for ForFiveState {
     }
 }
 pub type list_sort_comparator = ::core::option::Option<
-    unsafe extern "C" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6494,7 +6513,7 @@ pub struct PageXLogRecPtr {
     pub xrecoff: uint32,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PageHeaderData {
     pub pd_lsn: PageXLogRecPtr,
     pub pd_checksum: uint16,
@@ -6505,6 +6524,15 @@ pub struct PageHeaderData {
     pub pd_pagesize_version: uint16,
     pub pd_prune_xid: TransactionId,
     pub pd_linp: __IncompleteArrayField<ItemIdData>,
+}
+impl Default for PageHeaderData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub type PageHeader = *mut PageHeaderData;
 #[repr(C)]
@@ -6631,31 +6659,33 @@ impl Default for TupleTableSlot {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct TupleTableSlotOps {
     pub base_slot_size: usize,
-    pub init: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub release: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub clear: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub init: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub release: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub clear: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub getsomeattrs: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
     >,
     pub getsysattr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             slot: *mut TupleTableSlot,
             attnum: ::core::ffi::c_int,
             isnull: *mut bool,
         ) -> Datum,
     >,
-    pub materialize: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub materialize: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub copyslot: ::core::option::Option<
-        unsafe extern "C" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
+        unsafe extern "C-unwind" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
     >,
     pub get_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub get_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub get_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
     pub copy_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub copy_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub copy_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6826,11 +6856,12 @@ pub struct WorkerInstrumentation {
 }
 pub type fmNodePtr = *mut Node;
 pub type fmAggrefPtr = *mut Aggref;
-pub type fmExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type fmExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 pub type fmStringInfo = *mut StringInfoData;
 pub type FunctionCallInfo = *mut FunctionCallInfoBaseData;
 pub type PGFunction =
-    ::core::option::Option<unsafe extern "C" fn(fcinfo: FunctionCallInfo) -> Datum>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(fcinfo: FunctionCallInfo) -> Datum>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FmgrInfo {
@@ -6878,7 +6909,8 @@ impl Default for FunctionCallInfoBaseData {
 pub struct Pg_finfo_record {
     pub api_version: ::core::ffi::c_int,
 }
-pub type PGFInfoFunction = ::core::option::Option<unsafe extern "C" fn() -> *const Pg_finfo_record>;
+pub type PGFInfoFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_finfo_record>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Pg_magic_struct {
@@ -6890,16 +6922,21 @@ pub struct Pg_magic_struct {
     pub float8byval: ::core::ffi::c_int,
 }
 pub type PGModuleMagicFunction =
-    ::core::option::Option<unsafe extern "C" fn() -> *const Pg_magic_struct>;
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_magic_struct>;
 pub mod FmgrHookEventType {
     pub type Type = ::core::ffi::c_uint;
     pub const FHET_START: Type = 0;
     pub const FHET_END: Type = 1;
     pub const FHET_ABORT: Type = 2;
 }
-pub type needs_fmgr_hook_type = ::core::option::Option<unsafe extern "C" fn(fn_oid: Oid) -> bool>;
+pub type needs_fmgr_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(fn_oid: Oid) -> bool>;
 pub type fmgr_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(event: FmgrHookEventType::Type, flinfo: *mut FmgrInfo, arg: *mut Datum),
+    unsafe extern "C-unwind" fn(
+        event: FmgrHookEventType::Type,
+        flinfo: *mut FmgrInfo,
+        arg: *mut Datum,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6936,7 +6973,7 @@ impl Default for pairingheap_node {
     }
 }
 pub type pairingheap_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const pairingheap_node,
         b: *const pairingheap_node,
         arg: *mut ::core::ffi::c_void,
@@ -6977,7 +7014,7 @@ impl Default for ParamExternData {
 }
 pub type ParamListInfo = *mut ParamListInfoData;
 pub type ParamFetchHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         paramid: ::core::ffi::c_int,
         speculative: bool,
@@ -6985,7 +7022,7 @@ pub type ParamFetchHook = ::core::option::Option<
     ) -> *mut ParamExternData,
 >;
 pub type ParamCompileHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         param: *mut Param,
         state: *mut ExprState,
@@ -6994,7 +7031,7 @@ pub type ParamCompileHook = ::core::option::Option<
     ),
 >;
 pub type ParserSetupHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -9182,7 +9219,7 @@ pub struct PGShmemHeader {
     _unused: [u8; 0],
 }
 pub type on_dsm_detach_callback =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut dsm_segment, arg: Datum)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut dsm_segment, arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dsa_area {
@@ -9214,11 +9251,6 @@ pub struct TBMIterateResult {
     pub recheck: bool,
     pub offsets: __IncompleteArrayField<OffsetNumber>,
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionBoundInfoData {
-    _unused: [u8; 0],
-}
 pub type PartitionBoundInfo = *mut PartitionBoundInfoData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9226,11 +9258,6 @@ pub struct PartitionKeyData {
     _unused: [u8; 0],
 }
 pub type PartitionKey = *mut PartitionKeyData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionDescData {
-    _unused: [u8; 0],
-}
 pub type PartitionDesc = *mut PartitionDescData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9283,24 +9310,24 @@ pub struct ConditionVariable {
     pub wakeup: proclist_head,
 }
 pub type HashValueFunc = ::core::option::Option<
-    unsafe extern "C" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
+    unsafe extern "C-unwind" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
 >;
 pub type HashCompareFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         key1: *const ::core::ffi::c_void,
         key2: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> ::core::ffi::c_int,
 >;
 pub type HashCopyFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         dest: *mut ::core::ffi::c_void,
         src: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> *mut ::core::ffi::c_void,
 >;
 pub type HashAllocFunc =
-    ::core::option::Option<unsafe extern "C" fn(request: Size) -> *mut ::core::ffi::c_void>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(request: Size) -> *mut ::core::ffi::c_void>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HASHELEMENT {
@@ -9613,16 +9640,17 @@ pub struct SortSupportData {
     pub ssup_attno: AttrNumber,
     pub ssup_extra: *mut ::core::ffi::c_void,
     pub comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
     pub abbreviate: bool,
-    pub abbrev_converter:
-        ::core::option::Option<unsafe extern "C" fn(original: Datum, ssup: SortSupport) -> Datum>,
+    pub abbrev_converter: ::core::option::Option<
+        unsafe extern "C-unwind" fn(original: Datum, ssup: SortSupport) -> Datum,
+    >,
     pub abbrev_abort: ::core::option::Option<
-        unsafe extern "C" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
+        unsafe extern "C-unwind" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
     >,
     pub abbrev_full_comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
 }
 impl Default for SortSupportData {
@@ -9724,7 +9752,7 @@ pub struct CopyMultiInsertBuffer {
     _unused: [u8; 0],
 }
 pub type ExprStateEvalFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         expression: *mut ExprState,
         econtext: *mut ExprContext,
         isNull: *mut bool,
@@ -9796,7 +9824,8 @@ impl Default for IndexInfo {
         }
     }
 }
-pub type ExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type ExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExprContext_CB {
@@ -10302,8 +10331,9 @@ impl Default for DomainConstraintState {
         }
     }
 }
-pub type ExecProcNodeMtd =
-    ::core::option::Option<unsafe extern "C" fn(pstate: *mut PlanState) -> *mut TupleTableSlot>;
+pub type ExecProcNodeMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(pstate: *mut PlanState) -> *mut TupleTableSlot,
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PlanState {
@@ -10462,7 +10492,7 @@ pub struct AppendState {
     pub as_prune_state: *mut PartitionPruneState,
     pub as_valid_subplans: *mut Bitmapset,
     pub choose_next_subplan:
-        ::core::option::Option<unsafe extern "C" fn(arg1: *mut AppendState) -> bool>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut AppendState) -> bool>,
 }
 impl Default for AppendState {
     fn default() -> Self {
@@ -11828,17 +11858,17 @@ pub type DestReceiver = _DestReceiver;
 #[derive(Debug, Copy, Clone)]
 pub struct _DestReceiver {
     pub receiveSlot: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
     >,
     pub rStartup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             self_: *mut DestReceiver,
             operation: ::core::ffi::c_int,
             typeinfo: TupleDesc,
         ),
     >,
-    pub rShutdown: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
-    pub rDestroy: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
+    pub rShutdown: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
+    pub rDestroy: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
     pub mydest: CommandDest::Type,
 }
 impl Default for _DestReceiver {
@@ -15468,7 +15498,7 @@ pub struct MemoryContextCounters {
     pub freespace: Size,
 }
 pub type MemoryStatsPrintFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         context: MemoryContext,
         passthru: *mut ::core::ffi::c_void,
         stats_string: *const ::core::ffi::c_char,
@@ -15478,33 +15508,37 @@ pub type MemoryStatsPrintFunc = ::core::option::Option<
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MemoryContextMethods {
     pub alloc: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
+        unsafe extern "C-unwind" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
     >,
     pub free_p: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void),
+        unsafe extern "C-unwind" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void),
     >,
     pub realloc: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             pointer: *mut ::core::ffi::c_void,
             size: Size,
         ) -> *mut ::core::ffi::c_void,
     >,
-    pub reset: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
-    pub delete_context: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub reset: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
+    pub delete_context: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
     pub get_chunk_space: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void) -> Size,
+        unsafe extern "C-unwind" fn(
+            context: MemoryContext,
+            pointer: *mut ::core::ffi::c_void,
+        ) -> Size,
     >,
-    pub is_empty: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext) -> bool>,
+    pub is_empty:
+        ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext) -> bool>,
     pub stats: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             printfunc: MemoryStatsPrintFunc,
             passthru: *mut ::core::ffi::c_void,
             totals: *mut MemoryContextCounters,
         ),
     >,
-    pub check: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub check: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -15532,10 +15566,10 @@ impl Default for MemoryContextData {
     }
 }
 pub type ExecutorStart_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
 >;
 pub type ExecutorRun_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         queryDesc: *mut QueryDesc,
         direction: ScanDirection::Type,
         count: uint64,
@@ -15543,15 +15577,16 @@ pub type ExecutorRun_hook_type = ::core::option::Option<
     ),
 >;
 pub type ExecutorFinish_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorEnd_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorCheckPerms_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut List, arg2: bool) -> bool>;
-pub type ExecScanAccessMtd =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ScanState) -> *mut TupleTableSlot>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut List, arg2: bool) -> bool>;
+pub type ExecScanAccessMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(node: *mut ScanState) -> *mut TupleTableSlot,
+>;
 pub type ExecScanRecheckMtd = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -15811,7 +15846,7 @@ impl Default for RelFileNodeBackend {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct XLogRecord {
     pub xl_tot_len: uint32,
     pub xl_xid: TransactionId,
@@ -15819,6 +15854,15 @@ pub struct XLogRecord {
     pub xl_info: uint8,
     pub xl_rmid: RmgrId,
     pub xl_crc: pg_crc32c,
+}
+impl Default for XLogRecord {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -15873,7 +15917,7 @@ impl Default for WALSegmentContext {
     }
 }
 pub type XLogPageReadCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         targetPagePtr: XLogRecPtr,
         reqLen: ::core::ffi::c_int,
@@ -15882,14 +15926,14 @@ pub type XLogPageReadCB = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type WALSegmentOpenCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         nextSegNo: XLogSegNo,
         tli_p: *mut TimeLineID,
     ),
 >;
 pub type WALSegmentCloseCB =
-    ::core::option::Option<unsafe extern "C" fn(xlogreader: *mut XLogReaderState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(xlogreader: *mut XLogReaderState)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct XLogReaderRoutine {
@@ -16603,13 +16647,22 @@ impl Default for PGPROC {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct PGXACT {
     pub xid: TransactionId,
     pub xmin: TransactionId,
     pub vacuumFlags: uint8,
     pub overflowed: bool,
     pub nxids: uint8,
+}
+impl Default for PGXACT {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -17680,7 +17733,7 @@ pub struct IndexBulkDeleteResult {
     pub pages_free: BlockNumber,
 }
 pub type IndexBulkDeleteCallback = ::core::option::Option<
-    unsafe extern "C" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type IndexScanDesc = *mut IndexScanDescData;
 pub type SysScanDesc = *mut SysScanDescData;
@@ -17721,16 +17774,16 @@ pub mod IndexAMProperty {
     pub const AMPROP_CAN_INCLUDE: Type = 18;
 }
 pub type ambuild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         heapRelation: Relation,
         indexRelation: Relation,
         indexInfo: *mut IndexInfo,
     ) -> *mut IndexBuildResult,
 >;
 pub type ambuildempty_function =
-    ::core::option::Option<unsafe extern "C" fn(indexRelation: Relation)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexRelation: Relation)>;
 pub type aminsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         values: *mut Datum,
         isnull: *mut bool,
@@ -17741,7 +17794,7 @@ pub type aminsert_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type ambulkdelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
         callback: IndexBulkDeleteCallback,
@@ -17749,16 +17802,16 @@ pub type ambulkdelete_function = ::core::option::Option<
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amvacuumcleanup_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amcanreturn_function = ::core::option::Option<
-    unsafe extern "C" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
 >;
 pub type amcostestimate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         path: *mut IndexPath,
         loop_count: f64,
@@ -17769,10 +17822,11 @@ pub type amcostestimate_function = ::core::option::Option<
         indexPages: *mut f64,
     ),
 >;
-pub type amoptions_function =
-    ::core::option::Option<unsafe extern "C" fn(reloptions: Datum, validate: bool) -> *mut bytea>;
+pub type amoptions_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(reloptions: Datum, validate: bool) -> *mut bytea,
+>;
 pub type amproperty_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index_oid: Oid,
         attno: ::core::ffi::c_int,
         prop: IndexAMProperty::Type,
@@ -17781,19 +17835,20 @@ pub type amproperty_function = ::core::option::Option<
         isnull: *mut bool,
     ) -> bool,
 >;
-pub type ambuildphasename_function =
-    ::core::option::Option<unsafe extern "C" fn(phasenum: int64) -> *mut ::core::ffi::c_char>;
+pub type ambuildphasename_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(phasenum: int64) -> *mut ::core::ffi::c_char,
+>;
 pub type amvalidate_function =
-    ::core::option::Option<unsafe extern "C" fn(opclassoid: Oid) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(opclassoid: Oid) -> bool>;
 pub type ambeginscan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         nkeys: ::core::ffi::c_int,
         norderbys: ::core::ffi::c_int,
     ) -> IndexScanDesc,
 >;
 pub type amrescan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         scan: IndexScanDesc,
         keys: ScanKey,
         nkeys: ::core::ffi::c_int,
@@ -17802,18 +17857,23 @@ pub type amrescan_function = ::core::option::Option<
     ),
 >;
 pub type amgettuple_function = ::core::option::Option<
-    unsafe extern "C" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
 >;
-pub type amgetbitmap_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64>;
-pub type amendscan_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type ammarkpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amrestrpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amestimateparallelscan_function = ::core::option::Option<unsafe extern "C" fn() -> Size>;
+pub type amgetbitmap_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64,
+>;
+pub type amendscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type ammarkpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amrestrpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amestimateparallelscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> Size>;
 pub type aminitparallelscan_function =
-    ::core::option::Option<unsafe extern "C" fn(target: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(target: *mut ::core::ffi::c_void)>;
 pub type amparallelrescan_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IndexAmRoutine {
@@ -18023,15 +18083,17 @@ pub mod RecoveryTargetAction {
 #[derive(Debug, Copy, Clone)]
 pub struct RmgrData {
     pub rm_name: *const ::core::ffi::c_char,
-    pub rm_redo: ::core::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
-    pub rm_desc:
-        ::core::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
-    pub rm_identify:
-        ::core::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::core::ffi::c_char>,
-    pub rm_startup: ::core::option::Option<unsafe extern "C" fn()>,
-    pub rm_cleanup: ::core::option::Option<unsafe extern "C" fn()>,
+    pub rm_redo: ::core::option::Option<unsafe extern "C-unwind" fn(record: *mut XLogReaderState)>,
+    pub rm_desc: ::core::option::Option<
+        unsafe extern "C-unwind" fn(buf: StringInfo, record: *mut XLogReaderState),
+    >,
+    pub rm_identify: ::core::option::Option<
+        unsafe extern "C-unwind" fn(info: uint8) -> *const ::core::ffi::c_char,
+    >,
+    pub rm_startup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
+    pub rm_cleanup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     pub rm_mask: ::core::option::Option<
-        unsafe extern "C" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
+        unsafe extern "C-unwind" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
     >,
 }
 impl Default for RmgrData {
@@ -18656,9 +18718,9 @@ impl Default for SysScanDescData {
     }
 }
 pub type EOM_get_flat_size_method =
-    ::core::option::Option<unsafe extern "C" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
 pub type EOM_flatten_into_method = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         eohptr: *mut ExpandedObjectHeader,
         result: *mut ::core::ffi::c_void,
         allocated_size: Size,
@@ -18921,54 +18983,60 @@ impl Default for config_enum_entry {
     }
 }
 pub type GucBoolCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut bool,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucIntCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucRealCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut f64,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucStringCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut *mut ::core::ffi::c_char,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucEnumCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
-pub type GucBoolAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: bool, extra: *mut ::core::ffi::c_void)>;
-pub type GucIntAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+pub type GucBoolAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: bool, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucRealAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: f64, extra: *mut ::core::ffi::c_void)>;
+pub type GucIntAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+>;
+pub type GucRealAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: f64, extra: *mut ::core::ffi::c_void),
+>;
 pub type GucStringAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: *const ::core::ffi::c_char, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    ),
 >;
 pub type GucEnumAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucShowHook = ::core::option::Option<unsafe extern "C" fn() -> *const ::core::ffi::c_char>;
+pub type GucShowHook =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const ::core::ffi::c_char>;
 pub mod GucAction {
     pub type Type = ::core::ffi::c_uint;
     pub const GUC_ACTION_SET: Type = 0;
@@ -19003,15 +19071,24 @@ pub mod TM_Result {
     pub const TM_WouldBlock: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct TM_FailureData {
     pub ctid: ItemPointerData,
     pub xmax: TransactionId,
     pub cmax: CommandId,
     pub traversed: bool,
 }
+impl Default for TM_FailureData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 pub type IndexBuildCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index: Relation,
         tid: ItemPointer,
         values: *mut Datum,
@@ -19024,10 +19101,11 @@ pub type IndexBuildCallback = ::core::option::Option<
 #[derive(Debug, Copy, Clone)]
 pub struct TableAmRoutine {
     pub type_: NodeTag,
-    pub slot_callbacks:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *const TupleTableSlotOps>,
+    pub slot_callbacks: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *const TupleTableSlotOps,
+    >,
     pub scan_begin: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             snapshot: Snapshot,
             nkeys: ::core::ffi::c_int,
@@ -19036,9 +19114,9 @@ pub struct TableAmRoutine {
             flags: uint32,
         ) -> TableScanDesc,
     >,
-    pub scan_end: ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc)>,
+    pub scan_end: ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc)>,
     pub scan_rescan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             key: *mut ScanKeyData,
             set_params: bool,
@@ -19048,26 +19126,29 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_getnextslot: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub parallelscan_estimate: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Size>,
+    pub parallelscan_estimate:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Size>,
     pub parallelscan_initialize: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
     >,
-    pub parallelscan_reinitialize:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc)>,
-    pub index_fetch_begin:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *mut IndexFetchTableData>,
+    pub parallelscan_reinitialize: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc),
+    >,
+    pub index_fetch_begin: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *mut IndexFetchTableData,
+    >,
     pub index_fetch_reset:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_end:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: *mut IndexFetchTableData,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -19077,29 +19158,34 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub tuple_fetch_row_version: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub tuple_tid_valid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer) -> bool>,
+    pub tuple_tid_valid: ::core::option::Option<
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer) -> bool,
+    >,
     pub tuple_get_latest_tid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer)>,
     pub tuple_satisfies_snapshot: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, slot: *mut TupleTableSlot, snapshot: Snapshot) -> bool,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            slot: *mut TupleTableSlot,
+            snapshot: Snapshot,
+        ) -> bool,
     >,
     pub compute_xid_horizon_for_tuples: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             items: *mut ItemPointerData,
             nitems: ::core::ffi::c_int,
         ) -> TransactionId,
     >,
     pub tuple_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -19108,7 +19194,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_insert_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -19118,7 +19204,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_complete_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             specToken: uint32,
@@ -19126,7 +19212,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub multi_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slots: *mut *mut TupleTableSlot,
             nslots: ::core::ffi::c_int,
@@ -19136,7 +19222,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_delete: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             cid: CommandId,
@@ -19148,7 +19234,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_update: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             otid: ItemPointer,
             slot: *mut TupleTableSlot,
@@ -19162,7 +19248,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_lock: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -19174,10 +19260,11 @@ pub struct TableAmRoutine {
             tmfd: *mut TM_FailureData,
         ) -> TM_Result::Type,
     >,
-    pub finish_bulk_insert:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, options: ::core::ffi::c_int)>,
+    pub finish_bulk_insert: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, options: ::core::ffi::c_int),
+    >,
     pub relation_set_new_filenode: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             newrnode: *const RelFileNode,
             persistence: ::core::ffi::c_char,
@@ -19186,11 +19273,12 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_nontransactional_truncate:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation)>,
-    pub relation_copy_data:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, newrnode: *const RelFileNode)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation)>,
+    pub relation_copy_data: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, newrnode: *const RelFileNode),
+    >,
     pub relation_copy_for_cluster: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             OldTable: Relation,
             NewTable: Relation,
             OldIndex: Relation,
@@ -19204,21 +19292,21 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_vacuum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             onerel: Relation,
             params: *mut VacuumParams,
             bstrategy: BufferAccessStrategy,
         ),
     >,
     pub scan_analyze_next_block: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             blockno: BlockNumber,
             bstrategy: BufferAccessStrategy,
         ) -> bool,
     >,
     pub scan_analyze_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             OldestXmin: TransactionId,
             liverows: *mut f64,
@@ -19227,7 +19315,7 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub index_build_range_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -19242,7 +19330,7 @@ pub struct TableAmRoutine {
         ) -> f64,
     >,
     pub index_validate_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -19251,13 +19339,14 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_size: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
+        unsafe extern "C-unwind" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
     >,
     pub relation_needs_toast_table:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> bool>,
-    pub relation_toast_am: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Oid>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> bool>,
+    pub relation_toast_am:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Oid>,
     pub relation_fetch_toast_slice: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             toastrel: Relation,
             valueid: Oid,
             attrsize: int32,
@@ -19267,7 +19356,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_estimate_size: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             attr_widths: *mut int32,
             pages: *mut BlockNumber,
@@ -19276,20 +19365,20 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_bitmap_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
     >,
     pub scan_bitmap_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             tbmres: *mut TBMIterateResult,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_sample_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
     >,
     pub scan_sample_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             scanstate: *mut SampleScanState,
             slot: *mut TupleTableSlot,
@@ -19391,7 +19480,6 @@ impl Default for MultiXactMember {
     }
 }
 #[repr(C)]
-#[derive(Debug)]
 pub struct xl_multixact_create {
     pub mid: MultiXactId,
     pub moff: MultiXactOffset,
@@ -19408,7 +19496,6 @@ impl Default for xl_multixact_create {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct xl_multixact_truncate {
     pub oldestMultiDB: Oid,
     pub startTruncOff: MultiXactId,
@@ -19586,12 +19673,15 @@ impl Default for relopt_enum {
     }
 }
 pub type validate_string_relopt =
-    ::core::option::Option<unsafe extern "C" fn(value: *const ::core::ffi::c_char)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(value: *const ::core::ffi::c_char)>;
 pub type fill_string_relopt = ::core::option::Option<
-    unsafe extern "C" fn(value: *const ::core::ffi::c_char, ptr: *mut ::core::ffi::c_void) -> Size,
+    unsafe extern "C-unwind" fn(
+        value: *const ::core::ffi::c_char,
+        ptr: *mut ::core::ffi::c_void,
+    ) -> Size,
 >;
 pub type relopts_validator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parsed_options: *mut ::core::ffi::c_void,
         vals: *mut relopt_value,
         nvals: ::core::ffi::c_int,
@@ -19833,7 +19923,7 @@ pub mod XactEvent {
     pub const XACT_EVENT_PRE_PREPARE: Type = 7;
 }
 pub type XactCallback = ::core::option::Option<
-    unsafe extern "C" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
 >;
 pub mod SubXactEvent {
     pub type Type = ::core::ffi::c_uint;
@@ -19843,7 +19933,7 @@ pub mod SubXactEvent {
     pub const SUBXACT_EVENT_PRE_COMMIT_SUB: Type = 3;
 }
 pub type SubXactCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         event: SubXactEvent::Type,
         mySubid: SubTransactionId,
         parentSubid: SubTransactionId,
@@ -19851,11 +19941,20 @@ pub type SubXactCallback = ::core::option::Option<
     ),
 >;
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_assignment {
     pub xtop: TransactionId,
     pub nsubxacts: ::core::ffi::c_int,
     pub xsub: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_assignment {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19878,10 +19977,19 @@ impl Default for xl_xact_dbinfo {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_subxacts {
     pub nsubxacts: ::core::ffi::c_int,
     pub subxacts: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_subxacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -19913,9 +20021,18 @@ impl Default for xl_xact_invals {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct xl_xact_twophase {
     pub xid: TransactionId,
+}
+impl Default for xl_xact_twophase {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -20023,7 +20140,7 @@ pub mod ResourceReleasePhase {
     pub const RESOURCE_RELEASE_AFTER_LOCKS: Type = 2;
 }
 pub type ResourceReleaseCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         phase: ResourceReleasePhase::Type,
         isCommit: bool,
         isTopLevel: bool,
@@ -20051,11 +20168,6 @@ pub mod ReadBufferMode {
 pub struct PrefetchBufferResult {
     pub recent_buffer: Buffer,
     pub initiated_io: bool,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct WritebackContext {
-    _unused: [u8; 0],
 }
 pub mod XLogRedoAction {
     pub type Type = ::core::ffi::c_uint;
@@ -20207,7 +20319,7 @@ pub mod RVROption {
     pub const RVR_SKIP_LOCKED: Type = 4;
 }
 pub type RangeVarGetRelidCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: *const RangeVar,
         relId: Oid,
         oldRelId: Oid,
@@ -20255,7 +20367,7 @@ pub struct ObjectAccessNamespaceSearch {
     pub result: bool,
 }
 pub type object_access_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectId: Oid,
@@ -20638,20 +20750,20 @@ pub mod ParseExprKind {
     pub const EXPR_KIND_GENERATED_COLUMN: Type = 40;
 }
 pub type PreParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
 >;
 pub type PostParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         cref: *mut ColumnRef,
         var: *mut Node,
     ) -> *mut Node,
 >;
 pub type ParseParamRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
 >;
 pub type CoerceParamHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         param: *mut Param,
         targetTypeId: Oid,
@@ -20933,7 +21045,7 @@ pub struct CopyStateData {
 }
 pub type CopyState = *mut CopyStateData;
 pub type copy_data_source_cb = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         outbuf: *mut ::core::ffi::c_void,
         minread: ::core::ffi::c_int,
         maxread: ::core::ffi::c_int,
@@ -21226,7 +21338,7 @@ impl Default for ExplainState {
     }
 }
 pub type ExplainOneQuery_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         query: *mut Query,
         cursorOptions: ::core::ffi::c_int,
         into: *mut IntoClause,
@@ -21237,7 +21349,7 @@ pub type ExplainOneQuery_hook_type = ::core::option::Option<
     ),
 >;
 pub type explain_get_index_name_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
 pub mod PlanCacheMode {
     pub type Type = ::core::ffi::c_uint;
     pub const PLAN_CACHE_MODE_AUTO: Type = 0;
@@ -21349,7 +21461,7 @@ impl Default for PreparedStatement {
     }
 }
 pub type check_object_relabel_type = ::core::option::Option<
-    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
+    unsafe extern "C-unwind" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -21446,7 +21558,7 @@ pub mod PasswordType {
     pub const PASSWORD_TYPE_SCRAM_SHA_256: Type = 2;
 }
 pub type check_password_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         username: *const ::core::ffi::c_char,
         shadow_pass: *const ::core::ffi::c_char,
         password_type: PasswordType::Type,
@@ -21491,14 +21603,14 @@ impl Default for FormData_pg_statistic {
 pub type Form_pg_statistic = *mut FormData_pg_statistic;
 pub type VacAttrStatsP = *mut VacAttrStats;
 pub type AnalyzeAttrFetchFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         rownum: ::core::ffi::c_int,
         isNull: *mut bool,
     ) -> Datum,
 >;
 pub type AnalyzeAttrComputeStatsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         fetchfunc: AnalyzeAttrFetchFunc,
         samplerows: ::core::ffi::c_int,
@@ -21604,7 +21716,6 @@ impl Default for ConfigData {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct CheckPoint {
     pub redo: XLogRecPtr,
     pub ThisTimeLineID: TimeLineID,
@@ -21643,7 +21754,6 @@ pub mod DBState {
     pub const DB_IN_PRODUCTION: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct ControlFileData {
     pub system_identifier: uint64,
     pub pg_control_version: uint32,
@@ -21690,7 +21800,7 @@ impl Default for ControlFileData {
         }
     }
 }
-pub type bgworker_main_type = ::core::option::Option<unsafe extern "C" fn(main_arg: Datum)>;
+pub type bgworker_main_type = ::core::option::Option<unsafe extern "C-unwind" fn(main_arg: Datum)>;
 pub mod BgWorkerStartTime {
     pub type Type = ::core::ffi::c_uint;
     pub const BgWorkerStart_PostmasterStart: Type = 0;
@@ -21764,7 +21874,7 @@ pub mod shm_mq_result {
     pub const SHM_MQ_DETACHED: Type = 2;
 }
 pub type parallel_worker_main_type =
-    ::core::option::Option<unsafe extern "C" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ParallelWorkerInfo {
@@ -21955,7 +22065,11 @@ impl Default for AggStatePerHashData {
     }
 }
 pub type ExecEvalSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(state: *mut ExprState, op: *mut ExprEvalStep, econtext: *mut ExprContext),
+    unsafe extern "C-unwind" fn(
+        state: *mut ExprState,
+        op: *mut ExprEvalStep,
+        econtext: *mut ExprContext,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -22803,7 +22917,7 @@ pub struct PortalData {
     pub prepStmtName: *const ::core::ffi::c_char,
     pub portalContext: MemoryContext,
     pub resowner: ResourceOwner,
-    pub cleanup: ::core::option::Option<unsafe extern "C" fn(portal: Portal)>,
+    pub cleanup: ::core::option::Option<unsafe extern "C-unwind" fn(portal: Portal)>,
     pub createSubid: SubTransactionId,
     pub activeSubid: SubTransactionId,
     pub sourceText: *const ::core::ffi::c_char,
@@ -23157,7 +23271,7 @@ pub struct IndexOptInfo {
     pub amhasgetbitmap: bool,
     pub amcanparallel: bool,
     pub amcanmarkpos: bool,
-    pub amcostestimate: ::core::option::Option<unsafe extern "C" fn()>,
+    pub amcostestimate: ::core::option::Option<unsafe extern "C-unwind" fn()>,
 }
 impl Default for IndexOptInfo {
     fn default() -> Self {
@@ -24234,13 +24348,21 @@ pub struct JoinCostWorkspace {
     pub inner_rows_total: f64,
 }
 pub type GetForeignRelSize_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPlan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         baserel: *mut RelOptInfo,
         foreigntableid: Oid,
@@ -24251,20 +24373,20 @@ pub type GetForeignPlan_function = ::core::option::Option<
     ) -> *mut ForeignScan,
 >;
 pub type BeginForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type RecheckForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 pub type ReScanForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type EndForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignJoinPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -24274,7 +24396,7 @@ pub type GetForeignJoinPaths_function = ::core::option::Option<
     ),
 >;
 pub type GetForeignUpperPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -24283,14 +24405,14 @@ pub type GetForeignUpperPaths_function = ::core::option::Option<
     ),
 >;
 pub type AddForeignUpdateTargets_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parsetree: *mut Query,
         target_rte: *mut RangeTblEntry,
         target_relation: Relation,
     ),
 >;
 pub type PlanForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -24298,7 +24420,7 @@ pub type PlanForeignModify_function = ::core::option::Option<
     ) -> *mut List,
 >;
 pub type BeginForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -24307,7 +24429,7 @@ pub type BeginForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExecForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -24315,7 +24437,7 @@ pub type ExecForeignInsert_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignUpdate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -24323,24 +24445,26 @@ pub type ExecForeignUpdate_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignDelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
         planSlot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot,
 >;
-pub type EndForeignModify_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
-pub type BeginForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+pub type EndForeignModify_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
 >;
-pub type EndForeignInsert_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
+pub type BeginForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+>;
+pub type EndForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
+>;
 pub type IsForeignRelUpdatable_function =
-    ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> ::core::ffi::c_int>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> ::core::ffi::c_int>;
 pub type PlanDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -24348,21 +24472,21 @@ pub type PlanDirectModify_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type BeginDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type EndDirectModify_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignRowMarkType_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rte: *mut RangeTblEntry,
         strength: LockClauseStrength::Type,
     ) -> RowMarkType::Type,
 >;
 pub type RefetchForeignRow_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         erm: *mut ExecRowMark,
         rowid: Datum,
@@ -24371,10 +24495,10 @@ pub type RefetchForeignRow_function = ::core::option::Option<
     ),
 >;
 pub type ExplainForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type ExplainForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -24383,10 +24507,10 @@ pub type ExplainForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExplainDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type AcquireSampleRowsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         elevel: ::core::ffi::c_int,
         rows: *mut HeapTuple,
@@ -24396,50 +24520,50 @@ pub type AcquireSampleRowsFunc = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type AnalyzeForeignTable_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         func: *mut AcquireSampleRowsFunc,
         totalpages: *mut BlockNumber,
     ) -> bool,
 >;
 pub type ImportForeignSchema_function = ::core::option::Option<
-    unsafe extern "C" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
+    unsafe extern "C-unwind" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
 >;
 pub type EstimateDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
 >;
 pub type InitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ReInitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type InitializeWorkerForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         toc: *mut shm_toc,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ShutdownForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type IsForeignScanParallelSafe_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rte: *mut RangeTblEntry,
     ) -> bool,
 >;
 pub type ReparameterizeForeignPathByChild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         fdw_private: *mut List,
         child_rel: *mut RelOptInfo,
@@ -24601,12 +24725,12 @@ impl Default for JitContext {
     }
 }
 pub type JitProviderInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut JitProviderCallbacks)>;
-pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut JitProviderCallbacks)>;
+pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type JitProviderReleaseContextCB =
-    ::core::option::Option<unsafe extern "C" fn(context: *mut JitContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(context: *mut JitContext)>;
 pub type JitProviderCompileExprCB =
-    ::core::option::Option<unsafe extern "C" fn(state: *mut ExprState) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(state: *mut ExprState) -> bool>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct JitProviderCallbacks {
@@ -24692,30 +24816,30 @@ impl Default for pg_enc2gettext {
     }
 }
 pub type mb2wchar_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const ::core::ffi::c_uchar,
         to: *mut pg_wchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type wchar2mb_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const pg_wchar,
         to: *mut ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mblen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbdisplaylen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbcharacter_incrementer = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
 >;
 pub type mbverifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
@@ -24784,7 +24908,7 @@ pub struct pg_local_to_utf_combined {
     pub utf2: uint32,
 }
 pub type utf_local_conversion_func =
-    ::core::option::Option<unsafe extern "C" fn(code: uint32) -> uint32>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: uint32) -> uint32>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExtensibleNode {
@@ -24806,15 +24930,15 @@ pub struct ExtensibleNodeMethods {
     pub extnodename: *const ::core::ffi::c_char,
     pub node_size: Size,
     pub nodeCopy: ::core::option::Option<
-        unsafe extern "C" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
     >,
     pub nodeEqual: ::core::option::Option<
-        unsafe extern "C" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
+        unsafe extern "C-unwind" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
     >,
     pub nodeOut: ::core::option::Option<
-        unsafe extern "C" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
     >,
-    pub nodeRead: ::core::option::Option<unsafe extern "C" fn(node: *mut ExtensibleNode)>,
+    pub nodeRead: ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ExtensibleNode)>,
 }
 impl Default for ExtensibleNodeMethods {
     fn default() -> Self {
@@ -24830,7 +24954,7 @@ impl Default for ExtensibleNodeMethods {
 pub struct CustomPathMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub PlanCustomPath: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             rel: *mut RelOptInfo,
             best_path: *mut CustomPath,
@@ -24840,7 +24964,7 @@ pub struct CustomPathMethods {
         ) -> *mut Plan,
     >,
     pub ReparameterizeCustomPathByChild: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             custom_private: *mut List,
             child_rel: *mut RelOptInfo,
@@ -24861,7 +24985,7 @@ impl Default for CustomPathMethods {
 pub struct CustomScanMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub CreateCustomScanState:
-        ::core::option::Option<unsafe extern "C" fn(cscan: *mut CustomScan) -> *mut Node>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(cscan: *mut CustomScan) -> *mut Node>,
 }
 impl Default for CustomScanMethods {
     fn default() -> Self {
@@ -24877,48 +25001,51 @@ impl Default for CustomScanMethods {
 pub struct CustomExecMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub BeginCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             estate: *mut EState,
             eflags: ::core::ffi::c_int,
         ),
     >,
     pub ExecCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
     >,
-    pub EndCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub ReScanCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub MarkPosCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+    pub EndCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub ReScanCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub MarkPosCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub RestrPosCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub EstimateDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
     >,
     pub InitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ReInitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub InitializeWorkerCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             toc: *mut shm_toc,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ShutdownCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub ExplainCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             ancestors: *mut List,
             es: *mut ExplainState,
@@ -24935,7 +25062,7 @@ impl Default for CustomExecMethods {
     }
 }
 pub type check_function_callback = ::core::option::Option<
-    unsafe extern "C" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
 >;
 pub mod ReplicationKind {
     pub type Type = ::core::ffi::c_uint;
@@ -25182,7 +25309,7 @@ pub mod ForceParallelMode {
     pub const FORCE_PARALLEL_REGRESS: Type = 2;
 }
 pub type set_rel_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rti: Index,
@@ -25190,7 +25317,7 @@ pub type set_rel_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type set_join_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -25200,14 +25327,14 @@ pub type set_join_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type join_search_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         levels_needed: ::core::ffi::c_int,
         initial_rels: *mut List,
     ) -> *mut RelOptInfo,
 >;
 pub type ec_matches_callback_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         ec: *mut EquivalenceClass,
@@ -25223,7 +25350,7 @@ pub mod PathKeysComparison {
     pub const PATHKEYS_DIFFERENT: Type = 3;
 }
 pub type get_relation_info_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         relationObjectId: Oid,
         inhparent: bool,
@@ -25231,10 +25358,10 @@ pub type get_relation_info_hook_type = ::core::option::Option<
     ),
 >;
 pub type query_pathkeys_callback = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
 >;
 pub type planner_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parse: *mut Query,
         query_string: *const ::core::ffi::c_char,
         cursorOptions: ::core::ffi::c_int,
@@ -25242,7 +25369,7 @@ pub type planner_hook_type = ::core::option::Option<
     ) -> *mut PlannedStmt,
 >;
 pub type create_upper_paths_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -25251,7 +25378,7 @@ pub type create_upper_paths_hook_type = ::core::option::Option<
     ),
 >;
 pub type post_parse_analyze_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(pstate: *mut ParseState, query: *mut Query)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(pstate: *mut ParseState, query: *mut Query)>;
 pub mod FuncDetailCode {
     pub type Type = ::core::ffi::c_uint;
     pub const FUNCDETAIL_NOTFOUND: Type = 0;
@@ -25278,6 +25405,67 @@ pub mod BackslashQuoteType {
     pub const BACKSLASH_QUOTE_OFF: Type = 0;
     pub const BACKSLASH_QUOTE_ON: Type = 1;
     pub const BACKSLASH_QUOTE_SAFE_ENCODING: Type = 2;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionBoundInfoData {
+    pub strategy: ::core::ffi::c_char,
+    pub ndatums: ::core::ffi::c_int,
+    pub datums: *mut *mut Datum,
+    pub kind: *mut *mut PartitionRangeDatumKind::Type,
+    pub indexes: *mut ::core::ffi::c_int,
+    pub null_index: ::core::ffi::c_int,
+    pub default_index: ::core::ffi::c_int,
+    pub nindexes: ::core::ffi::c_int,
+}
+impl Default for PartitionBoundInfoData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionDescData {
+    pub nparts: ::core::ffi::c_int,
+    pub oids: *mut Oid,
+    pub is_leaf: *mut bool,
+    pub boundinfo: PartitionBoundInfo,
+}
+impl Default for PartitionDescData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionPruneContext {
+    pub strategy: ::core::ffi::c_char,
+    pub partnatts: ::core::ffi::c_int,
+    pub nparts: ::core::ffi::c_int,
+    pub boundinfo: PartitionBoundInfo,
+    pub partcollation: *mut Oid,
+    pub partsupfunc: *mut FmgrInfo,
+    pub stepcmpfuncs: *mut FmgrInfo,
+    pub ppccontext: MemoryContext,
+    pub planstate: *mut PlanState,
+    pub exprstates: *mut *mut ExprState,
+}
+impl Default for PartitionPruneContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -26571,23 +26759,24 @@ impl Default for PLpgSQL_execstate {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PLpgSQL_plugin {
     pub func_setup: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub stmt_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
     pub stmt_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
-    pub error_callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub error_callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub assign_expr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             expr: *mut PLpgSQL_expr,
@@ -26846,7 +27035,7 @@ impl Default for ReorderBufferTXN {
     }
 }
 pub type ReorderBufferApplyChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -26854,7 +27043,7 @@ pub type ReorderBufferApplyChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -26863,17 +27052,17 @@ pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -26937,19 +27126,19 @@ impl Default for OutputPluginOptions {
     }
 }
 pub type LogicalOutputPluginInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut OutputPluginCallbacks)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut OutputPluginCallbacks)>;
 pub type LogicalDecodeStartupCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         options: *mut OutputPluginOptions,
         is_init: bool,
     ),
 >;
 pub type LogicalDecodeBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -26957,7 +27146,7 @@ pub type LogicalDecodeChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -26966,14 +27155,14 @@ pub type LogicalDecodeTruncateCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -26984,10 +27173,10 @@ pub type LogicalDecodeMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeFilterByOriginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
 >;
 pub type LogicalDecodeShutdownCB =
-    ::core::option::Option<unsafe extern "C" fn(ctx: *mut LogicalDecodingContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct OutputPluginCallbacks {
@@ -27076,7 +27265,7 @@ impl Default for ReplicationSlotCtlData {
     }
 }
 pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -27085,7 +27274,11 @@ pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
 >;
 pub type LogicalOutputPluginWriterPrepareWrite = LogicalOutputPluginWriterWrite;
 pub type LogicalOutputPluginWriterUpdateProgress = ::core::option::Option<
-    unsafe extern "C" fn(lr: *mut LogicalDecodingContext, Ptr: XLogRecPtr, xid: TransactionId),
+    unsafe extern "C-unwind" fn(
+        lr: *mut LogicalDecodingContext,
+        Ptr: XLogRecPtr,
+        xid: TransactionId,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -27157,16 +27350,115 @@ impl Default for RowSecurityDesc {
     }
 }
 pub type row_security_policy_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
+    unsafe extern "C-unwind" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct buftag {
+    pub rnode: RelFileNode,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+}
+impl Default for buftag {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type BufferTag = buftag;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufferDesc {
+    pub tag: BufferTag,
+    pub buf_id: ::core::ffi::c_int,
+    pub state: pg_atomic_uint32,
+    pub wait_backend_pid: ::core::ffi::c_int,
+    pub freeNext: ::core::ffi::c_int,
+    pub content_lock: LWLock,
+}
+impl Default for BufferDesc {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union BufferDescPadded {
+    pub bufferdesc: BufferDesc,
+    pub pad: [::core::ffi::c_char; 64usize],
+}
+impl Default for BufferDescPadded {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PendingWriteback {
+    pub tag: BufferTag,
+}
+impl Default for PendingWriteback {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WritebackContext {
+    pub max_pending: *mut ::core::ffi::c_int,
+    pub nr_pending: ::core::ffi::c_int,
+    pub pending_writebacks: [PendingWriteback; 256usize],
+}
+impl Default for WritebackContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CkptSortItem {
+    pub tsId: Oid,
+    pub relNode: Oid,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+    pub buf_id: ::core::ffi::c_int,
+}
+impl Default for CkptSortItem {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BufFile {
     _unused: [u8; 0],
 }
 pub type pg_on_exit_callback =
-    ::core::option::Option<unsafe extern "C" fn(code: ::core::ffi::c_int, arg: Datum)>;
-pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: ::core::ffi::c_int, arg: Datum)>;
+pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub mod XLTW_Oper {
     pub type Type = ::core::ffi::c_uint;
     pub const XLTW_None: Type = 0;
@@ -27214,7 +27506,7 @@ impl Default for xl_standby_locks {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_running_xacts {
     pub xcnt: ::core::ffi::c_int,
     pub subxcnt: ::core::ffi::c_int,
@@ -27223,6 +27515,15 @@ pub struct xl_running_xacts {
     pub oldestRunningXid: TransactionId,
     pub latestCompletedXid: TransactionId,
     pub xids: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_running_xacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 pub struct xl_invalidations {
@@ -27329,7 +27630,7 @@ impl Default for AlterTableUtilityContext {
     }
 }
 pub type ProcessUtility_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstmt: *mut PlannedStmt,
         queryString: *const ::core::ffi::c_char,
         context: ProcessUtilityContext::Type,
@@ -27339,6 +27640,97 @@ pub type ProcessUtility_hook_type = ::core::option::Option<
         qc: *mut QueryCompletion,
     ),
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSAnyCacheEntry {
+    pub objId: Oid,
+    pub isvalid: bool,
+}
+impl Default for TSAnyCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSParserCacheEntry {
+    pub prsId: Oid,
+    pub isvalid: bool,
+    pub startOid: Oid,
+    pub tokenOid: Oid,
+    pub endOid: Oid,
+    pub headlineOid: Oid,
+    pub lextypeOid: Oid,
+    pub prsstart: FmgrInfo,
+    pub prstoken: FmgrInfo,
+    pub prsend: FmgrInfo,
+    pub prsheadline: FmgrInfo,
+}
+impl Default for TSParserCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSDictionaryCacheEntry {
+    pub dictId: Oid,
+    pub isvalid: bool,
+    pub lexizeOid: Oid,
+    pub lexize: FmgrInfo,
+    pub dictCtx: MemoryContext,
+    pub dictData: *mut ::core::ffi::c_void,
+}
+impl Default for TSDictionaryCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ListDictionary {
+    pub len: ::core::ffi::c_int,
+    pub dictIds: *mut Oid,
+}
+impl Default for ListDictionary {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSConfigCacheEntry {
+    pub cfgId: Oid,
+    pub isvalid: bool,
+    pub prsId: Oid,
+    pub lenmap: ::core::ffi::c_int,
+    pub map: *mut ListDictionary,
+}
+impl Default for TSConfigCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WordEntry {
@@ -28041,7 +28433,7 @@ pub struct TSQueryParserStateData {
 }
 pub type TSQueryParserState = *mut TSQueryParserStateData;
 pub type PushFunction = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opaque: Datum,
         state: TSQueryParserState,
         token: *mut ::core::ffi::c_char,
@@ -28126,7 +28518,7 @@ impl Default for ExecPhraseData {
     }
 }
 pub type TSExecuteCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         arg: *mut ::core::ffi::c_void,
         val: *mut QueryOperand,
         data: *mut ExecPhraseData,
@@ -28471,9 +28863,10 @@ impl Default for AttStatsSlot {
     }
 }
 pub type get_attavgwidth_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(relid: Oid, attnum: AttrNumber) -> int32>;
-pub type CCHashFN = ::core::option::Option<unsafe extern "C" fn(datum: Datum) -> uint32>;
-pub type CCFastEqualFN = ::core::option::Option<unsafe extern "C" fn(a: Datum, b: Datum) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(relid: Oid, attnum: AttrNumber) -> int32>;
+pub type CCHashFN = ::core::option::Option<unsafe extern "C-unwind" fn(datum: Datum) -> uint32>;
+pub type CCFastEqualFN =
+    ::core::option::Option<unsafe extern "C-unwind" fn(a: Datum, b: Datum) -> bool>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct catcache {
@@ -28599,7 +28992,7 @@ pub struct VariableStatData {
     pub var: *mut Node,
     pub rel: *mut RelOptInfo,
     pub statsTuple: HeapTuple,
-    pub freefunc: ::core::option::Option<unsafe extern "C" fn(tuple: HeapTuple)>,
+    pub freefunc: ::core::option::Option<unsafe extern "C-unwind" fn(tuple: HeapTuple)>,
     pub vartype: Oid,
     pub atttype: Oid,
     pub atttypmod: int32,
@@ -28628,7 +29021,7 @@ pub struct GenericCosts {
     pub num_sa_scans: f64,
 }
 pub type get_relation_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rte: *mut RangeTblEntry,
         attnum: AttrNumber,
@@ -28636,7 +29029,7 @@ pub type get_relation_stats_hook_type = ::core::option::Option<
     ) -> bool,
 >;
 pub type get_index_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         indexOid: Oid,
         indexattnum: AttrNumber,
@@ -28840,7 +29233,7 @@ pub struct SnapBuild {
     pub _address: u8,
 }
 #[pgrx_macros::pg_guard]
-unsafe extern "C" {
+unsafe extern "C-unwind" {
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         errorType: *const ::core::ffi::c_char,
@@ -29051,7 +29444,7 @@ unsafe extern "C" {
         nel: usize,
         elsize: usize,
         cmp: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
             ) -> ::core::ffi::c_int,
@@ -30601,9 +30994,9 @@ unsafe extern "C" {
     pub static pg_rightmost_one_pos: [uint8; 256usize];
     pub static pg_number_of_ones: [uint8; 256usize];
     pub static mut pg_popcount32:
-        ::core::option::Option<unsafe extern "C" fn(word: uint32) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint32) -> ::core::ffi::c_int>;
     pub static mut pg_popcount64:
-        ::core::option::Option<unsafe extern "C" fn(word: uint64) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint64) -> ::core::ffi::c_int>;
     pub fn pg_popcount(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int) -> uint64;
     pub fn tuplehash_create(
         ctx: MemoryContext,
@@ -31420,7 +31813,7 @@ unsafe extern "C" {
         len: usize,
     ) -> pg_crc32c;
     pub static mut pg_comp_crc32c: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             crc: pg_crc32c,
             data: *const ::core::ffi::c_void,
             len: usize,
@@ -33113,7 +33506,7 @@ unsafe extern "C" {
         oldtup_ptr: HeapTuple,
         buffer: Buffer,
         release_callback: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::core::ffi::c_void),
+            unsafe extern "C-unwind" fn(arg1: *mut ::core::ffi::c_void),
         >,
         arg: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -33462,9 +33855,9 @@ unsafe extern "C" {
     pub fn SendSharedInvalidMessages(msgs: *const SharedInvalidationMessage, n: ::core::ffi::c_int);
     pub fn ReceiveSharedInvalidMessages(
         invalFunction: ::core::option::Option<
-            unsafe extern "C" fn(msg: *mut SharedInvalidationMessage),
+            unsafe extern "C-unwind" fn(msg: *mut SharedInvalidationMessage),
         >,
-        resetFunction: ::core::option::Option<unsafe extern "C" fn()>,
+        resetFunction: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     );
     pub fn HandleCatchupInterrupt();
     pub fn ProcessCatchupInterrupt();
@@ -36727,24 +37120,24 @@ unsafe extern "C" {
     ) -> bool;
     pub fn expression_tree_mutator(
         node: *mut Node,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
     ) -> *mut Node;
     pub fn query_tree_mutator(
         query: *mut Query,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut Query;
     pub fn range_table_mutator(
         rtable: *mut List,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut List;
     pub fn query_or_expression_tree_mutator(
         node: *mut Node,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut Node;
@@ -38803,6 +39196,102 @@ unsafe extern "C" {
         warn: bool,
     );
     pub fn scanner_isspace(ch: ::core::ffi::c_char) -> bool;
+    pub fn get_hash_partition_greatest_modulus(b: PartitionBoundInfo) -> ::core::ffi::c_int;
+    pub fn compute_partition_hash_value(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        values: *mut Datum,
+        isnull: *mut bool,
+    ) -> uint64;
+    pub fn get_qual_from_partbound(
+        rel: Relation,
+        parent: Relation,
+        spec: *mut PartitionBoundSpec,
+    ) -> *mut List;
+    pub fn partition_bounds_create(
+        boundspecs: *mut *mut PartitionBoundSpec,
+        nparts: ::core::ffi::c_int,
+        key: PartitionKey,
+        mapping: *mut *mut ::core::ffi::c_int,
+    ) -> PartitionBoundInfo;
+    pub fn partition_bounds_equal(
+        partnatts: ::core::ffi::c_int,
+        parttyplen: *mut int16,
+        parttypbyval: *mut bool,
+        b1: PartitionBoundInfo,
+        b2: PartitionBoundInfo,
+    ) -> bool;
+    pub fn partition_bounds_copy(src: PartitionBoundInfo, key: PartitionKey) -> PartitionBoundInfo;
+    pub fn partition_bounds_merge(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        outer_rel: *mut RelOptInfo,
+        inner_rel: *mut RelOptInfo,
+        jointype: JoinType::Type,
+        outer_parts: *mut *mut List,
+        inner_parts: *mut *mut List,
+    ) -> PartitionBoundInfo;
+    pub fn partitions_are_ordered(
+        boundinfo: PartitionBoundInfo,
+        nparts: ::core::ffi::c_int,
+    ) -> bool;
+    pub fn check_new_partition_bound(
+        relname: *mut ::core::ffi::c_char,
+        parent: Relation,
+        spec: *mut PartitionBoundSpec,
+    );
+    pub fn check_default_partition_contents(
+        parent: Relation,
+        defaultRel: Relation,
+        new_spec: *mut PartitionBoundSpec,
+    );
+    pub fn partition_rbound_datum_cmp(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        rb_datums: *mut Datum,
+        rb_kind: *mut PartitionRangeDatumKind::Type,
+        tuple_datums: *mut Datum,
+        n_tuple_datums: ::core::ffi::c_int,
+    ) -> int32;
+    pub fn partition_list_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        value: Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_range_datum_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        nvalues: ::core::ffi::c_int,
+        values: *mut Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_hash_bsearch(
+        boundinfo: PartitionBoundInfo,
+        modulus: ::core::ffi::c_int,
+        remainder: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn RelationGetPartitionDesc(rel: Relation) -> PartitionDesc;
+    pub fn CreatePartitionDirectory(mcxt: MemoryContext) -> PartitionDirectory;
+    pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
+    pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
+    pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
+    pub fn make_partition_pruneinfo(
+        root: *mut PlannerInfo,
+        parentrel: *mut RelOptInfo,
+        subpaths: *mut List,
+        partitioned_rels: *mut List,
+        prunequal: *mut List,
+    ) -> *mut PartitionPruneInfo;
+    pub fn prune_append_rel_partitions(rel: *mut RelOptInfo) -> *mut Bitmapset;
+    pub fn get_matching_partitions(
+        context: *mut PartitionPruneContext,
+        pruning_steps: *mut List,
+    ) -> *mut Bitmapset;
     pub fn make_expanded_record_from_typeid(
         type_id: Oid,
         typmod: int32,
@@ -39288,6 +39777,61 @@ unsafe extern "C" {
         hasRowSecurity: *mut bool,
         hasSubLinks: *mut bool,
     );
+    pub static mut BufferIOLWLockArray: *mut LWLockMinimallyPadded;
+    pub fn LockBufHdr(desc: *mut BufferDesc) -> uint32;
+    pub static mut BufferDescriptors: *mut BufferDescPadded;
+    pub static mut BackendWritebackContext: WritebackContext;
+    pub static mut LocalBufferDescriptors: *mut BufferDesc;
+    pub static mut CkptBufferIds: *mut CkptSortItem;
+    pub fn WritebackContextInit(
+        context: *mut WritebackContext,
+        max_pending: *mut ::core::ffi::c_int,
+    );
+    pub fn IssuePendingWritebacks(context: *mut WritebackContext);
+    pub fn ScheduleBufferTagForWriteback(context: *mut WritebackContext, tag: *mut BufferTag);
+    pub fn StrategyGetBuffer(
+        strategy: BufferAccessStrategy,
+        buf_state: *mut uint32,
+    ) -> *mut BufferDesc;
+    pub fn StrategyFreeBuffer(buf: *mut BufferDesc);
+    pub fn StrategyRejectBuffer(strategy: BufferAccessStrategy, buf: *mut BufferDesc) -> bool;
+    pub fn StrategySyncStart(
+        complete_passes: *mut uint32,
+        num_buf_alloc: *mut uint32,
+    ) -> ::core::ffi::c_int;
+    pub fn StrategyNotifyBgWriter(bgwprocno: ::core::ffi::c_int);
+    pub fn StrategyShmemSize() -> Size;
+    pub fn StrategyInitialize(init: bool);
+    pub fn have_free_buffer() -> bool;
+    pub fn BufTableShmemSize(size: ::core::ffi::c_int) -> Size;
+    pub fn InitBufTable(size: ::core::ffi::c_int);
+    pub fn BufTableHashCode(tagPtr: *mut BufferTag) -> uint32;
+    pub fn BufTableLookup(tagPtr: *mut BufferTag, hashcode: uint32) -> ::core::ffi::c_int;
+    pub fn BufTableInsert(
+        tagPtr: *mut BufferTag,
+        hashcode: uint32,
+        buf_id: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn BufTableDelete(tagPtr: *mut BufferTag, hashcode: uint32);
+    pub fn PrefetchLocalBuffer(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+    ) -> PrefetchBufferResult;
+    pub fn LocalBufferAlloc(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+        foundPtr: *mut bool,
+    ) -> *mut BufferDesc;
+    pub fn MarkLocalBufferDirty(buffer: Buffer);
+    pub fn DropRelFileNodeLocalBuffers(
+        rnode: RelFileNode,
+        forkNum: ForkNumber::Type,
+        firstDelBlock: BlockNumber,
+    );
+    pub fn DropRelFileNodeAllLocalBuffers(rnode: RelFileNode);
+    pub fn AtEOXact_LocalBuffers(isCommit: bool);
     pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
     pub fn BufFileClose(file: *mut BufFile);
     pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::core::ffi::c_void, size: usize) -> usize;
@@ -39714,6 +40258,20 @@ unsafe extern "C" {
     pub fn CreateCommandTag(parsetree: *mut Node) -> CommandTag::Type;
     pub fn GetCommandLogLevel(parsetree: *mut Node) -> LogStmtLevel::Type;
     pub fn CommandIsReadOnly(pstmt: *mut PlannedStmt) -> bool;
+    pub static mut TSCurrentConfig: *mut ::core::ffi::c_char;
+    pub fn lookup_ts_parser_cache(prsId: Oid) -> *mut TSParserCacheEntry;
+    pub fn lookup_ts_dictionary_cache(dictId: Oid) -> *mut TSDictionaryCacheEntry;
+    pub fn lookup_ts_config_cache(cfgId: Oid) -> *mut TSConfigCacheEntry;
+    pub fn getTSCurrentConfig(emitError: bool) -> Oid;
+    pub fn check_TSCurrentConfig(
+        newval: *mut *mut ::core::ffi::c_char,
+        extra: *mut *mut ::core::ffi::c_void,
+        source: GucSource::Type,
+    ) -> bool;
+    pub fn assign_TSCurrentConfig(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    );
     pub fn compareWordEntryPos(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
@@ -39727,7 +40285,9 @@ unsafe extern "C" {
         fname: *const ::core::ffi::c_char,
         s: *mut StopList,
         wordop: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const ::core::ffi::c_char) -> *mut ::core::ffi::c_char,
+            unsafe extern "C-unwind" fn(
+                arg1: *const ::core::ffi::c_char,
+            ) -> *mut ::core::ffi::c_char,
         >,
     );
     pub fn searchstoplist(s: *mut StopList, key: *mut ::core::ffi::c_char) -> bool;
@@ -42936,7 +43496,7 @@ unsafe extern "C" {
         tuple: HeapTuple,
         newtuple: HeapTuple,
         function: ::core::option::Option<
-            unsafe extern "C" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
+            unsafe extern "C-unwind" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
         >,
     );
     pub fn PrintCatCacheLeakWarning(tuple: HeapTuple);
@@ -43188,6 +43748,13 @@ unsafe extern "C" {
         useOr: bool,
         varRelid: ::core::ffi::c_int,
     ) -> Selectivity;
+    pub fn get_tablespace_page_costs(
+        spcid: Oid,
+        spc_random_page_cost: *mut float8,
+        spc_seq_page_cost: *mut float8,
+    );
+    pub fn get_tablespace_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
+    pub fn get_tablespace_maintenance_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
     pub fn InitCatalogCache();
     pub fn InitCatalogCachePhase2();
     pub fn SearchSysCache(

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -5,7 +5,7 @@ easy to reference on docs.rs. Bindings are regenerated for your
 build of pgrx, and the values of your Postgres version may differ.
 */
 use crate as pg_sys;
-use crate::{Datum, Oid, PgNode};
+use crate::{Datum, MultiXactId, Oid, PgNode, TransactionId};
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct __BindgenBitfieldUnit<Storage> {
@@ -2237,6 +2237,25 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const BUF_REFCOUNT_ONE: u32 = 1;
+pub const BUF_REFCOUNT_MASK: u32 = 262143;
+pub const BUF_USAGECOUNT_MASK: u32 = 3932160;
+pub const BUF_USAGECOUNT_ONE: u32 = 262144;
+pub const BUF_USAGECOUNT_SHIFT: u32 = 18;
+pub const BUF_FLAG_MASK: u32 = 4290772992;
+pub const BM_LOCKED: u32 = 4194304;
+pub const BM_DIRTY: u32 = 8388608;
+pub const BM_VALID: u32 = 16777216;
+pub const BM_TAG_VALID: u32 = 33554432;
+pub const BM_IO_IN_PROGRESS: u32 = 67108864;
+pub const BM_IO_ERROR: u32 = 134217728;
+pub const BM_JUST_DIRTIED: u32 = 268435456;
+pub const BM_PIN_COUNT_WAITER: u32 = 536870912;
+pub const BM_CHECKPOINT_NEEDED: u32 = 1073741824;
+pub const BM_PERMANENT: u32 = 2147483648;
+pub const BM_MAX_USAGE_COUNT: u32 = 5;
+pub const FREENEXT_END_OF_LIST: i32 = -1;
+pub const FREENEXT_NOT_IN_LIST: i32 = -2;
 pub const XLOG_STANDBY_LOCK: u32 = 0;
 pub const XLOG_RUNNING_XACTS: u32 = 16;
 pub const XLOG_INVALIDATIONS: u32 = 32;
@@ -5737,7 +5756,7 @@ pub struct timespec {
     pub tv_sec: __time_t,
     pub tv_nsec: __syscall_slong_t,
 }
-pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C" fn()>;
+pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type Pointer = *mut ::core::ffi::c_char;
 pub type int8 = ::core::ffi::c_schar;
 pub type int16 = ::core::ffi::c_short;
@@ -5759,10 +5778,8 @@ pub type float4 = f32;
 pub type float8 = f64;
 pub type regproc = Oid;
 pub type RegProcedure = regproc;
-pub type TransactionId = uint32;
 pub type LocalTransactionId = uint32;
 pub type SubTransactionId = uint32;
-pub type MultiXactId = TransactionId;
 pub type MultiXactOffset = uint32;
 pub type CommandId = uint32;
 #[repr(C)]
@@ -5936,13 +5953,13 @@ impl Default for passwd {
 }
 pub type pgsocket = ::core::ffi::c_int;
 pub type qsort_arg_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
         arg: *mut ::core::ffi::c_void,
     ) -> ::core::ffi::c_int,
 >;
-pub type pqsigfunc = ::core::option::Option<unsafe extern "C" fn(signo: ::core::ffi::c_int)>;
+pub type pqsigfunc = ::core::option::Option<unsafe extern "C-unwind" fn(signo: ::core::ffi::c_int)>;
 pub type __jmp_buf = [::core::ffi::c_long; 8usize];
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5956,7 +5973,8 @@ pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[derive(Debug, Copy, Clone)]
 pub struct ErrorContextCallback {
     pub previous: *mut ErrorContextCallback,
-    pub callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub arg: *mut ::core::ffi::c_void,
 }
 impl Default for ErrorContextCallback {
@@ -6009,7 +6027,8 @@ impl Default for ErrorData {
         }
     }
 }
-pub type emit_log_hook_type = ::core::option::Option<unsafe extern "C" fn(edata: *mut ErrorData)>;
+pub type emit_log_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(edata: *mut ErrorData)>;
 pub mod PGErrorVerbosity {
     pub type Type = ::core::ffi::c_uint;
     pub const PGERROR_TERSE: Type = 0;
@@ -6018,7 +6037,7 @@ pub mod PGErrorVerbosity {
 }
 pub type MemoryContext = *mut MemoryContextData;
 pub type MemoryContextCallbackFunction =
-    ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryContextCallback {
@@ -6826,7 +6845,7 @@ impl Default for ForFiveState {
     }
 }
 pub type list_sort_comparator = ::core::option::Option<
-    unsafe extern "C" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7130,7 +7149,7 @@ pub struct PageXLogRecPtr {
     pub xrecoff: uint32,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PageHeaderData {
     pub pd_lsn: PageXLogRecPtr,
     pub pd_checksum: uint16,
@@ -7141,6 +7160,15 @@ pub struct PageHeaderData {
     pub pd_pagesize_version: uint16,
     pub pd_prune_xid: TransactionId,
     pub pd_linp: __IncompleteArrayField<ItemIdData>,
+}
+impl Default for PageHeaderData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub type PageHeader = *mut PageHeaderData;
 #[repr(C)]
@@ -7267,31 +7295,33 @@ impl Default for TupleTableSlot {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct TupleTableSlotOps {
     pub base_slot_size: usize,
-    pub init: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub release: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub clear: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub init: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub release: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub clear: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub getsomeattrs: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
     >,
     pub getsysattr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             slot: *mut TupleTableSlot,
             attnum: ::core::ffi::c_int,
             isnull: *mut bool,
         ) -> Datum,
     >,
-    pub materialize: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub materialize: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub copyslot: ::core::option::Option<
-        unsafe extern "C" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
+        unsafe extern "C-unwind" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
     >,
     pub get_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub get_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub get_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
     pub copy_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub copy_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub copy_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7463,11 +7493,12 @@ pub struct WorkerInstrumentation {
 }
 pub type fmNodePtr = *mut Node;
 pub type fmAggrefPtr = *mut Aggref;
-pub type fmExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type fmExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 pub type fmStringInfo = *mut StringInfoData;
 pub type FunctionCallInfo = *mut FunctionCallInfoBaseData;
 pub type PGFunction =
-    ::core::option::Option<unsafe extern "C" fn(fcinfo: FunctionCallInfo) -> Datum>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(fcinfo: FunctionCallInfo) -> Datum>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FmgrInfo {
@@ -7515,7 +7546,8 @@ impl Default for FunctionCallInfoBaseData {
 pub struct Pg_finfo_record {
     pub api_version: ::core::ffi::c_int,
 }
-pub type PGFInfoFunction = ::core::option::Option<unsafe extern "C" fn() -> *const Pg_finfo_record>;
+pub type PGFInfoFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_finfo_record>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Pg_magic_struct {
@@ -7527,16 +7559,21 @@ pub struct Pg_magic_struct {
     pub float8byval: ::core::ffi::c_int,
 }
 pub type PGModuleMagicFunction =
-    ::core::option::Option<unsafe extern "C" fn() -> *const Pg_magic_struct>;
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_magic_struct>;
 pub mod FmgrHookEventType {
     pub type Type = ::core::ffi::c_uint;
     pub const FHET_START: Type = 0;
     pub const FHET_END: Type = 1;
     pub const FHET_ABORT: Type = 2;
 }
-pub type needs_fmgr_hook_type = ::core::option::Option<unsafe extern "C" fn(fn_oid: Oid) -> bool>;
+pub type needs_fmgr_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(fn_oid: Oid) -> bool>;
 pub type fmgr_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(event: FmgrHookEventType::Type, flinfo: *mut FmgrInfo, arg: *mut Datum),
+    unsafe extern "C-unwind" fn(
+        event: FmgrHookEventType::Type,
+        flinfo: *mut FmgrInfo,
+        arg: *mut Datum,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7691,7 +7728,7 @@ impl Default for pairingheap_node {
     }
 }
 pub type pairingheap_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const pairingheap_node,
         b: *const pairingheap_node,
         arg: *mut ::core::ffi::c_void,
@@ -7732,7 +7769,7 @@ impl Default for ParamExternData {
 }
 pub type ParamListInfo = *mut ParamListInfoData;
 pub type ParamFetchHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         paramid: ::core::ffi::c_int,
         speculative: bool,
@@ -7740,7 +7777,7 @@ pub type ParamFetchHook = ::core::option::Option<
     ) -> *mut ParamExternData,
 >;
 pub type ParamCompileHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         param: *mut Param,
         state: *mut ExprState,
@@ -7749,7 +7786,7 @@ pub type ParamCompileHook = ::core::option::Option<
     ),
 >;
 pub type ParserSetupHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -9981,7 +10018,7 @@ pub struct PGShmemHeader {
     _unused: [u8; 0],
 }
 pub type on_dsm_detach_callback =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut dsm_segment, arg: Datum)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut dsm_segment, arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dsa_area {
@@ -10013,11 +10050,6 @@ pub struct TBMIterateResult {
     pub recheck: bool,
     pub offsets: __IncompleteArrayField<OffsetNumber>,
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionBoundInfoData {
-    _unused: [u8; 0],
-}
 pub type PartitionBoundInfo = *mut PartitionBoundInfoData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10025,11 +10057,6 @@ pub struct PartitionKeyData {
     _unused: [u8; 0],
 }
 pub type PartitionKey = *mut PartitionKeyData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionDescData {
-    _unused: [u8; 0],
-}
 pub type PartitionDesc = *mut PartitionDescData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10097,24 +10124,24 @@ impl Default for ConditionVariableMinimallyPadded {
     }
 }
 pub type HashValueFunc = ::core::option::Option<
-    unsafe extern "C" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
+    unsafe extern "C-unwind" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
 >;
 pub type HashCompareFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         key1: *const ::core::ffi::c_void,
         key2: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> ::core::ffi::c_int,
 >;
 pub type HashCopyFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         dest: *mut ::core::ffi::c_void,
         src: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> *mut ::core::ffi::c_void,
 >;
 pub type HashAllocFunc =
-    ::core::option::Option<unsafe extern "C" fn(request: Size) -> *mut ::core::ffi::c_void>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(request: Size) -> *mut ::core::ffi::c_void>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HASHELEMENT {
@@ -10433,16 +10460,17 @@ pub struct SortSupportData {
     pub ssup_attno: AttrNumber,
     pub ssup_extra: *mut ::core::ffi::c_void,
     pub comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
     pub abbreviate: bool,
-    pub abbrev_converter:
-        ::core::option::Option<unsafe extern "C" fn(original: Datum, ssup: SortSupport) -> Datum>,
+    pub abbrev_converter: ::core::option::Option<
+        unsafe extern "C-unwind" fn(original: Datum, ssup: SortSupport) -> Datum,
+    >,
     pub abbrev_abort: ::core::option::Option<
-        unsafe extern "C" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
+        unsafe extern "C-unwind" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
     >,
     pub abbrev_full_comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
 }
 impl Default for SortSupportData {
@@ -10539,7 +10567,7 @@ pub struct CopyMultiInsertBuffer {
     _unused: [u8; 0],
 }
 pub type ExprStateEvalFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         expression: *mut ExprState,
         econtext: *mut ExprContext,
         isNull: *mut bool,
@@ -10611,7 +10639,8 @@ impl Default for IndexInfo {
         }
     }
 }
-pub type ExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type ExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExprContext_CB {
@@ -11113,8 +11142,9 @@ impl Default for DomainConstraintState {
         }
     }
 }
-pub type ExecProcNodeMtd =
-    ::core::option::Option<unsafe extern "C" fn(pstate: *mut PlanState) -> *mut TupleTableSlot>;
+pub type ExecProcNodeMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(pstate: *mut PlanState) -> *mut TupleTableSlot,
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PlanState {
@@ -11300,7 +11330,7 @@ pub struct AppendState {
     pub as_valid_subplans: *mut Bitmapset,
     pub as_valid_asyncplans: *mut Bitmapset,
     pub choose_next_subplan:
-        ::core::option::Option<unsafe extern "C" fn(arg1: *mut AppendState) -> bool>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut AppendState) -> bool>,
 }
 impl Default for AppendState {
     fn default() -> Self {
@@ -12750,17 +12780,17 @@ pub type DestReceiver = _DestReceiver;
 #[derive(Debug, Copy, Clone)]
 pub struct _DestReceiver {
     pub receiveSlot: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
     >,
     pub rStartup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             self_: *mut DestReceiver,
             operation: ::core::ffi::c_int,
             typeinfo: TupleDesc,
         ),
     >,
-    pub rShutdown: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
-    pub rDestroy: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
+    pub rShutdown: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
+    pub rDestroy: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
     pub mydest: CommandDest::Type,
 }
 impl Default for _DestReceiver {
@@ -16503,7 +16533,7 @@ pub struct MemoryContextCounters {
     pub freespace: Size,
 }
 pub type MemoryStatsPrintFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         context: MemoryContext,
         passthru: *mut ::core::ffi::c_void,
         stats_string: *const ::core::ffi::c_char,
@@ -16514,26 +16544,30 @@ pub type MemoryStatsPrintFunc = ::core::option::Option<
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MemoryContextMethods {
     pub alloc: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
+        unsafe extern "C-unwind" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
     >,
     pub free_p: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void),
+        unsafe extern "C-unwind" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void),
     >,
     pub realloc: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             pointer: *mut ::core::ffi::c_void,
             size: Size,
         ) -> *mut ::core::ffi::c_void,
     >,
-    pub reset: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
-    pub delete_context: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub reset: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
+    pub delete_context: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
     pub get_chunk_space: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void) -> Size,
+        unsafe extern "C-unwind" fn(
+            context: MemoryContext,
+            pointer: *mut ::core::ffi::c_void,
+        ) -> Size,
     >,
-    pub is_empty: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext) -> bool>,
+    pub is_empty:
+        ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext) -> bool>,
     pub stats: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             printfunc: MemoryStatsPrintFunc,
             passthru: *mut ::core::ffi::c_void,
@@ -16541,7 +16575,7 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
-    pub check: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub check: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -16569,10 +16603,10 @@ impl Default for MemoryContextData {
     }
 }
 pub type ExecutorStart_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
 >;
 pub type ExecutorRun_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         queryDesc: *mut QueryDesc,
         direction: ScanDirection::Type,
         count: uint64,
@@ -16580,15 +16614,16 @@ pub type ExecutorRun_hook_type = ::core::option::Option<
     ),
 >;
 pub type ExecutorFinish_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorEnd_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorCheckPerms_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut List, arg2: bool) -> bool>;
-pub type ExecScanAccessMtd =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ScanState) -> *mut TupleTableSlot>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut List, arg2: bool) -> bool>;
+pub type ExecScanAccessMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(node: *mut ScanState) -> *mut TupleTableSlot,
+>;
 pub type ExecScanRecheckMtd = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -17992,7 +18027,7 @@ pub struct IndexBulkDeleteResult {
     pub pages_free: BlockNumber,
 }
 pub type IndexBulkDeleteCallback = ::core::option::Option<
-    unsafe extern "C" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type IndexScanDesc = *mut IndexScanDescData;
 pub type SysScanDesc = *mut SysScanDescData;
@@ -18055,16 +18090,16 @@ impl Default for OpFamilyMember {
     }
 }
 pub type ambuild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         heapRelation: Relation,
         indexRelation: Relation,
         indexInfo: *mut IndexInfo,
     ) -> *mut IndexBuildResult,
 >;
 pub type ambuildempty_function =
-    ::core::option::Option<unsafe extern "C" fn(indexRelation: Relation)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexRelation: Relation)>;
 pub type aminsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         values: *mut Datum,
         isnull: *mut bool,
@@ -18076,7 +18111,7 @@ pub type aminsert_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type ambulkdelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
         callback: IndexBulkDeleteCallback,
@@ -18084,16 +18119,16 @@ pub type ambulkdelete_function = ::core::option::Option<
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amvacuumcleanup_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amcanreturn_function = ::core::option::Option<
-    unsafe extern "C" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
 >;
 pub type amcostestimate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         path: *mut IndexPath,
         loop_count: f64,
@@ -18104,10 +18139,11 @@ pub type amcostestimate_function = ::core::option::Option<
         indexPages: *mut f64,
     ),
 >;
-pub type amoptions_function =
-    ::core::option::Option<unsafe extern "C" fn(reloptions: Datum, validate: bool) -> *mut bytea>;
+pub type amoptions_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(reloptions: Datum, validate: bool) -> *mut bytea,
+>;
 pub type amproperty_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index_oid: Oid,
         attno: ::core::ffi::c_int,
         prop: IndexAMProperty::Type,
@@ -18116,12 +18152,13 @@ pub type amproperty_function = ::core::option::Option<
         isnull: *mut bool,
     ) -> bool,
 >;
-pub type ambuildphasename_function =
-    ::core::option::Option<unsafe extern "C" fn(phasenum: int64) -> *mut ::core::ffi::c_char>;
+pub type ambuildphasename_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(phasenum: int64) -> *mut ::core::ffi::c_char,
+>;
 pub type amvalidate_function =
-    ::core::option::Option<unsafe extern "C" fn(opclassoid: Oid) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(opclassoid: Oid) -> bool>;
 pub type amadjustmembers_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opfamilyoid: Oid,
         opclassoid: Oid,
         operators: *mut List,
@@ -18129,14 +18166,14 @@ pub type amadjustmembers_function = ::core::option::Option<
     ),
 >;
 pub type ambeginscan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         nkeys: ::core::ffi::c_int,
         norderbys: ::core::ffi::c_int,
     ) -> IndexScanDesc,
 >;
 pub type amrescan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         scan: IndexScanDesc,
         keys: ScanKey,
         nkeys: ::core::ffi::c_int,
@@ -18145,18 +18182,23 @@ pub type amrescan_function = ::core::option::Option<
     ),
 >;
 pub type amgettuple_function = ::core::option::Option<
-    unsafe extern "C" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
 >;
-pub type amgetbitmap_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64>;
-pub type amendscan_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type ammarkpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amrestrpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amestimateparallelscan_function = ::core::option::Option<unsafe extern "C" fn() -> Size>;
+pub type amgetbitmap_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64,
+>;
+pub type amendscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type ammarkpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amrestrpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amestimateparallelscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> Size>;
 pub type aminitparallelscan_function =
-    ::core::option::Option<unsafe extern "C" fn(target: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(target: *mut ::core::ffi::c_void)>;
 pub type amparallelrescan_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IndexAmRoutine {
@@ -18281,7 +18323,7 @@ impl Default for RelFileNodeBackend {
 }
 pub type pg_crc32c = uint32;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct XLogRecord {
     pub xl_tot_len: uint32,
     pub xl_xid: TransactionId,
@@ -18289,6 +18331,15 @@ pub struct XLogRecord {
     pub xl_info: uint8,
     pub xl_rmid: RmgrId,
     pub xl_crc: pg_crc32c,
+}
+impl Default for XLogRecord {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -18343,7 +18394,7 @@ impl Default for WALSegmentContext {
     }
 }
 pub type XLogPageReadCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         targetPagePtr: XLogRecPtr,
         reqLen: ::core::ffi::c_int,
@@ -18352,14 +18403,14 @@ pub type XLogPageReadCB = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type WALSegmentOpenCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         nextSegNo: XLogSegNo,
         tli_p: *mut TimeLineID,
     ),
 >;
 pub type WALSegmentCloseCB =
-    ::core::option::Option<unsafe extern "C" fn(xlogreader: *mut XLogReaderState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(xlogreader: *mut XLogReaderState)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct XLogReaderRoutine {
@@ -18609,15 +18660,17 @@ pub mod RecoveryTargetAction {
 #[derive(Debug, Copy, Clone)]
 pub struct RmgrData {
     pub rm_name: *const ::core::ffi::c_char,
-    pub rm_redo: ::core::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
-    pub rm_desc:
-        ::core::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
-    pub rm_identify:
-        ::core::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::core::ffi::c_char>,
-    pub rm_startup: ::core::option::Option<unsafe extern "C" fn()>,
-    pub rm_cleanup: ::core::option::Option<unsafe extern "C" fn()>,
+    pub rm_redo: ::core::option::Option<unsafe extern "C-unwind" fn(record: *mut XLogReaderState)>,
+    pub rm_desc: ::core::option::Option<
+        unsafe extern "C-unwind" fn(buf: StringInfo, record: *mut XLogReaderState),
+    >,
+    pub rm_identify: ::core::option::Option<
+        unsafe extern "C-unwind" fn(info: uint8) -> *const ::core::ffi::c_char,
+    >,
+    pub rm_startup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
+    pub rm_cleanup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     pub rm_mask: ::core::option::Option<
-        unsafe extern "C" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
+        unsafe extern "C-unwind" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
     >,
 }
 impl Default for RmgrData {
@@ -19404,7 +19457,7 @@ pub mod XactEvent {
     pub const XACT_EVENT_PRE_PREPARE: Type = 7;
 }
 pub type XactCallback = ::core::option::Option<
-    unsafe extern "C" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
 >;
 pub mod SubXactEvent {
     pub type Type = ::core::ffi::c_uint;
@@ -19414,7 +19467,7 @@ pub mod SubXactEvent {
     pub const SUBXACT_EVENT_PRE_COMMIT_SUB: Type = 3;
 }
 pub type SubXactCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         event: SubXactEvent::Type,
         mySubid: SubTransactionId,
         parentSubid: SubTransactionId,
@@ -19422,11 +19475,20 @@ pub type SubXactCallback = ::core::option::Option<
     ),
 >;
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_assignment {
     pub xtop: TransactionId,
     pub nsubxacts: ::core::ffi::c_int,
     pub xsub: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_assignment {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19449,10 +19511,19 @@ impl Default for xl_xact_dbinfo {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_subxacts {
     pub nsubxacts: ::core::ffi::c_int,
     pub subxacts: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_subxacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -19484,9 +19555,18 @@ impl Default for xl_xact_invals {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct xl_xact_twophase {
     pub xid: TransactionId,
+}
+impl Default for xl_xact_twophase {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19587,9 +19667,9 @@ impl Default for xl_xact_parsed_abort {
     }
 }
 pub type EOM_get_flat_size_method =
-    ::core::option::Option<unsafe extern "C" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
 pub type EOM_flatten_into_method = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         eohptr: *mut ExpandedObjectHeader,
         result: *mut ::core::ffi::c_void,
         allocated_size: Size,
@@ -19852,54 +19932,60 @@ impl Default for config_enum_entry {
     }
 }
 pub type GucBoolCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut bool,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucIntCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucRealCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut f64,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucStringCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut *mut ::core::ffi::c_char,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucEnumCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
-pub type GucBoolAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: bool, extra: *mut ::core::ffi::c_void)>;
-pub type GucIntAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+pub type GucBoolAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: bool, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucRealAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: f64, extra: *mut ::core::ffi::c_void)>;
+pub type GucIntAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+>;
+pub type GucRealAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: f64, extra: *mut ::core::ffi::c_void),
+>;
 pub type GucStringAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: *const ::core::ffi::c_char, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    ),
 >;
 pub type GucEnumAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucShowHook = ::core::option::Option<unsafe extern "C" fn() -> *const ::core::ffi::c_char>;
+pub type GucShowHook =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const ::core::ffi::c_char>;
 pub mod GucAction {
     pub type Type = ::core::ffi::c_uint;
     pub const GUC_ACTION_SET: Type = 0;
@@ -19935,12 +20021,21 @@ pub mod TM_Result {
     pub const TM_WouldBlock: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct TM_FailureData {
     pub ctid: ItemPointerData,
     pub xmax: TransactionId,
     pub cmax: CommandId,
     pub traversed: bool,
+}
+impl Default for TM_FailureData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19975,7 +20070,7 @@ impl Default for TM_IndexDeleteOp {
     }
 }
 pub type IndexBuildCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index: Relation,
         tid: ItemPointer,
         values: *mut Datum,
@@ -19988,10 +20083,11 @@ pub type IndexBuildCallback = ::core::option::Option<
 #[derive(Debug, Copy, Clone)]
 pub struct TableAmRoutine {
     pub type_: NodeTag,
-    pub slot_callbacks:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *const TupleTableSlotOps>,
+    pub slot_callbacks: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *const TupleTableSlotOps,
+    >,
     pub scan_begin: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             snapshot: Snapshot,
             nkeys: ::core::ffi::c_int,
@@ -20000,9 +20096,9 @@ pub struct TableAmRoutine {
             flags: uint32,
         ) -> TableScanDesc,
     >,
-    pub scan_end: ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc)>,
+    pub scan_end: ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc)>,
     pub scan_rescan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             key: *mut ScanKeyData,
             set_params: bool,
@@ -20012,36 +20108,39 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_getnextslot: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_set_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
     >,
     pub scan_getnextslot_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub parallelscan_estimate: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Size>,
+    pub parallelscan_estimate:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Size>,
     pub parallelscan_initialize: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
     >,
-    pub parallelscan_reinitialize:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc)>,
-    pub index_fetch_begin:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *mut IndexFetchTableData>,
+    pub parallelscan_reinitialize: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc),
+    >,
+    pub index_fetch_begin: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *mut IndexFetchTableData,
+    >,
     pub index_fetch_reset:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_end:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: *mut IndexFetchTableData,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -20051,25 +20150,33 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub tuple_fetch_row_version: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub tuple_tid_valid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer) -> bool>,
+    pub tuple_tid_valid: ::core::option::Option<
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer) -> bool,
+    >,
     pub tuple_get_latest_tid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer)>,
     pub tuple_satisfies_snapshot: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, slot: *mut TupleTableSlot, snapshot: Snapshot) -> bool,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            slot: *mut TupleTableSlot,
+            snapshot: Snapshot,
+        ) -> bool,
     >,
     pub index_delete_tuples: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, delstate: *mut TM_IndexDeleteOp) -> TransactionId,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            delstate: *mut TM_IndexDeleteOp,
+        ) -> TransactionId,
     >,
     pub tuple_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -20078,7 +20185,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_insert_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -20088,7 +20195,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_complete_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             specToken: uint32,
@@ -20096,7 +20203,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub multi_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slots: *mut *mut TupleTableSlot,
             nslots: ::core::ffi::c_int,
@@ -20106,7 +20213,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_delete: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             cid: CommandId,
@@ -20118,7 +20225,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_update: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             otid: ItemPointer,
             slot: *mut TupleTableSlot,
@@ -20132,7 +20239,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_lock: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -20144,10 +20251,11 @@ pub struct TableAmRoutine {
             tmfd: *mut TM_FailureData,
         ) -> TM_Result::Type,
     >,
-    pub finish_bulk_insert:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, options: ::core::ffi::c_int)>,
+    pub finish_bulk_insert: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, options: ::core::ffi::c_int),
+    >,
     pub relation_set_new_filenode: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             newrnode: *const RelFileNode,
             persistence: ::core::ffi::c_char,
@@ -20156,11 +20264,12 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_nontransactional_truncate:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation)>,
-    pub relation_copy_data:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, newrnode: *const RelFileNode)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation)>,
+    pub relation_copy_data: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, newrnode: *const RelFileNode),
+    >,
     pub relation_copy_for_cluster: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             OldTable: Relation,
             NewTable: Relation,
             OldIndex: Relation,
@@ -20174,21 +20283,21 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_vacuum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             params: *mut VacuumParams,
             bstrategy: BufferAccessStrategy,
         ),
     >,
     pub scan_analyze_next_block: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             blockno: BlockNumber,
             bstrategy: BufferAccessStrategy,
         ) -> bool,
     >,
     pub scan_analyze_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             OldestXmin: TransactionId,
             liverows: *mut f64,
@@ -20197,7 +20306,7 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub index_build_range_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -20212,7 +20321,7 @@ pub struct TableAmRoutine {
         ) -> f64,
     >,
     pub index_validate_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -20221,13 +20330,14 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_size: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
+        unsafe extern "C-unwind" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
     >,
     pub relation_needs_toast_table:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> bool>,
-    pub relation_toast_am: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Oid>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> bool>,
+    pub relation_toast_am:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Oid>,
     pub relation_fetch_toast_slice: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             toastrel: Relation,
             valueid: Oid,
             attrsize: int32,
@@ -20237,7 +20347,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_estimate_size: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             attr_widths: *mut int32,
             pages: *mut BlockNumber,
@@ -20246,20 +20356,20 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_bitmap_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
     >,
     pub scan_bitmap_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             tbmres: *mut TBMIterateResult,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_sample_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
     >,
     pub scan_sample_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             scanstate: *mut SampleScanState,
             slot: *mut TupleTableSlot,
@@ -20432,7 +20542,6 @@ impl Default for MultiXactMember {
     }
 }
 #[repr(C)]
-#[derive(Debug)]
 pub struct xl_multixact_create {
     pub mid: MultiXactId,
     pub moff: MultiXactOffset,
@@ -20449,7 +20558,6 @@ impl Default for xl_multixact_create {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct xl_multixact_truncate {
     pub oldestMultiDB: Oid,
     pub startTruncOff: MultiXactId,
@@ -20943,12 +21051,15 @@ impl Default for relopt_enum {
     }
 }
 pub type validate_string_relopt =
-    ::core::option::Option<unsafe extern "C" fn(value: *const ::core::ffi::c_char)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(value: *const ::core::ffi::c_char)>;
 pub type fill_string_relopt = ::core::option::Option<
-    unsafe extern "C" fn(value: *const ::core::ffi::c_char, ptr: *mut ::core::ffi::c_void) -> Size,
+    unsafe extern "C-unwind" fn(
+        value: *const ::core::ffi::c_char,
+        ptr: *mut ::core::ffi::c_void,
+    ) -> Size,
 >;
 pub type relopts_validator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parsed_options: *mut ::core::ffi::c_void,
         vals: *mut relopt_value,
         nvals: ::core::ffi::c_int,
@@ -21028,7 +21139,7 @@ pub mod ResourceReleasePhase {
     pub const RESOURCE_RELEASE_AFTER_LOCKS: Type = 2;
 }
 pub type ResourceReleaseCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         phase: ResourceReleasePhase::Type,
         isCommit: bool,
         isTopLevel: bool,
@@ -21056,11 +21167,6 @@ pub mod ReadBufferMode {
 pub struct PrefetchBufferResult {
     pub recent_buffer: Buffer,
     pub initiated_io: bool,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct WritebackContext {
-    _unused: [u8; 0],
 }
 pub mod XLogRedoAction {
     pub type Type = ::core::ffi::c_uint;
@@ -21228,7 +21334,7 @@ pub mod RVROption {
     pub const RVR_SKIP_LOCKED: Type = 4;
 }
 pub type RangeVarGetRelidCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: *const RangeVar,
         relId: Oid,
         oldRelId: Oid,
@@ -21276,7 +21382,7 @@ pub struct ObjectAccessNamespaceSearch {
     pub result: bool,
 }
 pub type object_access_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectId: Oid,
@@ -21661,20 +21767,20 @@ pub mod ParseExprKind {
     pub const EXPR_KIND_CYCLE_MARK: Type = 42;
 }
 pub type PreParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
 >;
 pub type PostParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         cref: *mut ColumnRef,
         var: *mut Node,
     ) -> *mut Node,
 >;
 pub type ParseParamRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
 >;
 pub type CoerceParamHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         param: *mut Param,
         targetTypeId: Oid,
@@ -21998,7 +22104,7 @@ pub struct CopyToStateData {
 }
 pub type CopyToState = *mut CopyToStateData;
 pub type copy_data_source_cb = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         outbuf: *mut ::core::ffi::c_void,
         minread: ::core::ffi::c_int,
         maxread: ::core::ffi::c_int,
@@ -22291,7 +22397,7 @@ impl Default for ExplainState {
     }
 }
 pub type ExplainOneQuery_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         query: *mut Query,
         cursorOptions: ::core::ffi::c_int,
         into: *mut IntoClause,
@@ -22302,7 +22408,7 @@ pub type ExplainOneQuery_hook_type = ::core::option::Option<
     ),
 >;
 pub type explain_get_index_name_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
 pub mod PlanCacheMode {
     pub type Type = ::core::ffi::c_uint;
     pub const PLAN_CACHE_MODE_AUTO: Type = 0;
@@ -22415,7 +22521,7 @@ impl Default for PreparedStatement {
     }
 }
 pub type check_object_relabel_type = ::core::option::Option<
-    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
+    unsafe extern "C-unwind" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -22511,7 +22617,7 @@ pub mod PasswordType {
     pub const PASSWORD_TYPE_SCRAM_SHA_256: Type = 2;
 }
 pub type check_password_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         username: *const ::core::ffi::c_char,
         shadow_pass: *const ::core::ffi::c_char,
         password_type: PasswordType::Type,
@@ -22556,14 +22662,14 @@ impl Default for FormData_pg_statistic {
 pub type Form_pg_statistic = *mut FormData_pg_statistic;
 pub type VacAttrStatsP = *mut VacAttrStats;
 pub type AnalyzeAttrFetchFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         rownum: ::core::ffi::c_int,
         isNull: *mut bool,
     ) -> Datum,
 >;
 pub type AnalyzeAttrComputeStatsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         fetchfunc: AnalyzeAttrFetchFunc,
         samplerows: ::core::ffi::c_int,
@@ -22659,7 +22765,6 @@ impl Default for ConfigData {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct CheckPoint {
     pub redo: XLogRecPtr,
     pub ThisTimeLineID: TimeLineID,
@@ -22698,7 +22803,6 @@ pub mod DBState {
     pub const DB_IN_PRODUCTION: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct ControlFileData {
     pub system_identifier: uint64,
     pub pg_control_version: uint32,
@@ -22745,7 +22849,7 @@ impl Default for ControlFileData {
         }
     }
 }
-pub type bgworker_main_type = ::core::option::Option<unsafe extern "C" fn(main_arg: Datum)>;
+pub type bgworker_main_type = ::core::option::Option<unsafe extern "C-unwind" fn(main_arg: Datum)>;
 pub mod BgWorkerStartTime {
     pub type Type = ::core::ffi::c_uint;
     pub const BgWorkerStart_PostmasterStart: Type = 0;
@@ -22989,7 +23093,7 @@ pub mod shm_mq_result {
     pub const SHM_MQ_DETACHED: Type = 2;
 }
 pub type parallel_worker_main_type =
-    ::core::option::Option<unsafe extern "C" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ParallelWorkerInfo {
@@ -23185,10 +23289,14 @@ pub struct ScalarArrayOpExprHashTable {
     _unused: [u8; 0],
 }
 pub type ExecEvalSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(state: *mut ExprState, op: *mut ExprEvalStep, econtext: *mut ExprContext),
+    unsafe extern "C-unwind" fn(
+        state: *mut ExprState,
+        op: *mut ExprEvalStep,
+        econtext: *mut ExprContext,
+    ),
 >;
 pub type ExecEvalBoolSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         state: *mut ExprState,
         op: *mut ExprEvalStep,
         econtext: *mut ExprContext,
@@ -24057,7 +24165,7 @@ pub struct PortalData {
     pub prepStmtName: *const ::core::ffi::c_char,
     pub portalContext: MemoryContext,
     pub resowner: ResourceOwner,
-    pub cleanup: ::core::option::Option<unsafe extern "C" fn(portal: Portal)>,
+    pub cleanup: ::core::option::Option<unsafe extern "C-unwind" fn(portal: Portal)>,
     pub createSubid: SubTransactionId,
     pub activeSubid: SubTransactionId,
     pub sourceText: *const ::core::ffi::c_char,
@@ -24464,7 +24572,7 @@ pub struct IndexOptInfo {
     pub amhasgetbitmap: bool,
     pub amcanparallel: bool,
     pub amcanmarkpos: bool,
-    pub amcostestimate: ::core::option::Option<unsafe extern "C" fn()>,
+    pub amcostestimate: ::core::option::Option<unsafe extern "C-unwind" fn()>,
 }
 impl Default for IndexOptInfo {
     fn default() -> Self {
@@ -25648,13 +25756,21 @@ impl Default for AggTransInfo {
     }
 }
 pub type GetForeignRelSize_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPlan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         baserel: *mut RelOptInfo,
         foreigntableid: Oid,
@@ -25665,20 +25781,20 @@ pub type GetForeignPlan_function = ::core::option::Option<
     ) -> *mut ForeignScan,
 >;
 pub type BeginForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type RecheckForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 pub type ReScanForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type EndForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignJoinPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -25688,7 +25804,7 @@ pub type GetForeignJoinPaths_function = ::core::option::Option<
     ),
 >;
 pub type GetForeignUpperPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -25697,7 +25813,7 @@ pub type GetForeignUpperPaths_function = ::core::option::Option<
     ),
 >;
 pub type AddForeignUpdateTargets_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rtindex: Index,
         target_rte: *mut RangeTblEntry,
@@ -25705,7 +25821,7 @@ pub type AddForeignUpdateTargets_function = ::core::option::Option<
     ),
 >;
 pub type PlanForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -25713,7 +25829,7 @@ pub type PlanForeignModify_function = ::core::option::Option<
     ) -> *mut List,
 >;
 pub type BeginForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -25722,7 +25838,7 @@ pub type BeginForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExecForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -25730,7 +25846,7 @@ pub type ExecForeignInsert_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignBatchInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slots: *mut *mut TupleTableSlot,
@@ -25738,10 +25854,11 @@ pub type ExecForeignBatchInsert_function = ::core::option::Option<
         numSlots: *mut ::core::ffi::c_int,
     ) -> *mut *mut TupleTableSlot,
 >;
-pub type GetForeignModifyBatchSize_function =
-    ::core::option::Option<unsafe extern "C" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int>;
+pub type GetForeignModifyBatchSize_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int,
+>;
 pub type ExecForeignUpdate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -25749,24 +25866,26 @@ pub type ExecForeignUpdate_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignDelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
         planSlot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot,
 >;
-pub type EndForeignModify_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
-pub type BeginForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+pub type EndForeignModify_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
 >;
-pub type EndForeignInsert_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
+pub type BeginForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+>;
+pub type EndForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
+>;
 pub type IsForeignRelUpdatable_function =
-    ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> ::core::ffi::c_int>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> ::core::ffi::c_int>;
 pub type PlanDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -25774,21 +25893,21 @@ pub type PlanDirectModify_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type BeginDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type EndDirectModify_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignRowMarkType_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rte: *mut RangeTblEntry,
         strength: LockClauseStrength::Type,
     ) -> RowMarkType::Type,
 >;
 pub type RefetchForeignRow_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         erm: *mut ExecRowMark,
         rowid: Datum,
@@ -25797,10 +25916,10 @@ pub type RefetchForeignRow_function = ::core::option::Option<
     ),
 >;
 pub type ExplainForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type ExplainForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -25809,10 +25928,10 @@ pub type ExplainForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExplainDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type AcquireSampleRowsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         elevel: ::core::ffi::c_int,
         rows: *mut HeapTuple,
@@ -25822,66 +25941,66 @@ pub type AcquireSampleRowsFunc = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type AnalyzeForeignTable_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         func: *mut AcquireSampleRowsFunc,
         totalpages: *mut BlockNumber,
     ) -> bool,
 >;
 pub type ImportForeignSchema_function = ::core::option::Option<
-    unsafe extern "C" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
+    unsafe extern "C-unwind" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
 >;
 pub type ExecForeignTruncate_function = ::core::option::Option<
-    unsafe extern "C" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
+    unsafe extern "C-unwind" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
 >;
 pub type EstimateDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
 >;
 pub type InitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ReInitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type InitializeWorkerForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         toc: *mut shm_toc,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ShutdownForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type IsForeignScanParallelSafe_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rte: *mut RangeTblEntry,
     ) -> bool,
 >;
 pub type ReparameterizeForeignPathByChild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         fdw_private: *mut List,
         child_rel: *mut RelOptInfo,
     ) -> *mut List,
 >;
 pub type IsForeignPathAsyncCapable_function =
-    ::core::option::Option<unsafe extern "C" fn(path: *mut ForeignPath) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(path: *mut ForeignPath) -> bool>;
 pub type ForeignAsyncRequest_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncConfigureWait_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncNotify_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FdwRoutine {
@@ -26045,12 +26164,12 @@ impl Default for JitContext {
     }
 }
 pub type JitProviderInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut JitProviderCallbacks)>;
-pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut JitProviderCallbacks)>;
+pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type JitProviderReleaseContextCB =
-    ::core::option::Option<unsafe extern "C" fn(context: *mut JitContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(context: *mut JitContext)>;
 pub type JitProviderCompileExprCB =
-    ::core::option::Option<unsafe extern "C" fn(state: *mut ExprState) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(state: *mut ExprState) -> bool>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct JitProviderCallbacks {
@@ -26136,36 +26255,36 @@ impl Default for pg_enc2gettext {
     }
 }
 pub type mb2wchar_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const ::core::ffi::c_uchar,
         to: *mut pg_wchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type wchar2mb_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const pg_wchar,
         to: *mut ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mblen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbdisplaylen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbcharacter_incrementer = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
 >;
 pub type mbchar_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mbstr_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
@@ -26235,7 +26354,7 @@ pub struct pg_local_to_utf_combined {
     pub utf2: uint32,
 }
 pub type utf_local_conversion_func =
-    ::core::option::Option<unsafe extern "C" fn(code: uint32) -> uint32>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: uint32) -> uint32>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExtensibleNode {
@@ -26257,15 +26376,15 @@ pub struct ExtensibleNodeMethods {
     pub extnodename: *const ::core::ffi::c_char,
     pub node_size: Size,
     pub nodeCopy: ::core::option::Option<
-        unsafe extern "C" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
     >,
     pub nodeEqual: ::core::option::Option<
-        unsafe extern "C" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
+        unsafe extern "C-unwind" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
     >,
     pub nodeOut: ::core::option::Option<
-        unsafe extern "C" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
     >,
-    pub nodeRead: ::core::option::Option<unsafe extern "C" fn(node: *mut ExtensibleNode)>,
+    pub nodeRead: ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ExtensibleNode)>,
 }
 impl Default for ExtensibleNodeMethods {
     fn default() -> Self {
@@ -26281,7 +26400,7 @@ impl Default for ExtensibleNodeMethods {
 pub struct CustomPathMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub PlanCustomPath: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             rel: *mut RelOptInfo,
             best_path: *mut CustomPath,
@@ -26291,7 +26410,7 @@ pub struct CustomPathMethods {
         ) -> *mut Plan,
     >,
     pub ReparameterizeCustomPathByChild: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             custom_private: *mut List,
             child_rel: *mut RelOptInfo,
@@ -26312,7 +26431,7 @@ impl Default for CustomPathMethods {
 pub struct CustomScanMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub CreateCustomScanState:
-        ::core::option::Option<unsafe extern "C" fn(cscan: *mut CustomScan) -> *mut Node>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(cscan: *mut CustomScan) -> *mut Node>,
 }
 impl Default for CustomScanMethods {
     fn default() -> Self {
@@ -26328,48 +26447,51 @@ impl Default for CustomScanMethods {
 pub struct CustomExecMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub BeginCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             estate: *mut EState,
             eflags: ::core::ffi::c_int,
         ),
     >,
     pub ExecCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
     >,
-    pub EndCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub ReScanCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub MarkPosCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+    pub EndCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub ReScanCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub MarkPosCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub RestrPosCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub EstimateDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
     >,
     pub InitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ReInitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub InitializeWorkerCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             toc: *mut shm_toc,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ShutdownCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub ExplainCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             ancestors: *mut List,
             es: *mut ExplainState,
@@ -26386,7 +26508,7 @@ impl Default for CustomExecMethods {
     }
 }
 pub type check_function_callback = ::core::option::Option<
-    unsafe extern "C" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
 >;
 pub mod ReplicationKind {
     pub type Type = ::core::ffi::c_uint;
@@ -26506,7 +26628,7 @@ impl Default for SQLCmd {
     }
 }
 pub type SubscriptTransform = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *mut SubscriptingRef,
         indirection: *mut List,
         pstate: *mut ParseState,
@@ -26515,7 +26637,7 @@ pub type SubscriptTransform = ::core::option::Option<
     ),
 >;
 pub type SubscriptExecSetup = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *const SubscriptingRef,
         sbsrefstate: *mut SubscriptingRefState,
         methods: *mut SubscriptExecSteps,
@@ -26658,7 +26780,7 @@ pub mod ForceParallelMode {
     pub const FORCE_PARALLEL_REGRESS: Type = 2;
 }
 pub type set_rel_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rti: Index,
@@ -26666,7 +26788,7 @@ pub type set_rel_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type set_join_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -26676,14 +26798,14 @@ pub type set_join_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type join_search_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         levels_needed: ::core::ffi::c_int,
         initial_rels: *mut List,
     ) -> *mut RelOptInfo,
 >;
 pub type ec_matches_callback_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         ec: *mut EquivalenceClass,
@@ -26699,7 +26821,7 @@ pub mod PathKeysComparison {
     pub const PATHKEYS_DIFFERENT: Type = 3;
 }
 pub type get_relation_info_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         relationObjectId: Oid,
         inhparent: bool,
@@ -26707,10 +26829,10 @@ pub type get_relation_info_hook_type = ::core::option::Option<
     ),
 >;
 pub type query_pathkeys_callback = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
 >;
 pub type planner_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parse: *mut Query,
         query_string: *const ::core::ffi::c_char,
         cursorOptions: ::core::ffi::c_int,
@@ -26718,7 +26840,7 @@ pub type planner_hook_type = ::core::option::Option<
     ) -> *mut PlannedStmt,
 >;
 pub type create_upper_paths_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -26759,7 +26881,11 @@ pub mod ComputeQueryIdType {
     pub const COMPUTE_QUERY_ID_REGRESS: Type = 3;
 }
 pub type post_parse_analyze_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, query: *mut Query, jstate: *mut JumbleState),
+    unsafe extern "C-unwind" fn(
+        pstate: *mut ParseState,
+        query: *mut Query,
+        jstate: *mut JumbleState,
+    ),
 >;
 pub mod FuncDetailCode {
     pub type Type = ::core::ffi::c_uint;
@@ -26781,6 +26907,68 @@ pub mod CoercionPathType {
     pub const COERCION_PATH_RELABELTYPE: Type = 2;
     pub const COERCION_PATH_ARRAYCOERCE: Type = 3;
     pub const COERCION_PATH_COERCEVIAIO: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionBoundInfoData {
+    pub strategy: ::core::ffi::c_char,
+    pub ndatums: ::core::ffi::c_int,
+    pub datums: *mut *mut Datum,
+    pub kind: *mut *mut PartitionRangeDatumKind::Type,
+    pub nindexes: ::core::ffi::c_int,
+    pub indexes: *mut ::core::ffi::c_int,
+    pub null_index: ::core::ffi::c_int,
+    pub default_index: ::core::ffi::c_int,
+}
+impl Default for PartitionBoundInfoData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionDescData {
+    pub nparts: ::core::ffi::c_int,
+    pub detached_exist: bool,
+    pub oids: *mut Oid,
+    pub is_leaf: *mut bool,
+    pub boundinfo: PartitionBoundInfo,
+}
+impl Default for PartitionDescData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionPruneContext {
+    pub strategy: ::core::ffi::c_char,
+    pub partnatts: ::core::ffi::c_int,
+    pub nparts: ::core::ffi::c_int,
+    pub boundinfo: PartitionBoundInfo,
+    pub partcollation: *mut Oid,
+    pub partsupfunc: *mut FmgrInfo,
+    pub stepcmpfuncs: *mut FmgrInfo,
+    pub ppccontext: MemoryContext,
+    pub planstate: *mut PlanState,
+    pub exprstates: *mut *mut ExprState,
+}
+impl Default for PartitionPruneContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -28035,23 +28223,24 @@ impl Default for PLpgSQL_execstate {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PLpgSQL_plugin {
     pub func_setup: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub stmt_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
     pub stmt_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
-    pub error_callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub error_callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub assign_expr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             expr: *mut PLpgSQL_expr,
@@ -28334,7 +28523,7 @@ impl Default for ReorderBufferTXN {
     }
 }
 pub type ReorderBufferApplyChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28342,7 +28531,7 @@ pub type ReorderBufferApplyChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28351,17 +28540,17 @@ pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28372,24 +28561,24 @@ pub type ReorderBufferMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -28397,30 +28586,42 @@ pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, first_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        first_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, last_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        last_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, abort_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        abort_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28428,7 +28629,7 @@ pub type ReorderBufferStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28439,7 +28640,7 @@ pub type ReorderBufferStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28521,19 +28722,19 @@ impl Default for OutputPluginOptions {
     }
 }
 pub type LogicalOutputPluginInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut OutputPluginCallbacks)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut OutputPluginCallbacks)>;
 pub type LogicalDecodeStartupCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         options: *mut OutputPluginOptions,
         is_init: bool,
     ),
 >;
 pub type LogicalDecodeBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28541,7 +28742,7 @@ pub type LogicalDecodeChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28550,14 +28751,14 @@ pub type LogicalDecodeTruncateCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28568,36 +28769,36 @@ pub type LogicalDecodeMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeFilterByOriginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
 >;
 pub type LogicalDecodeShutdownCB =
-    ::core::option::Option<unsafe extern "C" fn(ctx: *mut LogicalDecodingContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext)>;
 pub type LogicalDecodeFilterPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         xid: TransactionId,
         gid: *const ::core::ffi::c_char,
     ) -> bool,
 >;
 pub type LogicalDecodeBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodePrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -28605,34 +28806,34 @@ pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         abort_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28640,7 +28841,7 @@ pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28651,7 +28852,7 @@ pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28757,11 +28958,20 @@ impl Default for LogicalRepTyp {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LogicalRepBeginData {
     pub final_lsn: XLogRecPtr,
     pub committime: TimestampTz,
     pub xid: TransactionId,
+}
+impl Default for LogicalRepBeginData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -28908,7 +29118,7 @@ impl Default for WalRcvExecResult {
     }
 }
 pub type walrcv_connect_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conninfo: *const ::core::ffi::c_char,
         logical: bool,
         appname: *const ::core::ffi::c_char,
@@ -28916,27 +29126,28 @@ pub type walrcv_connect_fn = ::core::option::Option<
     ) -> *mut WalReceiverConn,
 >;
 pub type walrcv_check_conninfo_fn =
-    ::core::option::Option<unsafe extern "C" fn(conninfo: *const ::core::ffi::c_char)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conninfo: *const ::core::ffi::c_char)>;
 pub type walrcv_get_conninfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_senderinfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         sender_host: *mut *mut ::core::ffi::c_char,
         sender_port: *mut ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_identify_system_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         primary_tli: *mut TimeLineID,
     ) -> *mut ::core::ffi::c_char,
 >;
-pub type walrcv_server_version_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int>;
+pub type walrcv_server_version_fn = ::core::option::Option<
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int,
+>;
 pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         tli: TimeLineID,
         filename: *mut *mut ::core::ffi::c_char,
@@ -28945,27 +29156,30 @@ pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
     ),
 >;
 pub type walrcv_startstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, options: *const WalRcvStreamOptions) -> bool,
+    unsafe extern "C-unwind" fn(
+        conn: *mut WalReceiverConn,
+        options: *const WalRcvStreamOptions,
+    ) -> bool,
 >;
 pub type walrcv_endstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
 >;
 pub type walrcv_receive_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *mut *mut ::core::ffi::c_char,
         wait_fd: *mut pgsocket,
     ) -> ::core::ffi::c_int,
 >;
 pub type walrcv_send_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *const ::core::ffi::c_char,
         nbytes: ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_create_slot_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         slotname: *const ::core::ffi::c_char,
         temporary: bool,
@@ -28974,9 +29188,9 @@ pub type walrcv_create_slot_fn = ::core::option::Option<
     ) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_backend_pid_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> pid_t>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> pid_t>;
 pub type walrcv_exec_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         query: *const ::core::ffi::c_char,
         nRetTypes: ::core::ffi::c_int,
@@ -28984,7 +29198,7 @@ pub type walrcv_exec_fn = ::core::option::Option<
     ) -> *mut WalRcvExecResult,
 >;
 pub type walrcv_disconnect_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WalReceiverFunctionsType {
@@ -29076,7 +29290,7 @@ impl Default for ReplicationSlotCtlData {
     }
 }
 pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -29085,7 +29299,11 @@ pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
 >;
 pub type LogicalOutputPluginWriterPrepareWrite = LogicalOutputPluginWriterWrite;
 pub type LogicalOutputPluginWriterUpdateProgress = ::core::option::Option<
-    unsafe extern "C" fn(lr: *mut LogicalDecodingContext, Ptr: XLogRecPtr, xid: TransactionId),
+    unsafe extern "C-unwind" fn(
+        lr: *mut LogicalDecodingContext,
+        Ptr: XLogRecPtr,
+        xid: TransactionId,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -29159,16 +29377,115 @@ impl Default for RowSecurityDesc {
     }
 }
 pub type row_security_policy_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
+    unsafe extern "C-unwind" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct buftag {
+    pub rnode: RelFileNode,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+}
+impl Default for buftag {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type BufferTag = buftag;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufferDesc {
+    pub tag: BufferTag,
+    pub buf_id: ::core::ffi::c_int,
+    pub state: pg_atomic_uint32,
+    pub wait_backend_pid: ::core::ffi::c_int,
+    pub freeNext: ::core::ffi::c_int,
+    pub content_lock: LWLock,
+}
+impl Default for BufferDesc {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union BufferDescPadded {
+    pub bufferdesc: BufferDesc,
+    pub pad: [::core::ffi::c_char; 64usize],
+}
+impl Default for BufferDescPadded {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PendingWriteback {
+    pub tag: BufferTag,
+}
+impl Default for PendingWriteback {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WritebackContext {
+    pub max_pending: *mut ::core::ffi::c_int,
+    pub nr_pending: ::core::ffi::c_int,
+    pub pending_writebacks: [PendingWriteback; 256usize],
+}
+impl Default for WritebackContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CkptSortItem {
+    pub tsId: Oid,
+    pub relNode: Oid,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+    pub buf_id: ::core::ffi::c_int,
+}
+impl Default for CkptSortItem {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BufFile {
     _unused: [u8; 0],
 }
 pub type pg_on_exit_callback =
-    ::core::option::Option<unsafe extern "C" fn(code: ::core::ffi::c_int, arg: Datum)>;
-pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: ::core::ffi::c_int, arg: Datum)>;
+pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub mod XLTW_Oper {
     pub type Type = ::core::ffi::c_uint;
     pub const XLTW_None: Type = 0;
@@ -29217,7 +29534,7 @@ impl Default for xl_standby_locks {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_running_xacts {
     pub xcnt: ::core::ffi::c_int,
     pub subxcnt: ::core::ffi::c_int,
@@ -29226,6 +29543,15 @@ pub struct xl_running_xacts {
     pub oldestRunningXid: TransactionId,
     pub latestCompletedXid: TransactionId,
     pub xids: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_running_xacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 pub struct xl_invalidations {
@@ -29304,7 +29630,7 @@ impl Default for AlterTableUtilityContext {
     }
 }
 pub type ProcessUtility_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstmt: *mut PlannedStmt,
         queryString: *const ::core::ffi::c_char,
         readOnlyTree: bool,
@@ -29315,6 +29641,97 @@ pub type ProcessUtility_hook_type = ::core::option::Option<
         qc: *mut QueryCompletion,
     ),
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSAnyCacheEntry {
+    pub objId: Oid,
+    pub isvalid: bool,
+}
+impl Default for TSAnyCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSParserCacheEntry {
+    pub prsId: Oid,
+    pub isvalid: bool,
+    pub startOid: Oid,
+    pub tokenOid: Oid,
+    pub endOid: Oid,
+    pub headlineOid: Oid,
+    pub lextypeOid: Oid,
+    pub prsstart: FmgrInfo,
+    pub prstoken: FmgrInfo,
+    pub prsend: FmgrInfo,
+    pub prsheadline: FmgrInfo,
+}
+impl Default for TSParserCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSDictionaryCacheEntry {
+    pub dictId: Oid,
+    pub isvalid: bool,
+    pub lexizeOid: Oid,
+    pub lexize: FmgrInfo,
+    pub dictCtx: MemoryContext,
+    pub dictData: *mut ::core::ffi::c_void,
+}
+impl Default for TSDictionaryCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ListDictionary {
+    pub len: ::core::ffi::c_int,
+    pub dictIds: *mut Oid,
+}
+impl Default for ListDictionary {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSConfigCacheEntry {
+    pub cfgId: Oid,
+    pub isvalid: bool,
+    pub prsId: Oid,
+    pub lenmap: ::core::ffi::c_int,
+    pub map: *mut ListDictionary,
+}
+impl Default for TSConfigCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WordEntry {
@@ -30017,7 +30434,7 @@ pub struct TSQueryParserStateData {
 }
 pub type TSQueryParserState = *mut TSQueryParserStateData;
 pub type PushFunction = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opaque: Datum,
         state: TSQueryParserState,
         token: *mut ::core::ffi::c_char,
@@ -30102,7 +30519,7 @@ impl Default for ExecPhraseData {
     }
 }
 pub type TSExecuteCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         arg: *mut ::core::ffi::c_void,
         val: *mut QueryOperand,
         data: *mut ExecPhraseData,
@@ -30481,9 +30898,10 @@ impl Default for AttStatsSlot {
     }
 }
 pub type get_attavgwidth_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(relid: Oid, attnum: AttrNumber) -> int32>;
-pub type CCHashFN = ::core::option::Option<unsafe extern "C" fn(datum: Datum) -> uint32>;
-pub type CCFastEqualFN = ::core::option::Option<unsafe extern "C" fn(a: Datum, b: Datum) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(relid: Oid, attnum: AttrNumber) -> int32>;
+pub type CCHashFN = ::core::option::Option<unsafe extern "C-unwind" fn(datum: Datum) -> uint32>;
+pub type CCFastEqualFN =
+    ::core::option::Option<unsafe extern "C-unwind" fn(a: Datum, b: Datum) -> bool>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct catcache {
@@ -30614,7 +31032,7 @@ pub struct VariableStatData {
     pub var: *mut Node,
     pub rel: *mut RelOptInfo,
     pub statsTuple: HeapTuple,
-    pub freefunc: ::core::option::Option<unsafe extern "C" fn(tuple: HeapTuple)>,
+    pub freefunc: ::core::option::Option<unsafe extern "C-unwind" fn(tuple: HeapTuple)>,
     pub vartype: Oid,
     pub atttype: Oid,
     pub atttypmod: int32,
@@ -30643,7 +31061,7 @@ pub struct GenericCosts {
     pub num_sa_scans: f64,
 }
 pub type get_relation_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rte: *mut RangeTblEntry,
         attnum: AttrNumber,
@@ -30651,7 +31069,7 @@ pub type get_relation_stats_hook_type = ::core::option::Option<
     ) -> bool,
 >;
 pub type get_index_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         indexOid: Oid,
         indexattnum: AttrNumber,
@@ -30866,7 +31284,7 @@ pub struct SnapBuild {
     pub _address: u8,
 }
 #[pgrx_macros::pg_guard]
-unsafe extern "C" {
+unsafe extern "C-unwind" {
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         errorType: *const ::core::ffi::c_char,
@@ -31072,7 +31490,7 @@ unsafe extern "C" {
         nel: usize,
         elsize: usize,
         cmp: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
             ) -> ::core::ffi::c_int,
@@ -31102,7 +31520,7 @@ unsafe extern "C" {
         nmemb: usize,
         size: usize,
         compar: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
                 arg3: *mut ::core::ffi::c_void,
@@ -32702,9 +33120,9 @@ unsafe extern "C" {
     pub static pg_rightmost_one_pos: [uint8; 256usize];
     pub static pg_number_of_ones: [uint8; 256usize];
     pub static mut pg_popcount32:
-        ::core::option::Option<unsafe extern "C" fn(word: uint32) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint32) -> ::core::ffi::c_int>;
     pub static mut pg_popcount64:
-        ::core::option::Option<unsafe extern "C" fn(word: uint64) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint64) -> ::core::ffi::c_int>;
     pub fn pg_popcount(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int) -> uint64;
     pub fn tuplehash_create(
         ctx: MemoryContext,
@@ -33945,7 +34363,7 @@ unsafe extern "C" {
         len: usize,
     ) -> pg_crc32c;
     pub static mut pg_comp_crc32c: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             crc: pg_crc32c,
             data: *const ::core::ffi::c_void,
             len: usize,
@@ -34338,9 +34756,9 @@ unsafe extern "C" {
     pub fn SendSharedInvalidMessages(msgs: *const SharedInvalidationMessage, n: ::core::ffi::c_int);
     pub fn ReceiveSharedInvalidMessages(
         invalFunction: ::core::option::Option<
-            unsafe extern "C" fn(msg: *mut SharedInvalidationMessage),
+            unsafe extern "C-unwind" fn(msg: *mut SharedInvalidationMessage),
         >,
-        resetFunction: ::core::option::Option<unsafe extern "C" fn()>,
+        resetFunction: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     );
     pub fn HandleCatchupInterrupt();
     pub fn ProcessCatchupInterrupt();
@@ -35218,7 +35636,7 @@ unsafe extern "C" {
         oldtup_ptr: HeapTuple,
         buffer: Buffer,
         release_callback: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::core::ffi::c_void),
+            unsafe extern "C-unwind" fn(arg1: *mut ::core::ffi::c_void),
         >,
         arg: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -38884,24 +39302,24 @@ unsafe extern "C" {
     ) -> bool;
     pub fn expression_tree_mutator(
         node: *mut Node,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
     ) -> *mut Node;
     pub fn query_tree_mutator(
         query: *mut Query,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut Query;
     pub fn range_table_mutator(
         rtable: *mut List,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut List;
     pub fn query_or_expression_tree_mutator(
         node: *mut Node,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut Node;
@@ -41016,6 +41434,103 @@ unsafe extern "C" {
         warn: bool,
     );
     pub fn scanner_isspace(ch: ::core::ffi::c_char) -> bool;
+    pub fn get_hash_partition_greatest_modulus(b: PartitionBoundInfo) -> ::core::ffi::c_int;
+    pub fn compute_partition_hash_value(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        values: *mut Datum,
+        isnull: *mut bool,
+    ) -> uint64;
+    pub fn get_qual_from_partbound(
+        rel: Relation,
+        parent: Relation,
+        spec: *mut PartitionBoundSpec,
+    ) -> *mut List;
+    pub fn partition_bounds_create(
+        boundspecs: *mut *mut PartitionBoundSpec,
+        nparts: ::core::ffi::c_int,
+        key: PartitionKey,
+        mapping: *mut *mut ::core::ffi::c_int,
+    ) -> PartitionBoundInfo;
+    pub fn partition_bounds_equal(
+        partnatts: ::core::ffi::c_int,
+        parttyplen: *mut int16,
+        parttypbyval: *mut bool,
+        b1: PartitionBoundInfo,
+        b2: PartitionBoundInfo,
+    ) -> bool;
+    pub fn partition_bounds_copy(src: PartitionBoundInfo, key: PartitionKey) -> PartitionBoundInfo;
+    pub fn partition_bounds_merge(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        outer_rel: *mut RelOptInfo,
+        inner_rel: *mut RelOptInfo,
+        jointype: JoinType::Type,
+        outer_parts: *mut *mut List,
+        inner_parts: *mut *mut List,
+    ) -> PartitionBoundInfo;
+    pub fn partitions_are_ordered(
+        boundinfo: PartitionBoundInfo,
+        nparts: ::core::ffi::c_int,
+    ) -> bool;
+    pub fn check_new_partition_bound(
+        relname: *mut ::core::ffi::c_char,
+        parent: Relation,
+        spec: *mut PartitionBoundSpec,
+        pstate: *mut ParseState,
+    );
+    pub fn check_default_partition_contents(
+        parent: Relation,
+        defaultRel: Relation,
+        new_spec: *mut PartitionBoundSpec,
+    );
+    pub fn partition_rbound_datum_cmp(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        rb_datums: *mut Datum,
+        rb_kind: *mut PartitionRangeDatumKind::Type,
+        tuple_datums: *mut Datum,
+        n_tuple_datums: ::core::ffi::c_int,
+    ) -> int32;
+    pub fn partition_list_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        value: Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_range_datum_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        nvalues: ::core::ffi::c_int,
+        values: *mut Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_hash_bsearch(
+        boundinfo: PartitionBoundInfo,
+        modulus: ::core::ffi::c_int,
+        remainder: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
+    pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
+        -> PartitionDirectory;
+    pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
+    pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
+    pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
+    pub fn make_partition_pruneinfo(
+        root: *mut PlannerInfo,
+        parentrel: *mut RelOptInfo,
+        subpaths: *mut List,
+        prunequal: *mut List,
+    ) -> *mut PartitionPruneInfo;
+    pub fn prune_append_rel_partitions(rel: *mut RelOptInfo) -> *mut Bitmapset;
+    pub fn get_matching_partitions(
+        context: *mut PartitionPruneContext,
+        pruning_steps: *mut List,
+    ) -> *mut Bitmapset;
     pub fn make_expanded_record_from_typeid(
         type_id: Oid,
         typmod: int32,
@@ -41699,6 +42214,61 @@ unsafe extern "C" {
         hasRowSecurity: *mut bool,
         hasSubLinks: *mut bool,
     );
+    pub static mut BufferIOCVArray: *mut ConditionVariableMinimallyPadded;
+    pub fn LockBufHdr(desc: *mut BufferDesc) -> uint32;
+    pub static mut BufferDescriptors: *mut BufferDescPadded;
+    pub static mut BackendWritebackContext: WritebackContext;
+    pub static mut LocalBufferDescriptors: *mut BufferDesc;
+    pub static mut CkptBufferIds: *mut CkptSortItem;
+    pub fn WritebackContextInit(
+        context: *mut WritebackContext,
+        max_pending: *mut ::core::ffi::c_int,
+    );
+    pub fn IssuePendingWritebacks(context: *mut WritebackContext);
+    pub fn ScheduleBufferTagForWriteback(context: *mut WritebackContext, tag: *mut BufferTag);
+    pub fn StrategyGetBuffer(
+        strategy: BufferAccessStrategy,
+        buf_state: *mut uint32,
+    ) -> *mut BufferDesc;
+    pub fn StrategyFreeBuffer(buf: *mut BufferDesc);
+    pub fn StrategyRejectBuffer(strategy: BufferAccessStrategy, buf: *mut BufferDesc) -> bool;
+    pub fn StrategySyncStart(
+        complete_passes: *mut uint32,
+        num_buf_alloc: *mut uint32,
+    ) -> ::core::ffi::c_int;
+    pub fn StrategyNotifyBgWriter(bgwprocno: ::core::ffi::c_int);
+    pub fn StrategyShmemSize() -> Size;
+    pub fn StrategyInitialize(init: bool);
+    pub fn have_free_buffer() -> bool;
+    pub fn BufTableShmemSize(size: ::core::ffi::c_int) -> Size;
+    pub fn InitBufTable(size: ::core::ffi::c_int);
+    pub fn BufTableHashCode(tagPtr: *mut BufferTag) -> uint32;
+    pub fn BufTableLookup(tagPtr: *mut BufferTag, hashcode: uint32) -> ::core::ffi::c_int;
+    pub fn BufTableInsert(
+        tagPtr: *mut BufferTag,
+        hashcode: uint32,
+        buf_id: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn BufTableDelete(tagPtr: *mut BufferTag, hashcode: uint32);
+    pub fn PrefetchLocalBuffer(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+    ) -> PrefetchBufferResult;
+    pub fn LocalBufferAlloc(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+        foundPtr: *mut bool,
+    ) -> *mut BufferDesc;
+    pub fn MarkLocalBufferDirty(buffer: Buffer);
+    pub fn DropRelFileNodeLocalBuffers(
+        rnode: RelFileNode,
+        forkNum: ForkNumber::Type,
+        firstDelBlock: BlockNumber,
+    );
+    pub fn DropRelFileNodeAllLocalBuffers(rnode: RelFileNode);
+    pub fn AtEOXact_LocalBuffers(isCommit: bool);
     pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
     pub fn BufFileClose(file: *mut BufFile);
     pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::core::ffi::c_void, size: usize) -> usize;
@@ -42135,6 +42705,20 @@ unsafe extern "C" {
     pub fn CreateCommandTag(parsetree: *mut Node) -> CommandTag::Type;
     pub fn GetCommandLogLevel(parsetree: *mut Node) -> LogStmtLevel::Type;
     pub fn CommandIsReadOnly(pstmt: *mut PlannedStmt) -> bool;
+    pub static mut TSCurrentConfig: *mut ::core::ffi::c_char;
+    pub fn lookup_ts_parser_cache(prsId: Oid) -> *mut TSParserCacheEntry;
+    pub fn lookup_ts_dictionary_cache(dictId: Oid) -> *mut TSDictionaryCacheEntry;
+    pub fn lookup_ts_config_cache(cfgId: Oid) -> *mut TSConfigCacheEntry;
+    pub fn getTSCurrentConfig(emitError: bool) -> Oid;
+    pub fn check_TSCurrentConfig(
+        newval: *mut *mut ::core::ffi::c_char,
+        extra: *mut *mut ::core::ffi::c_void,
+        source: GucSource::Type,
+    ) -> bool;
+    pub fn assign_TSCurrentConfig(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    );
     pub fn compareWordEntryPos(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
@@ -42148,7 +42732,9 @@ unsafe extern "C" {
         fname: *const ::core::ffi::c_char,
         s: *mut StopList,
         wordop: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const ::core::ffi::c_char) -> *mut ::core::ffi::c_char,
+            unsafe extern "C-unwind" fn(
+                arg1: *const ::core::ffi::c_char,
+            ) -> *mut ::core::ffi::c_char,
         >,
     );
     pub fn searchstoplist(s: *mut StopList, key: *mut ::core::ffi::c_char) -> bool;
@@ -45673,7 +46259,7 @@ unsafe extern "C" {
         tuple: HeapTuple,
         newtuple: HeapTuple,
         function: ::core::option::Option<
-            unsafe extern "C" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
+            unsafe extern "C-unwind" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
         >,
     );
     pub fn PrintCatCacheLeakWarning(tuple: HeapTuple);
@@ -45938,6 +46524,13 @@ unsafe extern "C" {
         useOr: bool,
         varRelid: ::core::ffi::c_int,
     ) -> Selectivity;
+    pub fn get_tablespace_page_costs(
+        spcid: Oid,
+        spc_random_page_cost: *mut float8,
+        spc_seq_page_cost: *mut float8,
+    );
+    pub fn get_tablespace_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
+    pub fn get_tablespace_maintenance_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
     pub fn InitCatalogCache();
     pub fn InitCatalogCachePhase2();
     pub fn SearchSysCache(

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -5,7 +5,7 @@ easy to reference on docs.rs. Bindings are regenerated for your
 build of pgrx, and the values of your Postgres version may differ.
 */
 use crate as pg_sys;
-use crate::{Datum, Oid, PgNode};
+use crate::{Datum, MultiXactId, Oid, PgNode, TransactionId};
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct __BindgenBitfieldUnit<Storage> {
@@ -2284,6 +2284,25 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const BUF_REFCOUNT_ONE: u32 = 1;
+pub const BUF_REFCOUNT_MASK: u32 = 262143;
+pub const BUF_USAGECOUNT_MASK: u32 = 3932160;
+pub const BUF_USAGECOUNT_ONE: u32 = 262144;
+pub const BUF_USAGECOUNT_SHIFT: u32 = 18;
+pub const BUF_FLAG_MASK: u32 = 4290772992;
+pub const BM_LOCKED: u32 = 4194304;
+pub const BM_DIRTY: u32 = 8388608;
+pub const BM_VALID: u32 = 16777216;
+pub const BM_TAG_VALID: u32 = 33554432;
+pub const BM_IO_IN_PROGRESS: u32 = 67108864;
+pub const BM_IO_ERROR: u32 = 134217728;
+pub const BM_JUST_DIRTIED: u32 = 268435456;
+pub const BM_PIN_COUNT_WAITER: u32 = 536870912;
+pub const BM_CHECKPOINT_NEEDED: u32 = 1073741824;
+pub const BM_PERMANENT: u32 = 2147483648;
+pub const BM_MAX_USAGE_COUNT: u32 = 5;
+pub const FREENEXT_END_OF_LIST: i32 = -1;
+pub const FREENEXT_NOT_IN_LIST: i32 = -2;
 pub const XLOG_STANDBY_LOCK: u32 = 0;
 pub const XLOG_RUNNING_XACTS: u32 = 16;
 pub const XLOG_INVALIDATIONS: u32 = 32;
@@ -5828,7 +5847,7 @@ pub struct timespec {
     pub tv_sec: __time_t,
     pub tv_nsec: __syscall_slong_t,
 }
-pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C" fn()>;
+pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type Pointer = *mut ::core::ffi::c_char;
 pub type int8 = ::core::ffi::c_schar;
 pub type int16 = ::core::ffi::c_short;
@@ -5850,10 +5869,8 @@ pub type float4 = f32;
 pub type float8 = f64;
 pub type regproc = Oid;
 pub type RegProcedure = regproc;
-pub type TransactionId = uint32;
 pub type LocalTransactionId = uint32;
 pub type SubTransactionId = uint32;
-pub type MultiXactId = TransactionId;
 pub type MultiXactOffset = uint32;
 pub type CommandId = uint32;
 #[repr(C)]
@@ -5956,13 +5973,13 @@ impl Default for PGAlignedXLogBlock {
 }
 pub type pgsocket = ::core::ffi::c_int;
 pub type qsort_arg_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
         arg: *mut ::core::ffi::c_void,
     ) -> ::core::ffi::c_int,
 >;
-pub type pqsigfunc = ::core::option::Option<unsafe extern "C" fn(signo: ::core::ffi::c_int)>;
+pub type pqsigfunc = ::core::option::Option<unsafe extern "C-unwind" fn(signo: ::core::ffi::c_int)>;
 pub type __jmp_buf = [::core::ffi::c_long; 8usize];
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -5976,7 +5993,8 @@ pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[derive(Debug, Copy, Clone)]
 pub struct ErrorContextCallback {
     pub previous: *mut ErrorContextCallback,
-    pub callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub arg: *mut ::core::ffi::c_void,
 }
 impl Default for ErrorContextCallback {
@@ -6029,7 +6047,8 @@ impl Default for ErrorData {
         }
     }
 }
-pub type emit_log_hook_type = ::core::option::Option<unsafe extern "C" fn(edata: *mut ErrorData)>;
+pub type emit_log_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(edata: *mut ErrorData)>;
 pub mod PGErrorVerbosity {
     pub type Type = ::core::ffi::c_uint;
     pub const PGERROR_TERSE: Type = 0;
@@ -6038,7 +6057,7 @@ pub mod PGErrorVerbosity {
 }
 pub type MemoryContext = *mut MemoryContextData;
 pub type MemoryContextCallbackFunction =
-    ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryContextCallback {
@@ -6854,7 +6873,7 @@ impl Default for ForFiveState {
     }
 }
 pub type list_sort_comparator = ::core::option::Option<
-    unsafe extern "C" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7173,7 +7192,7 @@ pub struct PageXLogRecPtr {
     pub xrecoff: uint32,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PageHeaderData {
     pub pd_lsn: PageXLogRecPtr,
     pub pd_checksum: uint16,
@@ -7184,6 +7203,15 @@ pub struct PageHeaderData {
     pub pd_pagesize_version: uint16,
     pub pd_prune_xid: TransactionId,
     pub pd_linp: __IncompleteArrayField<ItemIdData>,
+}
+impl Default for PageHeaderData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub type PageHeader = *mut PageHeaderData;
 #[repr(C)]
@@ -7310,31 +7338,33 @@ impl Default for TupleTableSlot {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct TupleTableSlotOps {
     pub base_slot_size: usize,
-    pub init: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub release: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub clear: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub init: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub release: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub clear: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub getsomeattrs: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
     >,
     pub getsysattr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             slot: *mut TupleTableSlot,
             attnum: ::core::ffi::c_int,
             isnull: *mut bool,
         ) -> Datum,
     >,
-    pub materialize: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub materialize: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub copyslot: ::core::option::Option<
-        unsafe extern "C" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
+        unsafe extern "C-unwind" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
     >,
     pub get_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub get_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub get_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
     pub copy_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub copy_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub copy_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7508,11 +7538,12 @@ pub struct WorkerInstrumentation {
 }
 pub type fmNodePtr = *mut Node;
 pub type fmAggrefPtr = *mut Aggref;
-pub type fmExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type fmExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 pub type fmStringInfo = *mut StringInfoData;
 pub type FunctionCallInfo = *mut FunctionCallInfoBaseData;
 pub type PGFunction =
-    ::core::option::Option<unsafe extern "C" fn(fcinfo: FunctionCallInfo) -> Datum>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(fcinfo: FunctionCallInfo) -> Datum>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FmgrInfo {
@@ -7560,7 +7591,8 @@ impl Default for FunctionCallInfoBaseData {
 pub struct Pg_finfo_record {
     pub api_version: ::core::ffi::c_int,
 }
-pub type PGFInfoFunction = ::core::option::Option<unsafe extern "C" fn() -> *const Pg_finfo_record>;
+pub type PGFInfoFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_finfo_record>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Pg_magic_struct {
@@ -7573,16 +7605,21 @@ pub struct Pg_magic_struct {
     pub abi_extra: [::core::ffi::c_char; 32usize],
 }
 pub type PGModuleMagicFunction =
-    ::core::option::Option<unsafe extern "C" fn() -> *const Pg_magic_struct>;
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_magic_struct>;
 pub mod FmgrHookEventType {
     pub type Type = ::core::ffi::c_uint;
     pub const FHET_START: Type = 0;
     pub const FHET_END: Type = 1;
     pub const FHET_ABORT: Type = 2;
 }
-pub type needs_fmgr_hook_type = ::core::option::Option<unsafe extern "C" fn(fn_oid: Oid) -> bool>;
+pub type needs_fmgr_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(fn_oid: Oid) -> bool>;
 pub type fmgr_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(event: FmgrHookEventType::Type, flinfo: *mut FmgrInfo, arg: *mut Datum),
+    unsafe extern "C-unwind" fn(
+        event: FmgrHookEventType::Type,
+        flinfo: *mut FmgrInfo,
+        arg: *mut Datum,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7737,7 +7774,7 @@ impl Default for pairingheap_node {
     }
 }
 pub type pairingheap_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const pairingheap_node,
         b: *const pairingheap_node,
         arg: *mut ::core::ffi::c_void,
@@ -7778,7 +7815,7 @@ impl Default for ParamExternData {
 }
 pub type ParamListInfo = *mut ParamListInfoData;
 pub type ParamFetchHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         paramid: ::core::ffi::c_int,
         speculative: bool,
@@ -7786,7 +7823,7 @@ pub type ParamFetchHook = ::core::option::Option<
     ) -> *mut ParamExternData,
 >;
 pub type ParamCompileHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         param: *mut Param,
         state: *mut ExprState,
@@ -7795,7 +7832,7 @@ pub type ParamCompileHook = ::core::option::Option<
     ),
 >;
 pub type ParserSetupHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -9055,11 +9092,6 @@ impl Default for BitString {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionBoundInfoData {
-    _unused: [u8; 0],
-}
 pub type PartitionBoundInfo = *mut PartitionBoundInfoData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9067,11 +9099,6 @@ pub struct PartitionKeyData {
     _unused: [u8; 0],
 }
 pub type PartitionKey = *mut PartitionKeyData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionDescData {
-    _unused: [u8; 0],
-}
 pub type PartitionDesc = *mut PartitionDescData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -13977,7 +14004,7 @@ pub struct PGShmemHeader {
     _unused: [u8; 0],
 }
 pub type on_dsm_detach_callback =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut dsm_segment, arg: Datum)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut dsm_segment, arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dsa_area {
@@ -14069,24 +14096,24 @@ impl Default for ConditionVariableMinimallyPadded {
     }
 }
 pub type HashValueFunc = ::core::option::Option<
-    unsafe extern "C" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
+    unsafe extern "C-unwind" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
 >;
 pub type HashCompareFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         key1: *const ::core::ffi::c_void,
         key2: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> ::core::ffi::c_int,
 >;
 pub type HashCopyFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         dest: *mut ::core::ffi::c_void,
         src: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> *mut ::core::ffi::c_void,
 >;
 pub type HashAllocFunc =
-    ::core::option::Option<unsafe extern "C" fn(request: Size) -> *mut ::core::ffi::c_void>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(request: Size) -> *mut ::core::ffi::c_void>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HASHELEMENT {
@@ -14438,16 +14465,17 @@ pub struct SortSupportData {
     pub ssup_attno: AttrNumber,
     pub ssup_extra: *mut ::core::ffi::c_void,
     pub comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
     pub abbreviate: bool,
-    pub abbrev_converter:
-        ::core::option::Option<unsafe extern "C" fn(original: Datum, ssup: SortSupport) -> Datum>,
+    pub abbrev_converter: ::core::option::Option<
+        unsafe extern "C-unwind" fn(original: Datum, ssup: SortSupport) -> Datum,
+    >,
     pub abbrev_abort: ::core::option::Option<
-        unsafe extern "C" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
+        unsafe extern "C-unwind" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
     >,
     pub abbrev_full_comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
 }
 impl Default for SortSupportData {
@@ -14549,7 +14577,7 @@ pub struct LogicalTapeSet {
     _unused: [u8; 0],
 }
 pub type ExprStateEvalFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         expression: *mut ExprState,
         econtext: *mut ExprContext,
         isNull: *mut bool,
@@ -14624,7 +14652,8 @@ impl Default for IndexInfo {
         }
     }
 }
-pub type ExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type ExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExprContext_CB {
@@ -15146,8 +15175,9 @@ impl Default for DomainConstraintState {
         }
     }
 }
-pub type ExecProcNodeMtd =
-    ::core::option::Option<unsafe extern "C" fn(pstate: *mut PlanState) -> *mut TupleTableSlot>;
+pub type ExecProcNodeMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(pstate: *mut PlanState) -> *mut TupleTableSlot,
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PlanState {
@@ -15337,7 +15367,7 @@ pub struct AppendState {
     pub as_valid_subplans: *mut Bitmapset,
     pub as_valid_asyncplans: *mut Bitmapset,
     pub choose_next_subplan:
-        ::core::option::Option<unsafe extern "C" fn(arg1: *mut AppendState) -> bool>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut AppendState) -> bool>,
 }
 impl Default for AppendState {
     fn default() -> Self {
@@ -16799,17 +16829,17 @@ pub type DestReceiver = _DestReceiver;
 #[derive(Debug, Copy, Clone)]
 pub struct _DestReceiver {
     pub receiveSlot: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
     >,
     pub rStartup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             self_: *mut DestReceiver,
             operation: ::core::ffi::c_int,
             typeinfo: TupleDesc,
         ),
     >,
-    pub rShutdown: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
-    pub rDestroy: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
+    pub rShutdown: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
+    pub rDestroy: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
     pub mydest: CommandDest::Type,
 }
 impl Default for _DestReceiver {
@@ -16857,7 +16887,7 @@ pub struct MemoryContextCounters {
     pub freespace: Size,
 }
 pub type MemoryStatsPrintFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         context: MemoryContext,
         passthru: *mut ::core::ffi::c_void,
         stats_string: *const ::core::ffi::c_char,
@@ -16868,26 +16898,30 @@ pub type MemoryStatsPrintFunc = ::core::option::Option<
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MemoryContextMethods {
     pub alloc: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
+        unsafe extern "C-unwind" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
     >,
     pub free_p: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void),
+        unsafe extern "C-unwind" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void),
     >,
     pub realloc: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             pointer: *mut ::core::ffi::c_void,
             size: Size,
         ) -> *mut ::core::ffi::c_void,
     >,
-    pub reset: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
-    pub delete_context: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub reset: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
+    pub delete_context: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
     pub get_chunk_space: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, pointer: *mut ::core::ffi::c_void) -> Size,
+        unsafe extern "C-unwind" fn(
+            context: MemoryContext,
+            pointer: *mut ::core::ffi::c_void,
+        ) -> Size,
     >,
-    pub is_empty: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext) -> bool>,
+    pub is_empty:
+        ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext) -> bool>,
     pub stats: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             printfunc: MemoryStatsPrintFunc,
             passthru: *mut ::core::ffi::c_void,
@@ -16895,7 +16929,7 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
-    pub check: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub check: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -16923,10 +16957,10 @@ impl Default for MemoryContextData {
     }
 }
 pub type ExecutorStart_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
 >;
 pub type ExecutorRun_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         queryDesc: *mut QueryDesc,
         direction: ScanDirection::Type,
         count: uint64,
@@ -16934,15 +16968,16 @@ pub type ExecutorRun_hook_type = ::core::option::Option<
     ),
 >;
 pub type ExecutorFinish_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorEnd_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorCheckPerms_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut List, arg2: bool) -> bool>;
-pub type ExecScanAccessMtd =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ScanState) -> *mut TupleTableSlot>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut List, arg2: bool) -> bool>;
+pub type ExecScanAccessMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(node: *mut ScanState) -> *mut TupleTableSlot,
+>;
 pub type ExecScanRecheckMtd = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -17087,15 +17122,15 @@ pub mod AuxProcType {
     pub const WalReceiverProcess: Type = 5;
     pub const NUM_AUXPROCTYPES: Type = 6;
 }
-pub type shmem_request_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
-pub type ArchiveCheckConfiguredCB = ::core::option::Option<unsafe extern "C" fn() -> bool>;
+pub type shmem_request_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
+pub type ArchiveCheckConfiguredCB = ::core::option::Option<unsafe extern "C-unwind" fn() -> bool>;
 pub type ArchiveFileCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         file: *const ::core::ffi::c_char,
         path: *const ::core::ffi::c_char,
     ) -> bool,
 >;
-pub type ArchiveShutdownCB = ::core::option::Option<unsafe extern "C" fn()>;
+pub type ArchiveShutdownCB = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ArchiveModuleCallbacks {
@@ -17104,7 +17139,7 @@ pub struct ArchiveModuleCallbacks {
     pub shutdown_cb: ArchiveShutdownCB,
 }
 pub type ArchiveModuleInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut ArchiveModuleCallbacks)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut ArchiveModuleCallbacks)>;
 pub mod ProgressCommandType {
     pub type Type = ::core::ffi::c_uint;
     pub const PROGRESS_COMMAND_INVALID: Type = 0;
@@ -17788,7 +17823,7 @@ pub struct IndexBulkDeleteResult {
     pub pages_free: BlockNumber,
 }
 pub type IndexBulkDeleteCallback = ::core::option::Option<
-    unsafe extern "C" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type IndexScanDesc = *mut IndexScanDescData;
 pub type SysScanDesc = *mut SysScanDescData;
@@ -17851,16 +17886,16 @@ impl Default for OpFamilyMember {
     }
 }
 pub type ambuild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         heapRelation: Relation,
         indexRelation: Relation,
         indexInfo: *mut IndexInfo,
     ) -> *mut IndexBuildResult,
 >;
 pub type ambuildempty_function =
-    ::core::option::Option<unsafe extern "C" fn(indexRelation: Relation)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexRelation: Relation)>;
 pub type aminsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         values: *mut Datum,
         isnull: *mut bool,
@@ -17872,7 +17907,7 @@ pub type aminsert_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type ambulkdelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
         callback: IndexBulkDeleteCallback,
@@ -17880,16 +17915,16 @@ pub type ambulkdelete_function = ::core::option::Option<
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amvacuumcleanup_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amcanreturn_function = ::core::option::Option<
-    unsafe extern "C" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
 >;
 pub type amcostestimate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         path: *mut IndexPath,
         loop_count: f64,
@@ -17900,10 +17935,11 @@ pub type amcostestimate_function = ::core::option::Option<
         indexPages: *mut f64,
     ),
 >;
-pub type amoptions_function =
-    ::core::option::Option<unsafe extern "C" fn(reloptions: Datum, validate: bool) -> *mut bytea>;
+pub type amoptions_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(reloptions: Datum, validate: bool) -> *mut bytea,
+>;
 pub type amproperty_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index_oid: Oid,
         attno: ::core::ffi::c_int,
         prop: IndexAMProperty::Type,
@@ -17912,12 +17948,13 @@ pub type amproperty_function = ::core::option::Option<
         isnull: *mut bool,
     ) -> bool,
 >;
-pub type ambuildphasename_function =
-    ::core::option::Option<unsafe extern "C" fn(phasenum: int64) -> *mut ::core::ffi::c_char>;
+pub type ambuildphasename_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(phasenum: int64) -> *mut ::core::ffi::c_char,
+>;
 pub type amvalidate_function =
-    ::core::option::Option<unsafe extern "C" fn(opclassoid: Oid) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(opclassoid: Oid) -> bool>;
 pub type amadjustmembers_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opfamilyoid: Oid,
         opclassoid: Oid,
         operators: *mut List,
@@ -17925,14 +17962,14 @@ pub type amadjustmembers_function = ::core::option::Option<
     ),
 >;
 pub type ambeginscan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         nkeys: ::core::ffi::c_int,
         norderbys: ::core::ffi::c_int,
     ) -> IndexScanDesc,
 >;
 pub type amrescan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         scan: IndexScanDesc,
         keys: ScanKey,
         nkeys: ::core::ffi::c_int,
@@ -17941,18 +17978,23 @@ pub type amrescan_function = ::core::option::Option<
     ),
 >;
 pub type amgettuple_function = ::core::option::Option<
-    unsafe extern "C" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
 >;
-pub type amgetbitmap_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64>;
-pub type amendscan_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type ammarkpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amrestrpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amestimateparallelscan_function = ::core::option::Option<unsafe extern "C" fn() -> Size>;
+pub type amgetbitmap_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64,
+>;
+pub type amendscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type ammarkpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amrestrpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amestimateparallelscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> Size>;
 pub type aminitparallelscan_function =
-    ::core::option::Option<unsafe extern "C" fn(target: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(target: *mut ::core::ffi::c_void)>;
 pub type amparallelrescan_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IndexAmRoutine {
@@ -18077,7 +18119,7 @@ impl Default for RelFileNodeBackend {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct XLogRecord {
     pub xl_tot_len: uint32,
     pub xl_xid: TransactionId,
@@ -18085,6 +18127,15 @@ pub struct XLogRecord {
     pub xl_info: uint8,
     pub xl_rmid: RmgrId,
     pub xl_crc: pg_crc32c,
+}
+impl Default for XLogRecord {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -18139,7 +18190,7 @@ impl Default for WALSegmentContext {
     }
 }
 pub type XLogPageReadCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         targetPagePtr: XLogRecPtr,
         reqLen: ::core::ffi::c_int,
@@ -18148,14 +18199,14 @@ pub type XLogPageReadCB = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type WALSegmentOpenCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         nextSegNo: XLogSegNo,
         tli_p: *mut TimeLineID,
     ),
 >;
 pub type WALSegmentCloseCB =
-    ::core::option::Option<unsafe extern "C" fn(xlogreader: *mut XLogReaderState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(xlogreader: *mut XLogReaderState)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct XLogReaderRoutine {
@@ -18425,18 +18476,20 @@ pub struct XLogRecordBuffer {
 #[derive(Debug, Copy, Clone)]
 pub struct RmgrData {
     pub rm_name: *const ::core::ffi::c_char,
-    pub rm_redo: ::core::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
-    pub rm_desc:
-        ::core::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
-    pub rm_identify:
-        ::core::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::core::ffi::c_char>,
-    pub rm_startup: ::core::option::Option<unsafe extern "C" fn()>,
-    pub rm_cleanup: ::core::option::Option<unsafe extern "C" fn()>,
+    pub rm_redo: ::core::option::Option<unsafe extern "C-unwind" fn(record: *mut XLogReaderState)>,
+    pub rm_desc: ::core::option::Option<
+        unsafe extern "C-unwind" fn(buf: StringInfo, record: *mut XLogReaderState),
+    >,
+    pub rm_identify: ::core::option::Option<
+        unsafe extern "C-unwind" fn(info: uint8) -> *const ::core::ffi::c_char,
+    >,
+    pub rm_startup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
+    pub rm_cleanup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     pub rm_mask: ::core::option::Option<
-        unsafe extern "C" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
+        unsafe extern "C-unwind" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
     >,
     pub rm_decode: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, buf: *mut XLogRecordBuffer),
+        unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, buf: *mut XLogRecordBuffer),
     >,
 }
 impl Default for RmgrData {
@@ -19251,7 +19304,7 @@ pub mod XactEvent {
     pub const XACT_EVENT_PRE_PREPARE: Type = 7;
 }
 pub type XactCallback = ::core::option::Option<
-    unsafe extern "C" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
 >;
 pub mod SubXactEvent {
     pub type Type = ::core::ffi::c_uint;
@@ -19261,7 +19314,7 @@ pub mod SubXactEvent {
     pub const SUBXACT_EVENT_PRE_COMMIT_SUB: Type = 3;
 }
 pub type SubXactCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         event: SubXactEvent::Type,
         mySubid: SubTransactionId,
         parentSubid: SubTransactionId,
@@ -19276,11 +19329,20 @@ pub struct SavedTransactionCharacteristics {
     pub save_XactDeferrable: bool,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_assignment {
     pub xtop: TransactionId,
     pub nsubxacts: ::core::ffi::c_int,
     pub xsub: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_assignment {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19303,10 +19365,19 @@ impl Default for xl_xact_dbinfo {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_subxacts {
     pub nsubxacts: ::core::ffi::c_int,
     pub subxacts: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_subxacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -19369,9 +19440,18 @@ impl Default for xl_xact_invals {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct xl_xact_twophase {
     pub xid: TransactionId,
+}
+impl Default for xl_xact_twophase {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19480,9 +19560,9 @@ impl Default for xl_xact_parsed_abort {
     }
 }
 pub type EOM_get_flat_size_method =
-    ::core::option::Option<unsafe extern "C" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
 pub type EOM_flatten_into_method = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         eohptr: *mut ExpandedObjectHeader,
         result: *mut ::core::ffi::c_void,
         allocated_size: Size,
@@ -19745,54 +19825,60 @@ impl Default for config_enum_entry {
     }
 }
 pub type GucBoolCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut bool,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucIntCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucRealCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut f64,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucStringCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut *mut ::core::ffi::c_char,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucEnumCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
-pub type GucBoolAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: bool, extra: *mut ::core::ffi::c_void)>;
-pub type GucIntAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+pub type GucBoolAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: bool, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucRealAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: f64, extra: *mut ::core::ffi::c_void)>;
+pub type GucIntAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+>;
+pub type GucRealAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: f64, extra: *mut ::core::ffi::c_void),
+>;
 pub type GucStringAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: *const ::core::ffi::c_char, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    ),
 >;
 pub type GucEnumAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucShowHook = ::core::option::Option<unsafe extern "C" fn() -> *const ::core::ffi::c_char>;
+pub type GucShowHook =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const ::core::ffi::c_char>;
 pub mod GucAction {
     pub type Type = ::core::ffi::c_uint;
     pub const GUC_ACTION_SET: Type = 0;
@@ -19828,12 +19914,21 @@ pub mod TM_Result {
     pub const TM_WouldBlock: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct TM_FailureData {
     pub ctid: ItemPointerData,
     pub xmax: TransactionId,
     pub cmax: CommandId,
     pub traversed: bool,
+}
+impl Default for TM_FailureData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19870,7 +19965,7 @@ impl Default for TM_IndexDeleteOp {
     }
 }
 pub type IndexBuildCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index: Relation,
         tid: ItemPointer,
         values: *mut Datum,
@@ -19883,10 +19978,11 @@ pub type IndexBuildCallback = ::core::option::Option<
 #[derive(Debug, Copy, Clone)]
 pub struct TableAmRoutine {
     pub type_: NodeTag,
-    pub slot_callbacks:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *const TupleTableSlotOps>,
+    pub slot_callbacks: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *const TupleTableSlotOps,
+    >,
     pub scan_begin: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             snapshot: Snapshot,
             nkeys: ::core::ffi::c_int,
@@ -19895,9 +19991,9 @@ pub struct TableAmRoutine {
             flags: uint32,
         ) -> TableScanDesc,
     >,
-    pub scan_end: ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc)>,
+    pub scan_end: ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc)>,
     pub scan_rescan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             key: *mut ScanKeyData,
             set_params: bool,
@@ -19907,36 +20003,39 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_getnextslot: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_set_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
     >,
     pub scan_getnextslot_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub parallelscan_estimate: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Size>,
+    pub parallelscan_estimate:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Size>,
     pub parallelscan_initialize: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
     >,
-    pub parallelscan_reinitialize:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc)>,
-    pub index_fetch_begin:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *mut IndexFetchTableData>,
+    pub parallelscan_reinitialize: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc),
+    >,
+    pub index_fetch_begin: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *mut IndexFetchTableData,
+    >,
     pub index_fetch_reset:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_end:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: *mut IndexFetchTableData,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -19946,25 +20045,33 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub tuple_fetch_row_version: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub tuple_tid_valid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer) -> bool>,
+    pub tuple_tid_valid: ::core::option::Option<
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer) -> bool,
+    >,
     pub tuple_get_latest_tid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer)>,
     pub tuple_satisfies_snapshot: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, slot: *mut TupleTableSlot, snapshot: Snapshot) -> bool,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            slot: *mut TupleTableSlot,
+            snapshot: Snapshot,
+        ) -> bool,
     >,
     pub index_delete_tuples: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, delstate: *mut TM_IndexDeleteOp) -> TransactionId,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            delstate: *mut TM_IndexDeleteOp,
+        ) -> TransactionId,
     >,
     pub tuple_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -19973,7 +20080,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_insert_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -19983,7 +20090,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_complete_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             specToken: uint32,
@@ -19991,7 +20098,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub multi_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slots: *mut *mut TupleTableSlot,
             nslots: ::core::ffi::c_int,
@@ -20001,7 +20108,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_delete: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             cid: CommandId,
@@ -20013,7 +20120,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_update: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             otid: ItemPointer,
             slot: *mut TupleTableSlot,
@@ -20027,7 +20134,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_lock: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -20039,10 +20146,11 @@ pub struct TableAmRoutine {
             tmfd: *mut TM_FailureData,
         ) -> TM_Result::Type,
     >,
-    pub finish_bulk_insert:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, options: ::core::ffi::c_int)>,
+    pub finish_bulk_insert: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, options: ::core::ffi::c_int),
+    >,
     pub relation_set_new_filenode: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             newrnode: *const RelFileNode,
             persistence: ::core::ffi::c_char,
@@ -20051,11 +20159,12 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_nontransactional_truncate:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation)>,
-    pub relation_copy_data:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, newrnode: *const RelFileNode)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation)>,
+    pub relation_copy_data: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, newrnode: *const RelFileNode),
+    >,
     pub relation_copy_for_cluster: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             OldTable: Relation,
             NewTable: Relation,
             OldIndex: Relation,
@@ -20069,21 +20178,21 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_vacuum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             params: *mut VacuumParams,
             bstrategy: BufferAccessStrategy,
         ),
     >,
     pub scan_analyze_next_block: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             blockno: BlockNumber,
             bstrategy: BufferAccessStrategy,
         ) -> bool,
     >,
     pub scan_analyze_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             OldestXmin: TransactionId,
             liverows: *mut f64,
@@ -20092,7 +20201,7 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub index_build_range_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -20107,7 +20216,7 @@ pub struct TableAmRoutine {
         ) -> f64,
     >,
     pub index_validate_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -20116,13 +20225,14 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_size: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
+        unsafe extern "C-unwind" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
     >,
     pub relation_needs_toast_table:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> bool>,
-    pub relation_toast_am: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Oid>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> bool>,
+    pub relation_toast_am:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Oid>,
     pub relation_fetch_toast_slice: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             toastrel: Relation,
             valueid: Oid,
             attrsize: int32,
@@ -20132,7 +20242,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_estimate_size: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             attr_widths: *mut int32,
             pages: *mut BlockNumber,
@@ -20141,20 +20251,20 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_bitmap_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
     >,
     pub scan_bitmap_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             tbmres: *mut TBMIterateResult,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_sample_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
     >,
     pub scan_sample_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             scanstate: *mut SampleScanState,
             slot: *mut TupleTableSlot,
@@ -20327,7 +20437,6 @@ impl Default for MultiXactMember {
     }
 }
 #[repr(C)]
-#[derive(Debug)]
 pub struct xl_multixact_create {
     pub mid: MultiXactId,
     pub moff: MultiXactOffset,
@@ -20344,7 +20453,6 @@ impl Default for xl_multixact_create {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct xl_multixact_truncate {
     pub oldestMultiDB: Oid,
     pub startTruncOff: MultiXactId,
@@ -20841,12 +20949,15 @@ impl Default for relopt_enum {
     }
 }
 pub type validate_string_relopt =
-    ::core::option::Option<unsafe extern "C" fn(value: *const ::core::ffi::c_char)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(value: *const ::core::ffi::c_char)>;
 pub type fill_string_relopt = ::core::option::Option<
-    unsafe extern "C" fn(value: *const ::core::ffi::c_char, ptr: *mut ::core::ffi::c_void) -> Size,
+    unsafe extern "C-unwind" fn(
+        value: *const ::core::ffi::c_char,
+        ptr: *mut ::core::ffi::c_void,
+    ) -> Size,
 >;
 pub type relopts_validator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parsed_options: *mut ::core::ffi::c_void,
         vals: *mut relopt_value,
         nvals: ::core::ffi::c_int,
@@ -20919,7 +21030,6 @@ impl Default for local_relopts {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct CheckPoint {
     pub redo: XLogRecPtr,
     pub ThisTimeLineID: TimeLineID,
@@ -20958,7 +21068,6 @@ pub mod DBState {
     pub const DB_IN_PRODUCTION: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct ControlFileData {
     pub system_identifier: uint64,
     pub pg_control_version: uint32,
@@ -21058,7 +21167,7 @@ pub mod ResourceReleasePhase {
     pub const RESOURCE_RELEASE_AFTER_LOCKS: Type = 2;
 }
 pub type ResourceReleaseCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         phase: ResourceReleasePhase::Type,
         isCommit: bool,
         isTopLevel: bool,
@@ -21086,11 +21195,6 @@ pub mod ReadBufferMode {
 pub struct PrefetchBufferResult {
     pub recent_buffer: Buffer,
     pub initiated_io: bool,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct WritebackContext {
-    _unused: [u8; 0],
 }
 pub mod HotStandbyState {
     pub type Type = ::core::ffi::c_uint;
@@ -21270,7 +21374,7 @@ pub mod RVROption {
     pub const RVR_SKIP_LOCKED: Type = 4;
 }
 pub type RangeVarGetRelidCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: *const RangeVar,
         relId: Oid,
         oldRelId: Oid,
@@ -21318,7 +21422,7 @@ pub struct ObjectAccessNamespaceSearch {
     pub result: bool,
 }
 pub type object_access_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectId: Oid,
@@ -21327,7 +21431,7 @@ pub type object_access_hook_type = ::core::option::Option<
     ),
 >;
 pub type object_access_hook_type_str = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectStr: *const ::core::ffi::c_char,
@@ -21709,20 +21813,20 @@ pub mod ParseExprKind {
     pub const EXPR_KIND_CYCLE_MARK: Type = 43;
 }
 pub type PreParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
 >;
 pub type PostParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         cref: *mut ColumnRef,
         var: *mut Node,
     ) -> *mut Node,
 >;
 pub type ParseParamRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
 >;
 pub type CoerceParamHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         param: *mut Param,
         targetTypeId: Oid,
@@ -22052,7 +22156,7 @@ pub struct CopyToStateData {
 }
 pub type CopyToState = *mut CopyToStateData;
 pub type copy_data_source_cb = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         outbuf: *mut ::core::ffi::c_void,
         minread: ::core::ffi::c_int,
         maxread: ::core::ffi::c_int,
@@ -22345,7 +22449,7 @@ impl Default for ExplainState {
     }
 }
 pub type ExplainOneQuery_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         query: *mut Query,
         cursorOptions: ::core::ffi::c_int,
         into: *mut IntoClause,
@@ -22356,7 +22460,7 @@ pub type ExplainOneQuery_hook_type = ::core::option::Option<
     ),
 >;
 pub type explain_get_index_name_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
 pub mod PlanCacheMode {
     pub type Type = ::core::ffi::c_uint;
     pub const PLAN_CACHE_MODE_AUTO: Type = 0;
@@ -22469,7 +22573,7 @@ impl Default for PreparedStatement {
     }
 }
 pub type check_object_relabel_type = ::core::option::Option<
-    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
+    unsafe extern "C-unwind" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -22565,7 +22669,7 @@ pub mod PasswordType {
     pub const PASSWORD_TYPE_SCRAM_SHA_256: Type = 2;
 }
 pub type check_password_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         username: *const ::core::ffi::c_char,
         shadow_pass: *const ::core::ffi::c_char,
         password_type: PasswordType::Type,
@@ -22573,7 +22677,7 @@ pub type check_password_hook_type = ::core::option::Option<
         validuntil_null: bool,
     ),
 >;
-pub type bgworker_main_type = ::core::option::Option<unsafe extern "C" fn(main_arg: Datum)>;
+pub type bgworker_main_type = ::core::option::Option<unsafe extern "C-unwind" fn(main_arg: Datum)>;
 pub mod BgWorkerStartTime {
     pub type Type = ::core::ffi::c_uint;
     pub const BgWorkerStart_PostmasterStart: Type = 0;
@@ -22814,7 +22918,7 @@ pub mod shm_mq_result {
     pub const SHM_MQ_DETACHED: Type = 2;
 }
 pub type parallel_worker_main_type =
-    ::core::option::Option<unsafe extern "C" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ParallelWorkerInfo {
@@ -22916,14 +23020,14 @@ pub struct ParallelVacuumState {
 }
 pub type VacAttrStatsP = *mut VacAttrStats;
 pub type AnalyzeAttrFetchFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         rownum: ::core::ffi::c_int,
         isNull: *mut bool,
     ) -> Datum,
 >;
 pub type AnalyzeAttrComputeStatsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         fetchfunc: AnalyzeAttrFetchFunc,
         samplerows: ::core::ffi::c_int,
@@ -23161,10 +23265,14 @@ pub struct ScalarArrayOpExprHashTable {
     _unused: [u8; 0],
 }
 pub type ExecEvalSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(state: *mut ExprState, op: *mut ExprEvalStep, econtext: *mut ExprContext),
+    unsafe extern "C-unwind" fn(
+        state: *mut ExprState,
+        op: *mut ExprEvalStep,
+        econtext: *mut ExprContext,
+    ),
 >;
 pub type ExecEvalBoolSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         state: *mut ExprState,
         op: *mut ExprEvalStep,
         econtext: *mut ExprContext,
@@ -24031,7 +24139,7 @@ pub struct PortalData {
     pub prepStmtName: *const ::core::ffi::c_char,
     pub portalContext: MemoryContext,
     pub resowner: ResourceOwner,
-    pub cleanup: ::core::option::Option<unsafe extern "C" fn(portal: Portal)>,
+    pub cleanup: ::core::option::Option<unsafe extern "C-unwind" fn(portal: Portal)>,
     pub createSubid: SubTransactionId,
     pub activeSubid: SubTransactionId,
     pub createLevel: ::core::ffi::c_int,
@@ -24440,7 +24548,7 @@ pub struct IndexOptInfo {
     pub amhasgetbitmap: bool,
     pub amcanparallel: bool,
     pub amcanmarkpos: bool,
-    pub amcostestimate: ::core::option::Option<unsafe extern "C" fn()>,
+    pub amcostestimate: ::core::option::Option<unsafe extern "C-unwind" fn()>,
 }
 impl Default for IndexOptInfo {
     fn default() -> Self {
@@ -25642,13 +25750,21 @@ impl Default for AggTransInfo {
     }
 }
 pub type GetForeignRelSize_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPlan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         baserel: *mut RelOptInfo,
         foreigntableid: Oid,
@@ -25659,20 +25775,20 @@ pub type GetForeignPlan_function = ::core::option::Option<
     ) -> *mut ForeignScan,
 >;
 pub type BeginForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type RecheckForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 pub type ReScanForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type EndForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignJoinPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -25682,7 +25798,7 @@ pub type GetForeignJoinPaths_function = ::core::option::Option<
     ),
 >;
 pub type GetForeignUpperPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -25691,7 +25807,7 @@ pub type GetForeignUpperPaths_function = ::core::option::Option<
     ),
 >;
 pub type AddForeignUpdateTargets_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rtindex: Index,
         target_rte: *mut RangeTblEntry,
@@ -25699,7 +25815,7 @@ pub type AddForeignUpdateTargets_function = ::core::option::Option<
     ),
 >;
 pub type PlanForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -25707,7 +25823,7 @@ pub type PlanForeignModify_function = ::core::option::Option<
     ) -> *mut List,
 >;
 pub type BeginForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -25716,7 +25832,7 @@ pub type BeginForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExecForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -25724,7 +25840,7 @@ pub type ExecForeignInsert_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignBatchInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slots: *mut *mut TupleTableSlot,
@@ -25732,10 +25848,11 @@ pub type ExecForeignBatchInsert_function = ::core::option::Option<
         numSlots: *mut ::core::ffi::c_int,
     ) -> *mut *mut TupleTableSlot,
 >;
-pub type GetForeignModifyBatchSize_function =
-    ::core::option::Option<unsafe extern "C" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int>;
+pub type GetForeignModifyBatchSize_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int,
+>;
 pub type ExecForeignUpdate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -25743,24 +25860,26 @@ pub type ExecForeignUpdate_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignDelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
         planSlot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot,
 >;
-pub type EndForeignModify_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
-pub type BeginForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+pub type EndForeignModify_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
 >;
-pub type EndForeignInsert_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
+pub type BeginForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+>;
+pub type EndForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
+>;
 pub type IsForeignRelUpdatable_function =
-    ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> ::core::ffi::c_int>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> ::core::ffi::c_int>;
 pub type PlanDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -25768,21 +25887,21 @@ pub type PlanDirectModify_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type BeginDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type EndDirectModify_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignRowMarkType_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rte: *mut RangeTblEntry,
         strength: LockClauseStrength::Type,
     ) -> RowMarkType::Type,
 >;
 pub type RefetchForeignRow_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         erm: *mut ExecRowMark,
         rowid: Datum,
@@ -25791,10 +25910,10 @@ pub type RefetchForeignRow_function = ::core::option::Option<
     ),
 >;
 pub type ExplainForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type ExplainForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -25803,10 +25922,10 @@ pub type ExplainForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExplainDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type AcquireSampleRowsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         elevel: ::core::ffi::c_int,
         rows: *mut HeapTuple,
@@ -25816,66 +25935,66 @@ pub type AcquireSampleRowsFunc = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type AnalyzeForeignTable_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         func: *mut AcquireSampleRowsFunc,
         totalpages: *mut BlockNumber,
     ) -> bool,
 >;
 pub type ImportForeignSchema_function = ::core::option::Option<
-    unsafe extern "C" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
+    unsafe extern "C-unwind" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
 >;
 pub type ExecForeignTruncate_function = ::core::option::Option<
-    unsafe extern "C" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
+    unsafe extern "C-unwind" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
 >;
 pub type EstimateDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
 >;
 pub type InitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ReInitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type InitializeWorkerForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         toc: *mut shm_toc,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ShutdownForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type IsForeignScanParallelSafe_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rte: *mut RangeTblEntry,
     ) -> bool,
 >;
 pub type ReparameterizeForeignPathByChild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         fdw_private: *mut List,
         child_rel: *mut RelOptInfo,
     ) -> *mut List,
 >;
 pub type IsForeignPathAsyncCapable_function =
-    ::core::option::Option<unsafe extern "C" fn(path: *mut ForeignPath) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(path: *mut ForeignPath) -> bool>;
 pub type ForeignAsyncRequest_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncConfigureWait_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncNotify_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FdwRoutine {
@@ -26039,12 +26158,12 @@ impl Default for JitContext {
     }
 }
 pub type JitProviderInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut JitProviderCallbacks)>;
-pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut JitProviderCallbacks)>;
+pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type JitProviderReleaseContextCB =
-    ::core::option::Option<unsafe extern "C" fn(context: *mut JitContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(context: *mut JitContext)>;
 pub type JitProviderCompileExprCB =
-    ::core::option::Option<unsafe extern "C" fn(state: *mut ExprState) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(state: *mut ExprState) -> bool>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct JitProviderCallbacks {
@@ -26130,36 +26249,36 @@ impl Default for pg_enc2gettext {
     }
 }
 pub type mb2wchar_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const ::core::ffi::c_uchar,
         to: *mut pg_wchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type wchar2mb_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const pg_wchar,
         to: *mut ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mblen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbdisplaylen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbcharacter_incrementer = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
 >;
 pub type mbchar_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mbstr_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
@@ -26229,7 +26348,7 @@ pub struct pg_local_to_utf_combined {
     pub utf2: uint32,
 }
 pub type utf_local_conversion_func =
-    ::core::option::Option<unsafe extern "C" fn(code: uint32) -> uint32>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: uint32) -> uint32>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExtensibleNode {
@@ -26251,15 +26370,15 @@ pub struct ExtensibleNodeMethods {
     pub extnodename: *const ::core::ffi::c_char,
     pub node_size: Size,
     pub nodeCopy: ::core::option::Option<
-        unsafe extern "C" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
     >,
     pub nodeEqual: ::core::option::Option<
-        unsafe extern "C" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
+        unsafe extern "C-unwind" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
     >,
     pub nodeOut: ::core::option::Option<
-        unsafe extern "C" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
     >,
-    pub nodeRead: ::core::option::Option<unsafe extern "C" fn(node: *mut ExtensibleNode)>,
+    pub nodeRead: ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ExtensibleNode)>,
 }
 impl Default for ExtensibleNodeMethods {
     fn default() -> Self {
@@ -26275,7 +26394,7 @@ impl Default for ExtensibleNodeMethods {
 pub struct CustomPathMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub PlanCustomPath: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             rel: *mut RelOptInfo,
             best_path: *mut CustomPath,
@@ -26285,7 +26404,7 @@ pub struct CustomPathMethods {
         ) -> *mut Plan,
     >,
     pub ReparameterizeCustomPathByChild: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             custom_private: *mut List,
             child_rel: *mut RelOptInfo,
@@ -26306,7 +26425,7 @@ impl Default for CustomPathMethods {
 pub struct CustomScanMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub CreateCustomScanState:
-        ::core::option::Option<unsafe extern "C" fn(cscan: *mut CustomScan) -> *mut Node>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(cscan: *mut CustomScan) -> *mut Node>,
 }
 impl Default for CustomScanMethods {
     fn default() -> Self {
@@ -26322,48 +26441,51 @@ impl Default for CustomScanMethods {
 pub struct CustomExecMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub BeginCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             estate: *mut EState,
             eflags: ::core::ffi::c_int,
         ),
     >,
     pub ExecCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
     >,
-    pub EndCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub ReScanCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub MarkPosCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+    pub EndCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub ReScanCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub MarkPosCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub RestrPosCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub EstimateDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
     >,
     pub InitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ReInitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub InitializeWorkerCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             toc: *mut shm_toc,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ShutdownCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub ExplainCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             ancestors: *mut List,
             es: *mut ExplainState,
@@ -26380,7 +26502,7 @@ impl Default for CustomExecMethods {
     }
 }
 pub type check_function_callback = ::core::option::Option<
-    unsafe extern "C" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
 >;
 pub mod ReplicationKind {
     pub type Type = ::core::ffi::c_uint;
@@ -26501,7 +26623,7 @@ impl Default for TimeLineHistoryCmd {
     }
 }
 pub type SubscriptTransform = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *mut SubscriptingRef,
         indirection: *mut List,
         pstate: *mut ParseState,
@@ -26510,7 +26632,7 @@ pub type SubscriptTransform = ::core::option::Option<
     ),
 >;
 pub type SubscriptExecSetup = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *const SubscriptingRef,
         sbsrefstate: *mut SubscriptingRefState,
         methods: *mut SubscriptExecSteps,
@@ -26670,7 +26792,7 @@ pub mod ForceParallelMode {
     pub const FORCE_PARALLEL_REGRESS: Type = 2;
 }
 pub type set_rel_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rti: Index,
@@ -26678,7 +26800,7 @@ pub type set_rel_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type set_join_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -26688,14 +26810,14 @@ pub type set_join_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type join_search_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         levels_needed: ::core::ffi::c_int,
         initial_rels: *mut List,
     ) -> *mut RelOptInfo,
 >;
 pub type ec_matches_callback_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         ec: *mut EquivalenceClass,
@@ -26711,7 +26833,7 @@ pub mod PathKeysComparison {
     pub const PATHKEYS_DIFFERENT: Type = 3;
 }
 pub type get_relation_info_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         relationObjectId: Oid,
         inhparent: bool,
@@ -26719,10 +26841,10 @@ pub type get_relation_info_hook_type = ::core::option::Option<
     ),
 >;
 pub type query_pathkeys_callback = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
 >;
 pub type planner_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parse: *mut Query,
         query_string: *const ::core::ffi::c_char,
         cursorOptions: ::core::ffi::c_int,
@@ -26730,7 +26852,7 @@ pub type planner_hook_type = ::core::option::Option<
     ) -> *mut PlannedStmt,
 >;
 pub type create_upper_paths_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -26771,7 +26893,11 @@ pub mod ComputeQueryIdType {
     pub const COMPUTE_QUERY_ID_REGRESS: Type = 3;
 }
 pub type post_parse_analyze_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, query: *mut Query, jstate: *mut JumbleState),
+    unsafe extern "C-unwind" fn(
+        pstate: *mut ParseState,
+        query: *mut Query,
+        jstate: *mut JumbleState,
+    ),
 >;
 pub mod FuncDetailCode {
     pub type Type = ::core::ffi::c_uint;
@@ -26793,6 +26919,70 @@ pub mod CoercionPathType {
     pub const COERCION_PATH_RELABELTYPE: Type = 2;
     pub const COERCION_PATH_ARRAYCOERCE: Type = 3;
     pub const COERCION_PATH_COERCEVIAIO: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionBoundInfoData {
+    pub strategy: ::core::ffi::c_char,
+    pub ndatums: ::core::ffi::c_int,
+    pub datums: *mut *mut Datum,
+    pub kind: *mut *mut PartitionRangeDatumKind::Type,
+    pub interleaved_parts: *mut Bitmapset,
+    pub nindexes: ::core::ffi::c_int,
+    pub indexes: *mut ::core::ffi::c_int,
+    pub null_index: ::core::ffi::c_int,
+    pub default_index: ::core::ffi::c_int,
+}
+impl Default for PartitionBoundInfoData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionDescData {
+    pub nparts: ::core::ffi::c_int,
+    pub detached_exist: bool,
+    pub oids: *mut Oid,
+    pub is_leaf: *mut bool,
+    pub boundinfo: PartitionBoundInfo,
+}
+impl Default for PartitionDescData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionPruneContext {
+    pub strategy: ::core::ffi::c_char,
+    pub partnatts: ::core::ffi::c_int,
+    pub nparts: ::core::ffi::c_int,
+    pub boundinfo: PartitionBoundInfo,
+    pub partcollation: *mut Oid,
+    pub partsupfunc: *mut FmgrInfo,
+    pub stepcmpfuncs: *mut FmgrInfo,
+    pub ppccontext: MemoryContext,
+    pub planstate: *mut PlanState,
+    pub exprcontext: *mut ExprContext,
+    pub exprstates: *mut *mut ExprState,
+}
+impl Default for PartitionPruneContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -28048,30 +28238,31 @@ impl Default for PLpgSQL_execstate {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PLpgSQL_plugin {
     pub func_setup: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub stmt_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
     pub stmt_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
-    pub error_callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub error_callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub assign_expr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             expr: *mut PLpgSQL_expr,
         ),
     >,
     pub assign_value: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             value: Datum,
@@ -28081,7 +28272,7 @@ pub struct PLpgSQL_plugin {
         ),
     >,
     pub eval_datum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             datum: *mut PLpgSQL_datum,
             typeId: *mut Oid,
@@ -28091,7 +28282,7 @@ pub struct PLpgSQL_plugin {
         ),
     >,
     pub cast_value: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             value: Datum,
             isnull: *mut bool,
@@ -28393,7 +28584,7 @@ impl Default for ReorderBufferTXN {
     }
 }
 pub type ReorderBufferApplyChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28401,7 +28592,7 @@ pub type ReorderBufferApplyChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28410,17 +28601,17 @@ pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28431,24 +28622,24 @@ pub type ReorderBufferMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -28456,30 +28647,42 @@ pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, first_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        first_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, last_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        last_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, abort_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        abort_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28487,7 +28690,7 @@ pub type ReorderBufferStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28498,7 +28701,7 @@ pub type ReorderBufferStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28580,19 +28783,19 @@ impl Default for OutputPluginOptions {
     }
 }
 pub type LogicalOutputPluginInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut OutputPluginCallbacks)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut OutputPluginCallbacks)>;
 pub type LogicalDecodeStartupCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         options: *mut OutputPluginOptions,
         is_init: bool,
     ),
 >;
 pub type LogicalDecodeBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28600,7 +28803,7 @@ pub type LogicalDecodeChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28609,14 +28812,14 @@ pub type LogicalDecodeTruncateCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28627,36 +28830,36 @@ pub type LogicalDecodeMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeFilterByOriginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
 >;
 pub type LogicalDecodeShutdownCB =
-    ::core::option::Option<unsafe extern "C" fn(ctx: *mut LogicalDecodingContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext)>;
 pub type LogicalDecodeFilterPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         xid: TransactionId,
         gid: *const ::core::ffi::c_char,
     ) -> bool,
 >;
 pub type LogicalDecodeBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodePrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -28664,34 +28867,34 @@ pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         abort_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -28699,7 +28902,7 @@ pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -28710,7 +28913,7 @@ pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -28821,11 +29024,20 @@ impl Default for LogicalRepTyp {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LogicalRepBeginData {
     pub final_lsn: XLogRecPtr,
     pub committime: TimestampTz,
     pub xid: TransactionId,
+}
+impl Default for LogicalRepBeginData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -29028,7 +29240,7 @@ impl Default for WalRcvExecResult {
     }
 }
 pub type walrcv_connect_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conninfo: *const ::core::ffi::c_char,
         logical: bool,
         appname: *const ::core::ffi::c_char,
@@ -29036,27 +29248,28 @@ pub type walrcv_connect_fn = ::core::option::Option<
     ) -> *mut WalReceiverConn,
 >;
 pub type walrcv_check_conninfo_fn =
-    ::core::option::Option<unsafe extern "C" fn(conninfo: *const ::core::ffi::c_char)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conninfo: *const ::core::ffi::c_char)>;
 pub type walrcv_get_conninfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_senderinfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         sender_host: *mut *mut ::core::ffi::c_char,
         sender_port: *mut ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_identify_system_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         primary_tli: *mut TimeLineID,
     ) -> *mut ::core::ffi::c_char,
 >;
-pub type walrcv_server_version_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int>;
+pub type walrcv_server_version_fn = ::core::option::Option<
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int,
+>;
 pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         tli: TimeLineID,
         filename: *mut *mut ::core::ffi::c_char,
@@ -29065,27 +29278,30 @@ pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
     ),
 >;
 pub type walrcv_startstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, options: *const WalRcvStreamOptions) -> bool,
+    unsafe extern "C-unwind" fn(
+        conn: *mut WalReceiverConn,
+        options: *const WalRcvStreamOptions,
+    ) -> bool,
 >;
 pub type walrcv_endstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
 >;
 pub type walrcv_receive_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *mut *mut ::core::ffi::c_char,
         wait_fd: *mut pgsocket,
     ) -> ::core::ffi::c_int,
 >;
 pub type walrcv_send_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *const ::core::ffi::c_char,
         nbytes: ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_create_slot_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         slotname: *const ::core::ffi::c_char,
         temporary: bool,
@@ -29095,9 +29311,9 @@ pub type walrcv_create_slot_fn = ::core::option::Option<
     ) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_backend_pid_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> pid_t>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> pid_t>;
 pub type walrcv_exec_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         query: *const ::core::ffi::c_char,
         nRetTypes: ::core::ffi::c_int,
@@ -29105,7 +29321,7 @@ pub type walrcv_exec_fn = ::core::option::Option<
     ) -> *mut WalRcvExecResult,
 >;
 pub type walrcv_disconnect_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WalReceiverFunctionsType {
@@ -29197,7 +29413,7 @@ impl Default for ReplicationSlotCtlData {
     }
 }
 pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -29206,7 +29422,7 @@ pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
 >;
 pub type LogicalOutputPluginWriterPrepareWrite = LogicalOutputPluginWriterWrite;
 pub type LogicalOutputPluginWriterUpdateProgress = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -29286,16 +29502,115 @@ impl Default for RowSecurityDesc {
     }
 }
 pub type row_security_policy_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
+    unsafe extern "C-unwind" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct buftag {
+    pub rnode: RelFileNode,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+}
+impl Default for buftag {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type BufferTag = buftag;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufferDesc {
+    pub tag: BufferTag,
+    pub buf_id: ::core::ffi::c_int,
+    pub state: pg_atomic_uint32,
+    pub wait_backend_pgprocno: ::core::ffi::c_int,
+    pub freeNext: ::core::ffi::c_int,
+    pub content_lock: LWLock,
+}
+impl Default for BufferDesc {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union BufferDescPadded {
+    pub bufferdesc: BufferDesc,
+    pub pad: [::core::ffi::c_char; 64usize],
+}
+impl Default for BufferDescPadded {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PendingWriteback {
+    pub tag: BufferTag,
+}
+impl Default for PendingWriteback {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WritebackContext {
+    pub max_pending: *mut ::core::ffi::c_int,
+    pub nr_pending: ::core::ffi::c_int,
+    pub pending_writebacks: [PendingWriteback; 256usize],
+}
+impl Default for WritebackContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CkptSortItem {
+    pub tsId: Oid,
+    pub relNode: Oid,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+    pub buf_id: ::core::ffi::c_int,
+}
+impl Default for CkptSortItem {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BufFile {
     _unused: [u8; 0],
 }
 pub type pg_on_exit_callback =
-    ::core::option::Option<unsafe extern "C" fn(code: ::core::ffi::c_int, arg: Datum)>;
-pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: ::core::ffi::c_int, arg: Datum)>;
+pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub mod XLTW_Oper {
     pub type Type = ::core::ffi::c_uint;
     pub const XLTW_None: Type = 0;
@@ -29344,7 +29659,7 @@ impl Default for xl_standby_locks {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_running_xacts {
     pub xcnt: ::core::ffi::c_int,
     pub subxcnt: ::core::ffi::c_int,
@@ -29353,6 +29668,15 @@ pub struct xl_running_xacts {
     pub oldestRunningXid: TransactionId,
     pub latestCompletedXid: TransactionId,
     pub xids: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_running_xacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 pub struct xl_invalidations {
@@ -29431,7 +29755,7 @@ impl Default for AlterTableUtilityContext {
     }
 }
 pub type ProcessUtility_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstmt: *mut PlannedStmt,
         queryString: *const ::core::ffi::c_char,
         readOnlyTree: bool,
@@ -29442,6 +29766,97 @@ pub type ProcessUtility_hook_type = ::core::option::Option<
         qc: *mut QueryCompletion,
     ),
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSAnyCacheEntry {
+    pub objId: Oid,
+    pub isvalid: bool,
+}
+impl Default for TSAnyCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSParserCacheEntry {
+    pub prsId: Oid,
+    pub isvalid: bool,
+    pub startOid: Oid,
+    pub tokenOid: Oid,
+    pub endOid: Oid,
+    pub headlineOid: Oid,
+    pub lextypeOid: Oid,
+    pub prsstart: FmgrInfo,
+    pub prstoken: FmgrInfo,
+    pub prsend: FmgrInfo,
+    pub prsheadline: FmgrInfo,
+}
+impl Default for TSParserCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSDictionaryCacheEntry {
+    pub dictId: Oid,
+    pub isvalid: bool,
+    pub lexizeOid: Oid,
+    pub lexize: FmgrInfo,
+    pub dictCtx: MemoryContext,
+    pub dictData: *mut ::core::ffi::c_void,
+}
+impl Default for TSDictionaryCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ListDictionary {
+    pub len: ::core::ffi::c_int,
+    pub dictIds: *mut Oid,
+}
+impl Default for ListDictionary {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSConfigCacheEntry {
+    pub cfgId: Oid,
+    pub isvalid: bool,
+    pub prsId: Oid,
+    pub lenmap: ::core::ffi::c_int,
+    pub map: *mut ListDictionary,
+}
+impl Default for TSConfigCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WordEntry {
@@ -30144,7 +30559,7 @@ pub struct TSQueryParserStateData {
 }
 pub type TSQueryParserState = *mut TSQueryParserStateData;
 pub type PushFunction = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opaque: Datum,
         state: TSQueryParserState,
         token: *mut ::core::ffi::c_char,
@@ -30229,7 +30644,7 @@ impl Default for ExecPhraseData {
     }
 }
 pub type TSExecuteCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         arg: *mut ::core::ffi::c_void,
         val: *mut QueryOperand,
         data: *mut ExecPhraseData,
@@ -30608,9 +31023,10 @@ impl Default for AttStatsSlot {
     }
 }
 pub type get_attavgwidth_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(relid: Oid, attnum: AttrNumber) -> int32>;
-pub type CCHashFN = ::core::option::Option<unsafe extern "C" fn(datum: Datum) -> uint32>;
-pub type CCFastEqualFN = ::core::option::Option<unsafe extern "C" fn(a: Datum, b: Datum) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(relid: Oid, attnum: AttrNumber) -> int32>;
+pub type CCHashFN = ::core::option::Option<unsafe extern "C-unwind" fn(datum: Datum) -> uint32>;
+pub type CCFastEqualFN =
+    ::core::option::Option<unsafe extern "C-unwind" fn(a: Datum, b: Datum) -> bool>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct catcache {
@@ -30746,7 +31162,7 @@ pub struct VariableStatData {
     pub var: *mut Node,
     pub rel: *mut RelOptInfo,
     pub statsTuple: HeapTuple,
-    pub freefunc: ::core::option::Option<unsafe extern "C" fn(tuple: HeapTuple)>,
+    pub freefunc: ::core::option::Option<unsafe extern "C-unwind" fn(tuple: HeapTuple)>,
     pub vartype: Oid,
     pub atttype: Oid,
     pub atttypmod: int32,
@@ -30775,7 +31191,7 @@ pub struct GenericCosts {
     pub num_sa_scans: f64,
 }
 pub type get_relation_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rte: *mut RangeTblEntry,
         attnum: AttrNumber,
@@ -30783,7 +31199,7 @@ pub type get_relation_stats_hook_type = ::core::option::Option<
     ) -> bool,
 >;
 pub type get_index_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         indexOid: Oid,
         indexattnum: AttrNumber,
@@ -30997,7 +31413,7 @@ pub struct SnapBuild {
     pub _address: u8,
 }
 #[pgrx_macros::pg_guard]
-unsafe extern "C" {
+unsafe extern "C-unwind" {
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         errorType: *const ::core::ffi::c_char,
@@ -31194,7 +31610,7 @@ unsafe extern "C" {
         nel: usize,
         elsize: usize,
         cmp: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
             ) -> ::core::ffi::c_int,
@@ -31224,7 +31640,7 @@ unsafe extern "C" {
         nmemb: usize,
         size: usize,
         compar: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
                 arg3: *mut ::core::ffi::c_void,
@@ -32851,9 +33267,9 @@ unsafe extern "C" {
     pub static pg_rightmost_one_pos: [uint8; 256usize];
     pub static pg_number_of_ones: [uint8; 256usize];
     pub static mut pg_popcount32:
-        ::core::option::Option<unsafe extern "C" fn(word: uint32) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint32) -> ::core::ffi::c_int>;
     pub static mut pg_popcount64:
-        ::core::option::Option<unsafe extern "C" fn(word: uint64) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint64) -> ::core::ffi::c_int>;
     pub fn pg_popcount(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int) -> uint64;
     pub fn tuplehash_create(
         ctx: MemoryContext,
@@ -34078,7 +34494,7 @@ unsafe extern "C" {
         len: usize,
     ) -> pg_crc32c;
     pub static mut pg_comp_crc32c: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             crc: pg_crc32c,
             data: *const ::core::ffi::c_void,
             len: usize,
@@ -34561,9 +34977,9 @@ unsafe extern "C" {
     pub fn SendSharedInvalidMessages(msgs: *const SharedInvalidationMessage, n: ::core::ffi::c_int);
     pub fn ReceiveSharedInvalidMessages(
         invalFunction: ::core::option::Option<
-            unsafe extern "C" fn(msg: *mut SharedInvalidationMessage),
+            unsafe extern "C-unwind" fn(msg: *mut SharedInvalidationMessage),
         >,
-        resetFunction: ::core::option::Option<unsafe extern "C" fn()>,
+        resetFunction: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     );
     pub fn HandleCatchupInterrupt();
     pub fn ProcessCatchupInterrupt();
@@ -35461,7 +35877,7 @@ unsafe extern "C" {
         oldtup_ptr: HeapTuple,
         buffer: Buffer,
         release_callback: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::core::ffi::c_void),
+            unsafe extern "C-unwind" fn(arg1: *mut ::core::ffi::c_void),
         >,
         arg: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -39326,24 +39742,24 @@ unsafe extern "C" {
     ) -> bool;
     pub fn expression_tree_mutator(
         node: *mut Node,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
     ) -> *mut Node;
     pub fn query_tree_mutator(
         query: *mut Query,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut Query;
     pub fn range_table_mutator(
         rtable: *mut List,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut List;
     pub fn query_or_expression_tree_mutator(
         node: *mut Node,
-        mutator: ::core::option::Option<unsafe extern "C" fn() -> *mut Node>,
+        mutator: ::core::option::Option<unsafe extern "C-unwind" fn() -> *mut Node>,
         context: *mut ::core::ffi::c_void,
         flags: ::core::ffi::c_int,
     ) -> *mut Node;
@@ -41481,6 +41897,99 @@ unsafe extern "C" {
         warn: bool,
     );
     pub fn scanner_isspace(ch: ::core::ffi::c_char) -> bool;
+    pub fn get_hash_partition_greatest_modulus(b: PartitionBoundInfo) -> ::core::ffi::c_int;
+    pub fn compute_partition_hash_value(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        values: *mut Datum,
+        isnull: *mut bool,
+    ) -> uint64;
+    pub fn get_qual_from_partbound(parent: Relation, spec: *mut PartitionBoundSpec) -> *mut List;
+    pub fn partition_bounds_create(
+        boundspecs: *mut *mut PartitionBoundSpec,
+        nparts: ::core::ffi::c_int,
+        key: PartitionKey,
+        mapping: *mut *mut ::core::ffi::c_int,
+    ) -> PartitionBoundInfo;
+    pub fn partition_bounds_equal(
+        partnatts: ::core::ffi::c_int,
+        parttyplen: *mut int16,
+        parttypbyval: *mut bool,
+        b1: PartitionBoundInfo,
+        b2: PartitionBoundInfo,
+    ) -> bool;
+    pub fn partition_bounds_copy(src: PartitionBoundInfo, key: PartitionKey) -> PartitionBoundInfo;
+    pub fn partition_bounds_merge(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        outer_rel: *mut RelOptInfo,
+        inner_rel: *mut RelOptInfo,
+        jointype: JoinType::Type,
+        outer_parts: *mut *mut List,
+        inner_parts: *mut *mut List,
+    ) -> PartitionBoundInfo;
+    pub fn partitions_are_ordered(
+        boundinfo: PartitionBoundInfo,
+        live_parts: *mut Bitmapset,
+    ) -> bool;
+    pub fn check_new_partition_bound(
+        relname: *mut ::core::ffi::c_char,
+        parent: Relation,
+        spec: *mut PartitionBoundSpec,
+        pstate: *mut ParseState,
+    );
+    pub fn check_default_partition_contents(
+        parent: Relation,
+        defaultRel: Relation,
+        new_spec: *mut PartitionBoundSpec,
+    );
+    pub fn partition_rbound_datum_cmp(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        rb_datums: *mut Datum,
+        rb_kind: *mut PartitionRangeDatumKind::Type,
+        tuple_datums: *mut Datum,
+        n_tuple_datums: ::core::ffi::c_int,
+    ) -> int32;
+    pub fn partition_list_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        value: Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_range_datum_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        nvalues: ::core::ffi::c_int,
+        values: *mut Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_hash_bsearch(
+        boundinfo: PartitionBoundInfo,
+        modulus: ::core::ffi::c_int,
+        remainder: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
+    pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
+        -> PartitionDirectory;
+    pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
+    pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
+    pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
+    pub fn make_partition_pruneinfo(
+        root: *mut PlannerInfo,
+        parentrel: *mut RelOptInfo,
+        subpaths: *mut List,
+        prunequal: *mut List,
+    ) -> *mut PartitionPruneInfo;
+    pub fn prune_append_rel_partitions(rel: *mut RelOptInfo) -> *mut Bitmapset;
+    pub fn get_matching_partitions(
+        context: *mut PartitionPruneContext,
+        pruning_steps: *mut List,
+    ) -> *mut Bitmapset;
     pub fn make_expanded_record_from_typeid(
         type_id: Oid,
         typmod: int32,
@@ -42216,6 +42725,61 @@ unsafe extern "C" {
         hasRowSecurity: *mut bool,
         hasSubLinks: *mut bool,
     );
+    pub static mut BufferIOCVArray: *mut ConditionVariableMinimallyPadded;
+    pub fn LockBufHdr(desc: *mut BufferDesc) -> uint32;
+    pub static mut BufferDescriptors: *mut BufferDescPadded;
+    pub static mut BackendWritebackContext: WritebackContext;
+    pub static mut LocalBufferDescriptors: *mut BufferDesc;
+    pub static mut CkptBufferIds: *mut CkptSortItem;
+    pub fn WritebackContextInit(
+        context: *mut WritebackContext,
+        max_pending: *mut ::core::ffi::c_int,
+    );
+    pub fn IssuePendingWritebacks(context: *mut WritebackContext);
+    pub fn ScheduleBufferTagForWriteback(context: *mut WritebackContext, tag: *mut BufferTag);
+    pub fn StrategyGetBuffer(
+        strategy: BufferAccessStrategy,
+        buf_state: *mut uint32,
+    ) -> *mut BufferDesc;
+    pub fn StrategyFreeBuffer(buf: *mut BufferDesc);
+    pub fn StrategyRejectBuffer(strategy: BufferAccessStrategy, buf: *mut BufferDesc) -> bool;
+    pub fn StrategySyncStart(
+        complete_passes: *mut uint32,
+        num_buf_alloc: *mut uint32,
+    ) -> ::core::ffi::c_int;
+    pub fn StrategyNotifyBgWriter(bgwprocno: ::core::ffi::c_int);
+    pub fn StrategyShmemSize() -> Size;
+    pub fn StrategyInitialize(init: bool);
+    pub fn have_free_buffer() -> bool;
+    pub fn BufTableShmemSize(size: ::core::ffi::c_int) -> Size;
+    pub fn InitBufTable(size: ::core::ffi::c_int);
+    pub fn BufTableHashCode(tagPtr: *mut BufferTag) -> uint32;
+    pub fn BufTableLookup(tagPtr: *mut BufferTag, hashcode: uint32) -> ::core::ffi::c_int;
+    pub fn BufTableInsert(
+        tagPtr: *mut BufferTag,
+        hashcode: uint32,
+        buf_id: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn BufTableDelete(tagPtr: *mut BufferTag, hashcode: uint32);
+    pub fn PrefetchLocalBuffer(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+    ) -> PrefetchBufferResult;
+    pub fn LocalBufferAlloc(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+        foundPtr: *mut bool,
+    ) -> *mut BufferDesc;
+    pub fn MarkLocalBufferDirty(buffer: Buffer);
+    pub fn DropRelFileNodeLocalBuffers(
+        rnode: RelFileNode,
+        forkNum: ForkNumber::Type,
+        firstDelBlock: BlockNumber,
+    );
+    pub fn DropRelFileNodeAllLocalBuffers(rnode: RelFileNode);
+    pub fn AtEOXact_LocalBuffers(isCommit: bool);
     pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
     pub fn BufFileClose(file: *mut BufFile);
     pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::core::ffi::c_void, size: usize) -> usize;
@@ -42665,6 +43229,20 @@ unsafe extern "C" {
     pub fn CreateCommandTag(parsetree: *mut Node) -> CommandTag::Type;
     pub fn GetCommandLogLevel(parsetree: *mut Node) -> LogStmtLevel::Type;
     pub fn CommandIsReadOnly(pstmt: *mut PlannedStmt) -> bool;
+    pub static mut TSCurrentConfig: *mut ::core::ffi::c_char;
+    pub fn lookup_ts_parser_cache(prsId: Oid) -> *mut TSParserCacheEntry;
+    pub fn lookup_ts_dictionary_cache(dictId: Oid) -> *mut TSDictionaryCacheEntry;
+    pub fn lookup_ts_config_cache(cfgId: Oid) -> *mut TSConfigCacheEntry;
+    pub fn getTSCurrentConfig(emitError: bool) -> Oid;
+    pub fn check_TSCurrentConfig(
+        newval: *mut *mut ::core::ffi::c_char,
+        extra: *mut *mut ::core::ffi::c_void,
+        source: GucSource::Type,
+    ) -> bool;
+    pub fn assign_TSCurrentConfig(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    );
     pub fn compareWordEntryPos(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
@@ -42678,7 +43256,9 @@ unsafe extern "C" {
         fname: *const ::core::ffi::c_char,
         s: *mut StopList,
         wordop: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const ::core::ffi::c_char) -> *mut ::core::ffi::c_char,
+            unsafe extern "C-unwind" fn(
+                arg1: *const ::core::ffi::c_char,
+            ) -> *mut ::core::ffi::c_char,
         >,
     );
     pub fn searchstoplist(s: *mut StopList, key: *mut ::core::ffi::c_char) -> bool;
@@ -46230,7 +46810,7 @@ unsafe extern "C" {
         tuple: HeapTuple,
         newtuple: HeapTuple,
         function: ::core::option::Option<
-            unsafe extern "C" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
+            unsafe extern "C-unwind" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
         >,
     );
     pub fn PrintCatCacheLeakWarning(tuple: HeapTuple);
@@ -46506,6 +47086,13 @@ unsafe extern "C" {
         useOr: bool,
         varRelid: ::core::ffi::c_int,
     ) -> Selectivity;
+    pub fn get_tablespace_page_costs(
+        spcid: Oid,
+        spc_random_page_cost: *mut float8,
+        spc_seq_page_cost: *mut float8,
+    );
+    pub fn get_tablespace_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
+    pub fn get_tablespace_maintenance_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
     pub fn InitCatalogCache();
     pub fn InitCatalogCachePhase2();
     pub fn SearchSysCache(

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -5,7 +5,7 @@ easy to reference on docs.rs. Bindings are regenerated for your
 build of pgrx, and the values of your Postgres version may differ.
 */
 use crate as pg_sys;
-use crate::{Datum, Oid, PgNode};
+use crate::{Datum, MultiXactId, Oid, PgNode, TransactionId};
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct __BindgenBitfieldUnit<Storage> {
@@ -2301,6 +2301,25 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const BUF_REFCOUNT_ONE: u32 = 1;
+pub const BUF_REFCOUNT_MASK: u32 = 262143;
+pub const BUF_USAGECOUNT_MASK: u32 = 3932160;
+pub const BUF_USAGECOUNT_ONE: u32 = 262144;
+pub const BUF_USAGECOUNT_SHIFT: u32 = 18;
+pub const BUF_FLAG_MASK: u32 = 4290772992;
+pub const BM_LOCKED: u32 = 4194304;
+pub const BM_DIRTY: u32 = 8388608;
+pub const BM_VALID: u32 = 16777216;
+pub const BM_TAG_VALID: u32 = 33554432;
+pub const BM_IO_IN_PROGRESS: u32 = 67108864;
+pub const BM_IO_ERROR: u32 = 134217728;
+pub const BM_JUST_DIRTIED: u32 = 268435456;
+pub const BM_PIN_COUNT_WAITER: u32 = 536870912;
+pub const BM_CHECKPOINT_NEEDED: u32 = 1073741824;
+pub const BM_PERMANENT: u32 = 2147483648;
+pub const BM_MAX_USAGE_COUNT: u32 = 5;
+pub const FREENEXT_END_OF_LIST: i32 = -1;
+pub const FREENEXT_NOT_IN_LIST: i32 = -2;
 pub const XLOG_STANDBY_LOCK: u32 = 0;
 pub const XLOG_RUNNING_XACTS: u32 = 16;
 pub const XLOG_INVALIDATIONS: u32 = 32;
@@ -5895,7 +5914,7 @@ pub type pid_t = __pid_t;
 pub struct __sigset_t {
     pub __val: [::core::ffi::c_ulong; 16usize],
 }
-pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C" fn()>;
+pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type Pointer = *mut ::core::ffi::c_char;
 pub type int8 = ::core::ffi::c_schar;
 pub type int16 = ::core::ffi::c_short;
@@ -5917,10 +5936,8 @@ pub type float4 = f32;
 pub type float8 = f64;
 pub type regproc = Oid;
 pub type RegProcedure = regproc;
-pub type TransactionId = uint32;
 pub type LocalTransactionId = uint32;
 pub type SubTransactionId = uint32;
-pub type MultiXactId = TransactionId;
 pub type MultiXactOffset = uint32;
 pub type CommandId = uint32;
 #[repr(C)]
@@ -6041,14 +6058,14 @@ impl Default for PGAlignedXLogBlock {
 }
 pub type pgsocket = ::core::ffi::c_int;
 pub type qsort_arg_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
         arg: *mut ::core::ffi::c_void,
     ) -> ::core::ffi::c_int,
 >;
 pub type pqsigfunc =
-    ::core::option::Option<unsafe extern "C" fn(postgres_signal_arg: ::core::ffi::c_int)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(postgres_signal_arg: ::core::ffi::c_int)>;
 pub type __jmp_buf = [::core::ffi::c_long; 8usize];
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -6080,7 +6097,8 @@ pub type StringInfo = *mut StringInfoData;
 #[derive(Debug, Copy, Clone)]
 pub struct ErrorContextCallback {
     pub previous: *mut ErrorContextCallback,
-    pub callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub arg: *mut ::core::ffi::c_void,
 }
 impl Default for ErrorContextCallback {
@@ -6133,7 +6151,8 @@ impl Default for ErrorData {
         }
     }
 }
-pub type emit_log_hook_type = ::core::option::Option<unsafe extern "C" fn(edata: *mut ErrorData)>;
+pub type emit_log_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(edata: *mut ErrorData)>;
 pub mod PGErrorVerbosity {
     pub type Type = ::core::ffi::c_uint;
     pub const PGERROR_TERSE: Type = 0;
@@ -6142,7 +6161,7 @@ pub mod PGErrorVerbosity {
 }
 pub type MemoryContext = *mut MemoryContextData;
 pub type MemoryContextCallbackFunction =
-    ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryContextCallback {
@@ -6885,7 +6904,7 @@ impl Default for ForFiveState {
     }
 }
 pub type list_sort_comparator = ::core::option::Option<
-    unsafe extern "C" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7189,7 +7208,7 @@ pub struct PageXLogRecPtr {
     pub xrecoff: uint32,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PageHeaderData {
     pub pd_lsn: PageXLogRecPtr,
     pub pd_checksum: uint16,
@@ -7200,6 +7219,15 @@ pub struct PageHeaderData {
     pub pd_pagesize_version: uint16,
     pub pd_prune_xid: TransactionId,
     pub pd_linp: __IncompleteArrayField<ItemIdData>,
+}
+impl Default for PageHeaderData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub type PageHeader = *mut PageHeaderData;
 #[repr(C)]
@@ -7418,31 +7446,33 @@ impl Default for TupleTableSlot {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct TupleTableSlotOps {
     pub base_slot_size: usize,
-    pub init: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub release: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub clear: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub init: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub release: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub clear: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub getsomeattrs: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
     >,
     pub getsysattr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             slot: *mut TupleTableSlot,
             attnum: ::core::ffi::c_int,
             isnull: *mut bool,
         ) -> Datum,
     >,
-    pub materialize: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub materialize: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub copyslot: ::core::option::Option<
-        unsafe extern "C" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
+        unsafe extern "C-unwind" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
     >,
     pub get_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub get_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub get_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
     pub copy_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub copy_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub copy_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7630,11 +7660,12 @@ pub struct WorkerInstrumentation {
 }
 pub type fmNodePtr = *mut Node;
 pub type fmAggrefPtr = *mut Aggref;
-pub type fmExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type fmExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 pub type fmStringInfo = *mut StringInfoData;
 pub type FunctionCallInfo = *mut FunctionCallInfoBaseData;
 pub type PGFunction =
-    ::core::option::Option<unsafe extern "C" fn(fcinfo: FunctionCallInfo) -> Datum>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(fcinfo: FunctionCallInfo) -> Datum>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FmgrInfo {
@@ -7682,7 +7713,8 @@ impl Default for FunctionCallInfoBaseData {
 pub struct Pg_finfo_record {
     pub api_version: ::core::ffi::c_int,
 }
-pub type PGFInfoFunction = ::core::option::Option<unsafe extern "C" fn() -> *const Pg_finfo_record>;
+pub type PGFInfoFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_finfo_record>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Pg_magic_struct {
@@ -7695,16 +7727,21 @@ pub struct Pg_magic_struct {
     pub abi_extra: [::core::ffi::c_char; 32usize],
 }
 pub type PGModuleMagicFunction =
-    ::core::option::Option<unsafe extern "C" fn() -> *const Pg_magic_struct>;
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_magic_struct>;
 pub mod FmgrHookEventType {
     pub type Type = ::core::ffi::c_uint;
     pub const FHET_START: Type = 0;
     pub const FHET_END: Type = 1;
     pub const FHET_ABORT: Type = 2;
 }
-pub type needs_fmgr_hook_type = ::core::option::Option<unsafe extern "C" fn(fn_oid: Oid) -> bool>;
+pub type needs_fmgr_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(fn_oid: Oid) -> bool>;
 pub type fmgr_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(event: FmgrHookEventType::Type, flinfo: *mut FmgrInfo, arg: *mut Datum),
+    unsafe extern "C-unwind" fn(
+        event: FmgrHookEventType::Type,
+        flinfo: *mut FmgrInfo,
+        arg: *mut Datum,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7856,7 +7893,7 @@ impl Default for pairingheap_node {
     }
 }
 pub type pairingheap_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const pairingheap_node,
         b: *const pairingheap_node,
         arg: *mut ::core::ffi::c_void,
@@ -7897,7 +7934,7 @@ impl Default for ParamExternData {
 }
 pub type ParamListInfo = *mut ParamListInfoData;
 pub type ParamFetchHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         paramid: ::core::ffi::c_int,
         speculative: bool,
@@ -7905,7 +7942,7 @@ pub type ParamFetchHook = ::core::option::Option<
     ) -> *mut ParamExternData,
 >;
 pub type ParamCompileHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         param: *mut Param,
         state: *mut ExprState,
@@ -7914,7 +7951,7 @@ pub type ParamCompileHook = ::core::option::Option<
     ),
 >;
 pub type ParserSetupHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -9305,11 +9342,6 @@ impl Default for BitString {
         }
     }
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionBoundInfoData {
-    _unused: [u8; 0],
-}
 pub type PartitionBoundInfo = *mut PartitionBoundInfoData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -9317,11 +9349,6 @@ pub struct PartitionKeyData {
     _unused: [u8; 0],
 }
 pub type PartitionKey = *mut PartitionKeyData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionDescData {
-    _unused: [u8; 0],
-}
 pub type PartitionDesc = *mut PartitionDescData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -14392,7 +14419,7 @@ pub struct PGShmemHeader {
     _unused: [u8; 0],
 }
 pub type on_dsm_detach_callback =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut dsm_segment, arg: Datum)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut dsm_segment, arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dsa_area {
@@ -14484,24 +14511,24 @@ impl Default for ConditionVariableMinimallyPadded {
     }
 }
 pub type HashValueFunc = ::core::option::Option<
-    unsafe extern "C" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
+    unsafe extern "C-unwind" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
 >;
 pub type HashCompareFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         key1: *const ::core::ffi::c_void,
         key2: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> ::core::ffi::c_int,
 >;
 pub type HashCopyFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         dest: *mut ::core::ffi::c_void,
         src: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> *mut ::core::ffi::c_void,
 >;
 pub type HashAllocFunc =
-    ::core::option::Option<unsafe extern "C" fn(request: Size) -> *mut ::core::ffi::c_void>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(request: Size) -> *mut ::core::ffi::c_void>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HASHELEMENT {
@@ -14854,16 +14881,17 @@ pub struct SortSupportData {
     pub ssup_attno: AttrNumber,
     pub ssup_extra: *mut ::core::ffi::c_void,
     pub comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
     pub abbreviate: bool,
-    pub abbrev_converter:
-        ::core::option::Option<unsafe extern "C" fn(original: Datum, ssup: SortSupport) -> Datum>,
+    pub abbrev_converter: ::core::option::Option<
+        unsafe extern "C-unwind" fn(original: Datum, ssup: SortSupport) -> Datum,
+    >,
     pub abbrev_abort: ::core::option::Option<
-        unsafe extern "C" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
+        unsafe extern "C-unwind" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
     >,
     pub abbrev_full_comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
 }
 impl Default for SortSupportData {
@@ -14977,7 +15005,7 @@ impl Default for SortTuple {
     }
 }
 pub type SortTupleComparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const SortTuple,
         b: *const SortTuple,
         state: *mut Tuplesortstate,
@@ -14988,28 +15016,28 @@ pub type SortTupleComparator = ::core::option::Option<
 pub struct TuplesortPublic {
     pub comparetup: SortTupleComparator,
     pub removeabbrev: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             state: *mut Tuplesortstate,
             stups: *mut SortTuple,
             count: ::core::ffi::c_int,
         ),
     >,
     pub writetup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             state: *mut Tuplesortstate,
             tape: *mut LogicalTape,
             stup: *mut SortTuple,
         ),
     >,
     pub readtup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             state: *mut Tuplesortstate,
             stup: *mut SortTuple,
             tape: *mut LogicalTape,
             len: ::core::ffi::c_uint,
         ),
     >,
-    pub freestate: ::core::option::Option<unsafe extern "C" fn(state: *mut Tuplesortstate)>,
+    pub freestate: ::core::option::Option<unsafe extern "C-unwind" fn(state: *mut Tuplesortstate)>,
     pub maincontext: MemoryContext,
     pub sortcontext: MemoryContext,
     pub tuplecontext: MemoryContext,
@@ -15046,7 +15074,7 @@ pub struct CopyMultiInsertBuffer {
     _unused: [u8; 0],
 }
 pub type ExprStateEvalFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         expression: *mut ExprState,
         econtext: *mut ExprContext,
         isNull: *mut bool,
@@ -15122,7 +15150,8 @@ impl Default for IndexInfo {
         }
     }
 }
-pub type ExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type ExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExprContext_CB {
@@ -15634,8 +15663,9 @@ impl Default for DomainConstraintState {
         }
     }
 }
-pub type ExecProcNodeMtd =
-    ::core::option::Option<unsafe extern "C" fn(pstate: *mut PlanState) -> *mut TupleTableSlot>;
+pub type ExecProcNodeMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(pstate: *mut PlanState) -> *mut TupleTableSlot,
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PlanState {
@@ -15812,7 +15842,7 @@ pub struct AppendState {
     pub as_valid_subplans: *mut Bitmapset,
     pub as_valid_asyncplans: *mut Bitmapset,
     pub choose_next_subplan:
-        ::core::option::Option<unsafe extern "C" fn(arg1: *mut AppendState) -> bool>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut AppendState) -> bool>,
 }
 impl Default for AppendState {
     fn default() -> Self {
@@ -17275,17 +17305,17 @@ pub type DestReceiver = _DestReceiver;
 #[derive(Debug, Copy, Clone)]
 pub struct _DestReceiver {
     pub receiveSlot: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
     >,
     pub rStartup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             self_: *mut DestReceiver,
             operation: ::core::ffi::c_int,
             typeinfo: TupleDesc,
         ),
     >,
-    pub rShutdown: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
-    pub rDestroy: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
+    pub rShutdown: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
+    pub rDestroy: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
     pub mydest: CommandDest::Type,
 }
 impl Default for _DestReceiver {
@@ -17333,7 +17363,7 @@ pub struct MemoryContextCounters {
     pub freespace: Size,
 }
 pub type MemoryStatsPrintFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         context: MemoryContext,
         passthru: *mut ::core::ffi::c_void,
         stats_string: *const ::core::ffi::c_char,
@@ -17344,25 +17374,28 @@ pub type MemoryStatsPrintFunc = ::core::option::Option<
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MemoryContextMethods {
     pub alloc: ::core::option::Option<
-        unsafe extern "C" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
+        unsafe extern "C-unwind" fn(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void,
     >,
-    pub free_p: ::core::option::Option<unsafe extern "C" fn(pointer: *mut ::core::ffi::c_void)>,
+    pub free_p:
+        ::core::option::Option<unsafe extern "C-unwind" fn(pointer: *mut ::core::ffi::c_void)>,
     pub realloc: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             pointer: *mut ::core::ffi::c_void,
             size: Size,
         ) -> *mut ::core::ffi::c_void,
     >,
-    pub reset: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
-    pub delete_context: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub reset: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
+    pub delete_context: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
     pub get_chunk_context: ::core::option::Option<
-        unsafe extern "C" fn(pointer: *mut ::core::ffi::c_void) -> MemoryContext,
+        unsafe extern "C-unwind" fn(pointer: *mut ::core::ffi::c_void) -> MemoryContext,
     >,
-    pub get_chunk_space:
-        ::core::option::Option<unsafe extern "C" fn(pointer: *mut ::core::ffi::c_void) -> Size>,
-    pub is_empty: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext) -> bool>,
+    pub get_chunk_space: ::core::option::Option<
+        unsafe extern "C-unwind" fn(pointer: *mut ::core::ffi::c_void) -> Size,
+    >,
+    pub is_empty:
+        ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext) -> bool>,
     pub stats: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             printfunc: MemoryStatsPrintFunc,
             passthru: *mut ::core::ffi::c_void,
@@ -17370,7 +17403,7 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
-    pub check: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub check: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -17398,10 +17431,10 @@ impl Default for MemoryContextData {
     }
 }
 pub type ExecutorStart_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
 >;
 pub type ExecutorRun_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         queryDesc: *mut QueryDesc,
         direction: ScanDirection::Type,
         count: uint64,
@@ -17409,20 +17442,21 @@ pub type ExecutorRun_hook_type = ::core::option::Option<
     ),
 >;
 pub type ExecutorFinish_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorEnd_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorCheckPerms_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rangeTable: *mut List,
         rtePermInfos: *mut List,
         ereport_on_violation: bool,
     ) -> bool,
 >;
-pub type ExecScanAccessMtd =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ScanState) -> *mut TupleTableSlot>;
+pub type ExecScanAccessMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(node: *mut ScanState) -> *mut TupleTableSlot,
+>;
 pub type ExecScanRecheckMtd = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -17568,7 +17602,7 @@ pub mod AuxProcType {
     pub const WalReceiverProcess: Type = 5;
     pub const NUM_AUXPROCTYPES: Type = 6;
 }
-pub type shmem_request_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
+pub type shmem_request_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub mod ProgressCommandType {
     pub type Type = ::core::ffi::c_uint;
     pub const PROGRESS_COMMAND_INVALID: Type = 0;
@@ -18312,7 +18346,7 @@ pub struct IndexBulkDeleteResult {
     pub pages_free: BlockNumber,
 }
 pub type IndexBulkDeleteCallback = ::core::option::Option<
-    unsafe extern "C" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type IndexScanDesc = *mut IndexScanDescData;
 pub type SysScanDesc = *mut SysScanDescData;
@@ -18375,16 +18409,16 @@ impl Default for OpFamilyMember {
     }
 }
 pub type ambuild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         heapRelation: Relation,
         indexRelation: Relation,
         indexInfo: *mut IndexInfo,
     ) -> *mut IndexBuildResult,
 >;
 pub type ambuildempty_function =
-    ::core::option::Option<unsafe extern "C" fn(indexRelation: Relation)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexRelation: Relation)>;
 pub type aminsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         values: *mut Datum,
         isnull: *mut bool,
@@ -18396,7 +18430,7 @@ pub type aminsert_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type ambulkdelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
         callback: IndexBulkDeleteCallback,
@@ -18404,16 +18438,16 @@ pub type ambulkdelete_function = ::core::option::Option<
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amvacuumcleanup_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amcanreturn_function = ::core::option::Option<
-    unsafe extern "C" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
 >;
 pub type amcostestimate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         path: *mut IndexPath,
         loop_count: f64,
@@ -18424,10 +18458,11 @@ pub type amcostestimate_function = ::core::option::Option<
         indexPages: *mut f64,
     ),
 >;
-pub type amoptions_function =
-    ::core::option::Option<unsafe extern "C" fn(reloptions: Datum, validate: bool) -> *mut bytea>;
+pub type amoptions_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(reloptions: Datum, validate: bool) -> *mut bytea,
+>;
 pub type amproperty_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index_oid: Oid,
         attno: ::core::ffi::c_int,
         prop: IndexAMProperty::Type,
@@ -18436,12 +18471,13 @@ pub type amproperty_function = ::core::option::Option<
         isnull: *mut bool,
     ) -> bool,
 >;
-pub type ambuildphasename_function =
-    ::core::option::Option<unsafe extern "C" fn(phasenum: int64) -> *mut ::core::ffi::c_char>;
+pub type ambuildphasename_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(phasenum: int64) -> *mut ::core::ffi::c_char,
+>;
 pub type amvalidate_function =
-    ::core::option::Option<unsafe extern "C" fn(opclassoid: Oid) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(opclassoid: Oid) -> bool>;
 pub type amadjustmembers_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opfamilyoid: Oid,
         opclassoid: Oid,
         operators: *mut List,
@@ -18449,14 +18485,14 @@ pub type amadjustmembers_function = ::core::option::Option<
     ),
 >;
 pub type ambeginscan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         nkeys: ::core::ffi::c_int,
         norderbys: ::core::ffi::c_int,
     ) -> IndexScanDesc,
 >;
 pub type amrescan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         scan: IndexScanDesc,
         keys: ScanKey,
         nkeys: ::core::ffi::c_int,
@@ -18465,18 +18501,23 @@ pub type amrescan_function = ::core::option::Option<
     ),
 >;
 pub type amgettuple_function = ::core::option::Option<
-    unsafe extern "C" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
 >;
-pub type amgetbitmap_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64>;
-pub type amendscan_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type ammarkpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amrestrpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amestimateparallelscan_function = ::core::option::Option<unsafe extern "C" fn() -> Size>;
+pub type amgetbitmap_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64,
+>;
+pub type amendscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type ammarkpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amrestrpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amestimateparallelscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> Size>;
 pub type aminitparallelscan_function =
-    ::core::option::Option<unsafe extern "C" fn(target: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(target: *mut ::core::ffi::c_void)>;
 pub type amparallelrescan_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IndexAmRoutine {
@@ -18669,7 +18710,7 @@ impl Default for RelFileLocatorBackend {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct XLogRecord {
     pub xl_tot_len: uint32,
     pub xl_xid: TransactionId,
@@ -18677,6 +18718,15 @@ pub struct XLogRecord {
     pub xl_info: uint8,
     pub xl_rmid: RmgrId,
     pub xl_crc: pg_crc32c,
+}
+impl Default for XLogRecord {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -18731,7 +18781,7 @@ impl Default for WALSegmentContext {
     }
 }
 pub type XLogPageReadCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         targetPagePtr: XLogRecPtr,
         reqLen: ::core::ffi::c_int,
@@ -18740,14 +18790,14 @@ pub type XLogPageReadCB = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type WALSegmentOpenCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         nextSegNo: XLogSegNo,
         tli_p: *mut TimeLineID,
     ),
 >;
 pub type WALSegmentCloseCB =
-    ::core::option::Option<unsafe extern "C" fn(xlogreader: *mut XLogReaderState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(xlogreader: *mut XLogReaderState)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct XLogReaderRoutine {
@@ -18963,18 +19013,20 @@ pub struct XLogRecordBuffer {
 #[derive(Debug, Copy, Clone)]
 pub struct RmgrData {
     pub rm_name: *const ::core::ffi::c_char,
-    pub rm_redo: ::core::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
-    pub rm_desc:
-        ::core::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
-    pub rm_identify:
-        ::core::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::core::ffi::c_char>,
-    pub rm_startup: ::core::option::Option<unsafe extern "C" fn()>,
-    pub rm_cleanup: ::core::option::Option<unsafe extern "C" fn()>,
+    pub rm_redo: ::core::option::Option<unsafe extern "C-unwind" fn(record: *mut XLogReaderState)>,
+    pub rm_desc: ::core::option::Option<
+        unsafe extern "C-unwind" fn(buf: StringInfo, record: *mut XLogReaderState),
+    >,
+    pub rm_identify: ::core::option::Option<
+        unsafe extern "C-unwind" fn(info: uint8) -> *const ::core::ffi::c_char,
+    >,
+    pub rm_startup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
+    pub rm_cleanup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     pub rm_mask: ::core::option::Option<
-        unsafe extern "C" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
+        unsafe extern "C-unwind" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
     >,
     pub rm_decode: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, buf: *mut XLogRecordBuffer),
+        unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, buf: *mut XLogRecordBuffer),
     >,
 }
 impl Default for RmgrData {
@@ -19791,7 +19843,7 @@ pub mod XactEvent {
     pub const XACT_EVENT_PRE_PREPARE: Type = 7;
 }
 pub type XactCallback = ::core::option::Option<
-    unsafe extern "C" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
 >;
 pub mod SubXactEvent {
     pub type Type = ::core::ffi::c_uint;
@@ -19801,7 +19853,7 @@ pub mod SubXactEvent {
     pub const SUBXACT_EVENT_PRE_COMMIT_SUB: Type = 3;
 }
 pub type SubXactCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         event: SubXactEvent::Type,
         mySubid: SubTransactionId,
         parentSubid: SubTransactionId,
@@ -19816,11 +19868,20 @@ pub struct SavedTransactionCharacteristics {
     pub save_XactDeferrable: bool,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_assignment {
     pub xtop: TransactionId,
     pub nsubxacts: ::core::ffi::c_int,
     pub xsub: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_assignment {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19843,10 +19904,19 @@ impl Default for xl_xact_dbinfo {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_subxacts {
     pub nsubxacts: ::core::ffi::c_int,
     pub subxacts: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_subxacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -19909,9 +19979,18 @@ impl Default for xl_xact_invals {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct xl_xact_twophase {
     pub xid: TransactionId,
+}
+impl Default for xl_xact_twophase {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -20054,12 +20133,21 @@ pub mod TU_UpdateIndexes {
     pub const TU_Summarizing: Type = 2;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct TM_FailureData {
     pub ctid: ItemPointerData,
     pub xmax: TransactionId,
     pub cmax: CommandId,
     pub traversed: bool,
+}
+impl Default for TM_FailureData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -20096,7 +20184,7 @@ impl Default for TM_IndexDeleteOp {
     }
 }
 pub type IndexBuildCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index: Relation,
         tid: ItemPointer,
         values: *mut Datum,
@@ -20109,10 +20197,11 @@ pub type IndexBuildCallback = ::core::option::Option<
 #[derive(Debug, Copy, Clone)]
 pub struct TableAmRoutine {
     pub type_: NodeTag,
-    pub slot_callbacks:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *const TupleTableSlotOps>,
+    pub slot_callbacks: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *const TupleTableSlotOps,
+    >,
     pub scan_begin: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             snapshot: Snapshot,
             nkeys: ::core::ffi::c_int,
@@ -20121,9 +20210,9 @@ pub struct TableAmRoutine {
             flags: uint32,
         ) -> TableScanDesc,
     >,
-    pub scan_end: ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc)>,
+    pub scan_end: ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc)>,
     pub scan_rescan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             key: *mut ScanKeyData,
             set_params: bool,
@@ -20133,36 +20222,39 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_getnextslot: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_set_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
     >,
     pub scan_getnextslot_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub parallelscan_estimate: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Size>,
+    pub parallelscan_estimate:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Size>,
     pub parallelscan_initialize: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
     >,
-    pub parallelscan_reinitialize:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc)>,
-    pub index_fetch_begin:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *mut IndexFetchTableData>,
+    pub parallelscan_reinitialize: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc),
+    >,
+    pub index_fetch_begin: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *mut IndexFetchTableData,
+    >,
     pub index_fetch_reset:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_end:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: *mut IndexFetchTableData,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -20172,25 +20264,33 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub tuple_fetch_row_version: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub tuple_tid_valid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer) -> bool>,
+    pub tuple_tid_valid: ::core::option::Option<
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer) -> bool,
+    >,
     pub tuple_get_latest_tid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer)>,
     pub tuple_satisfies_snapshot: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, slot: *mut TupleTableSlot, snapshot: Snapshot) -> bool,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            slot: *mut TupleTableSlot,
+            snapshot: Snapshot,
+        ) -> bool,
     >,
     pub index_delete_tuples: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, delstate: *mut TM_IndexDeleteOp) -> TransactionId,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            delstate: *mut TM_IndexDeleteOp,
+        ) -> TransactionId,
     >,
     pub tuple_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -20199,7 +20299,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_insert_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -20209,7 +20309,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_complete_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             specToken: uint32,
@@ -20217,7 +20317,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub multi_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slots: *mut *mut TupleTableSlot,
             nslots: ::core::ffi::c_int,
@@ -20227,7 +20327,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_delete: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             cid: CommandId,
@@ -20239,7 +20339,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_update: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             otid: ItemPointer,
             slot: *mut TupleTableSlot,
@@ -20253,7 +20353,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_lock: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -20265,10 +20365,11 @@ pub struct TableAmRoutine {
             tmfd: *mut TM_FailureData,
         ) -> TM_Result::Type,
     >,
-    pub finish_bulk_insert:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, options: ::core::ffi::c_int)>,
+    pub finish_bulk_insert: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, options: ::core::ffi::c_int),
+    >,
     pub relation_set_new_filelocator: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             newrlocator: *const RelFileLocator,
             persistence: ::core::ffi::c_char,
@@ -20277,12 +20378,12 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_nontransactional_truncate:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation)>,
     pub relation_copy_data: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, newrlocator: *const RelFileLocator),
+        unsafe extern "C-unwind" fn(rel: Relation, newrlocator: *const RelFileLocator),
     >,
     pub relation_copy_for_cluster: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             OldTable: Relation,
             NewTable: Relation,
             OldIndex: Relation,
@@ -20296,21 +20397,21 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_vacuum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             params: *mut VacuumParams,
             bstrategy: BufferAccessStrategy,
         ),
     >,
     pub scan_analyze_next_block: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             blockno: BlockNumber,
             bstrategy: BufferAccessStrategy,
         ) -> bool,
     >,
     pub scan_analyze_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             OldestXmin: TransactionId,
             liverows: *mut f64,
@@ -20319,7 +20420,7 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub index_build_range_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -20334,7 +20435,7 @@ pub struct TableAmRoutine {
         ) -> f64,
     >,
     pub index_validate_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -20343,13 +20444,14 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_size: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
+        unsafe extern "C-unwind" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
     >,
     pub relation_needs_toast_table:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> bool>,
-    pub relation_toast_am: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Oid>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> bool>,
+    pub relation_toast_am:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Oid>,
     pub relation_fetch_toast_slice: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             toastrel: Relation,
             valueid: Oid,
             attrsize: int32,
@@ -20359,7 +20461,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_estimate_size: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             attr_widths: *mut int32,
             pages: *mut BlockNumber,
@@ -20368,20 +20470,20 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_bitmap_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
     >,
     pub scan_bitmap_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             tbmres: *mut TBMIterateResult,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_sample_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
     >,
     pub scan_sample_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             scanstate: *mut SampleScanState,
             slot: *mut TupleTableSlot,
@@ -20478,7 +20580,7 @@ pub mod HTSV_Result {
     pub const HEAPTUPLE_DELETE_IN_PROGRESS: Type = 4;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct HeapTupleFreeze {
     pub xmax: TransactionId,
     pub t_infomask2: uint16,
@@ -20487,14 +20589,31 @@ pub struct HeapTupleFreeze {
     pub checkflags: uint8,
     pub offset: OffsetNumber,
 }
+impl Default for HeapTupleFreeze {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct HeapPageFreeze {
     pub freeze_required: bool,
     pub FreezePageRelfrozenXid: TransactionId,
     pub FreezePageRelminMxid: MultiXactId,
     pub NoFreezePageRelfrozenXid: TransactionId,
     pub NoFreezePageRelminMxid: MultiXactId,
+}
+impl Default for HeapPageFreeze {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -20559,7 +20678,6 @@ impl Default for MultiXactMember {
     }
 }
 #[repr(C)]
-#[derive(Debug)]
 pub struct xl_multixact_create {
     pub mid: MultiXactId,
     pub moff: MultiXactOffset,
@@ -20576,7 +20694,6 @@ impl Default for xl_multixact_create {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct xl_multixact_truncate {
     pub oldestMultiDB: Oid,
     pub startTruncOff: MultiXactId,
@@ -21061,12 +21178,15 @@ impl Default for relopt_enum {
     }
 }
 pub type validate_string_relopt =
-    ::core::option::Option<unsafe extern "C" fn(value: *const ::core::ffi::c_char)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(value: *const ::core::ffi::c_char)>;
 pub type fill_string_relopt = ::core::option::Option<
-    unsafe extern "C" fn(value: *const ::core::ffi::c_char, ptr: *mut ::core::ffi::c_void) -> Size,
+    unsafe extern "C-unwind" fn(
+        value: *const ::core::ffi::c_char,
+        ptr: *mut ::core::ffi::c_void,
+    ) -> Size,
 >;
 pub type relopts_validator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parsed_options: *mut ::core::ffi::c_void,
         vals: *mut relopt_value,
         nvals: ::core::ffi::c_int,
@@ -21139,7 +21259,6 @@ impl Default for local_relopts {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct CheckPoint {
     pub redo: XLogRecPtr,
     pub ThisTimeLineID: TimeLineID,
@@ -21178,7 +21297,6 @@ pub mod DBState {
     pub const DB_IN_PRODUCTION: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct ControlFileData {
     pub system_identifier: uint64,
     pub pg_control_version: uint32,
@@ -21278,7 +21396,7 @@ pub mod ResourceReleasePhase {
     pub const RESOURCE_RELEASE_AFTER_LOCKS: Type = 2;
 }
 pub type ResourceReleaseCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         phase: ResourceReleasePhase::Type,
         isCommit: bool,
         isTopLevel: bool,
@@ -21331,11 +21449,6 @@ impl Default for BufferManagerRelation {
             s.assume_init()
         }
     }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct WritebackContext {
-    _unused: [u8; 0],
 }
 pub mod HotStandbyState {
     pub type Type = ::core::ffi::c_uint;
@@ -21516,7 +21629,7 @@ pub mod RVROption {
     pub const RVR_SKIP_LOCKED: Type = 4;
 }
 pub type RangeVarGetRelidCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: *const RangeVar,
         relId: Oid,
         oldRelId: Oid,
@@ -21564,7 +21677,7 @@ pub struct ObjectAccessNamespaceSearch {
     pub result: bool,
 }
 pub type object_access_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectId: Oid,
@@ -21573,7 +21686,7 @@ pub type object_access_hook_type = ::core::option::Option<
     ),
 >;
 pub type object_access_hook_type_str = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectStr: *const ::core::ffi::c_char,
@@ -21955,20 +22068,20 @@ pub mod ParseExprKind {
     pub const EXPR_KIND_CYCLE_MARK: Type = 43;
 }
 pub type PreParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
 >;
 pub type PostParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         cref: *mut ColumnRef,
         var: *mut Node,
     ) -> *mut Node,
 >;
 pub type ParseParamRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
 >;
 pub type CoerceParamHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         param: *mut Param,
         targetTypeId: Oid,
@@ -22303,19 +22416,19 @@ pub struct CopyToStateData {
 }
 pub type CopyToState = *mut CopyToStateData;
 pub type copy_data_source_cb = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         outbuf: *mut ::core::ffi::c_void,
         minread: ::core::ffi::c_int,
         maxread: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type copy_data_dest_cb = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ::core::ffi::c_void, len: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(data: *mut ::core::ffi::c_void, len: ::core::ffi::c_int),
 >;
 pub type EOM_get_flat_size_method =
-    ::core::option::Option<unsafe extern "C" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
 pub type EOM_flatten_into_method = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         eohptr: *mut ExpandedObjectHeader,
         result: *mut ::core::ffi::c_void,
         allocated_size: Size,
@@ -22801,7 +22914,7 @@ impl Default for ExplainState {
     }
 }
 pub type ExplainOneQuery_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         query: *mut Query,
         cursorOptions: ::core::ffi::c_int,
         into: *mut IntoClause,
@@ -22812,7 +22925,7 @@ pub type ExplainOneQuery_hook_type = ::core::option::Option<
     ),
 >;
 pub type explain_get_index_name_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
 pub mod PlanCacheMode {
     pub type Type = ::core::ffi::c_uint;
     pub const PLAN_CACHE_MODE_AUTO: Type = 0;
@@ -22925,7 +23038,7 @@ impl Default for PreparedStatement {
     }
 }
 pub type check_object_relabel_type = ::core::option::Option<
-    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
+    unsafe extern "C-unwind" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -23085,54 +23198,60 @@ impl Default for config_enum_entry {
     }
 }
 pub type GucBoolCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut bool,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucIntCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucRealCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut f64,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucStringCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut *mut ::core::ffi::c_char,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucEnumCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
-pub type GucBoolAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: bool, extra: *mut ::core::ffi::c_void)>;
-pub type GucIntAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+pub type GucBoolAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: bool, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucRealAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: f64, extra: *mut ::core::ffi::c_void)>;
+pub type GucIntAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+>;
+pub type GucRealAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: f64, extra: *mut ::core::ffi::c_void),
+>;
 pub type GucStringAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: *const ::core::ffi::c_char, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    ),
 >;
 pub type GucEnumAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucShowHook = ::core::option::Option<unsafe extern "C" fn() -> *const ::core::ffi::c_char>;
+pub type GucShowHook =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const ::core::ffi::c_char>;
 pub mod GucAction {
     pub type Type = ::core::ffi::c_uint;
     pub const GUC_ACTION_SET: Type = 0;
@@ -23140,7 +23259,7 @@ pub mod GucAction {
     pub const GUC_ACTION_SAVE: Type = 2;
 }
 pub type check_password_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         username: *const ::core::ffi::c_char,
         shadow_pass: *const ::core::ffi::c_char,
         password_type: PasswordType::Type,
@@ -23148,7 +23267,7 @@ pub type check_password_hook_type = ::core::option::Option<
         validuntil_null: bool,
     ),
 >;
-pub type bgworker_main_type = ::core::option::Option<unsafe extern "C" fn(main_arg: Datum)>;
+pub type bgworker_main_type = ::core::option::Option<unsafe extern "C-unwind" fn(main_arg: Datum)>;
 pub mod BgWorkerStartTime {
     pub type Type = ::core::ffi::c_uint;
     pub const BgWorkerStart_PostmasterStart: Type = 0;
@@ -23389,7 +23508,7 @@ pub mod shm_mq_result {
     pub const SHM_MQ_DETACHED: Type = 2;
 }
 pub type parallel_worker_main_type =
-    ::core::option::Option<unsafe extern "C" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ParallelWorkerInfo {
@@ -23491,14 +23610,14 @@ pub struct ParallelVacuumState {
 }
 pub type VacAttrStatsP = *mut VacAttrStats;
 pub type AnalyzeAttrFetchFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         rownum: ::core::ffi::c_int,
         isNull: *mut bool,
     ) -> Datum,
 >;
 pub type AnalyzeAttrComputeStatsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         fetchfunc: AnalyzeAttrFetchFunc,
         samplerows: ::core::ffi::c_int,
@@ -23579,7 +23698,6 @@ impl Default for VacuumParams {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct VacuumCutoffs {
     pub relfrozenxid: TransactionId,
     pub relminmxid: MultiXactId,
@@ -23587,6 +23705,15 @@ pub struct VacuumCutoffs {
     pub OldestMxact: MultiXactId,
     pub FreezeLimit: TransactionId,
     pub MultiXactCutoff: MultiXactId,
+}
+impl Default for VacuumCutoffs {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -23750,10 +23877,14 @@ pub struct ScalarArrayOpExprHashTable {
     _unused: [u8; 0],
 }
 pub type ExecEvalSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(state: *mut ExprState, op: *mut ExprEvalStep, econtext: *mut ExprContext),
+    unsafe extern "C-unwind" fn(
+        state: *mut ExprState,
+        op: *mut ExprEvalStep,
+        econtext: *mut ExprContext,
+    ),
 >;
 pub type ExecEvalBoolSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         state: *mut ExprState,
         op: *mut ExprEvalStep,
         econtext: *mut ExprContext,
@@ -24705,7 +24836,7 @@ pub struct PortalData {
     pub prepStmtName: *const ::core::ffi::c_char,
     pub portalContext: MemoryContext,
     pub resowner: ResourceOwner,
-    pub cleanup: ::core::option::Option<unsafe extern "C" fn(portal: Portal)>,
+    pub cleanup: ::core::option::Option<unsafe extern "C-unwind" fn(portal: Portal)>,
     pub createSubid: SubTransactionId,
     pub activeSubid: SubTransactionId,
     pub createLevel: ::core::ffi::c_int,
@@ -25127,7 +25258,7 @@ pub struct IndexOptInfo {
     pub amcanparallel: bool,
     pub amcanmarkpos: bool,
     pub amcostestimate: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             arg1: *mut PlannerInfo,
             arg2: *mut IndexPath,
             arg3: f64,
@@ -26381,13 +26512,21 @@ impl Default for AggTransInfo {
     }
 }
 pub type GetForeignRelSize_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPlan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         baserel: *mut RelOptInfo,
         foreigntableid: Oid,
@@ -26398,20 +26537,20 @@ pub type GetForeignPlan_function = ::core::option::Option<
     ) -> *mut ForeignScan,
 >;
 pub type BeginForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type RecheckForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 pub type ReScanForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type EndForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignJoinPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -26421,7 +26560,7 @@ pub type GetForeignJoinPaths_function = ::core::option::Option<
     ),
 >;
 pub type GetForeignUpperPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -26430,7 +26569,7 @@ pub type GetForeignUpperPaths_function = ::core::option::Option<
     ),
 >;
 pub type AddForeignUpdateTargets_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rtindex: Index,
         target_rte: *mut RangeTblEntry,
@@ -26438,7 +26577,7 @@ pub type AddForeignUpdateTargets_function = ::core::option::Option<
     ),
 >;
 pub type PlanForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -26446,7 +26585,7 @@ pub type PlanForeignModify_function = ::core::option::Option<
     ) -> *mut List,
 >;
 pub type BeginForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -26455,7 +26594,7 @@ pub type BeginForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExecForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -26463,7 +26602,7 @@ pub type ExecForeignInsert_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignBatchInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slots: *mut *mut TupleTableSlot,
@@ -26471,10 +26610,11 @@ pub type ExecForeignBatchInsert_function = ::core::option::Option<
         numSlots: *mut ::core::ffi::c_int,
     ) -> *mut *mut TupleTableSlot,
 >;
-pub type GetForeignModifyBatchSize_function =
-    ::core::option::Option<unsafe extern "C" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int>;
+pub type GetForeignModifyBatchSize_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int,
+>;
 pub type ExecForeignUpdate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -26482,24 +26622,26 @@ pub type ExecForeignUpdate_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignDelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
         planSlot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot,
 >;
-pub type EndForeignModify_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
-pub type BeginForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+pub type EndForeignModify_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
 >;
-pub type EndForeignInsert_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
+pub type BeginForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+>;
+pub type EndForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
+>;
 pub type IsForeignRelUpdatable_function =
-    ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> ::core::ffi::c_int>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> ::core::ffi::c_int>;
 pub type PlanDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -26507,21 +26649,21 @@ pub type PlanDirectModify_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type BeginDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type EndDirectModify_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignRowMarkType_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rte: *mut RangeTblEntry,
         strength: LockClauseStrength::Type,
     ) -> RowMarkType::Type,
 >;
 pub type RefetchForeignRow_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         erm: *mut ExecRowMark,
         rowid: Datum,
@@ -26530,10 +26672,10 @@ pub type RefetchForeignRow_function = ::core::option::Option<
     ),
 >;
 pub type ExplainForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type ExplainForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -26542,10 +26684,10 @@ pub type ExplainForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExplainDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type AcquireSampleRowsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         elevel: ::core::ffi::c_int,
         rows: *mut HeapTuple,
@@ -26555,66 +26697,66 @@ pub type AcquireSampleRowsFunc = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type AnalyzeForeignTable_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         func: *mut AcquireSampleRowsFunc,
         totalpages: *mut BlockNumber,
     ) -> bool,
 >;
 pub type ImportForeignSchema_function = ::core::option::Option<
-    unsafe extern "C" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
+    unsafe extern "C-unwind" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
 >;
 pub type ExecForeignTruncate_function = ::core::option::Option<
-    unsafe extern "C" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
+    unsafe extern "C-unwind" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
 >;
 pub type EstimateDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
 >;
 pub type InitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ReInitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type InitializeWorkerForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         toc: *mut shm_toc,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ShutdownForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type IsForeignScanParallelSafe_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rte: *mut RangeTblEntry,
     ) -> bool,
 >;
 pub type ReparameterizeForeignPathByChild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         fdw_private: *mut List,
         child_rel: *mut RelOptInfo,
     ) -> *mut List,
 >;
 pub type IsForeignPathAsyncCapable_function =
-    ::core::option::Option<unsafe extern "C" fn(path: *mut ForeignPath) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(path: *mut ForeignPath) -> bool>;
 pub type ForeignAsyncRequest_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncConfigureWait_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncNotify_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FdwRoutine {
@@ -26778,12 +26920,12 @@ impl Default for JitContext {
     }
 }
 pub type JitProviderInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut JitProviderCallbacks)>;
-pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut JitProviderCallbacks)>;
+pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type JitProviderReleaseContextCB =
-    ::core::option::Option<unsafe extern "C" fn(context: *mut JitContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(context: *mut JitContext)>;
 pub type JitProviderCompileExprCB =
-    ::core::option::Option<unsafe extern "C" fn(state: *mut ExprState) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(state: *mut ExprState) -> bool>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct JitProviderCallbacks {
@@ -26869,36 +27011,36 @@ impl Default for pg_enc2gettext {
     }
 }
 pub type mb2wchar_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const ::core::ffi::c_uchar,
         to: *mut pg_wchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type wchar2mb_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const pg_wchar,
         to: *mut ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mblen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbdisplaylen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbcharacter_incrementer = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
 >;
 pub type mbchar_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mbstr_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
@@ -26968,7 +27110,7 @@ pub struct pg_local_to_utf_combined {
     pub utf2: uint32,
 }
 pub type utf_local_conversion_func =
-    ::core::option::Option<unsafe extern "C" fn(code: uint32) -> uint32>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: uint32) -> uint32>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExtensibleNode {
@@ -26990,15 +27132,15 @@ pub struct ExtensibleNodeMethods {
     pub extnodename: *const ::core::ffi::c_char,
     pub node_size: Size,
     pub nodeCopy: ::core::option::Option<
-        unsafe extern "C" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
     >,
     pub nodeEqual: ::core::option::Option<
-        unsafe extern "C" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
+        unsafe extern "C-unwind" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
     >,
     pub nodeOut: ::core::option::Option<
-        unsafe extern "C" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
     >,
-    pub nodeRead: ::core::option::Option<unsafe extern "C" fn(node: *mut ExtensibleNode)>,
+    pub nodeRead: ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ExtensibleNode)>,
 }
 impl Default for ExtensibleNodeMethods {
     fn default() -> Self {
@@ -27014,7 +27156,7 @@ impl Default for ExtensibleNodeMethods {
 pub struct CustomPathMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub PlanCustomPath: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             rel: *mut RelOptInfo,
             best_path: *mut CustomPath,
@@ -27024,7 +27166,7 @@ pub struct CustomPathMethods {
         ) -> *mut Plan,
     >,
     pub ReparameterizeCustomPathByChild: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             custom_private: *mut List,
             child_rel: *mut RelOptInfo,
@@ -27045,7 +27187,7 @@ impl Default for CustomPathMethods {
 pub struct CustomScanMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub CreateCustomScanState:
-        ::core::option::Option<unsafe extern "C" fn(cscan: *mut CustomScan) -> *mut Node>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(cscan: *mut CustomScan) -> *mut Node>,
 }
 impl Default for CustomScanMethods {
     fn default() -> Self {
@@ -27061,48 +27203,51 @@ impl Default for CustomScanMethods {
 pub struct CustomExecMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub BeginCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             estate: *mut EState,
             eflags: ::core::ffi::c_int,
         ),
     >,
     pub ExecCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
     >,
-    pub EndCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub ReScanCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub MarkPosCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+    pub EndCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub ReScanCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub MarkPosCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub RestrPosCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub EstimateDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
     >,
     pub InitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ReInitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub InitializeWorkerCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             toc: *mut shm_toc,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ShutdownCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub ExplainCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             ancestors: *mut List,
             es: *mut ExplainState,
@@ -27136,16 +27281,19 @@ impl Default for ErrorSaveContext {
     }
 }
 pub type check_function_callback = ::core::option::Option<
-    unsafe extern "C" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type tree_walker_callback = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type planstate_tree_walker_callback = ::core::option::Option<
-    unsafe extern "C" fn(planstate: *mut PlanState, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(
+        planstate: *mut PlanState,
+        context: *mut ::core::ffi::c_void,
+    ) -> bool,
 >;
 pub type tree_mutator_callback = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> *mut Node,
+    unsafe extern "C-unwind" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> *mut Node,
 >;
 pub mod ReplicationKind {
     pub type Type = ::core::ffi::c_uint;
@@ -27266,7 +27414,7 @@ impl Default for TimeLineHistoryCmd {
     }
 }
 pub type SubscriptTransform = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *mut SubscriptingRef,
         indirection: *mut List,
         pstate: *mut ParseState,
@@ -27275,7 +27423,7 @@ pub type SubscriptTransform = ::core::option::Option<
     ),
 >;
 pub type SubscriptExecSetup = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *const SubscriptingRef,
         sbsrefstate: *mut SubscriptingRefState,
         methods: *mut SubscriptExecSteps,
@@ -27452,7 +27600,7 @@ pub mod DebugParallelMode {
     pub const DEBUG_PARALLEL_REGRESS: Type = 2;
 }
 pub type set_rel_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rti: Index,
@@ -27460,7 +27608,7 @@ pub type set_rel_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type set_join_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -27470,14 +27618,14 @@ pub type set_join_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type join_search_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         levels_needed: ::core::ffi::c_int,
         initial_rels: *mut List,
     ) -> *mut RelOptInfo,
 >;
 pub type ec_matches_callback_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         ec: *mut EquivalenceClass,
@@ -27493,7 +27641,7 @@ pub mod PathKeysComparison {
     pub const PATHKEYS_DIFFERENT: Type = 3;
 }
 pub type get_relation_info_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         relationObjectId: Oid,
         inhparent: bool,
@@ -27501,10 +27649,10 @@ pub type get_relation_info_hook_type = ::core::option::Option<
     ),
 >;
 pub type query_pathkeys_callback = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
 >;
 pub type planner_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parse: *mut Query,
         query_string: *const ::core::ffi::c_char,
         cursorOptions: ::core::ffi::c_int,
@@ -27512,7 +27660,7 @@ pub type planner_hook_type = ::core::option::Option<
     ) -> *mut PlannedStmt,
 >;
 pub type create_upper_paths_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -27553,7 +27701,11 @@ pub mod ComputeQueryIdType {
     pub const COMPUTE_QUERY_ID_REGRESS: Type = 3;
 }
 pub type post_parse_analyze_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, query: *mut Query, jstate: *mut JumbleState),
+    unsafe extern "C-unwind" fn(
+        pstate: *mut ParseState,
+        query: *mut Query,
+        jstate: *mut JumbleState,
+    ),
 >;
 pub mod FuncDetailCode {
     pub type Type = ::core::ffi::c_uint;
@@ -27575,6 +27727,73 @@ pub mod CoercionPathType {
     pub const COERCION_PATH_RELABELTYPE: Type = 2;
     pub const COERCION_PATH_ARRAYCOERCE: Type = 3;
     pub const COERCION_PATH_COERCEVIAIO: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionBoundInfoData {
+    pub strategy: PartitionStrategy::Type,
+    pub ndatums: ::core::ffi::c_int,
+    pub datums: *mut *mut Datum,
+    pub kind: *mut *mut PartitionRangeDatumKind::Type,
+    pub interleaved_parts: *mut Bitmapset,
+    pub nindexes: ::core::ffi::c_int,
+    pub indexes: *mut ::core::ffi::c_int,
+    pub null_index: ::core::ffi::c_int,
+    pub default_index: ::core::ffi::c_int,
+}
+impl Default for PartitionBoundInfoData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionDescData {
+    pub nparts: ::core::ffi::c_int,
+    pub detached_exist: bool,
+    pub oids: *mut Oid,
+    pub is_leaf: *mut bool,
+    pub boundinfo: PartitionBoundInfo,
+    pub last_found_datum_index: ::core::ffi::c_int,
+    pub last_found_part_index: ::core::ffi::c_int,
+    pub last_found_count: ::core::ffi::c_int,
+}
+impl Default for PartitionDescData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionPruneContext {
+    pub strategy: ::core::ffi::c_char,
+    pub partnatts: ::core::ffi::c_int,
+    pub nparts: ::core::ffi::c_int,
+    pub boundinfo: PartitionBoundInfo,
+    pub partcollation: *mut Oid,
+    pub partsupfunc: *mut FmgrInfo,
+    pub stepcmpfuncs: *mut FmgrInfo,
+    pub ppccontext: MemoryContext,
+    pub planstate: *mut PlanState,
+    pub exprcontext: *mut ExprContext,
+    pub exprstates: *mut *mut ExprState,
+}
+impl Default for PartitionPruneContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -28830,30 +29049,31 @@ impl Default for PLpgSQL_execstate {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PLpgSQL_plugin {
     pub func_setup: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub stmt_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
     pub stmt_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
-    pub error_callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub error_callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub assign_expr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             expr: *mut PLpgSQL_expr,
         ),
     >,
     pub assign_value: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             value: Datum,
@@ -28863,7 +29083,7 @@ pub struct PLpgSQL_plugin {
         ),
     >,
     pub eval_datum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             datum: *mut PLpgSQL_datum,
             typeId: *mut Oid,
@@ -28873,7 +29093,7 @@ pub struct PLpgSQL_plugin {
         ),
     >,
     pub cast_value: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             value: Datum,
             isnull: *mut bool,
@@ -29182,7 +29402,7 @@ impl Default for ReorderBufferTXN {
     }
 }
 pub type ReorderBufferApplyChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -29190,7 +29410,7 @@ pub type ReorderBufferApplyChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -29199,17 +29419,17 @@ pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -29220,24 +29440,24 @@ pub type ReorderBufferMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -29245,30 +29465,42 @@ pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, first_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        first_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, last_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        last_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, abort_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        abort_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -29276,7 +29508,7 @@ pub type ReorderBufferStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -29287,7 +29519,7 @@ pub type ReorderBufferStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -29296,7 +29528,11 @@ pub type ReorderBufferStreamTruncateCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferUpdateProgressTxnCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        lsn: XLogRecPtr,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -29374,19 +29610,19 @@ impl Default for OutputPluginOptions {
     }
 }
 pub type LogicalOutputPluginInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut OutputPluginCallbacks)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut OutputPluginCallbacks)>;
 pub type LogicalDecodeStartupCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         options: *mut OutputPluginOptions,
         is_init: bool,
     ),
 >;
 pub type LogicalDecodeBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -29394,7 +29630,7 @@ pub type LogicalDecodeChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -29403,14 +29639,14 @@ pub type LogicalDecodeTruncateCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -29421,36 +29657,36 @@ pub type LogicalDecodeMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeFilterByOriginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
 >;
 pub type LogicalDecodeShutdownCB =
-    ::core::option::Option<unsafe extern "C" fn(ctx: *mut LogicalDecodingContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext)>;
 pub type LogicalDecodeFilterPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         xid: TransactionId,
         gid: *const ::core::ffi::c_char,
     ) -> bool,
 >;
 pub type LogicalDecodeBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodePrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -29458,34 +29694,34 @@ pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         abort_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -29493,7 +29729,7 @@ pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -29504,7 +29740,7 @@ pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -29615,11 +29851,20 @@ impl Default for LogicalRepTyp {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LogicalRepBeginData {
     pub final_lsn: XLogRecPtr,
     pub committime: TimestampTz,
     pub xid: TransactionId,
+}
+impl Default for LogicalRepBeginData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -29684,12 +29929,21 @@ impl Default for LogicalRepRollbackPreparedTxnData {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LogicalRepStreamAbortData {
     pub xid: TransactionId,
     pub subxid: TransactionId,
     pub abort_lsn: XLogRecPtr,
     pub abort_time: TimestampTz,
+}
+impl Default for LogicalRepStreamAbortData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub mod CRSSnapshotAction {
     pub type Type = ::core::ffi::c_uint;
@@ -29831,7 +30085,7 @@ impl Default for WalRcvExecResult {
     }
 }
 pub type walrcv_connect_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conninfo: *const ::core::ffi::c_char,
         logical: bool,
         must_use_password: bool,
@@ -29840,28 +30094,29 @@ pub type walrcv_connect_fn = ::core::option::Option<
     ) -> *mut WalReceiverConn,
 >;
 pub type walrcv_check_conninfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(conninfo: *const ::core::ffi::c_char, must_use_password: bool),
+    unsafe extern "C-unwind" fn(conninfo: *const ::core::ffi::c_char, must_use_password: bool),
 >;
 pub type walrcv_get_conninfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_senderinfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         sender_host: *mut *mut ::core::ffi::c_char,
         sender_port: *mut ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_identify_system_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         primary_tli: *mut TimeLineID,
     ) -> *mut ::core::ffi::c_char,
 >;
-pub type walrcv_server_version_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int>;
+pub type walrcv_server_version_fn = ::core::option::Option<
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int,
+>;
 pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         tli: TimeLineID,
         filename: *mut *mut ::core::ffi::c_char,
@@ -29870,27 +30125,30 @@ pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
     ),
 >;
 pub type walrcv_startstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, options: *const WalRcvStreamOptions) -> bool,
+    unsafe extern "C-unwind" fn(
+        conn: *mut WalReceiverConn,
+        options: *const WalRcvStreamOptions,
+    ) -> bool,
 >;
 pub type walrcv_endstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
 >;
 pub type walrcv_receive_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *mut *mut ::core::ffi::c_char,
         wait_fd: *mut pgsocket,
     ) -> ::core::ffi::c_int,
 >;
 pub type walrcv_send_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *const ::core::ffi::c_char,
         nbytes: ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_create_slot_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         slotname: *const ::core::ffi::c_char,
         temporary: bool,
@@ -29900,9 +30158,9 @@ pub type walrcv_create_slot_fn = ::core::option::Option<
     ) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_backend_pid_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> pid_t>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> pid_t>;
 pub type walrcv_exec_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         query: *const ::core::ffi::c_char,
         nRetTypes: ::core::ffi::c_int,
@@ -29910,7 +30168,7 @@ pub type walrcv_exec_fn = ::core::option::Option<
     ) -> *mut WalRcvExecResult,
 >;
 pub type walrcv_disconnect_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WalReceiverFunctionsType {
@@ -30009,7 +30267,7 @@ impl Default for ReplicationSlotCtlData {
     }
 }
 pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -30018,7 +30276,7 @@ pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
 >;
 pub type LogicalOutputPluginWriterPrepareWrite = LogicalOutputPluginWriterWrite;
 pub type LogicalOutputPluginWriterUpdateProgress = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -30098,16 +30356,117 @@ impl Default for RowSecurityDesc {
     }
 }
 pub type row_security_policy_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
+    unsafe extern "C-unwind" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct buftag {
+    pub spcOid: Oid,
+    pub dbOid: Oid,
+    pub relNumber: RelFileNumber,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+}
+impl Default for buftag {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type BufferTag = buftag;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufferDesc {
+    pub tag: BufferTag,
+    pub buf_id: ::core::ffi::c_int,
+    pub state: pg_atomic_uint32,
+    pub wait_backend_pgprocno: ::core::ffi::c_int,
+    pub freeNext: ::core::ffi::c_int,
+    pub content_lock: LWLock,
+}
+impl Default for BufferDesc {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union BufferDescPadded {
+    pub bufferdesc: BufferDesc,
+    pub pad: [::core::ffi::c_char; 64usize],
+}
+impl Default for BufferDescPadded {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PendingWriteback {
+    pub tag: BufferTag,
+}
+impl Default for PendingWriteback {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WritebackContext {
+    pub max_pending: *mut ::core::ffi::c_int,
+    pub nr_pending: ::core::ffi::c_int,
+    pub pending_writebacks: [PendingWriteback; 256usize],
+}
+impl Default for WritebackContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CkptSortItem {
+    pub tsId: Oid,
+    pub relNumber: RelFileNumber,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+    pub buf_id: ::core::ffi::c_int,
+}
+impl Default for CkptSortItem {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BufFile {
     _unused: [u8; 0],
 }
 pub type pg_on_exit_callback =
-    ::core::option::Option<unsafe extern "C" fn(code: ::core::ffi::c_int, arg: Datum)>;
-pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: ::core::ffi::c_int, arg: Datum)>;
+pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub mod XLTW_Oper {
     pub type Type = ::core::ffi::c_uint;
     pub const XLTW_None: Type = 0;
@@ -30158,7 +30517,7 @@ impl Default for xl_standby_locks {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_running_xacts {
     pub xcnt: ::core::ffi::c_int,
     pub subxcnt: ::core::ffi::c_int,
@@ -30167,6 +30526,15 @@ pub struct xl_running_xacts {
     pub oldestRunningXid: TransactionId,
     pub latestCompletedXid: TransactionId,
     pub xids: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_running_xacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 pub struct xl_invalidations {
@@ -30245,7 +30613,7 @@ impl Default for AlterTableUtilityContext {
     }
 }
 pub type ProcessUtility_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstmt: *mut PlannedStmt,
         queryString: *const ::core::ffi::c_char,
         readOnlyTree: bool,
@@ -30256,6 +30624,97 @@ pub type ProcessUtility_hook_type = ::core::option::Option<
         qc: *mut QueryCompletion,
     ),
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSAnyCacheEntry {
+    pub objId: Oid,
+    pub isvalid: bool,
+}
+impl Default for TSAnyCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSParserCacheEntry {
+    pub prsId: Oid,
+    pub isvalid: bool,
+    pub startOid: Oid,
+    pub tokenOid: Oid,
+    pub endOid: Oid,
+    pub headlineOid: Oid,
+    pub lextypeOid: Oid,
+    pub prsstart: FmgrInfo,
+    pub prstoken: FmgrInfo,
+    pub prsend: FmgrInfo,
+    pub prsheadline: FmgrInfo,
+}
+impl Default for TSParserCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSDictionaryCacheEntry {
+    pub dictId: Oid,
+    pub isvalid: bool,
+    pub lexizeOid: Oid,
+    pub lexize: FmgrInfo,
+    pub dictCtx: MemoryContext,
+    pub dictData: *mut ::core::ffi::c_void,
+}
+impl Default for TSDictionaryCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ListDictionary {
+    pub len: ::core::ffi::c_int,
+    pub dictIds: *mut Oid,
+}
+impl Default for ListDictionary {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSConfigCacheEntry {
+    pub cfgId: Oid,
+    pub isvalid: bool,
+    pub prsId: Oid,
+    pub lenmap: ::core::ffi::c_int,
+    pub map: *mut ListDictionary,
+}
+impl Default for TSConfigCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WordEntry {
@@ -30958,7 +31417,7 @@ pub struct TSQueryParserStateData {
 }
 pub type TSQueryParserState = *mut TSQueryParserStateData;
 pub type PushFunction = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opaque: Datum,
         state: TSQueryParserState,
         token: *mut ::core::ffi::c_char,
@@ -31043,7 +31502,7 @@ impl Default for ExecPhraseData {
     }
 }
 pub type TSExecuteCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         arg: *mut ::core::ffi::c_void,
         val: *mut QueryOperand,
         data: *mut ExecPhraseData,
@@ -31439,9 +31898,10 @@ impl Default for AttStatsSlot {
     }
 }
 pub type get_attavgwidth_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(relid: Oid, attnum: AttrNumber) -> int32>;
-pub type CCHashFN = ::core::option::Option<unsafe extern "C" fn(datum: Datum) -> uint32>;
-pub type CCFastEqualFN = ::core::option::Option<unsafe extern "C" fn(a: Datum, b: Datum) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(relid: Oid, attnum: AttrNumber) -> int32>;
+pub type CCHashFN = ::core::option::Option<unsafe extern "C-unwind" fn(datum: Datum) -> uint32>;
+pub type CCFastEqualFN =
+    ::core::option::Option<unsafe extern "C-unwind" fn(a: Datum, b: Datum) -> bool>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct catcache {
@@ -31580,7 +32040,7 @@ pub struct VariableStatData {
     pub var: *mut Node,
     pub rel: *mut RelOptInfo,
     pub statsTuple: HeapTuple,
-    pub freefunc: ::core::option::Option<unsafe extern "C" fn(tuple: HeapTuple)>,
+    pub freefunc: ::core::option::Option<unsafe extern "C-unwind" fn(tuple: HeapTuple)>,
     pub vartype: Oid,
     pub atttype: Oid,
     pub atttypmod: int32,
@@ -31609,7 +32069,7 @@ pub struct GenericCosts {
     pub num_sa_scans: f64,
 }
 pub type get_relation_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rte: *mut RangeTblEntry,
         attnum: AttrNumber,
@@ -31617,7 +32077,7 @@ pub type get_relation_stats_hook_type = ::core::option::Option<
     ) -> bool,
 >;
 pub type get_index_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         indexOid: Oid,
         indexattnum: AttrNumber,
@@ -31848,7 +32308,7 @@ pub struct SnapBuild {
     pub _address: u8,
 }
 #[pgrx_macros::pg_guard]
-unsafe extern "C" {
+unsafe extern "C-unwind" {
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         fileName: *const ::core::ffi::c_char,
@@ -32043,7 +32503,7 @@ unsafe extern "C" {
         nel: usize,
         elsize: usize,
         cmp: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
             ) -> ::core::ffi::c_int,
@@ -32073,7 +32533,7 @@ unsafe extern "C" {
         nmemb: usize,
         size: usize,
         compar: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
                 arg3: *mut ::core::ffi::c_void,
@@ -33838,9 +34298,9 @@ unsafe extern "C" {
     pub static pg_rightmost_one_pos: [uint8; 256usize];
     pub static pg_number_of_ones: [uint8; 256usize];
     pub static mut pg_popcount32:
-        ::core::option::Option<unsafe extern "C" fn(word: uint32) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint32) -> ::core::ffi::c_int>;
     pub static mut pg_popcount64:
-        ::core::option::Option<unsafe extern "C" fn(word: uint64) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint64) -> ::core::ffi::c_int>;
     pub fn pg_popcount(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int) -> uint64;
     pub fn tuplehash_create(
         ctx: MemoryContext,
@@ -35213,7 +35673,7 @@ unsafe extern "C" {
         len: usize,
     ) -> pg_crc32c;
     pub static mut pg_comp_crc32c: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             crc: pg_crc32c,
             data: *const ::core::ffi::c_void,
             len: usize,
@@ -35598,9 +36058,9 @@ unsafe extern "C" {
     pub fn SendSharedInvalidMessages(msgs: *const SharedInvalidationMessage, n: ::core::ffi::c_int);
     pub fn ReceiveSharedInvalidMessages(
         invalFunction: ::core::option::Option<
-            unsafe extern "C" fn(msg: *mut SharedInvalidationMessage),
+            unsafe extern "C-unwind" fn(msg: *mut SharedInvalidationMessage),
         >,
-        resetFunction: ::core::option::Option<unsafe extern "C" fn()>,
+        resetFunction: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     );
     pub fn HandleCatchupInterrupt();
     pub fn ProcessCatchupInterrupt();
@@ -35938,7 +36398,7 @@ unsafe extern "C" {
         oldtup_ptr: HeapTuple,
         buffer: Buffer,
         release_callback: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::core::ffi::c_void),
+            unsafe extern "C-unwind" fn(arg1: *mut ::core::ffi::c_void),
         >,
         arg: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -42510,6 +42970,99 @@ unsafe extern "C" {
         warn: bool,
     );
     pub fn scanner_isspace(ch: ::core::ffi::c_char) -> bool;
+    pub fn get_hash_partition_greatest_modulus(bound: PartitionBoundInfo) -> ::core::ffi::c_int;
+    pub fn compute_partition_hash_value(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        values: *mut Datum,
+        isnull: *mut bool,
+    ) -> uint64;
+    pub fn get_qual_from_partbound(parent: Relation, spec: *mut PartitionBoundSpec) -> *mut List;
+    pub fn partition_bounds_create(
+        boundspecs: *mut *mut PartitionBoundSpec,
+        nparts: ::core::ffi::c_int,
+        key: PartitionKey,
+        mapping: *mut *mut ::core::ffi::c_int,
+    ) -> PartitionBoundInfo;
+    pub fn partition_bounds_equal(
+        partnatts: ::core::ffi::c_int,
+        parttyplen: *mut int16,
+        parttypbyval: *mut bool,
+        b1: PartitionBoundInfo,
+        b2: PartitionBoundInfo,
+    ) -> bool;
+    pub fn partition_bounds_copy(src: PartitionBoundInfo, key: PartitionKey) -> PartitionBoundInfo;
+    pub fn partition_bounds_merge(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        outer_rel: *mut RelOptInfo,
+        inner_rel: *mut RelOptInfo,
+        jointype: JoinType::Type,
+        outer_parts: *mut *mut List,
+        inner_parts: *mut *mut List,
+    ) -> PartitionBoundInfo;
+    pub fn partitions_are_ordered(
+        boundinfo: PartitionBoundInfo,
+        live_parts: *mut Bitmapset,
+    ) -> bool;
+    pub fn check_new_partition_bound(
+        relname: *mut ::core::ffi::c_char,
+        parent: Relation,
+        spec: *mut PartitionBoundSpec,
+        pstate: *mut ParseState,
+    );
+    pub fn check_default_partition_contents(
+        parent: Relation,
+        default_rel: Relation,
+        new_spec: *mut PartitionBoundSpec,
+    );
+    pub fn partition_rbound_datum_cmp(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        rb_datums: *mut Datum,
+        rb_kind: *mut PartitionRangeDatumKind::Type,
+        tuple_datums: *mut Datum,
+        n_tuple_datums: ::core::ffi::c_int,
+    ) -> int32;
+    pub fn partition_list_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        value: Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_range_datum_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        nvalues: ::core::ffi::c_int,
+        values: *mut Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_hash_bsearch(
+        boundinfo: PartitionBoundInfo,
+        modulus: ::core::ffi::c_int,
+        remainder: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
+    pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
+        -> PartitionDirectory;
+    pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
+    pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
+    pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
+    pub fn make_partition_pruneinfo(
+        root: *mut PlannerInfo,
+        parentrel: *mut RelOptInfo,
+        subpaths: *mut List,
+        prunequal: *mut List,
+    ) -> *mut PartitionPruneInfo;
+    pub fn prune_append_rel_partitions(rel: *mut RelOptInfo) -> *mut Bitmapset;
+    pub fn get_matching_partitions(
+        context: *mut PartitionPruneContext,
+        pruning_steps: *mut List,
+    ) -> *mut Bitmapset;
     pub fn make_expanded_record_from_typeid(
         type_id: Oid,
         typmod: int32,
@@ -43267,6 +43820,82 @@ unsafe extern "C" {
         hasRowSecurity: *mut bool,
         hasSubLinks: *mut bool,
     );
+    pub static mut BufferDescriptors: *mut BufferDescPadded;
+    pub static mut BufferIOCVArray: *mut ConditionVariableMinimallyPadded;
+    pub static mut BackendWritebackContext: WritebackContext;
+    pub static mut LocalBufferDescriptors: *mut BufferDesc;
+    pub fn LockBufHdr(desc: *mut BufferDesc) -> uint32;
+    pub static mut CkptBufferIds: *mut CkptSortItem;
+    pub fn WritebackContextInit(
+        context: *mut WritebackContext,
+        max_pending: *mut ::core::ffi::c_int,
+    );
+    pub fn IssuePendingWritebacks(wb_context: *mut WritebackContext, io_context: IOContext::Type);
+    pub fn ScheduleBufferTagForWriteback(
+        wb_context: *mut WritebackContext,
+        io_context: IOContext::Type,
+        tag: *mut BufferTag,
+    );
+    pub fn IOContextForStrategy(strategy: BufferAccessStrategy) -> IOContext::Type;
+    pub fn StrategyGetBuffer(
+        strategy: BufferAccessStrategy,
+        buf_state: *mut uint32,
+        from_ring: *mut bool,
+    ) -> *mut BufferDesc;
+    pub fn StrategyFreeBuffer(buf: *mut BufferDesc);
+    pub fn StrategyRejectBuffer(
+        strategy: BufferAccessStrategy,
+        buf: *mut BufferDesc,
+        from_ring: bool,
+    ) -> bool;
+    pub fn StrategySyncStart(
+        complete_passes: *mut uint32,
+        num_buf_alloc: *mut uint32,
+    ) -> ::core::ffi::c_int;
+    pub fn StrategyNotifyBgWriter(bgwprocno: ::core::ffi::c_int);
+    pub fn StrategyShmemSize() -> Size;
+    pub fn StrategyInitialize(init: bool);
+    pub fn have_free_buffer() -> bool;
+    pub fn BufTableShmemSize(size: ::core::ffi::c_int) -> Size;
+    pub fn InitBufTable(size: ::core::ffi::c_int);
+    pub fn BufTableHashCode(tagPtr: *mut BufferTag) -> uint32;
+    pub fn BufTableLookup(tagPtr: *mut BufferTag, hashcode: uint32) -> ::core::ffi::c_int;
+    pub fn BufTableInsert(
+        tagPtr: *mut BufferTag,
+        hashcode: uint32,
+        buf_id: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn BufTableDelete(tagPtr: *mut BufferTag, hashcode: uint32);
+    pub fn PinLocalBuffer(buf_hdr: *mut BufferDesc, adjust_usagecount: bool) -> bool;
+    pub fn UnpinLocalBuffer(buffer: Buffer);
+    pub fn PrefetchLocalBuffer(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+    ) -> PrefetchBufferResult;
+    pub fn LocalBufferAlloc(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+        foundPtr: *mut bool,
+    ) -> *mut BufferDesc;
+    pub fn ExtendBufferedRelLocal(
+        bmr: BufferManagerRelation,
+        fork: ForkNumber::Type,
+        flags: uint32,
+        extend_by: uint32,
+        extend_upto: BlockNumber,
+        buffers: *mut Buffer,
+        extended_by: *mut uint32,
+    ) -> BlockNumber;
+    pub fn MarkLocalBufferDirty(buffer: Buffer);
+    pub fn DropRelationLocalBuffers(
+        rlocator: RelFileLocator,
+        forkNum: ForkNumber::Type,
+        firstDelBlock: BlockNumber,
+    );
+    pub fn DropRelationAllLocalBuffers(rlocator: RelFileLocator);
+    pub fn AtEOXact_LocalBuffers(isCommit: bool);
     pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
     pub fn BufFileClose(file: *mut BufFile);
     pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::core::ffi::c_void, size: usize) -> usize;
@@ -43728,6 +44357,11 @@ unsafe extern "C" {
     pub fn CreateCommandTag(parsetree: *mut Node) -> CommandTag::Type;
     pub fn GetCommandLogLevel(parsetree: *mut Node) -> LogStmtLevel::Type;
     pub fn CommandIsReadOnly(pstmt: *mut PlannedStmt) -> bool;
+    pub static mut TSCurrentConfig: *mut ::core::ffi::c_char;
+    pub fn lookup_ts_parser_cache(prsId: Oid) -> *mut TSParserCacheEntry;
+    pub fn lookup_ts_dictionary_cache(dictId: Oid) -> *mut TSDictionaryCacheEntry;
+    pub fn lookup_ts_config_cache(cfgId: Oid) -> *mut TSConfigCacheEntry;
+    pub fn getTSCurrentConfig(emitError: bool) -> Oid;
     pub fn compareWordEntryPos(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
@@ -43741,7 +44375,9 @@ unsafe extern "C" {
         fname: *const ::core::ffi::c_char,
         s: *mut StopList,
         wordop: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const ::core::ffi::c_char) -> *mut ::core::ffi::c_char,
+            unsafe extern "C-unwind" fn(
+                arg1: *const ::core::ffi::c_char,
+            ) -> *mut ::core::ffi::c_char,
         >,
     );
     pub fn searchstoplist(s: *mut StopList, key: *mut ::core::ffi::c_char) -> bool;
@@ -47416,7 +48052,7 @@ unsafe extern "C" {
         tuple: HeapTuple,
         newtuple: HeapTuple,
         function: ::core::option::Option<
-            unsafe extern "C" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
+            unsafe extern "C-unwind" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
         >,
     );
     pub fn PrintCatCacheLeakWarning(tuple: HeapTuple);
@@ -47696,6 +48332,13 @@ unsafe extern "C" {
         useOr: bool,
         varRelid: ::core::ffi::c_int,
     ) -> Selectivity;
+    pub fn get_tablespace_page_costs(
+        spcid: Oid,
+        spc_random_page_cost: *mut float8,
+        spc_seq_page_cost: *mut float8,
+    );
+    pub fn get_tablespace_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
+    pub fn get_tablespace_maintenance_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
     pub fn InitCatalogCache();
     pub fn InitCatalogCachePhase2();
     pub fn SearchSysCache(

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -5,7 +5,7 @@ easy to reference on docs.rs. Bindings are regenerated for your
 build of pgrx, and the values of your Postgres version may differ.
 */
 use crate as pg_sys;
-use crate::{Datum, Oid, PgNode};
+use crate::{Datum, MultiXactId, Oid, PgNode, TransactionId};
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct __BindgenBitfieldUnit<Storage> {
@@ -2388,6 +2388,25 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const BUF_REFCOUNT_ONE: u32 = 1;
+pub const BUF_REFCOUNT_MASK: u32 = 262143;
+pub const BUF_USAGECOUNT_MASK: u32 = 3932160;
+pub const BUF_USAGECOUNT_ONE: u32 = 262144;
+pub const BUF_USAGECOUNT_SHIFT: u32 = 18;
+pub const BUF_FLAG_MASK: u32 = 4290772992;
+pub const BM_LOCKED: u32 = 4194304;
+pub const BM_DIRTY: u32 = 8388608;
+pub const BM_VALID: u32 = 16777216;
+pub const BM_TAG_VALID: u32 = 33554432;
+pub const BM_IO_IN_PROGRESS: u32 = 67108864;
+pub const BM_IO_ERROR: u32 = 134217728;
+pub const BM_JUST_DIRTIED: u32 = 268435456;
+pub const BM_PIN_COUNT_WAITER: u32 = 536870912;
+pub const BM_CHECKPOINT_NEEDED: u32 = 1073741824;
+pub const BM_PERMANENT: u32 = 2147483648;
+pub const BM_MAX_USAGE_COUNT: u32 = 5;
+pub const FREENEXT_END_OF_LIST: i32 = -1;
+pub const FREENEXT_NOT_IN_LIST: i32 = -2;
 pub const XLOG_STANDBY_LOCK: u32 = 0;
 pub const XLOG_RUNNING_XACTS: u32 = 16;
 pub const XLOG_INVALIDATIONS: u32 = 32;
@@ -6015,7 +6034,7 @@ pub type pid_t = __pid_t;
 pub struct __sigset_t {
     pub __val: [::core::ffi::c_ulong; 16usize],
 }
-pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C" fn()>;
+pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type Pointer = *mut ::core::ffi::c_char;
 pub type int8 = ::core::ffi::c_schar;
 pub type int16 = ::core::ffi::c_short;
@@ -6037,10 +6056,8 @@ pub type float4 = f32;
 pub type float8 = f64;
 pub type regproc = Oid;
 pub type RegProcedure = regproc;
-pub type TransactionId = uint32;
 pub type LocalTransactionId = uint32;
 pub type SubTransactionId = uint32;
-pub type MultiXactId = TransactionId;
 pub type MultiXactOffset = uint32;
 pub type CommandId = uint32;
 #[repr(C)]
@@ -6161,14 +6178,14 @@ impl Default for PGAlignedXLogBlock {
 }
 pub type pgsocket = ::core::ffi::c_int;
 pub type qsort_arg_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
         arg: *mut ::core::ffi::c_void,
     ) -> ::core::ffi::c_int,
 >;
 pub type pqsigfunc =
-    ::core::option::Option<unsafe extern "C" fn(postgres_signal_arg: ::core::ffi::c_int)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(postgres_signal_arg: ::core::ffi::c_int)>;
 pub type __jmp_buf = [::core::ffi::c_long; 8usize];
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -6200,7 +6217,8 @@ pub type StringInfo = *mut StringInfoData;
 #[derive(Debug, Copy, Clone)]
 pub struct ErrorContextCallback {
     pub previous: *mut ErrorContextCallback,
-    pub callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub arg: *mut ::core::ffi::c_void,
 }
 impl Default for ErrorContextCallback {
@@ -6253,7 +6271,8 @@ impl Default for ErrorData {
         }
     }
 }
-pub type emit_log_hook_type = ::core::option::Option<unsafe extern "C" fn(edata: *mut ErrorData)>;
+pub type emit_log_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(edata: *mut ErrorData)>;
 pub mod PGErrorVerbosity {
     pub type Type = ::core::ffi::c_uint;
     pub const PGERROR_TERSE: Type = 0;
@@ -6262,7 +6281,7 @@ pub mod PGErrorVerbosity {
 }
 pub type MemoryContext = *mut MemoryContextData;
 pub type MemoryContextCallbackFunction =
-    ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryContextCallback {
@@ -7039,7 +7058,7 @@ impl Default for ForFiveState {
     }
 }
 pub type list_sort_comparator = ::core::option::Option<
-    unsafe extern "C" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(a: *const ListCell, b: *const ListCell) -> ::core::ffi::c_int,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7357,7 +7376,7 @@ pub struct PageXLogRecPtr {
     pub xrecoff: uint32,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PageHeaderData {
     pub pd_lsn: PageXLogRecPtr,
     pub pd_checksum: uint16,
@@ -7368,6 +7387,15 @@ pub struct PageHeaderData {
     pub pd_pagesize_version: uint16,
     pub pd_prune_xid: TransactionId,
     pub pd_linp: __IncompleteArrayField<ItemIdData>,
+}
+impl Default for PageHeaderData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub type PageHeader = *mut PageHeaderData;
 #[repr(C)]
@@ -7586,33 +7614,35 @@ impl Default for TupleTableSlot {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct TupleTableSlotOps {
     pub base_slot_size: usize,
-    pub init: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub release: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
-    pub clear: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+    pub init: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub release: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
+    pub clear: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub getsomeattrs: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, natts: ::core::ffi::c_int),
     >,
     pub getsysattr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             slot: *mut TupleTableSlot,
             attnum: ::core::ffi::c_int,
             isnull: *mut bool,
         ) -> Datum,
     >,
     pub is_current_xact_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> bool>,
-    pub materialize: ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> bool>,
+    pub materialize: ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot)>,
     pub copyslot: ::core::option::Option<
-        unsafe extern "C" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
+        unsafe extern "C-unwind" fn(dstslot: *mut TupleTableSlot, srcslot: *mut TupleTableSlot),
     >,
     pub get_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub get_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub get_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
     pub copy_heap_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
-    pub copy_minimal_tuple:
-        ::core::option::Option<unsafe extern "C" fn(slot: *mut TupleTableSlot) -> MinimalTuple>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> HeapTuple>,
+    pub copy_minimal_tuple: ::core::option::Option<
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot) -> MinimalTuple,
+    >,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7802,11 +7832,12 @@ pub struct WorkerInstrumentation {
 }
 pub type fmNodePtr = *mut Node;
 pub type fmAggrefPtr = *mut Aggref;
-pub type fmExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type fmExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 pub type fmStringInfo = *mut StringInfoData;
 pub type FunctionCallInfo = *mut FunctionCallInfoBaseData;
 pub type PGFunction =
-    ::core::option::Option<unsafe extern "C" fn(fcinfo: FunctionCallInfo) -> Datum>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(fcinfo: FunctionCallInfo) -> Datum>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FmgrInfo {
@@ -7854,7 +7885,8 @@ impl Default for FunctionCallInfoBaseData {
 pub struct Pg_finfo_record {
     pub api_version: ::core::ffi::c_int,
 }
-pub type PGFInfoFunction = ::core::option::Option<unsafe extern "C" fn() -> *const Pg_finfo_record>;
+pub type PGFInfoFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_finfo_record>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Pg_magic_struct {
@@ -7867,16 +7899,21 @@ pub struct Pg_magic_struct {
     pub abi_extra: [::core::ffi::c_char; 32usize],
 }
 pub type PGModuleMagicFunction =
-    ::core::option::Option<unsafe extern "C" fn() -> *const Pg_magic_struct>;
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const Pg_magic_struct>;
 pub mod FmgrHookEventType {
     pub type Type = ::core::ffi::c_uint;
     pub const FHET_START: Type = 0;
     pub const FHET_END: Type = 1;
     pub const FHET_ABORT: Type = 2;
 }
-pub type needs_fmgr_hook_type = ::core::option::Option<unsafe extern "C" fn(fn_oid: Oid) -> bool>;
+pub type needs_fmgr_hook_type =
+    ::core::option::Option<unsafe extern "C-unwind" fn(fn_oid: Oid) -> bool>;
 pub type fmgr_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(event: FmgrHookEventType::Type, flinfo: *mut FmgrInfo, arg: *mut Datum),
+    unsafe extern "C-unwind" fn(
+        event: FmgrHookEventType::Type,
+        flinfo: *mut FmgrInfo,
+        arg: *mut Datum,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -8028,7 +8065,7 @@ impl Default for pairingheap_node {
     }
 }
 pub type pairingheap_comparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const pairingheap_node,
         b: *const pairingheap_node,
         arg: *mut ::core::ffi::c_void,
@@ -8086,7 +8123,7 @@ impl Default for ParamExternData {
 }
 pub type ParamListInfo = *mut ParamListInfoData;
 pub type ParamFetchHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         paramid: ::core::ffi::c_int,
         speculative: bool,
@@ -8094,7 +8131,7 @@ pub type ParamFetchHook = ::core::option::Option<
     ) -> *mut ParamExternData,
 >;
 pub type ParamCompileHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         params: ParamListInfo,
         param: *mut Param,
         state: *mut ExprState,
@@ -8103,7 +8140,7 @@ pub type ParamCompileHook = ::core::option::Option<
     ),
 >;
 pub type ParserSetupHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, arg: *mut ::core::ffi::c_void),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -10721,7 +10758,7 @@ pub struct PGShmemHeader {
     _unused: [u8; 0],
 }
 pub type on_dsm_detach_callback =
-    ::core::option::Option<unsafe extern "C" fn(arg1: *mut dsm_segment, arg: Datum)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut dsm_segment, arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dsa_area {
@@ -10753,11 +10790,6 @@ pub struct TBMIterateResult {
     pub recheck: bool,
     pub offsets: __IncompleteArrayField<OffsetNumber>,
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionBoundInfoData {
-    _unused: [u8; 0],
-}
 pub type PartitionBoundInfo = *mut PartitionBoundInfoData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10765,11 +10797,6 @@ pub struct PartitionKeyData {
     _unused: [u8; 0],
 }
 pub type PartitionKey = *mut PartitionKeyData;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PartitionDescData {
-    _unused: [u8; 0],
-}
 pub type PartitionDesc = *mut PartitionDescData;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -10838,24 +10865,24 @@ impl Default for ConditionVariableMinimallyPadded {
     }
 }
 pub type HashValueFunc = ::core::option::Option<
-    unsafe extern "C" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
+    unsafe extern "C-unwind" fn(key: *const ::core::ffi::c_void, keysize: Size) -> uint32,
 >;
 pub type HashCompareFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         key1: *const ::core::ffi::c_void,
         key2: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> ::core::ffi::c_int,
 >;
 pub type HashCopyFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         dest: *mut ::core::ffi::c_void,
         src: *const ::core::ffi::c_void,
         keysize: Size,
     ) -> *mut ::core::ffi::c_void,
 >;
 pub type HashAllocFunc =
-    ::core::option::Option<unsafe extern "C" fn(request: Size) -> *mut ::core::ffi::c_void>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(request: Size) -> *mut ::core::ffi::c_void>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct HASHELEMENT {
@@ -11204,16 +11231,17 @@ pub struct SortSupportData {
     pub ssup_attno: AttrNumber,
     pub ssup_extra: *mut ::core::ffi::c_void,
     pub comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
     pub abbreviate: bool,
-    pub abbrev_converter:
-        ::core::option::Option<unsafe extern "C" fn(original: Datum, ssup: SortSupport) -> Datum>,
+    pub abbrev_converter: ::core::option::Option<
+        unsafe extern "C-unwind" fn(original: Datum, ssup: SortSupport) -> Datum,
+    >,
     pub abbrev_abort: ::core::option::Option<
-        unsafe extern "C" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
+        unsafe extern "C-unwind" fn(memtupcount: ::core::ffi::c_int, ssup: SortSupport) -> bool,
     >,
     pub abbrev_full_comparator: ::core::option::Option<
-        unsafe extern "C" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
+        unsafe extern "C-unwind" fn(x: Datum, y: Datum, ssup: SortSupport) -> ::core::ffi::c_int,
     >,
 }
 impl Default for SortSupportData {
@@ -11303,7 +11331,7 @@ pub struct IndexBulkDeleteResult {
     pub pages_free: BlockNumber,
 }
 pub type IndexBulkDeleteCallback = ::core::option::Option<
-    unsafe extern "C" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(itemptr: ItemPointer, state: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type IndexScanDesc = *mut IndexScanDescData;
 pub type SysScanDesc = *mut SysScanDescData;
@@ -11366,16 +11394,16 @@ impl Default for OpFamilyMember {
     }
 }
 pub type ambuild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         heapRelation: Relation,
         indexRelation: Relation,
         indexInfo: *mut IndexInfo,
     ) -> *mut IndexBuildResult,
 >;
 pub type ambuildempty_function =
-    ::core::option::Option<unsafe extern "C" fn(indexRelation: Relation)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexRelation: Relation)>;
 pub type aminsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         values: *mut Datum,
         isnull: *mut bool,
@@ -11387,10 +11415,10 @@ pub type aminsert_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type aminsertcleanup_function = ::core::option::Option<
-    unsafe extern "C" fn(indexRelation: Relation, indexInfo: *mut IndexInfo),
+    unsafe extern "C-unwind" fn(indexRelation: Relation, indexInfo: *mut IndexInfo),
 >;
 pub type ambulkdelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
         callback: IndexBulkDeleteCallback,
@@ -11398,16 +11426,16 @@ pub type ambulkdelete_function = ::core::option::Option<
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amvacuumcleanup_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         info: *mut IndexVacuumInfo,
         stats: *mut IndexBulkDeleteResult,
     ) -> *mut IndexBulkDeleteResult,
 >;
 pub type amcanreturn_function = ::core::option::Option<
-    unsafe extern "C" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(indexRelation: Relation, attno: ::core::ffi::c_int) -> bool,
 >;
 pub type amcostestimate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         path: *mut IndexPath,
         loop_count: f64,
@@ -11418,10 +11446,11 @@ pub type amcostestimate_function = ::core::option::Option<
         indexPages: *mut f64,
     ),
 >;
-pub type amoptions_function =
-    ::core::option::Option<unsafe extern "C" fn(reloptions: Datum, validate: bool) -> *mut bytea>;
+pub type amoptions_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(reloptions: Datum, validate: bool) -> *mut bytea,
+>;
 pub type amproperty_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index_oid: Oid,
         attno: ::core::ffi::c_int,
         prop: IndexAMProperty::Type,
@@ -11430,12 +11459,13 @@ pub type amproperty_function = ::core::option::Option<
         isnull: *mut bool,
     ) -> bool,
 >;
-pub type ambuildphasename_function =
-    ::core::option::Option<unsafe extern "C" fn(phasenum: int64) -> *mut ::core::ffi::c_char>;
+pub type ambuildphasename_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(phasenum: int64) -> *mut ::core::ffi::c_char,
+>;
 pub type amvalidate_function =
-    ::core::option::Option<unsafe extern "C" fn(opclassoid: Oid) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(opclassoid: Oid) -> bool>;
 pub type amadjustmembers_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opfamilyoid: Oid,
         opclassoid: Oid,
         operators: *mut List,
@@ -11443,14 +11473,14 @@ pub type amadjustmembers_function = ::core::option::Option<
     ),
 >;
 pub type ambeginscan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         indexRelation: Relation,
         nkeys: ::core::ffi::c_int,
         norderbys: ::core::ffi::c_int,
     ) -> IndexScanDesc,
 >;
 pub type amrescan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         scan: IndexScanDesc,
         keys: ScanKey,
         nkeys: ::core::ffi::c_int,
@@ -11459,20 +11489,24 @@ pub type amrescan_function = ::core::option::Option<
     ),
 >;
 pub type amgettuple_function = ::core::option::Option<
-    unsafe extern "C" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, direction: ScanDirection::Type) -> bool,
 >;
-pub type amgetbitmap_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64>;
-pub type amendscan_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type ammarkpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
-pub type amrestrpos_function = ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
+pub type amgetbitmap_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(scan: IndexScanDesc, tbm: *mut TIDBitmap) -> int64,
+>;
+pub type amendscan_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type ammarkpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
+pub type amrestrpos_function =
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
 pub type amestimateparallelscan_function = ::core::option::Option<
-    unsafe extern "C" fn(nkeys: ::core::ffi::c_int, norderbys: ::core::ffi::c_int) -> Size,
+    unsafe extern "C-unwind" fn(nkeys: ::core::ffi::c_int, norderbys: ::core::ffi::c_int) -> Size,
 >;
 pub type aminitparallelscan_function =
-    ::core::option::Option<unsafe extern "C" fn(target: *mut ::core::ffi::c_void)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(target: *mut ::core::ffi::c_void)>;
 pub type amparallelrescan_function =
-    ::core::option::Option<unsafe extern "C" fn(scan: IndexScanDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(scan: IndexScanDesc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IndexAmRoutine {
@@ -11654,8 +11688,9 @@ impl Default for BrinDesc {
         }
     }
 }
-pub type brin_serialize_callback_type =
-    ::core::option::Option<unsafe extern "C" fn(bdesc: *mut BrinDesc, src: Datum, dst: *mut Datum)>;
+pub type brin_serialize_callback_type = ::core::option::Option<
+    unsafe extern "C-unwind" fn(bdesc: *mut BrinDesc, src: Datum, dst: *mut Datum),
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BrinValues {
@@ -11805,7 +11840,7 @@ impl Default for SortTuple {
     }
 }
 pub type SortTupleComparator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         a: *const SortTuple,
         b: *const SortTuple,
         state: *mut Tuplesortstate,
@@ -11817,28 +11852,28 @@ pub struct TuplesortPublic {
     pub comparetup: SortTupleComparator,
     pub comparetup_tiebreak: SortTupleComparator,
     pub removeabbrev: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             state: *mut Tuplesortstate,
             stups: *mut SortTuple,
             count: ::core::ffi::c_int,
         ),
     >,
     pub writetup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             state: *mut Tuplesortstate,
             tape: *mut LogicalTape,
             stup: *mut SortTuple,
         ),
     >,
     pub readtup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             state: *mut Tuplesortstate,
             stup: *mut SortTuple,
             tape: *mut LogicalTape,
             len: ::core::ffi::c_uint,
         ),
     >,
-    pub freestate: ::core::option::Option<unsafe extern "C" fn(state: *mut Tuplesortstate)>,
+    pub freestate: ::core::option::Option<unsafe extern "C-unwind" fn(state: *mut Tuplesortstate)>,
     pub maincontext: MemoryContext,
     pub sortcontext: MemoryContext,
     pub tuplecontext: MemoryContext,
@@ -11875,7 +11910,7 @@ pub struct CopyMultiInsertBuffer {
     _unused: [u8; 0],
 }
 pub type ExprStateEvalFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         expression: *mut ExprState,
         econtext: *mut ExprContext,
         isNull: *mut bool,
@@ -11951,7 +11986,8 @@ impl Default for IndexInfo {
         }
     }
 }
-pub type ExprContextCallbackFunction = ::core::option::Option<unsafe extern "C" fn(arg: Datum)>;
+pub type ExprContextCallbackFunction =
+    ::core::option::Option<unsafe extern "C-unwind" fn(arg: Datum)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExprContext_CB {
@@ -12488,8 +12524,9 @@ impl Default for JsonExprState {
         }
     }
 }
-pub type ExecProcNodeMtd =
-    ::core::option::Option<unsafe extern "C" fn(pstate: *mut PlanState) -> *mut TupleTableSlot>;
+pub type ExecProcNodeMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(pstate: *mut PlanState) -> *mut TupleTableSlot,
+>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PlanState {
@@ -12668,7 +12705,7 @@ pub struct AppendState {
     pub as_valid_subplans: *mut Bitmapset,
     pub as_valid_asyncplans: *mut Bitmapset,
     pub choose_next_subplan:
-        ::core::option::Option<unsafe extern "C" fn(arg1: *mut AppendState) -> bool>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg1: *mut AppendState) -> bool>,
 }
 impl Default for AppendState {
     fn default() -> Self {
@@ -14127,17 +14164,17 @@ pub type DestReceiver = _DestReceiver;
 #[derive(Debug, Copy, Clone)]
 pub struct _DestReceiver {
     pub receiveSlot: ::core::option::Option<
-        unsafe extern "C" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
+        unsafe extern "C-unwind" fn(slot: *mut TupleTableSlot, self_: *mut DestReceiver) -> bool,
     >,
     pub rStartup: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             self_: *mut DestReceiver,
             operation: ::core::ffi::c_int,
             typeinfo: TupleDesc,
         ),
     >,
-    pub rShutdown: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
-    pub rDestroy: ::core::option::Option<unsafe extern "C" fn(self_: *mut DestReceiver)>,
+    pub rShutdown: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
+    pub rDestroy: ::core::option::Option<unsafe extern "C-unwind" fn(self_: *mut DestReceiver)>,
     pub mydest: CommandDest::Type,
 }
 impl Default for _DestReceiver {
@@ -18407,7 +18444,7 @@ pub struct MemoryContextCounters {
     pub freespace: Size,
 }
 pub type MemoryStatsPrintFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         context: MemoryContext,
         passthru: *mut ::core::ffi::c_void,
         stats_string: *const ::core::ffi::c_char,
@@ -18418,30 +18455,33 @@ pub type MemoryStatsPrintFunc = ::core::option::Option<
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MemoryContextMethods {
     pub alloc: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             size: Size,
             flags: ::core::ffi::c_int,
         ) -> *mut ::core::ffi::c_void,
     >,
-    pub free_p: ::core::option::Option<unsafe extern "C" fn(pointer: *mut ::core::ffi::c_void)>,
+    pub free_p:
+        ::core::option::Option<unsafe extern "C-unwind" fn(pointer: *mut ::core::ffi::c_void)>,
     pub realloc: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             pointer: *mut ::core::ffi::c_void,
             size: Size,
             flags: ::core::ffi::c_int,
         ) -> *mut ::core::ffi::c_void,
     >,
-    pub reset: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
-    pub delete_context: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub reset: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
+    pub delete_context: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
     pub get_chunk_context: ::core::option::Option<
-        unsafe extern "C" fn(pointer: *mut ::core::ffi::c_void) -> MemoryContext,
+        unsafe extern "C-unwind" fn(pointer: *mut ::core::ffi::c_void) -> MemoryContext,
     >,
-    pub get_chunk_space:
-        ::core::option::Option<unsafe extern "C" fn(pointer: *mut ::core::ffi::c_void) -> Size>,
-    pub is_empty: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext) -> bool>,
+    pub get_chunk_space: ::core::option::Option<
+        unsafe extern "C-unwind" fn(pointer: *mut ::core::ffi::c_void) -> Size,
+    >,
+    pub is_empty:
+        ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext) -> bool>,
     pub stats: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             context: MemoryContext,
             printfunc: MemoryStatsPrintFunc,
             passthru: *mut ::core::ffi::c_void,
@@ -18449,7 +18489,7 @@ pub struct MemoryContextMethods {
             print_to_stderr: bool,
         ),
     >,
-    pub check: ::core::option::Option<unsafe extern "C" fn(context: MemoryContext)>,
+    pub check: ::core::option::Option<unsafe extern "C-unwind" fn(context: MemoryContext)>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -18477,10 +18517,10 @@ impl Default for MemoryContextData {
     }
 }
 pub type ExecutorStart_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc, eflags: ::core::ffi::c_int),
 >;
 pub type ExecutorRun_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         queryDesc: *mut QueryDesc,
         direction: ScanDirection::Type,
         count: uint64,
@@ -18488,20 +18528,21 @@ pub type ExecutorRun_hook_type = ::core::option::Option<
     ),
 >;
 pub type ExecutorFinish_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorEnd_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(queryDesc: *mut QueryDesc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(queryDesc: *mut QueryDesc)>;
 pub type ExecutorCheckPerms_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rangeTable: *mut List,
         rtePermInfos: *mut List,
         ereport_on_violation: bool,
     ) -> bool,
 >;
-pub type ExecScanAccessMtd =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ScanState) -> *mut TupleTableSlot>;
+pub type ExecScanAccessMtd = ::core::option::Option<
+    unsafe extern "C-unwind" fn(node: *mut ScanState) -> *mut TupleTableSlot,
+>;
 pub type ExecScanRecheckMtd = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -18637,7 +18678,7 @@ pub mod ProcessingMode {
     pub const InitProcessing: Type = 1;
     pub const NormalProcessing: Type = 2;
 }
-pub type shmem_request_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
+pub type shmem_request_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub mod ProgressCommandType {
     pub type Type = ::core::ffi::c_uint;
     pub const PROGRESS_COMMAND_INVALID: Type = 0;
@@ -19465,7 +19506,7 @@ impl Default for RelFileLocatorBackend {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct XLogRecord {
     pub xl_tot_len: uint32,
     pub xl_xid: TransactionId,
@@ -19473,6 +19514,15 @@ pub struct XLogRecord {
     pub xl_info: uint8,
     pub xl_rmid: RmgrId,
     pub xl_crc: pg_crc32c,
+}
+impl Default for XLogRecord {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -19527,7 +19577,7 @@ impl Default for WALSegmentContext {
     }
 }
 pub type XLogPageReadCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         targetPagePtr: XLogRecPtr,
         reqLen: ::core::ffi::c_int,
@@ -19536,14 +19586,14 @@ pub type XLogPageReadCB = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type WALSegmentOpenCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         xlogreader: *mut XLogReaderState,
         nextSegNo: XLogSegNo,
         tli_p: *mut TimeLineID,
     ),
 >;
 pub type WALSegmentCloseCB =
-    ::core::option::Option<unsafe extern "C" fn(xlogreader: *mut XLogReaderState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(xlogreader: *mut XLogReaderState)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct XLogReaderRoutine {
@@ -20475,7 +20525,7 @@ pub mod XactEvent {
     pub const XACT_EVENT_PRE_PREPARE: Type = 7;
 }
 pub type XactCallback = ::core::option::Option<
-    unsafe extern "C" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(event: XactEvent::Type, arg: *mut ::core::ffi::c_void),
 >;
 pub mod SubXactEvent {
     pub type Type = ::core::ffi::c_uint;
@@ -20485,7 +20535,7 @@ pub mod SubXactEvent {
     pub const SUBXACT_EVENT_PRE_COMMIT_SUB: Type = 3;
 }
 pub type SubXactCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         event: SubXactEvent::Type,
         mySubid: SubTransactionId,
         parentSubid: SubTransactionId,
@@ -20500,11 +20550,20 @@ pub struct SavedTransactionCharacteristics {
     pub save_XactDeferrable: bool,
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_assignment {
     pub xtop: TransactionId,
     pub nsubxacts: ::core::ffi::c_int,
     pub xsub: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_assignment {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -20527,10 +20586,19 @@ impl Default for xl_xact_dbinfo {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_xact_subxacts {
     pub nsubxacts: ::core::ffi::c_int,
     pub subxacts: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_xact_subxacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -20593,9 +20661,18 @@ impl Default for xl_xact_invals {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct xl_xact_twophase {
     pub xid: TransactionId,
+}
+impl Default for xl_xact_twophase {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -20722,9 +20799,9 @@ pub struct ResourceOwnerDesc {
     pub name: *const ::core::ffi::c_char,
     pub release_phase: ResourceReleasePhase::Type,
     pub release_priority: ResourceReleasePriority,
-    pub ReleaseResource: ::core::option::Option<unsafe extern "C" fn(res: Datum)>,
+    pub ReleaseResource: ::core::option::Option<unsafe extern "C-unwind" fn(res: Datum)>,
     pub DebugPrint:
-        ::core::option::Option<unsafe extern "C" fn(res: Datum) -> *mut ::core::ffi::c_char>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(res: Datum) -> *mut ::core::ffi::c_char>,
 }
 impl Default for ResourceOwnerDesc {
     fn default() -> Self {
@@ -20736,7 +20813,7 @@ impl Default for ResourceOwnerDesc {
     }
 }
 pub type ResourceReleaseCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         phase: ResourceReleasePhase::Type,
         isCommit: bool,
         isTopLevel: bool,
@@ -20815,16 +20892,11 @@ impl Default for ReadBuffersOperation {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct WritebackContext {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct ReadStream {
     _unused: [u8; 0],
 }
 pub type ReadStreamBlockNumberCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stream: *mut ReadStream,
         callback_private_data: *mut ::core::ffi::c_void,
         per_buffer_data: *mut ::core::ffi::c_void,
@@ -20866,12 +20938,21 @@ pub mod TU_UpdateIndexes {
     pub const TU_Summarizing: Type = 2;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct TM_FailureData {
     pub ctid: ItemPointerData,
     pub xmax: TransactionId,
     pub cmax: CommandId,
     pub traversed: bool,
+}
+impl Default for TM_FailureData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -20908,7 +20989,7 @@ impl Default for TM_IndexDeleteOp {
     }
 }
 pub type IndexBuildCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         index: Relation,
         tid: ItemPointer,
         values: *mut Datum,
@@ -20921,10 +21002,11 @@ pub type IndexBuildCallback = ::core::option::Option<
 #[derive(Debug, Copy, Clone)]
 pub struct TableAmRoutine {
     pub type_: NodeTag,
-    pub slot_callbacks:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *const TupleTableSlotOps>,
+    pub slot_callbacks: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *const TupleTableSlotOps,
+    >,
     pub scan_begin: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             snapshot: Snapshot,
             nkeys: ::core::ffi::c_int,
@@ -20933,9 +21015,9 @@ pub struct TableAmRoutine {
             flags: uint32,
         ) -> TableScanDesc,
     >,
-    pub scan_end: ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc)>,
+    pub scan_end: ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc)>,
     pub scan_rescan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             key: *mut ScanKeyData,
             set_params: bool,
@@ -20945,36 +21027,39 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_getnextslot: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_set_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, mintid: ItemPointer, maxtid: ItemPointer),
     >,
     pub scan_getnextslot_tidrange: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             direction: ScanDirection::Type,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub parallelscan_estimate: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Size>,
+    pub parallelscan_estimate:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Size>,
     pub parallelscan_initialize: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc) -> Size,
     >,
-    pub parallelscan_reinitialize:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, pscan: ParallelTableScanDesc)>,
-    pub index_fetch_begin:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> *mut IndexFetchTableData>,
+    pub parallelscan_reinitialize: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, pscan: ParallelTableScanDesc),
+    >,
+    pub index_fetch_begin: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation) -> *mut IndexFetchTableData,
+    >,
     pub index_fetch_reset:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_end:
-        ::core::option::Option<unsafe extern "C" fn(data: *mut IndexFetchTableData)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(data: *mut IndexFetchTableData)>,
     pub index_fetch_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: *mut IndexFetchTableData,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -20984,25 +21069,33 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub tuple_fetch_row_version: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
-    pub tuple_tid_valid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer) -> bool>,
+    pub tuple_tid_valid: ::core::option::Option<
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer) -> bool,
+    >,
     pub tuple_get_latest_tid:
-        ::core::option::Option<unsafe extern "C" fn(scan: TableScanDesc, tid: ItemPointer)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(scan: TableScanDesc, tid: ItemPointer)>,
     pub tuple_satisfies_snapshot: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, slot: *mut TupleTableSlot, snapshot: Snapshot) -> bool,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            slot: *mut TupleTableSlot,
+            snapshot: Snapshot,
+        ) -> bool,
     >,
     pub index_delete_tuples: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, delstate: *mut TM_IndexDeleteOp) -> TransactionId,
+        unsafe extern "C-unwind" fn(
+            rel: Relation,
+            delstate: *mut TM_IndexDeleteOp,
+        ) -> TransactionId,
     >,
     pub tuple_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -21011,7 +21104,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_insert_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             cid: CommandId,
@@ -21021,7 +21114,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_complete_speculative: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slot: *mut TupleTableSlot,
             specToken: uint32,
@@ -21029,7 +21122,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub multi_insert: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             slots: *mut *mut TupleTableSlot,
             nslots: ::core::ffi::c_int,
@@ -21039,7 +21132,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub tuple_delete: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             cid: CommandId,
@@ -21051,7 +21144,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_update: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             otid: ItemPointer,
             slot: *mut TupleTableSlot,
@@ -21065,7 +21158,7 @@ pub struct TableAmRoutine {
         ) -> TM_Result::Type,
     >,
     pub tuple_lock: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             tid: ItemPointer,
             snapshot: Snapshot,
@@ -21077,10 +21170,11 @@ pub struct TableAmRoutine {
             tmfd: *mut TM_FailureData,
         ) -> TM_Result::Type,
     >,
-    pub finish_bulk_insert:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation, options: ::core::ffi::c_int)>,
+    pub finish_bulk_insert: ::core::option::Option<
+        unsafe extern "C-unwind" fn(rel: Relation, options: ::core::ffi::c_int),
+    >,
     pub relation_set_new_filelocator: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             newrlocator: *const RelFileLocator,
             persistence: ::core::ffi::c_char,
@@ -21089,12 +21183,12 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_nontransactional_truncate:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation)>,
     pub relation_copy_data: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, newrlocator: *const RelFileLocator),
+        unsafe extern "C-unwind" fn(rel: Relation, newrlocator: *const RelFileLocator),
     >,
     pub relation_copy_for_cluster: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             OldTable: Relation,
             NewTable: Relation,
             OldIndex: Relation,
@@ -21108,17 +21202,17 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_vacuum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             params: *mut VacuumParams,
             bstrategy: BufferAccessStrategy,
         ),
     >,
     pub scan_analyze_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, stream: *mut ReadStream) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, stream: *mut ReadStream) -> bool,
     >,
     pub scan_analyze_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             OldestXmin: TransactionId,
             liverows: *mut f64,
@@ -21127,7 +21221,7 @@ pub struct TableAmRoutine {
         ) -> bool,
     >,
     pub index_build_range_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -21142,7 +21236,7 @@ pub struct TableAmRoutine {
         ) -> f64,
     >,
     pub index_validate_scan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             table_rel: Relation,
             index_rel: Relation,
             index_info: *mut IndexInfo,
@@ -21151,13 +21245,14 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_size: ::core::option::Option<
-        unsafe extern "C" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
+        unsafe extern "C-unwind" fn(rel: Relation, forkNumber: ForkNumber::Type) -> uint64,
     >,
     pub relation_needs_toast_table:
-        ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> bool>,
-    pub relation_toast_am: ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> Oid>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> bool>,
+    pub relation_toast_am:
+        ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> Oid>,
     pub relation_fetch_toast_slice: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             toastrel: Relation,
             valueid: Oid,
             attrsize: int32,
@@ -21167,7 +21262,7 @@ pub struct TableAmRoutine {
         ),
     >,
     pub relation_estimate_size: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             rel: Relation,
             attr_widths: *mut int32,
             pages: *mut BlockNumber,
@@ -21176,20 +21271,20 @@ pub struct TableAmRoutine {
         ),
     >,
     pub scan_bitmap_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, tbmres: *mut TBMIterateResult) -> bool,
     >,
     pub scan_bitmap_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             tbmres: *mut TBMIterateResult,
             slot: *mut TupleTableSlot,
         ) -> bool,
     >,
     pub scan_sample_next_block: ::core::option::Option<
-        unsafe extern "C" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
+        unsafe extern "C-unwind" fn(scan: TableScanDesc, scanstate: *mut SampleScanState) -> bool,
     >,
     pub scan_sample_next_tuple: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             scan: TableScanDesc,
             scanstate: *mut SampleScanState,
             slot: *mut TupleTableSlot,
@@ -21291,7 +21386,7 @@ pub mod HTSV_Result {
     pub const HEAPTUPLE_DELETE_IN_PROGRESS: Type = 4;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct HeapTupleFreeze {
     pub xmax: TransactionId,
     pub t_infomask2: uint16,
@@ -21300,14 +21395,31 @@ pub struct HeapTupleFreeze {
     pub checkflags: uint8,
     pub offset: OffsetNumber,
 }
+impl Default for HeapTupleFreeze {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct HeapPageFreeze {
     pub freeze_required: bool,
     pub FreezePageRelfrozenXid: TransactionId,
     pub FreezePageRelminMxid: MultiXactId,
     pub NoFreezePageRelfrozenXid: TransactionId,
     pub NoFreezePageRelminMxid: MultiXactId,
+}
+impl Default for HeapPageFreeze {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -21402,7 +21514,6 @@ impl Default for MultiXactMember {
     }
 }
 #[repr(C)]
-#[derive(Debug)]
 pub struct xl_multixact_create {
     pub mid: MultiXactId,
     pub moff: MultiXactOffset,
@@ -21419,7 +21530,6 @@ impl Default for xl_multixact_create {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct xl_multixact_truncate {
     pub oldestMultiDB: Oid,
     pub startTruncOff: MultiXactId,
@@ -21913,12 +22023,15 @@ impl Default for relopt_enum {
     }
 }
 pub type validate_string_relopt =
-    ::core::option::Option<unsafe extern "C" fn(value: *const ::core::ffi::c_char)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(value: *const ::core::ffi::c_char)>;
 pub type fill_string_relopt = ::core::option::Option<
-    unsafe extern "C" fn(value: *const ::core::ffi::c_char, ptr: *mut ::core::ffi::c_void) -> Size,
+    unsafe extern "C-unwind" fn(
+        value: *const ::core::ffi::c_char,
+        ptr: *mut ::core::ffi::c_void,
+    ) -> Size,
 >;
 pub type relopts_validator = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parsed_options: *mut ::core::ffi::c_void,
         vals: *mut relopt_value,
         nvals: ::core::ffi::c_int,
@@ -22081,18 +22194,20 @@ pub struct XLogRecordBuffer {
 #[derive(Debug, Copy, Clone)]
 pub struct RmgrData {
     pub rm_name: *const ::core::ffi::c_char,
-    pub rm_redo: ::core::option::Option<unsafe extern "C" fn(record: *mut XLogReaderState)>,
-    pub rm_desc:
-        ::core::option::Option<unsafe extern "C" fn(buf: StringInfo, record: *mut XLogReaderState)>,
-    pub rm_identify:
-        ::core::option::Option<unsafe extern "C" fn(info: uint8) -> *const ::core::ffi::c_char>,
-    pub rm_startup: ::core::option::Option<unsafe extern "C" fn()>,
-    pub rm_cleanup: ::core::option::Option<unsafe extern "C" fn()>,
+    pub rm_redo: ::core::option::Option<unsafe extern "C-unwind" fn(record: *mut XLogReaderState)>,
+    pub rm_desc: ::core::option::Option<
+        unsafe extern "C-unwind" fn(buf: StringInfo, record: *mut XLogReaderState),
+    >,
+    pub rm_identify: ::core::option::Option<
+        unsafe extern "C-unwind" fn(info: uint8) -> *const ::core::ffi::c_char,
+    >,
+    pub rm_startup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
+    pub rm_cleanup: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     pub rm_mask: ::core::option::Option<
-        unsafe extern "C" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
+        unsafe extern "C-unwind" fn(pagedata: *mut ::core::ffi::c_char, blkno: BlockNumber),
     >,
     pub rm_decode: ::core::option::Option<
-        unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, buf: *mut XLogRecordBuffer),
+        unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, buf: *mut XLogRecordBuffer),
     >,
 }
 impl Default for RmgrData {
@@ -22105,7 +22220,6 @@ impl Default for RmgrData {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct CheckPoint {
     pub redo: XLogRecPtr,
     pub ThisTimeLineID: TimeLineID,
@@ -22145,7 +22259,6 @@ pub mod DBState {
     pub const DB_IN_PRODUCTION: Type = 6;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct ControlFileData {
     pub system_identifier: uint64,
     pub pg_control_version: uint32,
@@ -22373,7 +22486,7 @@ pub mod RVROption {
     pub const RVR_SKIP_LOCKED: Type = 4;
 }
 pub type RangeVarGetRelidCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: *const RangeVar,
         relId: Oid,
         oldRelId: Oid,
@@ -22421,7 +22534,7 @@ pub struct ObjectAccessNamespaceSearch {
     pub result: bool,
 }
 pub type object_access_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectId: Oid,
@@ -22430,7 +22543,7 @@ pub type object_access_hook_type = ::core::option::Option<
     ),
 >;
 pub type object_access_hook_type_str = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         access: ObjectAccessType::Type,
         classId: Oid,
         objectStr: *const ::core::ffi::c_char,
@@ -22814,20 +22927,20 @@ pub mod ParseExprKind {
     pub const EXPR_KIND_CYCLE_MARK: Type = 44;
 }
 pub type PreParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, cref: *mut ColumnRef) -> *mut Node,
 >;
 pub type PostParseColumnRefHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         cref: *mut ColumnRef,
         var: *mut Node,
     ) -> *mut Node,
 >;
 pub type ParseParamRefHook = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
+    unsafe extern "C-unwind" fn(pstate: *mut ParseState, pref: *mut ParamRef) -> *mut Node,
 >;
 pub type CoerceParamHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstate: *mut ParseState,
         param: *mut Param,
         targetTypeId: Oid,
@@ -23176,19 +23289,19 @@ pub struct CopyToStateData {
 }
 pub type CopyToState = *mut CopyToStateData;
 pub type copy_data_source_cb = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         outbuf: *mut ::core::ffi::c_void,
         minread: ::core::ffi::c_int,
         maxread: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type copy_data_dest_cb = ::core::option::Option<
-    unsafe extern "C" fn(data: *mut ::core::ffi::c_void, len: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(data: *mut ::core::ffi::c_void, len: ::core::ffi::c_int),
 >;
 pub type EOM_get_flat_size_method =
-    ::core::option::Option<unsafe extern "C" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(eohptr: *mut ExpandedObjectHeader) -> Size>;
 pub type EOM_flatten_into_method = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         eohptr: *mut ExpandedObjectHeader,
         result: *mut ::core::ffi::c_void,
         allocated_size: Size,
@@ -23682,7 +23795,7 @@ impl Default for ExplainState {
     }
 }
 pub type ExplainOneQuery_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         query: *mut Query,
         cursorOptions: ::core::ffi::c_int,
         into: *mut IntoClause,
@@ -23693,7 +23806,7 @@ pub type ExplainOneQuery_hook_type = ::core::option::Option<
     ),
 >;
 pub type explain_get_index_name_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(indexId: Oid) -> *const ::core::ffi::c_char>;
 pub mod PlanCacheMode {
     pub type Type = ::core::ffi::c_uint;
     pub const PLAN_CACHE_MODE_AUTO: Type = 0;
@@ -23806,7 +23919,7 @@ impl Default for PreparedStatement {
     }
 }
 pub type check_object_relabel_type = ::core::option::Option<
-    unsafe extern "C" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
+    unsafe extern "C-unwind" fn(object: *const ObjectAddress, seclabel: *const ::core::ffi::c_char),
 >;
 #[repr(C)]
 #[derive(Debug)]
@@ -23972,54 +24085,60 @@ impl Default for config_enum_entry {
     }
 }
 pub type GucBoolCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut bool,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucIntCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucRealCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut f64,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucStringCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut *mut ::core::ffi::c_char,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
 pub type GucEnumCheckHook = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         newval: *mut ::core::ffi::c_int,
         extra: *mut *mut ::core::ffi::c_void,
         source: GucSource::Type,
     ) -> bool,
 >;
-pub type GucBoolAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: bool, extra: *mut ::core::ffi::c_void)>;
-pub type GucIntAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+pub type GucBoolAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: bool, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucRealAssignHook =
-    ::core::option::Option<unsafe extern "C" fn(newval: f64, extra: *mut ::core::ffi::c_void)>;
+pub type GucIntAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+>;
+pub type GucRealAssignHook = ::core::option::Option<
+    unsafe extern "C-unwind" fn(newval: f64, extra: *mut ::core::ffi::c_void),
+>;
 pub type GucStringAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: *const ::core::ffi::c_char, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    ),
 >;
 pub type GucEnumAssignHook = ::core::option::Option<
-    unsafe extern "C" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void),
 >;
-pub type GucShowHook = ::core::option::Option<unsafe extern "C" fn() -> *const ::core::ffi::c_char>;
+pub type GucShowHook =
+    ::core::option::Option<unsafe extern "C-unwind" fn() -> *const ::core::ffi::c_char>;
 pub mod GucAction {
     pub type Type = ::core::ffi::c_uint;
     pub const GUC_ACTION_SET: Type = 0;
@@ -24027,7 +24146,7 @@ pub mod GucAction {
     pub const GUC_ACTION_SAVE: Type = 2;
 }
 pub type check_password_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         username: *const ::core::ffi::c_char,
         shadow_pass: *const ::core::ffi::c_char,
         password_type: PasswordType::Type,
@@ -24035,7 +24154,7 @@ pub type check_password_hook_type = ::core::option::Option<
         validuntil_null: bool,
     ),
 >;
-pub type bgworker_main_type = ::core::option::Option<unsafe extern "C" fn(main_arg: Datum)>;
+pub type bgworker_main_type = ::core::option::Option<unsafe extern "C-unwind" fn(main_arg: Datum)>;
 pub mod BgWorkerStartTime {
     pub type Type = ::core::ffi::c_uint;
     pub const BgWorkerStart_PostmasterStart: Type = 0;
@@ -24280,7 +24399,7 @@ pub mod shm_mq_result {
     pub const SHM_MQ_DETACHED: Type = 2;
 }
 pub type parallel_worker_main_type =
-    ::core::option::Option<unsafe extern "C" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(seg: *mut dsm_segment, toc: *mut shm_toc)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ParallelWorkerInfo {
@@ -24408,14 +24527,14 @@ pub struct ParallelVacuumState {
 }
 pub type VacAttrStatsP = *mut VacAttrStats;
 pub type AnalyzeAttrFetchFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         rownum: ::core::ffi::c_int,
         isNull: *mut bool,
     ) -> Datum,
 >;
 pub type AnalyzeAttrComputeStatsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         stats: VacAttrStatsP,
         fetchfunc: AnalyzeAttrFetchFunc,
         samplerows: ::core::ffi::c_int,
@@ -24497,7 +24616,6 @@ impl Default for VacuumParams {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
 pub struct VacuumCutoffs {
     pub relfrozenxid: TransactionId,
     pub relminmxid: MultiXactId,
@@ -24505,6 +24623,15 @@ pub struct VacuumCutoffs {
     pub OldestMxact: MultiXactId,
     pub FreezeLimit: TransactionId,
     pub MultiXactCutoff: MultiXactId,
+}
+impl Default for VacuumCutoffs {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -24667,10 +24794,14 @@ pub struct ScalarArrayOpExprHashTable {
     _unused: [u8; 0],
 }
 pub type ExecEvalSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(state: *mut ExprState, op: *mut ExprEvalStep, econtext: *mut ExprContext),
+    unsafe extern "C-unwind" fn(
+        state: *mut ExprState,
+        op: *mut ExprEvalStep,
+        econtext: *mut ExprContext,
+    ),
 >;
 pub type ExecEvalBoolSubroutine = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         state: *mut ExprState,
         op: *mut ExprEvalStep,
         econtext: *mut ExprContext,
@@ -25665,7 +25796,7 @@ pub struct PortalData {
     pub prepStmtName: *const ::core::ffi::c_char,
     pub portalContext: MemoryContext,
     pub resowner: ResourceOwner,
-    pub cleanup: ::core::option::Option<unsafe extern "C" fn(portal: Portal)>,
+    pub cleanup: ::core::option::Option<unsafe extern "C-unwind" fn(portal: Portal)>,
     pub createSubid: SubTransactionId,
     pub activeSubid: SubTransactionId,
     pub createLevel: ::core::ffi::c_int,
@@ -26090,7 +26221,7 @@ pub struct IndexOptInfo {
     pub amcanparallel: bool,
     pub amcanmarkpos: bool,
     pub amcostestimate: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             arg1: *mut PlannerInfo,
             arg2: *mut IndexPath,
             arg3: f64,
@@ -27364,13 +27495,21 @@ impl Default for AggTransInfo {
     }
 }
 pub type GetForeignRelSize_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, baserel: *mut RelOptInfo, foreigntableid: Oid),
+    unsafe extern "C-unwind" fn(
+        root: *mut PlannerInfo,
+        baserel: *mut RelOptInfo,
+        foreigntableid: Oid,
+    ),
 >;
 pub type GetForeignPlan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         baserel: *mut RelOptInfo,
         foreigntableid: Oid,
@@ -27381,20 +27520,20 @@ pub type GetForeignPlan_function = ::core::option::Option<
     ) -> *mut ForeignScan,
 >;
 pub type BeginForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type RecheckForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, slot: *mut TupleTableSlot) -> bool,
 >;
 pub type ReScanForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type EndForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignJoinPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -27404,7 +27543,7 @@ pub type GetForeignJoinPaths_function = ::core::option::Option<
     ),
 >;
 pub type GetForeignUpperPaths_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -27413,7 +27552,7 @@ pub type GetForeignUpperPaths_function = ::core::option::Option<
     ),
 >;
 pub type AddForeignUpdateTargets_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rtindex: Index,
         target_rte: *mut RangeTblEntry,
@@ -27421,7 +27560,7 @@ pub type AddForeignUpdateTargets_function = ::core::option::Option<
     ),
 >;
 pub type PlanForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -27429,7 +27568,7 @@ pub type PlanForeignModify_function = ::core::option::Option<
     ) -> *mut List,
 >;
 pub type BeginForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -27438,7 +27577,7 @@ pub type BeginForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExecForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -27446,7 +27585,7 @@ pub type ExecForeignInsert_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignBatchInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slots: *mut *mut TupleTableSlot,
@@ -27454,10 +27593,11 @@ pub type ExecForeignBatchInsert_function = ::core::option::Option<
         numSlots: *mut ::core::ffi::c_int,
     ) -> *mut *mut TupleTableSlot,
 >;
-pub type GetForeignModifyBatchSize_function =
-    ::core::option::Option<unsafe extern "C" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int>;
+pub type GetForeignModifyBatchSize_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(rinfo: *mut ResultRelInfo) -> ::core::ffi::c_int,
+>;
 pub type ExecForeignUpdate_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
@@ -27465,24 +27605,26 @@ pub type ExecForeignUpdate_function = ::core::option::Option<
     ) -> *mut TupleTableSlot,
 >;
 pub type ExecForeignDelete_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         rinfo: *mut ResultRelInfo,
         slot: *mut TupleTableSlot,
         planSlot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot,
 >;
-pub type EndForeignModify_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
-pub type BeginForeignInsert_function = ::core::option::Option<
-    unsafe extern "C" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+pub type EndForeignModify_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
 >;
-pub type EndForeignInsert_function =
-    ::core::option::Option<unsafe extern "C" fn(estate: *mut EState, rinfo: *mut ResultRelInfo)>;
+pub type BeginForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(mtstate: *mut ModifyTableState, rinfo: *mut ResultRelInfo),
+>;
+pub type EndForeignInsert_function = ::core::option::Option<
+    unsafe extern "C-unwind" fn(estate: *mut EState, rinfo: *mut ResultRelInfo),
+>;
 pub type IsForeignRelUpdatable_function =
-    ::core::option::Option<unsafe extern "C" fn(rel: Relation) -> ::core::ffi::c_int>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(rel: Relation) -> ::core::ffi::c_int>;
 pub type PlanDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         plan: *mut ModifyTable,
         resultRelation: Index,
@@ -27490,21 +27632,21 @@ pub type PlanDirectModify_function = ::core::option::Option<
     ) -> bool,
 >;
 pub type BeginDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, eflags: ::core::ffi::c_int),
 >;
 pub type IterateDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState) -> *mut TupleTableSlot,
 >;
 pub type EndDirectModify_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type GetForeignRowMarkType_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rte: *mut RangeTblEntry,
         strength: LockClauseStrength::Type,
     ) -> RowMarkType::Type,
 >;
 pub type RefetchForeignRow_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         estate: *mut EState,
         erm: *mut ExecRowMark,
         rowid: Datum,
@@ -27513,10 +27655,10 @@ pub type RefetchForeignRow_function = ::core::option::Option<
     ),
 >;
 pub type ExplainForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type ExplainForeignModify_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mtstate: *mut ModifyTableState,
         rinfo: *mut ResultRelInfo,
         fdw_private: *mut List,
@@ -27525,10 +27667,10 @@ pub type ExplainForeignModify_function = ::core::option::Option<
     ),
 >;
 pub type ExplainDirectModify_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, es: *mut ExplainState),
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, es: *mut ExplainState),
 >;
 pub type AcquireSampleRowsFunc = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         elevel: ::core::ffi::c_int,
         rows: *mut HeapTuple,
@@ -27538,66 +27680,66 @@ pub type AcquireSampleRowsFunc = ::core::option::Option<
     ) -> ::core::ffi::c_int,
 >;
 pub type AnalyzeForeignTable_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         relation: Relation,
         func: *mut AcquireSampleRowsFunc,
         totalpages: *mut BlockNumber,
     ) -> bool,
 >;
 pub type ImportForeignSchema_function = ::core::option::Option<
-    unsafe extern "C" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
+    unsafe extern "C-unwind" fn(stmt: *mut ImportForeignSchemaStmt, serverOid: Oid) -> *mut List,
 >;
 pub type ExecForeignTruncate_function = ::core::option::Option<
-    unsafe extern "C" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
+    unsafe extern "C-unwind" fn(rels: *mut List, behavior: DropBehavior::Type, restart_seqs: bool),
 >;
 pub type EstimateDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
+    unsafe extern "C-unwind" fn(node: *mut ForeignScanState, pcxt: *mut ParallelContext) -> Size,
 >;
 pub type InitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ReInitializeDSMForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         pcxt: *mut ParallelContext,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type InitializeWorkerForeignScan_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         node: *mut ForeignScanState,
         toc: *mut shm_toc,
         coordinate: *mut ::core::ffi::c_void,
     ),
 >;
 pub type ShutdownForeignScan_function =
-    ::core::option::Option<unsafe extern "C" fn(node: *mut ForeignScanState)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ForeignScanState)>;
 pub type IsForeignScanParallelSafe_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rte: *mut RangeTblEntry,
     ) -> bool,
 >;
 pub type ReparameterizeForeignPathByChild_function = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         fdw_private: *mut List,
         child_rel: *mut RelOptInfo,
     ) -> *mut List,
 >;
 pub type IsForeignPathAsyncCapable_function =
-    ::core::option::Option<unsafe extern "C" fn(path: *mut ForeignPath) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(path: *mut ForeignPath) -> bool>;
 pub type ForeignAsyncRequest_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncConfigureWait_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 pub type ForeignAsyncNotify_function =
-    ::core::option::Option<unsafe extern "C" fn(areq: *mut AsyncRequest)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(areq: *mut AsyncRequest)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct FdwRoutine {
@@ -27752,12 +27894,12 @@ pub struct JitContext {
     pub instr: JitInstrumentation,
 }
 pub type JitProviderInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut JitProviderCallbacks)>;
-pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut JitProviderCallbacks)>;
+pub type JitProviderResetAfterErrorCB = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type JitProviderReleaseContextCB =
-    ::core::option::Option<unsafe extern "C" fn(context: *mut JitContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(context: *mut JitContext)>;
 pub type JitProviderCompileExprCB =
-    ::core::option::Option<unsafe extern "C" fn(state: *mut ExprState) -> bool>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(state: *mut ExprState) -> bool>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct JitProviderCallbacks {
@@ -27828,36 +27970,36 @@ impl Default for pg_enc2name {
     }
 }
 pub type mb2wchar_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const ::core::ffi::c_uchar,
         to: *mut pg_wchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type wchar2mb_with_len_converter = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         from: *const pg_wchar,
         to: *mut ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mblen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbdisplaylen_converter = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
+    unsafe extern "C-unwind" fn(mbstr: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int,
 >;
 pub type mbcharacter_incrementer = ::core::option::Option<
-    unsafe extern "C" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
+    unsafe extern "C-unwind" fn(mbstr: *mut ::core::ffi::c_uchar, len: ::core::ffi::c_int) -> bool,
 >;
 pub type mbchar_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
 >;
 pub type mbstr_verifier = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         mbstr: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
     ) -> ::core::ffi::c_int,
@@ -27927,7 +28069,7 @@ pub struct pg_local_to_utf_combined {
     pub utf2: uint32,
 }
 pub type utf_local_conversion_func =
-    ::core::option::Option<unsafe extern "C" fn(code: uint32) -> uint32>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: uint32) -> uint32>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ExtensibleNode {
@@ -27949,15 +28091,15 @@ pub struct ExtensibleNodeMethods {
     pub extnodename: *const ::core::ffi::c_char,
     pub node_size: Size,
     pub nodeCopy: ::core::option::Option<
-        unsafe extern "C" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(newnode: *mut ExtensibleNode, oldnode: *const ExtensibleNode),
     >,
     pub nodeEqual: ::core::option::Option<
-        unsafe extern "C" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
+        unsafe extern "C-unwind" fn(a: *const ExtensibleNode, b: *const ExtensibleNode) -> bool,
     >,
     pub nodeOut: ::core::option::Option<
-        unsafe extern "C" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
+        unsafe extern "C-unwind" fn(str_: *mut StringInfoData, node: *const ExtensibleNode),
     >,
-    pub nodeRead: ::core::option::Option<unsafe extern "C" fn(node: *mut ExtensibleNode)>,
+    pub nodeRead: ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut ExtensibleNode)>,
 }
 impl Default for ExtensibleNodeMethods {
     fn default() -> Self {
@@ -27973,7 +28115,7 @@ impl Default for ExtensibleNodeMethods {
 pub struct CustomPathMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub PlanCustomPath: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             rel: *mut RelOptInfo,
             best_path: *mut CustomPath,
@@ -27983,7 +28125,7 @@ pub struct CustomPathMethods {
         ) -> *mut Plan,
     >,
     pub ReparameterizeCustomPathByChild: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             root: *mut PlannerInfo,
             custom_private: *mut List,
             child_rel: *mut RelOptInfo,
@@ -28004,7 +28146,7 @@ impl Default for CustomPathMethods {
 pub struct CustomScanMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub CreateCustomScanState:
-        ::core::option::Option<unsafe extern "C" fn(cscan: *mut CustomScan) -> *mut Node>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(cscan: *mut CustomScan) -> *mut Node>,
 }
 impl Default for CustomScanMethods {
     fn default() -> Self {
@@ -28020,48 +28162,51 @@ impl Default for CustomScanMethods {
 pub struct CustomExecMethods {
     pub CustomName: *const ::core::ffi::c_char,
     pub BeginCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             estate: *mut EState,
             eflags: ::core::ffi::c_int,
         ),
     >,
     pub ExecCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState) -> *mut TupleTableSlot,
     >,
-    pub EndCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub ReScanCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
-    pub MarkPosCustomScan: ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+    pub EndCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub ReScanCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
+    pub MarkPosCustomScan:
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub RestrPosCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub EstimateDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
+        unsafe extern "C-unwind" fn(node: *mut CustomScanState, pcxt: *mut ParallelContext) -> Size,
     >,
     pub InitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ReInitializeDSMCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             pcxt: *mut ParallelContext,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub InitializeWorkerCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             toc: *mut shm_toc,
             coordinate: *mut ::core::ffi::c_void,
         ),
     >,
     pub ShutdownCustomScan:
-        ::core::option::Option<unsafe extern "C" fn(node: *mut CustomScanState)>,
+        ::core::option::Option<unsafe extern "C-unwind" fn(node: *mut CustomScanState)>,
     pub ExplainCustomScan: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             node: *mut CustomScanState,
             ancestors: *mut List,
             es: *mut ExplainState,
@@ -28078,16 +28223,19 @@ impl Default for CustomExecMethods {
     }
 }
 pub type check_function_callback = ::core::option::Option<
-    unsafe extern "C" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(func_id: Oid, context: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type tree_walker_callback = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> bool,
 >;
 pub type planstate_tree_walker_callback = ::core::option::Option<
-    unsafe extern "C" fn(planstate: *mut PlanState, context: *mut ::core::ffi::c_void) -> bool,
+    unsafe extern "C-unwind" fn(
+        planstate: *mut PlanState,
+        context: *mut ::core::ffi::c_void,
+    ) -> bool,
 >;
 pub type tree_mutator_callback = ::core::option::Option<
-    unsafe extern "C" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> *mut Node,
+    unsafe extern "C-unwind" fn(node: *mut Node, context: *mut ::core::ffi::c_void) -> *mut Node,
 >;
 pub mod ReplicationKind {
     pub type Type = ::core::ffi::c_uint;
@@ -28238,7 +28386,7 @@ impl Default for UploadManifestCmd {
     }
 }
 pub type SubscriptTransform = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *mut SubscriptingRef,
         indirection: *mut List,
         pstate: *mut ParseState,
@@ -28247,7 +28395,7 @@ pub type SubscriptTransform = ::core::option::Option<
     ),
 >;
 pub type SubscriptExecSetup = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         sbsref: *const SubscriptingRef,
         sbsrefstate: *mut SubscriptingRefState,
         methods: *mut SubscriptExecSteps,
@@ -28424,7 +28572,7 @@ pub mod DebugParallelMode {
     pub const DEBUG_PARALLEL_REGRESS: Type = 2;
 }
 pub type set_rel_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         rti: Index,
@@ -28432,7 +28580,7 @@ pub type set_rel_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type set_join_pathlist_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
         outerrel: *mut RelOptInfo,
@@ -28442,14 +28590,14 @@ pub type set_join_pathlist_hook_type = ::core::option::Option<
     ),
 >;
 pub type join_search_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         levels_needed: ::core::ffi::c_int,
         initial_rels: *mut List,
     ) -> *mut RelOptInfo,
 >;
 pub type ec_matches_callback_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rel: *mut RelOptInfo,
         ec: *mut EquivalenceClass,
@@ -28465,7 +28613,7 @@ pub mod PathKeysComparison {
     pub const PATHKEYS_DIFFERENT: Type = 3;
 }
 pub type get_relation_info_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         relationObjectId: Oid,
         inhparent: bool,
@@ -28473,10 +28621,10 @@ pub type get_relation_info_hook_type = ::core::option::Option<
     ),
 >;
 pub type query_pathkeys_callback = ::core::option::Option<
-    unsafe extern "C" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
+    unsafe extern "C-unwind" fn(root: *mut PlannerInfo, extra: *mut ::core::ffi::c_void),
 >;
 pub type planner_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         parse: *mut Query,
         query_string: *const ::core::ffi::c_char,
         cursorOptions: ::core::ffi::c_int,
@@ -28484,7 +28632,7 @@ pub type planner_hook_type = ::core::option::Option<
     ) -> *mut PlannedStmt,
 >;
 pub type create_upper_paths_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         stage: UpperRelationKind::Type,
         input_rel: *mut RelOptInfo,
@@ -28525,7 +28673,11 @@ pub mod ComputeQueryIdType {
     pub const COMPUTE_QUERY_ID_REGRESS: Type = 3;
 }
 pub type post_parse_analyze_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(pstate: *mut ParseState, query: *mut Query, jstate: *mut JumbleState),
+    unsafe extern "C-unwind" fn(
+        pstate: *mut ParseState,
+        query: *mut Query,
+        jstate: *mut JumbleState,
+    ),
 >;
 pub mod FuncDetailCode {
     pub type Type = ::core::ffi::c_uint;
@@ -28547,6 +28699,73 @@ pub mod CoercionPathType {
     pub const COERCION_PATH_RELABELTYPE: Type = 2;
     pub const COERCION_PATH_ARRAYCOERCE: Type = 3;
     pub const COERCION_PATH_COERCEVIAIO: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionBoundInfoData {
+    pub strategy: PartitionStrategy::Type,
+    pub ndatums: ::core::ffi::c_int,
+    pub datums: *mut *mut Datum,
+    pub kind: *mut *mut PartitionRangeDatumKind::Type,
+    pub interleaved_parts: *mut Bitmapset,
+    pub nindexes: ::core::ffi::c_int,
+    pub indexes: *mut ::core::ffi::c_int,
+    pub null_index: ::core::ffi::c_int,
+    pub default_index: ::core::ffi::c_int,
+}
+impl Default for PartitionBoundInfoData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionDescData {
+    pub nparts: ::core::ffi::c_int,
+    pub detached_exist: bool,
+    pub oids: *mut Oid,
+    pub is_leaf: *mut bool,
+    pub boundinfo: PartitionBoundInfo,
+    pub last_found_datum_index: ::core::ffi::c_int,
+    pub last_found_part_index: ::core::ffi::c_int,
+    pub last_found_count: ::core::ffi::c_int,
+}
+impl Default for PartitionDescData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PartitionPruneContext {
+    pub strategy: ::core::ffi::c_char,
+    pub partnatts: ::core::ffi::c_int,
+    pub nparts: ::core::ffi::c_int,
+    pub boundinfo: PartitionBoundInfo,
+    pub partcollation: *mut Oid,
+    pub partsupfunc: *mut FmgrInfo,
+    pub stepcmpfuncs: *mut FmgrInfo,
+    pub ppccontext: MemoryContext,
+    pub planstate: *mut PlanState,
+    pub exprcontext: *mut ExprContext,
+    pub exprstates: *mut *mut ExprState,
+}
+impl Default for PartitionPruneContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -29716,30 +29935,31 @@ impl Default for PLpgSQL_execstate {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PLpgSQL_plugin {
     pub func_setup: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub func_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, func: *mut PLpgSQL_function),
     >,
     pub stmt_beg: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
     pub stmt_end: ::core::option::Option<
-        unsafe extern "C" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
+        unsafe extern "C-unwind" fn(estate: *mut PLpgSQL_execstate, stmt: *mut PLpgSQL_stmt),
     >,
-    pub error_callback: ::core::option::Option<unsafe extern "C" fn(arg: *mut ::core::ffi::c_void)>,
+    pub error_callback:
+        ::core::option::Option<unsafe extern "C-unwind" fn(arg: *mut ::core::ffi::c_void)>,
     pub assign_expr: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             expr: *mut PLpgSQL_expr,
         ),
     >,
     pub assign_value: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             target: *mut PLpgSQL_datum,
             value: Datum,
@@ -29749,7 +29969,7 @@ pub struct PLpgSQL_plugin {
         ),
     >,
     pub eval_datum: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             datum: *mut PLpgSQL_datum,
             typeId: *mut Oid,
@@ -29759,7 +29979,7 @@ pub struct PLpgSQL_plugin {
         ),
     >,
     pub cast_value: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             estate: *mut PLpgSQL_execstate,
             value: Datum,
             isnull: *mut bool,
@@ -30058,7 +30278,7 @@ impl Default for ReorderBufferTXN {
     }
 }
 pub type ReorderBufferApplyChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -30066,7 +30286,7 @@ pub type ReorderBufferApplyChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -30075,17 +30295,17 @@ pub type ReorderBufferApplyTruncateCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -30096,24 +30316,24 @@ pub type ReorderBufferMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN),
 >;
 pub type ReorderBufferPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -30121,30 +30341,42 @@ pub type ReorderBufferRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, first_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        first_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, last_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        last_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, abort_lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        abort_lsn: XLogRecPtr,
+    ),
 >;
 pub type ReorderBufferStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type ReorderBufferStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -30152,7 +30384,7 @@ pub type ReorderBufferStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -30163,7 +30395,7 @@ pub type ReorderBufferStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         rb: *mut ReorderBuffer,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -30172,7 +30404,11 @@ pub type ReorderBufferStreamTruncateCB = ::core::option::Option<
     ),
 >;
 pub type ReorderBufferUpdateProgressTxnCB = ::core::option::Option<
-    unsafe extern "C" fn(rb: *mut ReorderBuffer, txn: *mut ReorderBufferTXN, lsn: XLogRecPtr),
+    unsafe extern "C-unwind" fn(
+        rb: *mut ReorderBuffer,
+        txn: *mut ReorderBufferTXN,
+        lsn: XLogRecPtr,
+    ),
 >;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -30251,19 +30487,19 @@ impl Default for OutputPluginOptions {
     }
 }
 pub type LogicalOutputPluginInit =
-    ::core::option::Option<unsafe extern "C" fn(cb: *mut OutputPluginCallbacks)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(cb: *mut OutputPluginCallbacks)>;
 pub type LogicalDecodeStartupCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         options: *mut OutputPluginOptions,
         is_init: bool,
     ),
 >;
 pub type LogicalDecodeBeginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -30271,7 +30507,7 @@ pub type LogicalDecodeChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -30280,14 +30516,14 @@ pub type LogicalDecodeTruncateCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -30298,36 +30534,36 @@ pub type LogicalDecodeMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeFilterByOriginCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, origin_id: RepOriginId) -> bool,
 >;
 pub type LogicalDecodeShutdownCB =
-    ::core::option::Option<unsafe extern "C" fn(ctx: *mut LogicalDecodingContext)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext)>;
 pub type LogicalDecodeFilterPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         xid: TransactionId,
         gid: *const ::core::ffi::c_char,
     ) -> bool,
 >;
 pub type LogicalDecodeBeginPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodePrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeCommitPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_end_lsn: XLogRecPtr,
@@ -30335,34 +30571,34 @@ pub type LogicalDecodeRollbackPreparedCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamStartCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamStopCB = ::core::option::Option<
-    unsafe extern "C" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
+    unsafe extern "C-unwind" fn(ctx: *mut LogicalDecodingContext, txn: *mut ReorderBufferTXN),
 >;
 pub type LogicalDecodeStreamAbortCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         abort_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamPrepareCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         prepare_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamCommitCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         commit_lsn: XLogRecPtr,
     ),
 >;
 pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         relation: Relation,
@@ -30370,7 +30606,7 @@ pub type LogicalDecodeStreamChangeCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         message_lsn: XLogRecPtr,
@@ -30381,7 +30617,7 @@ pub type LogicalDecodeStreamMessageCB = ::core::option::Option<
     ),
 >;
 pub type LogicalDecodeStreamTruncateCB = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         ctx: *mut LogicalDecodingContext,
         txn: *mut ReorderBufferTXN,
         nrelations: ::core::ffi::c_int,
@@ -30492,11 +30728,20 @@ impl Default for LogicalRepTyp {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LogicalRepBeginData {
     pub final_lsn: XLogRecPtr,
     pub committime: TimestampTz,
     pub xid: TransactionId,
+}
+impl Default for LogicalRepBeginData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -30561,12 +30806,21 @@ impl Default for LogicalRepRollbackPreparedTxnData {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LogicalRepStreamAbortData {
     pub xid: TransactionId,
     pub subxid: TransactionId,
     pub abort_lsn: XLogRecPtr,
     pub abort_time: TimestampTz,
+}
+impl Default for LogicalRepStreamAbortData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub mod CRSSnapshotAction {
     pub type Type = ::core::ffi::c_uint;
@@ -30708,7 +30962,7 @@ impl Default for WalRcvExecResult {
     }
 }
 pub type walrcv_connect_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conninfo: *const ::core::ffi::c_char,
         replication: bool,
         logical: bool,
@@ -30718,31 +30972,32 @@ pub type walrcv_connect_fn = ::core::option::Option<
     ) -> *mut WalReceiverConn,
 >;
 pub type walrcv_check_conninfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(conninfo: *const ::core::ffi::c_char, must_use_password: bool),
+    unsafe extern "C-unwind" fn(conninfo: *const ::core::ffi::c_char, must_use_password: bool),
 >;
 pub type walrcv_get_conninfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_senderinfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         sender_host: *mut *mut ::core::ffi::c_char,
         sender_port: *mut ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_identify_system_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         primary_tli: *mut TimeLineID,
     ) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_get_dbname_from_conninfo_fn = ::core::option::Option<
-    unsafe extern "C" fn(conninfo: *const ::core::ffi::c_char) -> *mut ::core::ffi::c_char,
+    unsafe extern "C-unwind" fn(conninfo: *const ::core::ffi::c_char) -> *mut ::core::ffi::c_char,
 >;
-pub type walrcv_server_version_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int>;
+pub type walrcv_server_version_fn = ::core::option::Option<
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> ::core::ffi::c_int,
+>;
 pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         tli: TimeLineID,
         filename: *mut *mut ::core::ffi::c_char,
@@ -30751,27 +31006,30 @@ pub type walrcv_readtimelinehistoryfile_fn = ::core::option::Option<
     ),
 >;
 pub type walrcv_startstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, options: *const WalRcvStreamOptions) -> bool,
+    unsafe extern "C-unwind" fn(
+        conn: *mut WalReceiverConn,
+        options: *const WalRcvStreamOptions,
+    ) -> bool,
 >;
 pub type walrcv_endstreaming_fn = ::core::option::Option<
-    unsafe extern "C" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
+    unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn, next_tli: *mut TimeLineID),
 >;
 pub type walrcv_receive_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *mut *mut ::core::ffi::c_char,
         wait_fd: *mut pgsocket,
     ) -> ::core::ffi::c_int,
 >;
 pub type walrcv_send_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         buffer: *const ::core::ffi::c_char,
         nbytes: ::core::ffi::c_int,
     ),
 >;
 pub type walrcv_create_slot_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         slotname: *const ::core::ffi::c_char,
         temporary: bool,
@@ -30782,16 +31040,16 @@ pub type walrcv_create_slot_fn = ::core::option::Option<
     ) -> *mut ::core::ffi::c_char,
 >;
 pub type walrcv_alter_slot_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         slotname: *const ::core::ffi::c_char,
         failover: bool,
     ),
 >;
 pub type walrcv_get_backend_pid_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn) -> pid_t>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn) -> pid_t>;
 pub type walrcv_exec_fn = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         conn: *mut WalReceiverConn,
         query: *const ::core::ffi::c_char,
         nRetTypes: ::core::ffi::c_int,
@@ -30799,7 +31057,7 @@ pub type walrcv_exec_fn = ::core::option::Option<
     ) -> *mut WalRcvExecResult,
 >;
 pub type walrcv_disconnect_fn =
-    ::core::option::Option<unsafe extern "C" fn(conn: *mut WalReceiverConn)>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(conn: *mut WalReceiverConn)>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WalReceiverFunctionsType {
@@ -30904,7 +31162,7 @@ impl Default for ReplicationSlotCtlData {
     }
 }
 pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -30913,7 +31171,7 @@ pub type LogicalOutputPluginWriterWrite = ::core::option::Option<
 >;
 pub type LogicalOutputPluginWriterPrepareWrite = LogicalOutputPluginWriterWrite;
 pub type LogicalOutputPluginWriterUpdateProgress = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         lr: *mut LogicalDecodingContext,
         Ptr: XLogRecPtr,
         xid: TransactionId,
@@ -30993,16 +31251,117 @@ impl Default for RowSecurityDesc {
     }
 }
 pub type row_security_policy_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
+    unsafe extern "C-unwind" fn(cmdtype: CmdType::Type, relation: Relation) -> *mut List,
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct buftag {
+    pub spcOid: Oid,
+    pub dbOid: Oid,
+    pub relNumber: RelFileNumber,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+}
+impl Default for buftag {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type BufferTag = buftag;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct BufferDesc {
+    pub tag: BufferTag,
+    pub buf_id: ::core::ffi::c_int,
+    pub state: pg_atomic_uint32,
+    pub wait_backend_pgprocno: ::core::ffi::c_int,
+    pub freeNext: ::core::ffi::c_int,
+    pub content_lock: LWLock,
+}
+impl Default for BufferDesc {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union BufferDescPadded {
+    pub bufferdesc: BufferDesc,
+    pub pad: [::core::ffi::c_char; 64usize],
+}
+impl Default for BufferDescPadded {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PendingWriteback {
+    pub tag: BufferTag,
+}
+impl Default for PendingWriteback {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WritebackContext {
+    pub max_pending: *mut ::core::ffi::c_int,
+    pub nr_pending: ::core::ffi::c_int,
+    pub pending_writebacks: [PendingWriteback; 256usize],
+}
+impl Default for WritebackContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct CkptSortItem {
+    pub tsId: Oid,
+    pub relNumber: RelFileNumber,
+    pub forkNum: ForkNumber::Type,
+    pub blockNum: BlockNumber,
+    pub buf_id: ::core::ffi::c_int,
+}
+impl Default for CkptSortItem {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BufFile {
     _unused: [u8; 0],
 }
 pub type pg_on_exit_callback =
-    ::core::option::Option<unsafe extern "C" fn(code: ::core::ffi::c_int, arg: Datum)>;
-pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C" fn()>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(code: ::core::ffi::c_int, arg: Datum)>;
+pub type shmem_startup_hook_type = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub mod XLTW_Oper {
     pub type Type = ::core::ffi::c_uint;
     pub const XLTW_None: Type = 0;
@@ -31055,7 +31414,7 @@ impl Default for xl_standby_locks {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct xl_running_xacts {
     pub xcnt: ::core::ffi::c_int,
     pub subxcnt: ::core::ffi::c_int,
@@ -31064,6 +31423,15 @@ pub struct xl_running_xacts {
     pub oldestRunningXid: TransactionId,
     pub latestCompletedXid: TransactionId,
     pub xids: __IncompleteArrayField<TransactionId>,
+}
+impl Default for xl_running_xacts {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 #[repr(C)]
 pub struct xl_invalidations {
@@ -31143,7 +31511,7 @@ impl Default for AlterTableUtilityContext {
     }
 }
 pub type ProcessUtility_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         pstmt: *mut PlannedStmt,
         queryString: *const ::core::ffi::c_char,
         readOnlyTree: bool,
@@ -31154,6 +31522,97 @@ pub type ProcessUtility_hook_type = ::core::option::Option<
         qc: *mut QueryCompletion,
     ),
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSAnyCacheEntry {
+    pub objId: Oid,
+    pub isvalid: bool,
+}
+impl Default for TSAnyCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSParserCacheEntry {
+    pub prsId: Oid,
+    pub isvalid: bool,
+    pub startOid: Oid,
+    pub tokenOid: Oid,
+    pub endOid: Oid,
+    pub headlineOid: Oid,
+    pub lextypeOid: Oid,
+    pub prsstart: FmgrInfo,
+    pub prstoken: FmgrInfo,
+    pub prsend: FmgrInfo,
+    pub prsheadline: FmgrInfo,
+}
+impl Default for TSParserCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSDictionaryCacheEntry {
+    pub dictId: Oid,
+    pub isvalid: bool,
+    pub lexizeOid: Oid,
+    pub lexize: FmgrInfo,
+    pub dictCtx: MemoryContext,
+    pub dictData: *mut ::core::ffi::c_void,
+}
+impl Default for TSDictionaryCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ListDictionary {
+    pub len: ::core::ffi::c_int,
+    pub dictIds: *mut Oid,
+}
+impl Default for ListDictionary {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TSConfigCacheEntry {
+    pub cfgId: Oid,
+    pub isvalid: bool,
+    pub prsId: Oid,
+    pub lenmap: ::core::ffi::c_int,
+    pub map: *mut ListDictionary,
+}
+impl Default for TSConfigCacheEntry {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WordEntry {
@@ -31856,7 +32315,7 @@ pub struct TSQueryParserStateData {
 }
 pub type TSQueryParserState = *mut TSQueryParserStateData;
 pub type PushFunction = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         opaque: Datum,
         state: TSQueryParserState,
         token: *mut ::core::ffi::c_char,
@@ -31941,7 +32400,7 @@ impl Default for ExecPhraseData {
     }
 }
 pub type TSExecuteCallback = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         arg: *mut ::core::ffi::c_void,
         val: *mut QueryOperand,
         data: *mut ExecPhraseData,
@@ -32343,7 +32802,7 @@ impl Default for AttStatsSlot {
     }
 }
 pub type get_attavgwidth_hook_type =
-    ::core::option::Option<unsafe extern "C" fn(relid: Oid, attnum: AttrNumber) -> int32>;
+    ::core::option::Option<unsafe extern "C-unwind" fn(relid: Oid, attnum: AttrNumber) -> int32>;
 pub mod CheckEnableRlsResult {
     pub type Type = ::core::ffi::c_uint;
     pub const RLS_NONE: Type = 0;
@@ -32378,7 +32837,7 @@ pub struct VariableStatData {
     pub var: *mut Node,
     pub rel: *mut RelOptInfo,
     pub statsTuple: HeapTuple,
-    pub freefunc: ::core::option::Option<unsafe extern "C" fn(tuple: HeapTuple)>,
+    pub freefunc: ::core::option::Option<unsafe extern "C-unwind" fn(tuple: HeapTuple)>,
     pub vartype: Oid,
     pub atttype: Oid,
     pub atttypmod: int32,
@@ -32407,7 +32866,7 @@ pub struct GenericCosts {
     pub num_sa_scans: f64,
 }
 pub type get_relation_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         rte: *mut RangeTblEntry,
         attnum: AttrNumber,
@@ -32415,15 +32874,16 @@ pub type get_relation_stats_hook_type = ::core::option::Option<
     ) -> bool,
 >;
 pub type get_index_stats_hook_type = ::core::option::Option<
-    unsafe extern "C" fn(
+    unsafe extern "C-unwind" fn(
         root: *mut PlannerInfo,
         indexOid: Oid,
         indexattnum: AttrNumber,
         vardata: *mut VariableStatData,
     ) -> bool,
 >;
-pub type CCHashFN = ::core::option::Option<unsafe extern "C" fn(datum: Datum) -> uint32>;
-pub type CCFastEqualFN = ::core::option::Option<unsafe extern "C" fn(a: Datum, b: Datum) -> bool>;
+pub type CCHashFN = ::core::option::Option<unsafe extern "C-unwind" fn(datum: Datum) -> uint32>;
+pub type CCFastEqualFN =
+    ::core::option::Option<unsafe extern "C-unwind" fn(a: Datum, b: Datum) -> bool>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct catcache {
@@ -32740,7 +33200,7 @@ pub struct SnapBuild {
     pub _address: u8,
 }
 #[pgrx_macros::pg_guard]
-unsafe extern "C" {
+unsafe extern "C-unwind" {
     pub fn ExceptionalCondition(
         conditionName: *const ::core::ffi::c_char,
         fileName: *const ::core::ffi::c_char,
@@ -32931,7 +33391,7 @@ unsafe extern "C" {
         nel: usize,
         elsize: usize,
         cmp: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
             ) -> ::core::ffi::c_int,
@@ -32961,7 +33421,7 @@ unsafe extern "C" {
         nmemb: usize,
         size: usize,
         compar: ::core::option::Option<
-            unsafe extern "C" fn(
+            unsafe extern "C-unwind" fn(
                 arg1: *const ::core::ffi::c_void,
                 arg2: *const ::core::ffi::c_void,
                 arg3: *mut ::core::ffi::c_void,
@@ -35014,14 +35474,17 @@ unsafe extern "C" {
     pub static pg_rightmost_one_pos: [uint8; 256usize];
     pub static pg_number_of_ones: [uint8; 256usize];
     pub static mut pg_popcount32:
-        ::core::option::Option<unsafe extern "C" fn(word: uint32) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint32) -> ::core::ffi::c_int>;
     pub static mut pg_popcount64:
-        ::core::option::Option<unsafe extern "C" fn(word: uint64) -> ::core::ffi::c_int>;
+        ::core::option::Option<unsafe extern "C-unwind" fn(word: uint64) -> ::core::ffi::c_int>;
     pub static mut pg_popcount_optimized: ::core::option::Option<
-        unsafe extern "C" fn(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int) -> uint64,
+        unsafe extern "C-unwind" fn(
+            buf: *const ::core::ffi::c_char,
+            bytes: ::core::ffi::c_int,
+        ) -> uint64,
     >;
     pub static mut pg_popcount_masked_optimized: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             buf: *const ::core::ffi::c_char,
             bytes: ::core::ffi::c_int,
             mask: bits8,
@@ -36281,7 +36744,7 @@ unsafe extern "C" {
         len: usize,
     ) -> pg_crc32c;
     pub static mut pg_comp_crc32c: ::core::option::Option<
-        unsafe extern "C" fn(
+        unsafe extern "C-unwind" fn(
             crc: pg_crc32c,
             data: *const ::core::ffi::c_void,
             len: usize,
@@ -36651,9 +37114,9 @@ unsafe extern "C" {
     pub fn SendSharedInvalidMessages(msgs: *const SharedInvalidationMessage, n: ::core::ffi::c_int);
     pub fn ReceiveSharedInvalidMessages(
         invalFunction: ::core::option::Option<
-            unsafe extern "C" fn(msg: *mut SharedInvalidationMessage),
+            unsafe extern "C-unwind" fn(msg: *mut SharedInvalidationMessage),
         >,
-        resetFunction: ::core::option::Option<unsafe extern "C" fn()>,
+        resetFunction: ::core::option::Option<unsafe extern "C-unwind" fn()>,
     );
     pub fn HandleCatchupInterrupt();
     pub fn ProcessCatchupInterrupt();
@@ -37253,7 +37716,7 @@ unsafe extern "C" {
         oldtup_ptr: HeapTuple,
         buffer: Buffer,
         release_callback: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::core::ffi::c_void),
+            unsafe extern "C-unwind" fn(arg1: *mut ::core::ffi::c_void),
         >,
         arg: *mut ::core::ffi::c_void,
     ) -> bool;
@@ -43810,6 +44273,99 @@ unsafe extern "C" {
         warn: bool,
     );
     pub fn scanner_isspace(ch: ::core::ffi::c_char) -> bool;
+    pub fn get_hash_partition_greatest_modulus(bound: PartitionBoundInfo) -> ::core::ffi::c_int;
+    pub fn compute_partition_hash_value(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *const Oid,
+        values: *const Datum,
+        isnull: *const bool,
+    ) -> uint64;
+    pub fn get_qual_from_partbound(parent: Relation, spec: *mut PartitionBoundSpec) -> *mut List;
+    pub fn partition_bounds_create(
+        boundspecs: *mut *mut PartitionBoundSpec,
+        nparts: ::core::ffi::c_int,
+        key: PartitionKey,
+        mapping: *mut *mut ::core::ffi::c_int,
+    ) -> PartitionBoundInfo;
+    pub fn partition_bounds_equal(
+        partnatts: ::core::ffi::c_int,
+        parttyplen: *mut int16,
+        parttypbyval: *mut bool,
+        b1: PartitionBoundInfo,
+        b2: PartitionBoundInfo,
+    ) -> bool;
+    pub fn partition_bounds_copy(src: PartitionBoundInfo, key: PartitionKey) -> PartitionBoundInfo;
+    pub fn partition_bounds_merge(
+        partnatts: ::core::ffi::c_int,
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        outer_rel: *mut RelOptInfo,
+        inner_rel: *mut RelOptInfo,
+        jointype: JoinType::Type,
+        outer_parts: *mut *mut List,
+        inner_parts: *mut *mut List,
+    ) -> PartitionBoundInfo;
+    pub fn partitions_are_ordered(
+        boundinfo: PartitionBoundInfo,
+        live_parts: *mut Bitmapset,
+    ) -> bool;
+    pub fn check_new_partition_bound(
+        relname: *mut ::core::ffi::c_char,
+        parent: Relation,
+        spec: *mut PartitionBoundSpec,
+        pstate: *mut ParseState,
+    );
+    pub fn check_default_partition_contents(
+        parent: Relation,
+        default_rel: Relation,
+        new_spec: *mut PartitionBoundSpec,
+    );
+    pub fn partition_rbound_datum_cmp(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        rb_datums: *mut Datum,
+        rb_kind: *mut PartitionRangeDatumKind::Type,
+        tuple_datums: *mut Datum,
+        n_tuple_datums: ::core::ffi::c_int,
+    ) -> int32;
+    pub fn partition_list_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        value: Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_range_datum_bsearch(
+        partsupfunc: *mut FmgrInfo,
+        partcollation: *mut Oid,
+        boundinfo: PartitionBoundInfo,
+        nvalues: ::core::ffi::c_int,
+        values: *mut Datum,
+        is_equal: *mut bool,
+    ) -> ::core::ffi::c_int;
+    pub fn partition_hash_bsearch(
+        boundinfo: PartitionBoundInfo,
+        modulus: ::core::ffi::c_int,
+        remainder: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
+    pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
+        -> PartitionDirectory;
+    pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
+    pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
+    pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
+    pub fn make_partition_pruneinfo(
+        root: *mut PlannerInfo,
+        parentrel: *mut RelOptInfo,
+        subpaths: *mut List,
+        prunequal: *mut List,
+    ) -> *mut PartitionPruneInfo;
+    pub fn prune_append_rel_partitions(rel: *mut RelOptInfo) -> *mut Bitmapset;
+    pub fn get_matching_partitions(
+        context: *mut PartitionPruneContext,
+        pruning_steps: *mut List,
+    ) -> *mut Bitmapset;
     pub fn make_expanded_record_from_typeid(
         type_id: Oid,
         typmod: int32,
@@ -44580,6 +45136,85 @@ unsafe extern "C" {
         hasRowSecurity: *mut bool,
         hasSubLinks: *mut bool,
     );
+    pub static mut BufferDescriptors: *mut BufferDescPadded;
+    pub static mut BufferIOCVArray: *mut ConditionVariableMinimallyPadded;
+    pub static mut BackendWritebackContext: WritebackContext;
+    pub static mut LocalBufferDescriptors: *mut BufferDesc;
+    pub fn LockBufHdr(desc: *mut BufferDesc) -> uint32;
+    pub static mut CkptBufferIds: *mut CkptSortItem;
+    pub static buffer_io_resowner_desc: ResourceOwnerDesc;
+    pub static buffer_pin_resowner_desc: ResourceOwnerDesc;
+    pub fn WritebackContextInit(
+        context: *mut WritebackContext,
+        max_pending: *mut ::core::ffi::c_int,
+    );
+    pub fn IssuePendingWritebacks(wb_context: *mut WritebackContext, io_context: IOContext::Type);
+    pub fn ScheduleBufferTagForWriteback(
+        wb_context: *mut WritebackContext,
+        io_context: IOContext::Type,
+        tag: *mut BufferTag,
+    );
+    pub fn IOContextForStrategy(strategy: BufferAccessStrategy) -> IOContext::Type;
+    pub fn StrategyGetBuffer(
+        strategy: BufferAccessStrategy,
+        buf_state: *mut uint32,
+        from_ring: *mut bool,
+    ) -> *mut BufferDesc;
+    pub fn StrategyFreeBuffer(buf: *mut BufferDesc);
+    pub fn StrategyRejectBuffer(
+        strategy: BufferAccessStrategy,
+        buf: *mut BufferDesc,
+        from_ring: bool,
+    ) -> bool;
+    pub fn StrategySyncStart(
+        complete_passes: *mut uint32,
+        num_buf_alloc: *mut uint32,
+    ) -> ::core::ffi::c_int;
+    pub fn StrategyNotifyBgWriter(bgwprocno: ::core::ffi::c_int);
+    pub fn StrategyShmemSize() -> Size;
+    pub fn StrategyInitialize(init: bool);
+    pub fn have_free_buffer() -> bool;
+    pub fn BufTableShmemSize(size: ::core::ffi::c_int) -> Size;
+    pub fn InitBufTable(size: ::core::ffi::c_int);
+    pub fn BufTableHashCode(tagPtr: *mut BufferTag) -> uint32;
+    pub fn BufTableLookup(tagPtr: *mut BufferTag, hashcode: uint32) -> ::core::ffi::c_int;
+    pub fn BufTableInsert(
+        tagPtr: *mut BufferTag,
+        hashcode: uint32,
+        buf_id: ::core::ffi::c_int,
+    ) -> ::core::ffi::c_int;
+    pub fn BufTableDelete(tagPtr: *mut BufferTag, hashcode: uint32);
+    pub fn PinLocalBuffer(buf_hdr: *mut BufferDesc, adjust_usagecount: bool) -> bool;
+    pub fn UnpinLocalBuffer(buffer: Buffer);
+    pub fn UnpinLocalBufferNoOwner(buffer: Buffer);
+    pub fn PrefetchLocalBuffer(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+    ) -> PrefetchBufferResult;
+    pub fn LocalBufferAlloc(
+        smgr: SMgrRelation,
+        forkNum: ForkNumber::Type,
+        blockNum: BlockNumber,
+        foundPtr: *mut bool,
+    ) -> *mut BufferDesc;
+    pub fn ExtendBufferedRelLocal(
+        bmr: BufferManagerRelation,
+        fork: ForkNumber::Type,
+        flags: uint32,
+        extend_by: uint32,
+        extend_upto: BlockNumber,
+        buffers: *mut Buffer,
+        extended_by: *mut uint32,
+    ) -> BlockNumber;
+    pub fn MarkLocalBufferDirty(buffer: Buffer);
+    pub fn DropRelationLocalBuffers(
+        rlocator: RelFileLocator,
+        forkNum: ForkNumber::Type,
+        firstDelBlock: BlockNumber,
+    );
+    pub fn DropRelationAllLocalBuffers(rlocator: RelFileLocator);
+    pub fn AtEOXact_LocalBuffers(isCommit: bool);
     pub fn BufFileCreateTemp(interXact: bool) -> *mut BufFile;
     pub fn BufFileClose(file: *mut BufFile);
     pub fn BufFileRead(file: *mut BufFile, ptr: *mut ::core::ffi::c_void, size: usize) -> usize;
@@ -45055,6 +45690,11 @@ unsafe extern "C" {
     pub fn CreateCommandTag(parsetree: *mut Node) -> CommandTag::Type;
     pub fn GetCommandLogLevel(parsetree: *mut Node) -> LogStmtLevel::Type;
     pub fn CommandIsReadOnly(pstmt: *mut PlannedStmt) -> bool;
+    pub static mut TSCurrentConfig: *mut ::core::ffi::c_char;
+    pub fn lookup_ts_parser_cache(prsId: Oid) -> *mut TSParserCacheEntry;
+    pub fn lookup_ts_dictionary_cache(dictId: Oid) -> *mut TSDictionaryCacheEntry;
+    pub fn lookup_ts_config_cache(cfgId: Oid) -> *mut TSConfigCacheEntry;
+    pub fn getTSCurrentConfig(emitError: bool) -> Oid;
     pub fn compareWordEntryPos(
         a: *const ::core::ffi::c_void,
         b: *const ::core::ffi::c_void,
@@ -45068,7 +45708,9 @@ unsafe extern "C" {
         fname: *const ::core::ffi::c_char,
         s: *mut StopList,
         wordop: ::core::option::Option<
-            unsafe extern "C" fn(arg1: *const ::core::ffi::c_char) -> *mut ::core::ffi::c_char,
+            unsafe extern "C-unwind" fn(
+                arg1: *const ::core::ffi::c_char,
+            ) -> *mut ::core::ffi::c_char,
         >,
     );
     pub fn searchstoplist(s: *mut StopList, key: *mut ::core::ffi::c_char) -> bool;
@@ -48977,6 +49619,13 @@ unsafe extern "C" {
         useOr: bool,
         varRelid: ::core::ffi::c_int,
     ) -> Selectivity;
+    pub fn get_tablespace_page_costs(
+        spcid: Oid,
+        spc_random_page_cost: *mut float8,
+        spc_seq_page_cost: *mut float8,
+    );
+    pub fn get_tablespace_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
+    pub fn get_tablespace_maintenance_io_concurrency(spcid: Oid) -> ::core::ffi::c_int;
     pub fn CreateCacheMemoryContext();
     pub fn InitCatCache(
         id: ::core::ffi::c_int,
@@ -49029,7 +49678,7 @@ unsafe extern "C" {
         tuple: HeapTuple,
         newtuple: HeapTuple,
         function: ::core::option::Option<
-            unsafe extern "C" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
+            unsafe extern "C-unwind" fn(arg1: ::core::ffi::c_int, arg2: uint32, arg3: Oid),
         >,
     );
     pub fn InitCatalogCache();

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -76,7 +76,7 @@ rand = "0.9.0"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.13.1"
+version = "=0.14.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = [

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"


### PR DESCRIPTION
Welcome to pgrx v0.14.0!

This is our very first release with Windows support.  How cool is that?  😎  Much thanks go to all the contributors that have been working on Windows support for so long.  There's basic instructions for getting started in [the project README](https://github.com/pgcentralfoundation/pgrx?tab=readme-ov-file#windows).

Beyond that, this release officially removes support for Postgres v12.  If you still need to support it, you'll need to lock your dependencies to pgrx v0.13.1.

Additionally, there's a number of bugfixes, more included Postgres headers, and some breaking code changes that'll need attention.

As always, make sure to first install `cargo-pgrx` with `cargo install cargo-pgrx --version 0.14.0 --locked` and to update your extension `Cargo.toml` files using our `cargo pgrx upgrade` tool.

# What's Changed

## Windows Support

One important note for Windows Support:

> If an extension is compiled for Windows, the pgrx `cshim` feature *must* be enabled. If an extension does not enable the `cshim` feature in its `Cargo.toml`, `cargo build --features pgrx/cshim` can be used at build time.

* fix cargo-pgrx and pgrx-tests on Windows by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/1934
* tell C compiler to put code and data in separate sections by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2006
* force using extern "C-unwind" for functions marked with #[pg_guard] by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2014

This change (using `extern "C-unwind"`) is important to call out separately as it'll require any functions with `#[pg_guard]` to be changed to use `"C-unwind"`.  This came about as a requirement for Windows, but is necessary for all supported platforms.

## Breaking Changes

* `pgrx::pg_guard`: functions marked with `#[pg_guard]` must use the `C-unwind` ABI, and `pg_guard` macro generates an error for functions that do not use the `C-unwind` ABI.
* `pgrx::lwlock`: the parameter `name` of `PgLwLock::new` is required; `PgLwLock::from_named` is removed; the type of the parameter `value` of `PgLwLock::attach` is changed.
* `pgrx::atomic`: the parameter `name` of `PgAtomic::new` is required.
* `pgrx::pg_sys`: ABI of all generated binding function types has been changed from `C` to `C-unwind`.
* `pgrx-tests`: on Linux, before using `cargo-pgrx` with `--runas`, you must relax kernel security restrictions by running `sudo sysctl fs.protected_fifos=0` due to internal implementation details.


## Bug Fixes

* fix: invalid error info in PgHeapTuple::set_by_index by @silver-ymz in https://github.com/pgcentralfoundation/pgrx/pull/1998
* Fixed expected message for retinfo check by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2031

## API Changes (likely breaking) 

* `DatumWithOid`: Add `new_from_datum(Option<Datum>, Oid)` and `null_oid(Oid)` by @the-kenny in https://github.com/pgcentralfoundation/pgrx/pull/1999
* Implemented `pgstat` macros by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2007
* Implemented `Display` for `Oid` by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2029
* Added mapping for `xid` by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2003

This PR actually adds a hand-rolled representation for Postgres' `pg_sys::TransactionId` type.  As such, usages of `pg_sys::TransactionId` may need adjustments.  If we missed any UX for the type, please file issues (or PRs!) and we'll address them immediately.  A benefit of this is that it's now possible to use `pg_sys::TransactionId` as arguments or the return type of `#[pg_extern]` functions.

* Renamed `Oid::as_u32` to `to_u32` by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2011


## New Features

* Enable cross compiling extensions by @rhelmot in https://github.com/pgcentralfoundation/pgrx/pull/1994
* feat: add `PgHeapTuple::set_by_index_unchecked` by @silver-ymz in https://github.com/pgcentralfoundation/pgrx/pull/2012

## More Headers

* include `storage/buf_internals.h` by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2008
* include `tsearch/ts_cache.h` by @silver-ymz in https://github.com/pgcentralfoundation/pgrx/pull/2010
* include `utils/spccache.h` by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2023
* add partitioning headers by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2018

## Code Cleanups

* Dedup array `IntoDatum`, drop intermediate Vecs for `tuples` by @vrmiguel in https://github.com/pgcentralfoundation/pgrx/pull/2017
* A number of small lints by @nyurik in https://github.com/pgcentralfoundation/pgrx/pull/2026

A special thanks to @nyurik for this one.  It was a lot of work and should make clippy users a lot happier!

## Administrative/CI

* Removed support of PostgreSQL 12 by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2028 and https://github.com/pgcentralfoundation/pgrx/pull/2036
* Fix typo on README.md by @lizardoluis in https://github.com/pgcentralfoundation/pgrx/pull/1995
* Pinned cargo-edit version  by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2004
* Updated cargo-edit by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2005
* Updated Alpine version to 3.21 by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2015
* Instruct `rustfmt` to use `--edition 2021` by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2002
* Fixed typo in gcd docs by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2027
* Fixed docker file for alpine by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2024
* update readme about Windows requirements by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2019
* Search artifacts by manifest path by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2032
* Fixed Discord invitation link by @YohDeadfall in https://github.com/pgcentralfoundation/pgrx/pull/2033
* cargo-fmt by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2038
* update dependencies and fix compilation problem on pg13 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2039

# Thank You!

I just want to send a sincere thank you to all the contributors for this release.  It represents a lot of work and I'm sure they hope y'all enjoy it and can make good use of it!

## New Contributors
* @lizardoluis made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1995
* @rhelmot made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1994

**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.13.1...v0.14.0