### PR TITLE
pass bundle and bundle_loader to linker on macos

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,3 @@ b = "build --features"
 c = "check --features"
 t = "test --features"
 r = "run --features"
-
-[target.'cfg(target_os="macos")']
-# Postgres symbols won't be available until runtime
-rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -466,10 +466,15 @@ jobs:
       # hack Cargo.toml to use this version of pgrx from github
       - name: hack Cargo.toml
         run: |
-          echo "[patch.crates-io]" >> /tmp/sample/Cargo.toml
-          echo "pgrx        = { path = \"${GITHUB_WORKSPACE}/pgrx\"        }" >> /tmp/sample/Cargo.toml
-          echo "pgrx-macros = { path = \"${GITHUB_WORKSPACE}/pgrx-macros\" }" >> /tmp/sample/Cargo.toml
-          echo "pgrx-tests  = { path = \"${GITHUB_WORKSPACE}/pgrx-tests\"  }" >> /tmp/sample/Cargo.toml
+          cat <<EOF >> /tmp/sample/Cargo.toml
+          [patch.crates-io]
+          pgrx = { path = "${GITHUB_WORKSPACE}/pgrx" }
+          pgrx-macros = { path = "${GITHUB_WORKSPACE}/pgrx-macros" }
+          pgrx-pg-config = { path = "${GITHUB_WORKSPACE}/pgrx-pg-config" }
+          pgrx-pg-sys = { path = "${GITHUB_WORKSPACE}/pgrx-pg-sys" }
+          pgrx-sql-entity-graph = { path = "${GITHUB_WORKSPACE}/pgrx-sql-entity-graph" }
+          pgrx-tests = { path = "${GITHUB_WORKSPACE}/pgrx-tests" }
+          EOF
 
       - name: show Cargo.toml
         run: cat /tmp/sample/Cargo.toml

--- a/cargo-pgrx/src/command/new.rs
+++ b/cargo-pgrx/src/command/new.rs
@@ -54,18 +54,17 @@ pub(crate) fn create_crate_template(
     create_directory_structure(path.clone())?;
     create_control_file(path.clone(), name)?;
     create_cargo_toml(path.clone(), name)?;
-    create_dotcargo_config_toml(path.clone(), name)?;
     create_lib_rs(path.clone(), name, is_bgworker)?;
     create_git_ignore(path.clone(), name)?;
     create_pgrx_embed_rs(path.clone())?;
     create_setup_sql(path.clone(), name)?;
     create_setup_out(path.clone(), name)?;
+    create_build_rs(path)?;
 
     Ok(())
 }
 
 fn create_directory_structure(root: PathBuf) -> Result<(), std::io::Error> {
-    std::fs::create_dir_all(root.join(".cargo"))?;
     std::fs::create_dir_all(root.join("src").join("bin"))?;
     std::fs::create_dir_all(root.join("pg_regress").join("expected"))?;
     std::fs::create_dir_all(root.join("pg_regress").join("sql"))?;
@@ -88,16 +87,6 @@ fn create_cargo_toml(mut filename: PathBuf, name: &str) -> Result<(), std::io::E
     let mut file = std::fs::File::create(filename)?;
 
     file.write_all(format!(include_str!("../templates/cargo_toml"), name = name).as_bytes())?;
-
-    Ok(())
-}
-
-fn create_dotcargo_config_toml(mut filename: PathBuf, _name: &str) -> Result<(), std::io::Error> {
-    filename.push(".cargo");
-    filename.push("config.toml");
-    let mut file = std::fs::File::create(filename)?;
-
-    file.write_all(include_bytes!("../templates/cargo_config_toml"))?;
 
     Ok(())
 }
@@ -155,5 +144,12 @@ fn create_setup_out(mut filename: PathBuf, name: &str) -> Result<(), std::io::Er
     filename.push("setup.out");
     let mut file = std::fs::File::create(filename)?;
     file.write_all(format!(include_str!("../templates/setup_out"), name = name).as_bytes())?;
