### PR TITLE
fix GUC

### DIFF
--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1068,7 +1068,7 @@ fn impl_guc_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     }
 
     stream.extend(quote! {
-        impl ::pgrx::guc::GucEnum<#enum_name> for #enum_name {
+        unsafe impl ::pgrx::guc::GucEnum<#enum_name> for #enum_name {
             fn from_ordinal(ordinal: i32) -> #enum_name {
                 match ordinal {
                     #from_match_arms
@@ -1081,12 +1081,12 @@ fn impl_guc_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 }
             }
 
-            unsafe fn config_matrix(&self) -> *const ::pgrx::pg_sys::config_enum_entry {
-                let slice = ::pgrx::memcxt::PgMemoryContexts::TopMemoryContext.palloc0_slice::<::pgrx::pg_sys::config_enum_entry>(#enum_len + 1usize);
-
-                #build_array_body
-
-                slice.as_ptr()
+            fn config_matrix() -> *const ::pgrx::pg_sys::config_enum_entry {
+                unsafe {
+                    let slice = ::pgrx::memcxt::PgMemoryContexts::TopMemoryContext.palloc0_slice::<::pgrx::pg_sys::config_enum_entry>(#enum_len + 1usize);
+                    #build_array_body
+                    slice.as_ptr()
+                }
             }
         }
     });

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -136,6 +136,7 @@
 #include "partitioning/partprune.h"
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
+#include "postmaster/interrupt.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
 #include "replication/logical.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -137,6 +137,7 @@
 #include "partitioning/partprune.h"
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
+#include "postmaster/interrupt.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
 #include "replication/logical.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -138,6 +138,7 @@
 #include "partitioning/partprune.h"
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
+#include "postmaster/interrupt.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
 #include "replication/logical.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -140,6 +140,7 @@
 #include "partitioning/partprune.h"
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
+#include "postmaster/interrupt.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
 #include "replication/logical.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -140,6 +140,7 @@
 #include "partitioning/partprune.h"
 #include "plpgsql.h"
 #include "postmaster/bgworker.h"
+#include "postmaster/interrupt.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
 #include "replication/logical.h"

--- a/pgrx-pg-sys/src/submodules/mod.rs
+++ b/pgrx-pg-sys/src/submodules/mod.rs
@@ -18,7 +18,8 @@ pub mod htup;
 pub mod oids;
 pub mod panic;
 pub mod pg_try;
-pub(crate) mod thread_check;
+#[doc(hidden)]
+pub mod thread_check;
 pub mod tupdesc;
 
 pub mod utils;

--- a/pgrx-pg-sys/src/submodules/thread_check.rs
+++ b/pgrx-pg-sys/src/submodules/thread_check.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 static ACTIVE_THREAD: AtomicUsize = AtomicUsize::new(0);
 #[track_caller]
-pub(crate) fn check_active_thread() {
+pub fn check_active_thread() {
     let current_thread = nonzero_thread_id();
     // Relaxed is sufficient as we're only interested in the effects on a single
     // atomic variable, and don't need synchronization beyond that.

--- a/pgrx-tests/src/tests/guc_tests.rs
+++ b/pgrx-tests/src/tests/guc_tests.rs
@@ -12,7 +12,7 @@
 mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
-    use std::ffi::CStr;
+    use std::ffi::CString;
 
     use pgrx::guc::*;
     use pgrx::prelude::*;
@@ -105,8 +105,8 @@ mod tests {
 
     #[pg_test]
     fn test_string_guc() {
-        static GUC: GucSetting<Option<&'static CStr>> =
-            GucSetting::<Option<&'static CStr>>::new(Some(c"this is a test"));
+        static GUC: GucSetting<Option<CString>> =
+            GucSetting::<Option<CString>>::new(Some(c"this is a test"));
         GucRegistry::define_string_guc(
             "test.string",
             "test string guc",
@@ -127,8 +127,7 @@ mod tests {
 
     #[pg_test]
     fn test_string_guc_null_default() {
-        static GUC: GucSetting<Option<&'static CStr>> =
-            GucSetting::<Option<&'static CStr>>::new(None);
+        static GUC: GucSetting<Option<CString>> = GucSetting::<Option<CString>>::new(None);
         GucRegistry::define_string_guc(
             "test.string",
             "test string guc",

--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -253,12 +253,13 @@ impl BackgroundWorker {
 
 unsafe extern "C-unwind" fn worker_spi_sighup(_signal_args: i32) {
     GOT_SIGHUP.store(true, Ordering::SeqCst);
-    pg_sys::ProcessConfigFile(pg_sys::GucContext::PGC_SIGHUP);
+    (&raw mut pg_sys::ConfigReloadPending).write_volatile(1);
     pg_sys::SetLatch(pg_sys::MyLatch);
 }
 
 unsafe extern "C-unwind" fn worker_spi_sigterm(_signal_args: i32) {
     GOT_SIGTERM.store(true, Ordering::SeqCst);
+    (&raw mut pg_sys::ShutdownRequestPending).write_volatile(1);
     pg_sys::SetLatch(pg_sys::MyLatch);
 }
 

--- a/pgrx/src/guc.rs
+++ b/pgrx/src/guc.rs
@@ -11,7 +11,7 @@
 use crate::{pg_sys, PgMemoryContexts};
 use core::ffi::CStr;
 pub use pgrx_macros::PostgresGucEnum;
-use std::cell::Cell;
+use std::{cell::Cell, ffi::CString};
 
 /// Defines at what level this GUC can be set
 pub enum GucContext {
@@ -104,107 +104,113 @@ bitflags! {
 
 /// A trait that can be derived using [`PostgresGucEnum`] on enums, such that they can be
 /// used as a GUC.
-pub trait GucEnum<T>
+pub unsafe trait GucEnum<T>
 where
     T: Copy,
 {
     fn from_ordinal(ordinal: i32) -> T;
     fn to_ordinal(&self) -> i32;
-    unsafe fn config_matrix(&self) -> *const pg_sys::config_enum_entry;
+    fn config_matrix() -> *const pg_sys::config_enum_entry;
+}
+
+pub unsafe trait GucValue {
+    type Raw: Copy;
+    unsafe fn from_raw(raw: Self::Raw) -> Self;
+    type BoolVal: Copy;
 }
 
 /// A safe wrapper around a global variable that can be edited through a GUC
-pub struct GucSetting<T> {
-    value: Cell<usize>,
-    boot_val: T,
+pub struct GucSetting<T: GucValue> {
+    value: Cell<T::Raw>,
+    boot_val: T::BoolVal,
 }
 
-unsafe impl Sync for GucSetting<bool> {}
+unsafe impl<T: GucValue> Sync for GucSetting<T> {}
+
+impl<T: GucValue> GucSetting<T> {
+    pub fn get(&self) -> T {
+        pg_sys::submodules::thread_check::check_active_thread();
+        unsafe { GucValue::from_raw(self.value.get()) }
+    }
+
+    pub const fn as_ptr(&self) -> *mut T::Raw {
+        self.value.as_ptr()
+    }
+}
+
+unsafe impl GucValue for bool {
+    type Raw = bool;
+    unsafe fn from_raw(raw: Self::Raw) -> Self {
+        raw
+    }
+    type BoolVal = ();
+}
 impl GucSetting<bool> {
     pub const fn new(value: bool) -> Self {
-        GucSetting { value: Cell::new(value as usize), boot_val: value }
-    }
-
-    pub fn get(&self) -> bool {
-        self.value.get() == 1
-    }
-
-    fn as_ptr(&self) -> *mut bool {
-        self.value.as_ptr() as *mut _
+        GucSetting { value: Cell::new(value), boot_val: () }
     }
 }
 
-unsafe impl Sync for GucSetting<i32> {}
+unsafe impl GucValue for i32 {
+    type Raw = i32;
+    unsafe fn from_raw(raw: Self::Raw) -> Self {
+        raw
+    }
+    type BoolVal = ();
+}
 impl GucSetting<i32> {
     pub const fn new(value: i32) -> Self {
-        GucSetting { value: Cell::new(value as usize), boot_val: value }
-    }
-
-    pub fn get(&self) -> i32 {
-        self.value.get() as i32
-    }
-
-    fn as_ptr(&self) -> *mut i32 {
-        self.value.as_ptr() as *mut _
+        GucSetting { value: Cell::new(value), boot_val: () }
     }
 }
 
-unsafe impl Sync for GucSetting<f64> {}
+unsafe impl GucValue for f64 {
+    type Raw = f64;
+    unsafe fn from_raw(raw: Self::Raw) -> Self {
+        raw
+    }
+    type BoolVal = ();
+}
 impl GucSetting<f64> {
     pub const fn new(value: f64) -> Self {
-        unsafe {
-            GucSetting {
-                value: Cell::new(std::mem::transmute::<f64, u64>(value) as usize),
-                boot_val: value,
-            }
-        }
-    }
-
-    pub fn get(&self) -> f64 {
-        f64::from_bits(self.value.get() as u64)
-    }
-
-    fn as_ptr(&self) -> *mut f64 {
-        self.value.as_ptr() as *mut _
+        GucSetting { value: Cell::new(value), boot_val: () }
     }
 }
 
-unsafe impl Sync for GucSetting<Option<&'static CStr>> {}
-impl GucSetting<Option<&'static CStr>> {
+unsafe impl GucValue for Option<CString> {
+    type Raw = *mut std::ffi::c_char;
+    unsafe fn from_raw(raw: Self::Raw) -> Self {
+        if raw.is_null() {
+            None
+        } else {
+            Some(CStr::from_ptr(raw).to_owned())
+        }
+    }
+    type BoolVal = ();
+}
+impl GucSetting<Option<CString>> {
     pub const fn new(value: Option<&'static CStr>) -> Self {
-        GucSetting { value: Cell::new(0), boot_val: value }
-    }
-
-    pub fn get(&self) -> Option<&CStr> {
-        unsafe {
-            if self.value.get() == 0 {
-                None
+        GucSetting {
+            value: Cell::new(if let Some(value) = value {
+                value.as_ptr().cast_mut()
             } else {
-                Some(CStr::from_ptr(self.value.get() as *const _))
-            }
+                std::ptr::null_mut()
+            }),
+            boot_val: (),
         }
-    }
-
-    fn as_ptr(&self) -> *mut *mut std::os::raw::c_char {
-        self.value.as_ptr() as *mut *mut std::os::raw::c_char
     }
 }
 
-unsafe impl<T> Sync for GucSetting<T> where T: GucEnum<T> + Copy {}
-impl<T> GucSetting<T>
-where
-    T: GucEnum<T> + Copy,
-{
+unsafe impl<T: GucEnum<T> + Copy> GucValue for T {
+    type Raw = i32;
+    unsafe fn from_raw(raw: Self::Raw) -> Self {
+        T::from_ordinal(raw)
+    }
+    type BoolVal = T;
+}
+impl<T: GucEnum<T> + Copy> GucSetting<T> {
     pub const fn new(value: T) -> Self {
         GucSetting { value: Cell::new(0), boot_val: value }
-    }
-
-    pub fn get(&self) -> T {
-        T::from_ordinal(self.value.get() as _)
-    }
-
-    pub fn as_ptr(&self) -> *mut i32 {
-        self.value.as_ptr() as *mut _
     }
 }
 
@@ -215,7 +221,7 @@ impl GucRegistry {
         name: &str,
         short_description: &str,
         long_description: &str,
-        setting: &GucSetting<bool>,
+        setting: &'static GucSetting<bool>,
         context: GucContext,
         flags: GucFlags,
     ) {
@@ -225,7 +231,7 @@ impl GucRegistry {
                 PgMemoryContexts::TopMemoryContext.pstrdup(short_description),
                 PgMemoryContexts::TopMemoryContext.pstrdup(long_description),
                 setting.as_ptr(),
-                setting.get(),
+                setting.value.get(),
                 context as isize as _,
                 flags.bits(),
                 None,
@@ -239,7 +245,7 @@ impl GucRegistry {
         name: &str,
         short_description: &str,
         long_description: &str,
-        setting: &GucSetting<i32>,
+        setting: &'static GucSetting<i32>,
         min_value: i32,
         max_value: i32,
         context: GucContext,
@@ -251,7 +257,7 @@ impl GucRegistry {
                 PgMemoryContexts::TopMemoryContext.pstrdup(short_description),
                 PgMemoryContexts::TopMemoryContext.pstrdup(long_description),
                 setting.as_ptr(),
-                setting.get(),
+                setting.value.get(),
                 min_value,
                 max_value,
                 context as isize as _,
@@ -267,19 +273,17 @@ impl GucRegistry {
         name: &str,
         short_description: &str,
         long_description: &str,
-        setting: &GucSetting<Option<&'static CStr>>,
+        setting: &'static GucSetting<Option<CString>>,
         context: GucContext,
         flags: GucFlags,
     ) {
         unsafe {
-            let boot_val = setting.boot_val.map_or(std::ptr::null(), |s| s.as_ptr());
-            *setting.as_ptr() = boot_val as *mut _;
             pg_sys::DefineCustomStringVariable(
                 PgMemoryContexts::TopMemoryContext.pstrdup(name),
                 PgMemoryContexts::TopMemoryContext.pstrdup(short_description),
                 PgMemoryContexts::TopMemoryContext.pstrdup(long_description),
                 setting.as_ptr(),
-                boot_val,
+                setting.value.get(),
                 context as isize as _,
                 flags.bits(),
                 None,
@@ -293,7 +297,7 @@ impl GucRegistry {
         name: &str,
         short_description: &str,
         long_description: &str,
-        setting: &GucSetting<f64>,
+        setting: &'static GucSetting<f64>,
         min_value: f64,
         max_value: f64,
         context: GucContext,
@@ -305,7 +309,7 @@ impl GucRegistry {
                 PgMemoryContexts::TopMemoryContext.pstrdup(short_description),
                 PgMemoryContexts::TopMemoryContext.pstrdup(long_description),
                 setting.as_ptr(),
-                setting.boot_val,
+                setting.value.get(),
                 min_value,
                 max_value,
                 context as isize as _,
@@ -317,26 +321,23 @@ impl GucRegistry {
         }
     }
 
-    pub fn define_enum_guc<T>(
+    pub fn define_enum_guc<T: GucEnum<T> + Copy>(
         name: &str,
         short_description: &str,
         long_description: &str,
-        setting: &GucSetting<T>,
+        setting: &'static GucSetting<T>,
         context: GucContext,
         flags: GucFlags,
-    ) where
-        T: GucEnum<T> + Copy,
-    {
+    ) {
+        setting.value.set(setting.boot_val.to_ordinal());
         unsafe {
-            let boot_val = setting.boot_val.to_ordinal();
-            (*setting.as_ptr()) = boot_val;
             pg_sys::DefineCustomEnumVariable(
                 PgMemoryContexts::TopMemoryContext.pstrdup(name),
                 PgMemoryContexts::TopMemoryContext.pstrdup(short_description),
                 PgMemoryContexts::TopMemoryContext.pstrdup(long_description),
                 setting.as_ptr(),
-                boot_val,
-                setting.get().config_matrix(),
+                setting.value.get(),
+                T::config_matrix(),
                 context as isize as _,
                 flags.bits(),
                 None,


### PR DESCRIPTION
closes #2055
closes #2057

breaks api (downstream must switch to `GucSetting<Option<CString>>`)

This patch introduces main thread check to `GucSetting<T>::get` to avoid data race.

This patch introduces an allocation to `GucSetting<Option<CString>>::get`.

If someone is concerned about overhead, they can use `GucSetting<Option<T>>::as_ptr` and handle the pointer manually.