### PR TITLE
fix `cargo pgrx install` error if there is a build script

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -436,7 +436,10 @@ pub(crate) fn find_library_file(
             _ => None,
         })
         // normalize being flattened and low to the ground
-        .find(|artifact| manifest_path == artifact.manifest_path)
+        .find(|artifact| {
+            artifact.manifest_path == manifest_path
+                && artifact.target.crate_types.iter().any(|s| s == "cdylib")
+        })
         .and_then(|artifact| {
             artifact
                 .filenames


### PR DESCRIPTION
If there is a build script for extension, `cargo pgrx install` would error because `cargo-pgrx` thinks the build script artifact is expected dynamic library artifact.