+    Ok(())
+}
+
+fn create_build_rs(mut filename: PathBuf) -> Result<(), std::io::Error> {
+    filename.push("build.rs");
+    let mut file = std::fs::File::create(filename)?;
+    file.write_all(include_bytes!("../templates/build_rs"))?;
     Ok(())
 }

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -414,9 +414,9 @@ fn compute_codegen(
             .to_str()
             .expect(".control file filename should be valid UTF8");
         let mut out = quote::quote! {
-            // call the marker.  Primarily this ensures that rustc will actually link to the library
+            // Primarily this ensures that rustc will actually link to the library
             // during the "pgrx_embed" build initiated by `cargo-pgrx schema` generation
-            #lib_name_ident::__pgrx_marker();
+            extern crate #lib_name_ident as _;
 
             let mut entities = Vec::new();
             let control_file_path = std::path::PathBuf::from(#control_file_path);

--- a/cargo-pgrx/src/templates/build_rs
+++ b/cargo-pgrx/src/templates/build_rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/cargo-pgrx/src/templates/cargo_config_toml
+++ b/cargo-pgrx/src/templates/cargo_config_toml
@@ -1,3 +1,0 @@
-[target.'cfg(target_os="macos")']
-# Postgres symbols won't be available until runtime
-rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -25,6 +25,9 @@ pgrx = "=0.14.3"
 [dev-dependencies]
 pgrx-tests = "=0.14.3"
 
+[build-dependencies]
+pgrx-pg-config = "=0.14.3"
+
 [profile.dev]
 panic = "unwind"
 

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use bindgen::callbacks::{DeriveTrait, EnumVariantValue, ImplementsTrait, MacroParsingBehavior};
 use bindgen::NonCopyUnionStyle;
-use eyre::{eyre, WrapErr};
+use eyre::{eyre, ContextCompat, WrapErr};
 use pgrx_pg_config::{
     is_supported_major_version, PgConfig, PgConfigSelector, PgMinorVersion, PgVersion, Pgrx,
     SUPPORTED_VERSIONS,
@@ -171,6 +171,38 @@ pub fn main() -> eyre::Result<()> {
 
     emit_rerun_if_changed();
 
+    let found_ver = {
+        let mut found = Vec::new();
+        for pgver in SUPPORTED_VERSIONS() {
+            if env_tracked(&format!("CARGO_FEATURE_PG{}", pgver.major)).is_some() {
+                found.push(pgver);
+            }
+        }
+        match &found[..] {
+            [ver] => ver.clone(),
+            [] => {
+                return Err(eyre!(
+                    "Did not find `pg$VERSION` feature. `pgrx-pg-sys` requires one of {} to be set",
+                    SUPPORTED_VERSIONS()
+                        .iter()
+                        .map(|pgver| format!("`pg{}`", pgver.major))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
+            }
+            versions => {
+                return Err(eyre!(
+                    "Multiple `pg$VERSION` features found.\n`--no-default-features` may be required.\nFound: {}",
+                    versions
+                        .iter()
+                        .map(|version| format!("pg{}", version.major))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                ))
+            }
+        }
+    };
+
     let pg_configs: Vec<(u16, PgConfig)> = if is_for_release {
         // This does not cross-check config.toml and Cargo.toml versions, as it is release infra.
         Pgrx::from_config()?.iter(PgConfigSelector::All)
@@ -192,36 +224,6 @@ pub fn main() -> eyre::Result<()> {
             })
             .collect()
     } else {
-        let mut found = Vec::new();
-        for pgver in SUPPORTED_VERSIONS() {
-            if env_tracked(&format!("CARGO_FEATURE_PG{}", pgver.major)).is_some() {
-                found.push(pgver);
-            }
-        }
-        let found_ver = match &found[..] {
-            [ver] => ver,
-            [] => {
-                return Err(eyre!(
-                    "Did not find `pg$VERSION` feature. `pgrx-pg-sys` requires one of {} to be set",
-                    SUPPORTED_VERSIONS()
-                        .iter()
-                        .map(|pgver| format!("`pg{}`", pgver.major))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ))
-            }
-            versions => {
-                return Err(eyre!(
-                    "Multiple `pg$VERSION` features found.\n`--no-default-features` may be required.\nFound: {}",
-                    versions
-                        .iter()
-                        .map(|version| format!("pg{}", version.major))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ))
-            }
-        };
-
         let found_major = found_ver.major;
         if let Ok(pg_config) = PgConfig::from_env() {
             let major_version = pg_config.major_version()?;
@@ -235,6 +237,20 @@ pub fn main() -> eyre::Result<()> {
             vec![(found_ver.major, specific)]
         }
     };
+
+    for (_, pg_config) in pg_configs.iter().filter(|(major, _)| *major == found_ver.major) {
+        let lib_dir = pg_config.lib_dir()?;
+        println!(
+            "cargo:rustc-link-search={}",
+            lib_dir.to_str().ok_or(eyre!("{lib_dir:?} is not valid UTF-8 string"))?
+        );
+
+        let pg_config_path = pg_config.path().wrap_err("failed to get pg_config path")?;
+        println!(
+            "cargo:PG_CONFIG={}",
+            pg_config_path.to_str().ok_or(eyre!("{pg_config_path:?} is not valid UTF-8 string"))?
+        );
+    }
 
     // make sure we're not trying to build any of the yanked postgres versions
     for (_, pg_config) in &pg_configs {
@@ -369,12 +385,6 @@ fn generate_bindings(
             )
         })?;
     }
-
-    let lib_dir = pg_config.lib_dir()?;
-    println!(
-        "cargo:rustc-link-search={}",
-        lib_dir.to_str().ok_or(eyre!("{lib_dir:?} is not valid UTF-8 string"))?
-    );
     Ok(())
 }
 

--- a/pgrx-examples/aggregate/Cargo.toml
+++ b/pgrx-examples/aggregate/Cargo.toml
@@ -38,6 +38,9 @@ serde = "1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/aggregate/build.rs
+++ b/pgrx-examples/aggregate/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/arrays/Cargo.toml
+++ b/pgrx-examples/arrays/Cargo.toml
@@ -38,6 +38,9 @@ rand = "*"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/arrays/build.rs
+++ b/pgrx-examples/arrays/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/bad_ideas/Cargo.toml
+++ b/pgrx-examples/bad_ideas/Cargo.toml
@@ -38,6 +38,9 @@ ureq = "3.0.10"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/bad_ideas/build.rs
+++ b/pgrx-examples/bad_ideas/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/bgworker/Cargo.toml
+++ b/pgrx-examples/bgworker/Cargo.toml
@@ -36,6 +36,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/bgworker/build.rs
+++ b/pgrx-examples/bgworker/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/bytea/Cargo.toml
+++ b/pgrx-examples/bytea/Cargo.toml
@@ -37,6 +37,9 @@ libflate = "2.1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/bytea/build.rs
+++ b/pgrx-examples/bytea/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/composite_type/Cargo.toml
+++ b/pgrx-examples/composite_type/Cargo.toml
@@ -37,6 +37,9 @@ serde = "1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/composite_type/build.rs
+++ b/pgrx-examples/composite_type/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/custom_libname/Cargo.toml
+++ b/pgrx-examples/custom_libname/Cargo.toml
@@ -37,6 +37,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 #[profile.dev]
 #panic = "unwind"

--- a/pgrx-examples/custom_libname/build.rs
+++ b/pgrx-examples/custom_libname/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/custom_sql/Cargo.toml
+++ b/pgrx-examples/custom_sql/Cargo.toml
@@ -37,6 +37,9 @@ serde = "1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/custom_sql/build.rs
+++ b/pgrx-examples/custom_sql/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/custom_types/Cargo.toml
+++ b/pgrx-examples/custom_types/Cargo.toml
@@ -39,6 +39,9 @@ serde = "1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/custom_types/build.rs
+++ b/pgrx-examples/custom_types/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/datetime/Cargo.toml
+++ b/pgrx-examples/datetime/Cargo.toml
@@ -37,6 +37,9 @@ rand = "0.9"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/datetime/build.rs
+++ b/pgrx-examples/datetime/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/errors/Cargo.toml
+++ b/pgrx-examples/errors/Cargo.toml
@@ -36,6 +36,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/errors/build.rs
+++ b/pgrx-examples/errors/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/nostd/Cargo.toml
+++ b/pgrx-examples/nostd/Cargo.toml
@@ -37,6 +37,9 @@ serde = "1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/nostd/build.rs
+++ b/pgrx-examples/nostd/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/numeric/Cargo.toml
+++ b/pgrx-examples/numeric/Cargo.toml
@@ -38,6 +38,9 @@ rand = "0.8.5"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 #[profile.dev]
 #panic = "unwind"
 #

--- a/pgrx-examples/numeric/build.rs
+++ b/pgrx-examples/numeric/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/operators/Cargo.toml
+++ b/pgrx-examples/operators/Cargo.toml
@@ -37,6 +37,9 @@ serde = "1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/operators/build.rs
+++ b/pgrx-examples/operators/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/pgtrybuilder/Cargo.toml
+++ b/pgrx-examples/pgtrybuilder/Cargo.toml
@@ -36,6 +36,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/pgtrybuilder/build.rs
+++ b/pgrx-examples/pgtrybuilder/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/range/Cargo.toml
+++ b/pgrx-examples/range/Cargo.toml
@@ -36,6 +36,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/range/build.rs
+++ b/pgrx-examples/range/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/schemas/Cargo.toml
+++ b/pgrx-examples/schemas/Cargo.toml
@@ -37,6 +37,9 @@ serde = "1.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/schemas/build.rs
+++ b/pgrx-examples/schemas/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/shmem/Cargo.toml
+++ b/pgrx-examples/shmem/Cargo.toml
@@ -38,6 +38,9 @@ serde = { version = "1.0", features = ["derive"] }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/shmem/build.rs
+++ b/pgrx-examples/shmem/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/spi/Cargo.toml
+++ b/pgrx-examples/spi/Cargo.toml
@@ -36,6 +36,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/spi/build.rs
+++ b/pgrx-examples/spi/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/spi_srf/Cargo.toml
+++ b/pgrx-examples/spi_srf/Cargo.toml
@@ -37,6 +37,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/spi_srf/build.rs
+++ b/pgrx-examples/spi_srf/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/srf/Cargo.toml
+++ b/pgrx-examples/srf/Cargo.toml
@@ -37,6 +37,9 @@ rand = "0.9.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/srf/build.rs
+++ b/pgrx-examples/srf/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/strings/Cargo.toml
+++ b/pgrx-examples/strings/Cargo.toml
@@ -36,6 +36,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]
 # panic = "unwind"

--- a/pgrx-examples/strings/build.rs
+++ b/pgrx-examples/strings/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/triggers/Cargo.toml
+++ b/pgrx-examples/triggers/Cargo.toml
@@ -37,6 +37,9 @@ thiserror = "2.0"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 #[profile.dev]
 #panic = "unwind"

--- a/pgrx-examples/triggers/build.rs
+++ b/pgrx-examples/triggers/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/versioned_custom_libname_so/Cargo.toml
+++ b/pgrx-examples/versioned_custom_libname_so/Cargo.toml
@@ -37,6 +37,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 #[profile.dev]
 #panic = "unwind"

--- a/pgrx-examples/versioned_custom_libname_so/build.rs
+++ b/pgrx-examples/versioned_custom_libname_so/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/versioned_so/Cargo.toml
+++ b/pgrx-examples/versioned_so/Cargo.toml
@@ -36,6 +36,9 @@ pgrx = { path = "../../pgrx", default-features = false }
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 # uncomment these if compiling outside of 'pgrx'
 #[profile.dev]
 #panic = "unwind"

--- a/pgrx-examples/versioned_so/build.rs
+++ b/pgrx-examples/versioned_so/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-examples/wal_decoder/Cargo.toml
+++ b/pgrx-examples/wal_decoder/Cargo.toml
@@ -27,6 +27,9 @@ serde_json = "1.0.140"
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }
 
+[build-dependencies]
+pgrx-pg-config = { path = "../../pgrx-pg-config" }
+
 [profile.dev]
 panic = "unwind"
 

--- a/pgrx-examples/wal_decoder/build.rs
+++ b/pgrx-examples/wal_decoder/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -16,11 +16,29 @@ use std::env::consts::EXE_SUFFIX;
 use std::ffi::OsString;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use thiserror::Error;
 use url::Url;
+
+pub fn main() -> eyre::Result<()> {
+    use std::env::var;
+
+    println!("cargo:rustc-check-cfg=cfg(pgrx)");
+    println!("cargo:rustc-cfg=pgrx");
+
+    let pg_config = PgConfig::from_pg_config_path(var("DEP_PGRX_PG_CONFIG")?);
+
+    if var("CARGO_CFG_TARGET_OS")? == "macos" {
+        let postmaster_path = pg_config.postmaster_path()?;
+        println!(
+            "cargo:rustc-link-arg-cdylib=-Wl,-bundle,-bundle_loader,{}",
+            postmaster_path.display()
+        );
+    }
+    Ok(())
+}
 
 pub mod cargo;
 
@@ -166,6 +184,10 @@ impl PgConfig {
             base_port: BASE_POSTGRES_PORT_NO,
             base_testing_port: BASE_POSTGRES_TESTING_PORT_NO,
         }
+    }
+
+    pub fn from_pg_config_path(path: impl AsRef<Path>) -> Self {
+        Self::new_with_defaults(path.as_ref().to_path_buf())
     }
 
     pub fn from_path() -> Self {

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -21,6 +21,7 @@ readme = "README.md"
 edition = "2021"
 include = ["src/**/*", "README.md", "include/*", "pgrx-cshim.c", "bindgen.rs"]
 build = "bindgen.rs"
+links = "postgres"
 
 [features]
 default = []

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -92,6 +92,9 @@ winapi = { version = "0.3.9", features = [
 eyre.workspace = true # testing functions that return `eyre::Result`
 trybuild = "1"
 
+[build-dependencies]
+pgrx-pg-config.workspace = true
+
 [lints]
 rust.unused-lifetimes = "deny"
 clippy.used-underscore-binding = "deny"

--- a/pgrx-tests/build.rs
+++ b/pgrx-tests/build.rs
@@ -1,0 +1,1 @@
+pub use pgrx_pg_config::main;

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -21,7 +21,8 @@ categories = ["database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 readme = "../README.md"
 edition = "2021"
-include = ["src/**/*"]
+include = ["src/**/*", "build.rs"]
+links = "pgrx"
 
 [lib]
 crate-type = ["rlib"]

--- a/pgrx/build.rs
+++ b/pgrx/build.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::var("DEP_POSTGRES_PG_CONFIG")?;
+    println!("cargo:PG_CONFIG={}", path);
+    Ok(())
+}

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -183,15 +183,10 @@ const _: () = {
 #[macro_export]
 macro_rules! pg_module_magic {
     () => {
-        $crate::pg_magic_func!();
+        #[cfg(not(pgrx))]
+        compile_error!("`pgrx_pg_config::main` does not run in the build script");
 
-        // A marker function which must exist in the root of the extension for proper linking by the
-        // "pgrx_embed" binary during `cargo-pgrx schema` generation.
-        #[inline(never)] /* we don't want DCE to remove this as it *could* cause the compiler to decide to not link to us */
-        #[doc(hidden)]
-        pub fn __pgrx_marker() {
-            // noop
-        }
+        $crate::pg_magic_func!();
     };
 }
 


### PR DESCRIPTION
fix #731

Since this pull request requires all extensions to include a build script, it introduces a breaking change to the API.