### PR TITLE
Remove the $libdir/ prefix from module_pathname

### DIFF
--- a/cargo-pgrx/README.md
+++ b/cargo-pgrx/README.md
@@ -699,7 +699,7 @@ AS 'MODULE_PATHNAME', 'hello_extension_wrapper';
 ```
 
 `MODULE_PATHNAME` is replaced by Postgres with the configured value in the `.control` file. For pgrx-based extensions,
-this is  usually set to `$libdir/<extension-name>`.
+this is  usually set to `<extension-name>`.
 
 When using versioned shared-object support, the same SQL would look as follows:
 
@@ -707,7 +707,7 @@ When using versioned shared-object support, the same SQL would look as follows:
 CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
 STRICT
 LANGUAGE c /* Rust */
-AS '$libdir/extension-0.0.0', 'hello_extension_wrapper';
+AS 'extension-0.0.0', 'hello_extension_wrapper';
 ```
 
 Note that the versioned shared library is hard-coded in the function definition. This corresponds to the
@@ -722,7 +722,7 @@ produce the following SQL for the above function:
 CREATE OR REPLACE FUNCTION "hello_extension"() RETURNS text /* &str */
 STRICT
 LANGUAGE c /* Rust */
-AS '$libdir/extension-0.1.0', 'hello_extension_wrapper';
+AS 'extension-0.1.0', 'hello_extension_wrapper';
 ```
 
 This SQL must be used in the upgrade script from `0.0.0` to `0.1.0` in order to point the `hello_extension` function to

--- a/cargo-pgrx/src/templates/control
+++ b/cargo-pgrx/src/templates/control
@@ -1,6 +1,6 @@
 comment = '{name}:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/{name}'
+module_pathname = '{name}'
 relocatable = false
 superuser = true
 trusted = false

--- a/pgrx-examples/aggregate/aggregate.control
+++ b/pgrx-examples/aggregate/aggregate.control
@@ -1,5 +1,5 @@
 comment = 'aggregate:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/aggregate'
+module_pathname = 'aggregate'
 relocatable = false
 superuser = false

--- a/pgrx-examples/arrays/arrays.control
+++ b/pgrx-examples/arrays/arrays.control
@@ -1,6 +1,6 @@
 comment = 'arrays:  Created by pgrx'
 default_version = '0.1.0'
-module_pathname = '$libdir/arrays'
+module_pathname = 'arrays'
 relocatable = false
 superuser = false
 schema = arrays

--- a/pgrx-examples/bad_ideas/bad_ideas.control
+++ b/pgrx-examples/bad_ideas/bad_ideas.control
@@ -1,5 +1,5 @@
 comment = 'bad_ideas:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/bad_ideas'
+module_pathname = 'bad_ideas'
 relocatable = false
 superuser = false

--- a/pgrx-examples/bgworker/bgworker.control
+++ b/pgrx-examples/bgworker/bgworker.control
@@ -1,5 +1,5 @@
 comment = 'bgworker:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/bgworker'
+module_pathname = 'bgworker'
 relocatable = false
 superuser = false

--- a/pgrx-examples/bytea/bytea.control
+++ b/pgrx-examples/bytea/bytea.control
@@ -1,5 +1,5 @@
 comment = 'bytea:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/bytea'
+module_pathname = 'bytea'
 relocatable = false
 superuser = false

--- a/pgrx-examples/composite_type/composite_type.control
+++ b/pgrx-examples/composite_type/composite_type.control
@@ -1,5 +1,5 @@
 comment = 'composite_type:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/composite_type'
+module_pathname = 'composite_type'
 relocatable = false
 superuser = false

--- a/pgrx-examples/custom_libname/other_name.control
+++ b/pgrx-examples/custom_libname/other_name.control
@@ -1,5 +1,5 @@
 comment = 'custom_libname:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/other_name'
+module_pathname = 'other_name'
 relocatable = false
 superuser = false

--- a/pgrx-examples/custom_sql/custom_sql.control
+++ b/pgrx-examples/custom_sql/custom_sql.control
@@ -1,5 +1,5 @@
 comment = 'custom_sql:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/custom_sql'
+module_pathname = 'custom_sql'
 relocatable = false
 superuser = false

--- a/pgrx-examples/custom_types/custom_types.control
+++ b/pgrx-examples/custom_types/custom_types.control
@@ -1,6 +1,6 @@
 comment = 'custom_types:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/custom_types'
+module_pathname = 'custom_types'
 relocatable = false
 superuser = false
 trusted = false

--- a/pgrx-examples/datetime/datetime.control
+++ b/pgrx-examples/datetime/datetime.control
@@ -1,5 +1,5 @@
 comment = 'arrays:  Created by pgrx'
 default_version = '0.1.0'
-module_pathname = '$libdir/datetime'
+module_pathname = 'datetime'
 relocatable = true
 superuser = false

--- a/pgrx-examples/errors/errors.control
+++ b/pgrx-examples/errors/errors.control
@@ -1,6 +1,6 @@
 comment = 'errors:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/errors'
+module_pathname = 'errors'
 relocatable = false
 superuser = false
 schema = errors

--- a/pgrx-examples/nostd/nostd.control
+++ b/pgrx-examples/nostd/nostd.control
@@ -1,5 +1,5 @@
 comment = 'nostd:  Created by pgrx'
 default_version = '1.0'
-module_pathname = '$libdir/nostd'
+module_pathname = 'nostd'
 relocatable = false
 superuser = false

--- a/pgrx-examples/numeric/numeric.control
+++ b/pgrx-examples/numeric/numeric.control
@@ -1,5 +1,5 @@
 comment = 'numeric:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/numeric'
+module_pathname = 'numeric'
 relocatable = false
 superuser = false

--- a/pgrx-examples/operators/operators.control
+++ b/pgrx-examples/operators/operators.control
@@ -1,5 +1,5 @@
 comment = 'operators:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/operators'
+module_pathname = 'operators'
 relocatable = false
 superuser = false

--- a/pgrx-examples/pgtrybuilder/pgtrybuilder.control
+++ b/pgrx-examples/pgtrybuilder/pgtrybuilder.control
@@ -1,6 +1,6 @@
 comment = 'pgtrybuilder:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/pgtrybuilder'
+module_pathname = 'pgtrybuilder'
 relocatable = false
 superuser = false
 schema = pgtrybuilder

--- a/pgrx-examples/range/range.control
+++ b/pgrx-examples/range/range.control
@@ -1,6 +1,6 @@
 comment = 'range:  Created by pgrx'
 default_version = '0.1.0'
-module_pathname = '$libdir/range'
+module_pathname = 'range'
 relocatable = false
 superuser = false
 schema = range

--- a/pgrx-examples/schemas/schemas.control
+++ b/pgrx-examples/schemas/schemas.control
@@ -1,5 +1,5 @@
 comment = 'schemas:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/schemas'
+module_pathname = 'schemas'
 relocatable = false
 superuser = true    # b/c this extension creates objects in "pg_catalog"

--- a/pgrx-examples/shmem/shmem.control
+++ b/pgrx-examples/shmem/shmem.control
@@ -1,5 +1,5 @@
 comment = 'shmem:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/shmem'
+module_pathname = 'shmem'
 relocatable = false
 superuser = false

--- a/pgrx-examples/spi/spi.control
+++ b/pgrx-examples/spi/spi.control
@@ -1,6 +1,6 @@
 comment = 'spi:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/spi'
+module_pathname = 'spi'
 relocatable = false
 superuser = false
 schema = 'spi'

--- a/pgrx-examples/spi_srf/spi_srf.control
+++ b/pgrx-examples/spi_srf/spi_srf.control
@@ -1,6 +1,6 @@
 comment = 'spi_srf:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/spi_srf'
+module_pathname = 'spi_srf'
 relocatable = false
 superuser = false
 schema = 'spi_srf'

--- a/pgrx-examples/srf/srf.control
+++ b/pgrx-examples/srf/srf.control
@@ -1,6 +1,6 @@
 comment = 'srf:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/srf'
+module_pathname = 'srf'
 relocatable = false
 superuser = false
 schema = srf

--- a/pgrx-examples/strings/strings.control
+++ b/pgrx-examples/strings/strings.control
@@ -1,6 +1,6 @@
 comment = 'strings:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/strings'
+module_pathname = 'strings'
 relocatable = false
 superuser = false
 schema = strings

--- a/pgrx-examples/triggers/triggers.control
+++ b/pgrx-examples/triggers/triggers.control
@@ -1,5 +1,5 @@
 comment = 'triggers:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/triggers'
+module_pathname = 'triggers'
 relocatable = false
 superuser = false

--- a/pgrx-examples/versioned_custom_libname_so/versioned_othername.control
+++ b/pgrx-examples/versioned_custom_libname_so/versioned_othername.control
@@ -1,6 +1,6 @@
 comment = 'versioned_custom_libname_so:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
 # commenting-out module_pathname results in this extension being built/run/tested in "versioned shared-object mode"
-# module_pathname = '$libdir/versioned_othername'
+# module_pathname = 'versioned_othername'
 relocatable = false
 superuser = false

--- a/pgrx-examples/versioned_so/versioned_so.control
+++ b/pgrx-examples/versioned_so/versioned_so.control
@@ -1,6 +1,6 @@
 comment = 'versioned_so:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
 # commenting-out module_pathname results in this extension being built/run/tested in "versioned shared-object mode"
-# module_pathname = '$libdir/versioned_so'
+# module_pathname = 'versioned_so'
 relocatable = false
 superuser = false

--- a/pgrx-examples/wal_decoder/wal_decoder.control
+++ b/pgrx-examples/wal_decoder/wal_decoder.control
@@ -1,6 +1,6 @@
 comment = 'wal_decoder:  Created by pgrx'
 default_version = '@CARGO_VERSION@'
-module_pathname = '$libdir/wal_decoder'
+module_pathname = 'wal_decoder'
 relocatable = false
 superuser = true
 trusted = false

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -456,7 +456,7 @@ impl PgrxSql {
             let extname = &self.extension_name;
             let extver = &self.control.default_version;
             // Note: versioned so-name format must agree with cargo pgrx
-            format!("$libdir/{extname}-{extver}")
+            format!("{extname}-{extver}")
         } else {
             String::from("MODULE_PATHNAME")
         }

--- a/pgrx-tests/pgrx_tests.control
+++ b/pgrx-tests/pgrx_tests.control
@@ -1,5 +1,5 @@
 comment = 'tests:  Created by pgrx'
 default_version = '1.0'
-module_pathname = '$libdir/pgrx_tests'
+module_pathname = 'pgrx_tests'
 relocatable = false
 superuser = false


### PR DESCRIPTION
It limits the search to PKGLIBDIR; if anyone installs it into another directory in `dynamic_library_path`, Postgres won't be able to find it.

[Details](https://justatheory.com/2025/04/update-control/).

I think pgrx should also consider adding something equivalent to the PGRX `prefix` param to allow the sharedir and pkglibdir files to be installed somewhere other than where `pg_config` suggests to properly support `dynamic_library_path` and the new `extension_control_path` configs.