### PR TITLE
Include `pg_statistic_ext` catalog

### DIFF
--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -62,6 +62,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_seclabel.h"
+#include "catalog/pg_statistic_ext.h"
 #include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -143,6 +143,7 @@
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
+#include "statistics/statistics.h"
 #include "storage/block.h"
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -62,6 +62,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_seclabel.h"
+#include "catalog/pg_statistic_ext.h"
 #include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -144,6 +144,7 @@
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
+#include "statistics/statistics.h"
 #include "storage/block.h"
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -63,6 +63,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_seclabel.h"
+#include "catalog/pg_statistic_ext.h"
 #include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -145,6 +145,7 @@
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
+#include "statistics/statistics.h"
 #include "storage/block.h"
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -64,6 +64,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_seclabel.h"
+#include "catalog/pg_statistic_ext.h"
 #include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -147,6 +147,7 @@
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
+#include "statistics/statistics.h"
 #include "storage/block.h"
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -64,6 +64,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_seclabel.h"
+#include "catalog/pg_statistic_ext.h"
 #include "catalog/pg_tablespace.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -147,6 +147,7 @@
 #include "replication/output_plugin.h"
 #include "rewrite/rewriteHandler.h"
 #include "rewrite/rowsecurity.h"
+#include "statistics/statistics.h"
 #include "storage/block.h"
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"


### PR DESCRIPTION
To support `pg_statistic_ext` (extended statistics):
- Added `catalog/pg_statistic_ext.h`: `pg_statistic_ext`, `pg_statistic_ext_data` catalog definition
- Added `statistics/statistics.h`: necessary data structures and methods to manipulate extended statistics