### PR TITLE
Update version to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bzip2",
  "cargo-edit",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "atomic-traits",
  "bitflags 2.9.0",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "cee-scape",
  "libc",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "clap-cargo 0.14.1",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ exclude = [
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-macros = { path = "./pgrx-macros", version = "=0.14.0" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.14.0" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.14.0" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.14.0" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.14.0" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.14.1" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.14.1" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.14.1" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.14.1" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.14.1" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "=0.13.2" # format-preserving edits to cargo.toml

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "cargo-pgrx"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -20,10 +20,10 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.14.0"
+pgrx = "=0.14.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.14.0"
+pgrx-tests = "=0.14.1"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -76,7 +76,7 @@ rand = "0.9.0"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.14.0"
+version = "=0.14.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = [

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"


### PR DESCRIPTION
This is pgrx v0.14.1.  It is a small bugfix release that fixes a problem building extensions that have their own `build.rs`.

Please update with `cargo install cargo-pgrx --version 0.14.1 --locked` and update your extension `Cargo.toml` files with `cargo pgrx upgrade`.


## What's Changed
* fix `cargo pgrx install` error if there is a build script by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2041


**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.14.0...v0.14.1