### PR TITLE
Update version to 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "bzip2",
  "cargo-edit",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "atomic-traits",
  "bitflags 2.9.0",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "bindgen",
  "cc",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "cargo_toml",
  "eyre",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "cee-scape",
  "libc",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "clap-cargo 0.14.1",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ exclude = [
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-macros = { path = "./pgrx-macros", version = "=0.14.2" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.14.2" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.14.2" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.14.2" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.14.2" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.14.3" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.14.3" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.14.3" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.14.3" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.14.3" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "=0.13.2" # format-preserving edits to cargo.toml

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "cargo-pgrx"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -20,10 +20,10 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.14.2"
+pgrx = "=0.14.3"
 
 [dev-dependencies]
-pgrx-tests = "=0.14.2"
+pgrx-tests = "=0.14.3"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-pg-config"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -183,18 +183,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 13.20";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 13.21";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"13.20";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"13.21";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"13";
 pub const PG_MAJORVERSION_NUM: u32 = 13;
-pub const PG_MINORVERSION_NUM: u32 = 20;
+pub const PG_MINORVERSION_NUM: u32 = 21;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"13.20";
-pub const PG_VERSION_NUM: u32 = 130020;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 13.20 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"13.21";
+pub const PG_VERSION_NUM: u32 = 130021;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 13.21 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -255,7 +255,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 13.20\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 13.21\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -32685,11 +32685,7 @@ unsafe extern "C-unwind" {
     pub fn XLogFlush(RecPtr: XLogRecPtr);
     pub fn XLogBackgroundFlush() -> bool;
     pub fn XLogNeedsFlush(RecPtr: XLogRecPtr) -> bool;
-    pub fn XLogFileInit(
-        segno: XLogSegNo,
-        use_existent: *mut bool,
-        use_lock: bool,
-    ) -> ::core::ffi::c_int;
+    pub fn XLogFileInit(segno: XLogSegNo) -> ::core::ffi::c_int;
     pub fn XLogFileOpen(segno: XLogSegNo) -> ::core::ffi::c_int;
     pub fn CheckXLogRemoved(segno: XLogSegNo, tli: TimeLineID);
     pub fn XLogGetLastRemovedSegno() -> XLogSegNo;
@@ -36798,6 +36794,11 @@ unsafe extern "C-unwind" {
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
     ) -> ::core::ffi::c_int;
+    pub fn pg_encoding_mblen_or_incomplete(
+        encoding: ::core::ffi::c_int,
+        mbstr: *const ::core::ffi::c_char,
+        remaining: usize,
+    ) -> ::core::ffi::c_int;
     pub fn pg_encoding_mblen_bounded(
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
@@ -39807,6 +39808,11 @@ unsafe extern "C-unwind" {
     pub fn ReorderBufferGetOldestTXN(arg1: *mut ReorderBuffer) -> *mut ReorderBufferTXN;
     pub fn ReorderBufferGetOldestXmin(rb: *mut ReorderBuffer) -> TransactionId;
     pub fn ReorderBufferSetRestartPoint(arg1: *mut ReorderBuffer, ptr: XLogRecPtr);
+    pub fn ReorderBufferGetInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        msgs: *mut *mut SharedInvalidationMessage,
+    ) -> uint32;
     pub fn StartupReorderBuffer();
     pub fn OutputPluginPrepareWrite(ctx: *mut LogicalDecodingContext, last_write: bool);
     pub fn OutputPluginWrite(ctx: *mut LogicalDecodingContext, last_write: bool);

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -183,18 +183,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 14.17";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 14.18";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"14.17";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"14.18";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"14";
 pub const PG_MAJORVERSION_NUM: u32 = 14;
-pub const PG_MINORVERSION_NUM: u32 = 17;
+pub const PG_MINORVERSION_NUM: u32 = 18;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"14.17";
-pub const PG_VERSION_NUM: u32 = 140017;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 14.17 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"14.18";
+pub const PG_VERSION_NUM: u32 = 140018;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 14.18 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -252,7 +252,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 14.17\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 14.18\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -34623,11 +34623,7 @@ unsafe extern "C-unwind" {
     pub fn XLogFlush(RecPtr: XLogRecPtr);
     pub fn XLogBackgroundFlush() -> bool;
     pub fn XLogNeedsFlush(RecPtr: XLogRecPtr) -> bool;
-    pub fn XLogFileInit(
-        segno: XLogSegNo,
-        use_existent: *mut bool,
-        use_lock: bool,
-    ) -> ::core::ffi::c_int;
+    pub fn XLogFileInit(segno: XLogSegNo) -> ::core::ffi::c_int;
     pub fn XLogFileOpen(segno: XLogSegNo) -> ::core::ffi::c_int;
     pub fn CheckXLogRemoved(segno: XLogSegNo, tli: TimeLineID);
     pub fn XLogGetLastRemovedSegno() -> XLogSegNo;
@@ -38973,6 +38969,11 @@ unsafe extern "C-unwind" {
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
     ) -> ::core::ffi::c_int;
+    pub fn pg_encoding_mblen_or_incomplete(
+        encoding: ::core::ffi::c_int,
+        mbstr: *const ::core::ffi::c_char,
+        remaining: usize,
+    ) -> ::core::ffi::c_int;
     pub fn pg_encoding_mblen_bounded(
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
@@ -42087,6 +42088,11 @@ unsafe extern "C-unwind" {
     pub fn ReorderBufferGetOldestTXN(arg1: *mut ReorderBuffer) -> *mut ReorderBufferTXN;
     pub fn ReorderBufferGetOldestXmin(rb: *mut ReorderBuffer) -> TransactionId;
     pub fn ReorderBufferSetRestartPoint(arg1: *mut ReorderBuffer, ptr: XLogRecPtr);
+    pub fn ReorderBufferGetInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        msgs: *mut *mut SharedInvalidationMessage,
+    ) -> uint32;
     pub fn StartupReorderBuffer();
     pub fn OutputPluginPrepareWrite(ctx: *mut LogicalDecodingContext, last_write: bool);
     pub fn OutputPluginWrite(ctx: *mut LogicalDecodingContext, last_write: bool);

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -184,18 +184,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 15.12";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 15.13";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"15.12";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"15.13";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"15";
 pub const PG_MAJORVERSION_NUM: u32 = 15;
-pub const PG_MINORVERSION_NUM: u32 = 12;
+pub const PG_MINORVERSION_NUM: u32 = 13;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"15.12";
-pub const PG_VERSION_NUM: u32 = 150012;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 15.12 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"15.13";
+pub const PG_VERSION_NUM: u32 = 150013;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 15.13 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -254,7 +254,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 15.12\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 15.13\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -39412,6 +39412,11 @@ unsafe extern "C-unwind" {
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
     ) -> ::core::ffi::c_int;
+    pub fn pg_encoding_mblen_or_incomplete(
+        encoding: ::core::ffi::c_int,
+        mbstr: *const ::core::ffi::c_char,
+        remaining: usize,
+    ) -> ::core::ffi::c_int;
     pub fn pg_encoding_mblen_bounded(
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
@@ -42546,6 +42551,11 @@ unsafe extern "C-unwind" {
     pub fn ReorderBufferGetOldestTXN(arg1: *mut ReorderBuffer) -> *mut ReorderBufferTXN;
     pub fn ReorderBufferGetOldestXmin(rb: *mut ReorderBuffer) -> TransactionId;
     pub fn ReorderBufferSetRestartPoint(arg1: *mut ReorderBuffer, ptr: XLogRecPtr);
+    pub fn ReorderBufferGetInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        msgs: *mut *mut SharedInvalidationMessage,
+    ) -> uint32;
     pub fn StartupReorderBuffer();
     pub fn OutputPluginPrepareWrite(ctx: *mut LogicalDecodingContext, last_write: bool);
     pub fn OutputPluginWrite(ctx: *mut LogicalDecodingContext, last_write: bool);

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -184,18 +184,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 16.8";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 16.9";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"16.8";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"16.9";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"16";
 pub const PG_MAJORVERSION_NUM: u32 = 16;
-pub const PG_MINORVERSION_NUM: u32 = 8;
+pub const PG_MINORVERSION_NUM: u32 = 9;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"16.8";
-pub const PG_VERSION_NUM: u32 = 160008;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 16.8 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"16.9";
+pub const PG_VERSION_NUM: u32 = 160009;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 16.9 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -255,7 +255,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 16.8\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 16.9\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -40397,6 +40397,11 @@ unsafe extern "C-unwind" {
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
     ) -> ::core::ffi::c_int;
+    pub fn pg_encoding_mblen_or_incomplete(
+        encoding: ::core::ffi::c_int,
+        mbstr: *const ::core::ffi::c_char,
+        remaining: usize,
+    ) -> ::core::ffi::c_int;
     pub fn pg_encoding_mblen_bounded(
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
@@ -43625,6 +43630,11 @@ unsafe extern "C-unwind" {
     pub fn ReorderBufferGetOldestXmin(rb: *mut ReorderBuffer) -> TransactionId;
     pub fn ReorderBufferGetCatalogChangesXacts(rb: *mut ReorderBuffer) -> *mut TransactionId;
     pub fn ReorderBufferSetRestartPoint(rb: *mut ReorderBuffer, ptr: XLogRecPtr);
+    pub fn ReorderBufferGetInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        msgs: *mut *mut SharedInvalidationMessage,
+    ) -> uint32;
     pub fn StartupReorderBuffer();
     pub fn _PG_output_plugin_init(cb: *mut OutputPluginCallbacks);
     pub fn OutputPluginPrepareWrite(ctx: *mut LogicalDecodingContext, last_write: bool);

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -183,18 +183,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 17.4";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 17.5";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"17.4";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"17.5";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"17";
 pub const PG_MAJORVERSION_NUM: u32 = 17;
-pub const PG_MINORVERSION_NUM: u32 = 4;
+pub const PG_MINORVERSION_NUM: u32 = 5;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"17.4";
-pub const PG_VERSION_NUM: u32 = 170004;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 17.4 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"17.5";
+pub const PG_VERSION_NUM: u32 = 170005;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 17.5 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -255,7 +255,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 17.4\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 17.5\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -41648,6 +41648,11 @@ unsafe extern "C-unwind" {
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
     ) -> ::core::ffi::c_int;
+    pub fn pg_encoding_mblen_or_incomplete(
+        encoding: ::core::ffi::c_int,
+        mbstr: *const ::core::ffi::c_char,
+        remaining: usize,
+    ) -> ::core::ffi::c_int;
     pub fn pg_encoding_mblen_bounded(
         encoding: ::core::ffi::c_int,
         mbstr: *const ::core::ffi::c_char,
@@ -44909,6 +44914,11 @@ unsafe extern "C-unwind" {
     pub fn ReorderBufferGetOldestXmin(rb: *mut ReorderBuffer) -> TransactionId;
     pub fn ReorderBufferGetCatalogChangesXacts(rb: *mut ReorderBuffer) -> *mut TransactionId;
     pub fn ReorderBufferSetRestartPoint(rb: *mut ReorderBuffer, ptr: XLogRecPtr);
+    pub fn ReorderBufferGetInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        msgs: *mut *mut SharedInvalidationMessage,
+    ) -> uint32;
     pub fn StartupReorderBuffer();
     pub fn _PG_output_plugin_init(cb: *mut OutputPluginCallbacks);
     pub fn OutputPluginPrepareWrite(ctx: *mut LogicalDecodingContext, last_write: bool);

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -76,7 +76,7 @@ rand = "0.9.0"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.14.2"
+version = "=0.14.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = [

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
 license = "MIT"
 description = "pgrx:  A Rust framework for creating Postgres extensions"


### PR DESCRIPTION
Welcome to pgrx v0.14.3.  

This point release fixes some issues discovered with the new `cargo pgrx regress` command.  Additionally, bindings have been regenerated against the latest Postgres point releases that dropped on May 8th, 2025, though no new headers have been included.


As always, please update with `cargo install cargo-pgrx --version 0.14.3 --locked` and update your extension `Cargo.toml` files with `cargo pgrx upgrade`.

## What's Changed

* Fixes to `cargo pgrx regress` by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2062
   1) Pressing `<ENTER>` to "Accept[Y, n]?" a test no longer panics
   2) While we still `git add <new expected/test_name.out>` files, we no longer do it to the expected files that we promote in the face of a test failure
   3) Fix a bug where we'd think there's a `test_name.out` file to copy to `expected/` when that's not actually true
   4) The `setup.sql` test is now treated as a normal test, and the only special handling around is that we'll only run it if we detect we need to
   5) Cleanup test run output to be consistent between Postgres versions
   6) Set `PGRX_REGRESS_TESTING=1` so an extension running under the regression test suite can detect it


**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.14.2...v0.14.3