### PR TITLE
Added `pg_binary_protocol` attribute to derive send and receive functions for `PostgresType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - **Easy Custom Types**
    + `#[derive(PostgresType)]` to use a Rust struct as a Postgres type
       - By default, represented as a CBOR-encoded object in-memory/on-disk, and JSON as human-readable
+      - Supports `#[pg_binary_protocol]` to generate binary protocol send/recv functions
       - Provide custom in-memory/on-disk/human-readable representations
    + `#[derive(PostgresEnum)]` to use a Rust enum as a Postgres enum
    + Composite types supported with the `pgrx::composite_type!("Sample")` macro

--- a/articles/forging-sql-from-rust.md
+++ b/articles/forging-sql-from-rust.md
@@ -98,7 +98,6 @@ These `sql` files must be generated from data within the Rust code. The SQL gene
   ```rust
   #[derive(PostgresType, Serialize, Deserialize, Debug, Eq, PartialEq)]
   #[pg_binary_protocol]
-  #[]
   pub struct Animals {
       names: Vec<String>,
       age_lookup: HashMap<i32, String>,

--- a/articles/forging-sql-from-rust.md
+++ b/articles/forging-sql-from-rust.md
@@ -97,6 +97,8 @@ These `sql` files must be generated from data within the Rust code. The SQL gene
 - Create 'Shell types', in & out functions, and 'Base types' for each `#[derive(PostgresType)]` marked type.
   ```rust
   #[derive(PostgresType, Serialize, Deserialize, Debug, Eq, PartialEq)]
+  #[pg_binary_protocol]
+  #[]
   pub struct Animals {
       names: Vec<String>,
       age_lookup: HashMap<i32, String>,
@@ -140,6 +142,7 @@ These `sql` files must be generated from data within the Rust code. The SQL gene
       Eq, PartialEq, Ord, Hash, PartialOrd,
       PostgresType, Serialize, Deserialize
   )]
+  #[pg_binary_protocol]
   pub struct Thing(String);
   ```
   ```sql

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1012,8 +1012,15 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
-            buf.cursor = buf.len;
-            unsafe{::pgrx::datum::cbor_decode(buf.data as *mut ::pgrx::pg_sys::varlena)}
+
+            unsafe{
+                let varlena = ::pgrx::pg_sys::varlena {
+                    vl_len_: ((buf.len + ::pgrx::pg_sys::VARHDRSZ as ::core::ffi::c_int) << 2).to_le_bytes(),
+                    vl_dat: core::mem::transmute(buf.data),
+                };
+                buf.cursor = buf.len;
+                ::pgrx::datum::cbor_decode(varlena.as_mut_ptr())
+            }
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -956,10 +956,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
+            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
                 unsafe{internal.get().map(|bytes: &Vec<u8>| {
-                    serde_cbor::from_slice(&bytes).ok()
-                }).flatten()}
+                    serde_cbor::from_slice(&bytes).unwrap()
+                }).unwrap()}
             }
             
             #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1030,7 +1030,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
             };
             unsafe {
-                let Some(serialized): Option<Vec<u8>> = #name::from_datum(datum, false) else {
+                let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
                     ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
                 };
                 serialized

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1009,15 +1009,11 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
         pub fn #funcname_recv #generics(
-            internal: ::pgrx::datum::Internal,
-        ) -> #name #generics {
-            use ::pgrx::datum::{FromDatum, IntoDatum};
-            let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
-            let slice_i8: &[i8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len as usize) };
-            // We transmute the data from &[i8] to &[u8]:
-            let slice_u8: &[u8] = unsafe { ::core::mem::transmute(slice_i8) };
-            let object: #name #generics  = ::pgrx::serde_cbor::from_slice(slice_u8).expect("failed to decode CBOR");
-            todo!("Retrieved object: {:?}", object);
+            internal: Option<&#lifetime ::pgrx::datum::Internal>,
+        ) -> Option<#name #generics> {
+            let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>()? };
+            let slice = unsafe { ::core::slice::from_raw_parts(buf.data as *const u8, buf.len as usize) };
+            ::pgrx::serde_cbor::from_slice(slice).ok()
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -830,7 +830,9 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         }
     }
 
-    if args.is_empty() {
+    if !args.contains(&PostgresTypeAttribute::InOutFuncs)
+        && !args.contains(&PostgresTypeAttribute::PgVarlenaInOutFuncs)
+    {
         // assume the user wants us to implement the InOutFuncs
         args.insert(PostgresTypeAttribute::Default);
     }

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1012,6 +1012,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
             use ::pgrx::datum::{FromDatum, IntoDatum};
+            let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
+            todo!("Debugging buffer: {:?}", buf);
             let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
                 ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
             };

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -956,20 +956,18 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(input: *mut ::pgrx::pg_sys::varlena) -> ::pgrx::datum::PgVarlena<#name #generics> {
-                use ::pgrx::datum::varlena::cbor_decode;
-                use ::pgrx::datum::PgVarlena;
-            
-                let val: #name #generics = unsafe { cbor_decode(input) };
-                PgVarlena::from(val)
+            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
+                let ptr = internal.get().expect("internal input pointer is NULL");
+                let string_info = unsafe { StringInfo::from_pg(ptr as *mut pgrx::pg_sys::StringInfoData) };
+                let bytes = unsafe { std::slice::from_raw_parts(string_info.data as *const u8, string_info.len as usize) };
+
+                serde_cbor::from_slice(bytes).expect("failed to decode from CBOR")
             }
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_send #generics(input: ::pgrx::datum::PgVarlena<#name #generics>) -> *const ::pgrx::pg_sys::varlena {
-                use ::pgrx::datum::varlena::cbor_encode;
-            
-                unsafe { cbor_encode(&*input) }
+            pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
+                serde_cbor::to_vec(&input).expect("failed to encode to CBOR")
             }
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1011,11 +1011,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         pub fn #funcname_recv #generics(
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
-            let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
-
-            // We cast 
-            let data: &[u8] = unsafe { ::core::slice::from_raw_parts(buf.data as *mut u8, buf.len as usize) };
-            ::pgrx::datum::cbor_decode(buf.data as *mut pg_sys::varlena)
+            let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
+            ::pgrx::datum::cbor_decode(buf.data as *mut ::pgrx::pg_sys::varlena)
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -976,14 +976,14 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     if args.contains(&PostgresTypeAttribute::Default) {
         stream.extend(quote! {
             #[doc(hidden)]
-            #[::pgrx::pgrx_macros::pg_extern(immutable,parallel_safe)]
+            #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_in #generics(input: Option<&#lifetime ::core::ffi::CStr>) -> Option<#name #generics> {
                 use ::pgrx::inoutfuncs::json_from_slice;
                 input.map(|cstr| json_from_slice(cstr.to_bytes()).ok()).flatten()
             }
 
             #[doc(hidden)]
-            #[::pgrx::pgrx_macros::pg_extern (immutable,parallel_safe)]
+            #[::pgrx::pgrx_macros::pg_extern (immutable, parallel_safe)]
             pub fn #funcname_out #generics(input: #name #generics) -> ::pgrx::ffi::CString {
                 use ::pgrx::inoutfuncs::json_to_vec;
                 let mut bytes = json_to_vec(&input).unwrap();
@@ -992,26 +992,30 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             }
 
             #[doc(hidden)]
-            #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
+            #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
+            pub fn #funcname_recv #generics(
+                internal: ::pgrx::datum::Internal,
+                oid: Oid,
+                typmod: i32
+            ) -> #name #generics {
                 use std::io::Cursor;
                 use byteorder::{ReadBytesExt, BigEndian};
-                let string_info = unsafe {
-                    let data = internal.get_mut::<::pgrx::pg_sys::StringInfoData>();
-                    ::pgrx::StringInfo::from_pg(data.expect("internal input pointer is NULL"))
-                }
-                .expect("failed to create StringInfo from internal");
+
+                let _ = (oid, typmod);
+                let Some(string_info) = unsafe {
+                    let Some(data) = internal.get_mut::<::pgrx::pg_sys::StringInfoData>() else {
+                        pgrx::error!("internal input pointer is NULL");
+                        unreachable!()
+                    };
+                    ::pgrx::StringInfo::from_pg(data)
+                } else {
+                    pgrx::error!("failed to create StringInfo from internal");
+                    unreachable!()
+                };
 
                 let bytes = string_info.as_bytes();
 
                 let mut cursor = Cursor::new(bytes);
-
-                // Composite types start with field count
-                let number_of_attributes = cursor
-                    .read_i32::<BigEndian>()
-                    .expect("failed to read number of attributes");
-
-                assert_eq!(number_of_attributes, #number_of_attributes);
 
                 #(
                     let #attribute_names = cursor.#readers::<BigEndian>().expect(
@@ -1028,16 +1032,11 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             }
             
             #[doc(hidden)]
-            #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
+            #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
             pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
                 use std::io::Write;
                 use byteorder::{WriteBytesExt, BigEndian};
                 let mut buffer = Vec::new();
-
-                // Composite types start with field count
-                buffer
-                    .write_i32::<BigEndian>(#number_of_attributes)
-                    .expect("failed to write number of attributes");
 
                 #(
                     buffer.#writers::<BigEndian>(input.#attribute_names).expect(

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1003,7 +1003,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         });
     }
 
-    if args.contains(&PostgresTypeAttribute::pg_binary_protocol) {
+    if args.contains(&PostgresTypeAttribute::PgBinaryProtocol) {
         // At this time, the `PostgresTypeAttribute` does not impact the way we generate
         // the `recv` and `send` functions.
         stream.extend(quote! {
@@ -1052,7 +1052,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
     let sql_graph_entity_item = sql_gen::PostgresTypeDerive::from_derive_input(
         ast,
-        args.contains(&PostgresTypeAttribute::InOutFuncs),
+        args.contains(&PostgresTypeAttribute::PgBinaryProtocol),
     )?;
     sql_graph_entity_item.to_tokens(&mut stream);
 
@@ -1150,7 +1150,7 @@ fn impl_guc_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
 enum PostgresTypeAttribute {
     InOutFuncs,
-    pg_binary_protocol,
+    PgBinaryProtocol,
     PgVarlenaInOutFuncs,
     Default,
     ManualFromIntoDatum,
@@ -1167,7 +1167,7 @@ fn parse_postgres_type_args(attributes: &[Attribute]) -> HashSet<PostgresTypeAtt
                 categorized_attributes.insert(PostgresTypeAttribute::InOutFuncs);
             }
             "pg_binary_protocol" => {
-                categorized_attributes.insert(PostgresTypeAttribute::pg_binary_protocol);
+                categorized_attributes.insert(PostgresTypeAttribute::PgBinaryProtocol);
             }
             "pgvarlena_inoutfuncs" => {
                 categorized_attributes.insert(PostgresTypeAttribute::PgVarlenaInOutFuncs);

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -815,6 +815,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     } else {
         panic!("DieselPGRX can only be derived for structs, not enums");
     };
+    let string_attribute_names: Vec<String> = attribute_names.iter().map(|i| i.to_string()).collect();
 
     let attribute_types: Vec<Type> = if let syn::Data::Struct(data) = &ast.data {
         data.fields.iter().map(|field| field.ty.clone()).collect()
@@ -1013,7 +1014,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 assert_eq!(number_of_attributes, #number_of_attributes);
 
                 #(
-                    let #attribute_names = cursor.#readers::<BigEndian>().unwrap();
+                    let #attribute_names = cursor.#readers::<BigEndian>().expect(
+                        "failed to read {} from internal input",
+                        #string_attribute_names
+                    );
                 )*
 
                 #name {
@@ -1034,7 +1038,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                     .expect("failed to write number of attributes");
 
                 #(
-                    buffer.#writers::<BigEndian>(input.#attribute_names).unwrap();
+                    buffer.#writers::<BigEndian>(input.#attribute_names).expect(
+                        "failed to write {} to internal output",
+                        #string_attribute_names
+                    );
                 )*
 
                 buffer

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1013,9 +1013,13 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
 
+            let len_including_header = buf.len + ::pgrx::pg_sys::VARHDRSZ as ::core::ffi::c_int;
+            let shifted_len_including_header = len_including_header << 2;
+            let header: [u8; 4] = shifted_len_including_header.to_le_bytes();
+
             unsafe{
                 let mut varlena = ::pgrx::pg_sys::varlena {
-                    vl_len_: ((buf.len as u32 + ::pgrx::pg_sys::VARHDRSZ as u32) << 2).to_le_bytes(),
+                    vl_len_: core::mem::transmute(header),
                     vl_dat: core::mem::transmute(buf.data),
                 };
                 buf.cursor = buf.len;

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1015,12 +1015,11 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
                 ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
             };
-            // unsafe {
-            //     let Some(object) = FromDatum::from_datum(datum, false) else {
-            //         ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
-            //     };
-            //     object
-            // }
+            unsafe {
+                let Some(object) = FromDatum::from_datum(datum, false) else {
+                    ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
+                };
+            }
             todo!("implement `recv` function for `{}`", stringify!(#name))
         }
         #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1011,7 +1011,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         pub fn #funcname_recv #generics(
             internal: Option<&#lifetime ::pgrx::datum::Internal>,
         ) -> Option<#name #generics> {
-            let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>()? };
+            let buf = unsafe { internal?.get_mut::<pgrx::pg_sys::StringInfoData>()? };
             let slice = unsafe { ::core::slice::from_raw_parts(buf.data as *const u8, buf.len as usize) };
             ::pgrx::serde_cbor::from_slice(slice).ok()
         }

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -957,9 +957,14 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
-                unsafe{internal.get().map(|bytes: &Vec<u8>| {
-                    serde_cbor::from_slice(&bytes).unwrap()
-                }).unwrap()}
+                let string_info = unsafe {
+                    let data = internal.get_mut::<::pgrx::pg_sys::StringInfoData>();
+                    ::pgrx::StringInfo::from_pg(data.expect("internal input pointer is NULL"))
+                }
+                .expect("failed to create StringInfo from internal");
+
+                let bytes = string_info.as_bytes();
+                serde_cbor::from_slice(bytes).expect("failed to decode from CBOR")
             }
             
             #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1014,12 +1014,12 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
 
             unsafe{
-                let varlena = ::pgrx::pg_sys::varlena {
-                    vl_len_: ((buf.len + ::pgrx::pg_sys::VARHDRSZ as ::core::ffi::c_int) << 2).to_le_bytes(),
+                let mut varlena = ::pgrx::pg_sys::varlena {
+                    vl_len_: ((buf.len as u32 + ::pgrx::pg_sys::VARHDRSZ as u32) << 2).to_le_bytes(),
                     vl_dat: core::mem::transmute(buf.data),
                 };
                 buf.cursor = buf.len;
-                ::pgrx::datum::cbor_decode(varlena.as_mut_ptr())
+                ::pgrx::datum::cbor_decode((&mut varlena) as *mut ::pgrx::pg_sys::varlena)
             }
         }
         #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1013,7 +1013,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         ) -> #name #generics {
             use ::pgrx::datum::{FromDatum, IntoDatum};
             let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
-            todo!("Debugging buffer: {:?}", buf);
+            let data: &[u8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len) };
+            todo!("Debugging buffer: {:?}", data);
             // let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
             //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
             // };

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -957,13 +957,16 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
-                let ptr = internal.get().expect("internal input pointer is NULL");
-                let string_info = unsafe { ::pgrx::StringInfo::from_pg(ptr as *mut ::pgrx::pg_sys::StringInfoData) };
-                let bytes = unsafe { std::slice::from_raw_parts(string_info.data as *const u8, string_info.len as usize) };
+                let string_info = unsafe {
+                    let data = internal.get_mut::<::pgrx::pg_sys::StringInfoData>();
+                    ::pgrx::StringInfo::from_pg(data.expect("internal input pointer is NULL"))
+                }
+                .expect("failed to create StringInfo from internal");
 
+                let bytes = string_info.as_bytes();
                 serde_cbor::from_slice(bytes).expect("failed to decode from CBOR")
             }
-
+            
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1018,17 +1018,16 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
         pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
-            // use ::pgrx::datum::{FromDatum, IntoDatum};
-            // let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
-            //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            // };
-            // unsafe {
-            //     let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
-            //         ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
-            //     };
-            //     serialized
-            // }
-            todo!("implement `send` function for `{}`", stringify!(#name))
+            use ::pgrx::datum::{FromDatum, IntoDatum};
+            let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
+                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+            };
+            unsafe {
+                let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
+                    ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
+                };
+                serialized
+            }
         }
     });
 

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1013,17 +1013,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         ) -> #name #generics {
             use ::pgrx::datum::{FromDatum, IntoDatum};
             let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
-            let data: &[i8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len as usize) };
-            todo!("Debugging buffer: {:?}", data);
-            // let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
-            //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            // };
-            // unsafe {
-            //     let Some(object) = FromDatum::from_datum(datum, false) else {
-            //         ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
-            //     };
-            //     object
-            // }
+            let slice_i8: &[i8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len as usize) };
+            // We transmute the data from &[i8] to &[u8]:
+            let slice_u8: &[u8] = unsafe { ::core::mem::transmute(slice_i8) };
+            serde_cbor::from_slice(slice_u8).expect("failed to decode CBOR")
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1013,17 +1013,18 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
 
-            let len_including_header = buf.len + ::pgrx::pg_sys::VARHDRSZ as ::core::ffi::c_int;
-            let shifted_len_including_header = len_including_header << 2;
-            let header: [u8; 4] = shifted_len_including_header.to_le_bytes();
+            let mut serialized = StringInfo::new();
+
+            serialized.push_bytes(&[0u8; pg_sys::VARHDRSZ]); // reserve space for the header
+            serialized.push_bytes(buf.data);
+
+            let size = serialized.len();
+            let varlena = serialized.into_char_ptr();
 
             unsafe{
-                let mut varlena = ::pgrx::pg_sys::varlena {
-                    vl_len_: core::mem::transmute(header),
-                    vl_dat: core::mem::transmute(buf.data),
-                };
+                ::pgrx::set_varsize_4b(varlena as *mut ::pgrx::pg_sys::varlena, size as i32);
                 buf.cursor = buf.len;
-                ::pgrx::datum::cbor_decode((&mut varlena) as *mut ::pgrx::pg_sys::varlena)
+                ::pgrx::datum::cbor_decode(varlena as *mut ::pgrx::pg_sys::varlena)
             }
         }
         #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1012,7 +1012,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
-            ::pgrx::datum::cbor_decode(buf.data as *mut ::pgrx::pg_sys::varlena)
+            unsafe{::pgrx::datum::cbor_decode(buf.data as *mut ::pgrx::pg_sys::varlena)}
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1016,7 +1016,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             let slice_i8: &[i8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len as usize) };
             // We transmute the data from &[i8] to &[u8]:
             let slice_u8: &[u8] = unsafe { ::core::mem::transmute(slice_i8) };
-            ::pgrx::serde_cbor::from_slice(slice_u8).expect("failed to decode CBOR")
+            let object: #name #generics  = ::pgrx::serde_cbor::from_slice(slice_u8).expect("failed to decode CBOR");
+            todo!("Retrieved object: {:?}", object);
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1012,6 +1012,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
+            buf.cursor = buf.len;
             unsafe{::pgrx::datum::cbor_decode(buf.data as *mut ::pgrx::pg_sys::varlena)}
         }
         #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1027,7 +1027,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             use ::pgrx::datum::{FromDatum, IntoDatum};
             let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
                 ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            }
+            };
             let Some(serialized): Option<Vec<u8>> = unsafe{ #name::from_datum(datum, false) else {
                 ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
             } };

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -964,22 +964,23 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
                     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
                 };
-                // In order to satisfy the `from_polymorphic_datum` method signature,
-                // we create a dummy Oid which is afterwards ignored in the `from_polymorphic_datum` method.
-                // This is safe because the Oid is not used in any way for the implementation
-                // of the current function.
-                let dummy_oid = ::pgrx::pg_sys::Oid::from(0);
-                let Some(object) = #name::from_polymorphic_datum(datum, false, dummy_oid) else {
+                let Some(object) = unsafe{ #name::from_datum(datum, false) else {
                     ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
-                };
+                } };
 
                 object
             }
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
-            pub fn #funcname_send #generics(input: #name #generics) -> ::pgrx::datum::Internal {
-                use ::pgrx::datum::IntoDatum;
-                ::pgrx::datum::::from(input.into_datum())
+            pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
+                use ::pgrx::datum::{FromDatum, IntoDatum};
+                let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
+                    ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+                }
+                let Some(serialized): Option<Vec<u8>> = unsafe{ #name::from_datum(datum, false) else {
+                    ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
+                } };
+                serialized
             }
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1015,11 +1015,12 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
                 ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
             };
-            let Some(object) = unsafe{ #name::from_datum(datum, false) else {
-                ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
-            } };
-
-            object
+            unsafe {
+                let Some(object) = #name::from_datum(datum, false) else {
+                    ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
+                };
+                object
+            }
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
@@ -1028,10 +1029,12 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
                 ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
             };
-            let Some(serialized): Option<Vec<u8>> = unsafe{ #name::from_datum(datum, false) else {
-                ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
-            } };
-            serialized
+            unsafe {
+                let Some(serialized): Option<Vec<u8>> = #name::from_datum(datum, false) else {
+                    ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
+                };
+                serialized
+            }
         }
     });
 

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -789,6 +789,7 @@ Optionally accepts the following attributes:
     attributes(
         inoutfuncs,
         pgvarlena_inoutfuncs,
+        pg_binary_protocol,
         bikeshed_postgres_type_manually_impl_from_into_datum,
         requires,
         pgrx

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1009,11 +1009,11 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
         pub fn #funcname_recv #generics(
-            internal: Option<&#lifetime ::pgrx::datum::Internal>,
-        ) -> Option<#name #generics> {
-            let buf = unsafe { internal?.get_mut::<pgrx::pg_sys::StringInfoData>()? };
+            internal: ::pgrx::datum::Internal,
+        ) -> #name #generics {
+            let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
             let slice = unsafe { ::core::slice::from_raw_parts(buf.data as *const u8, buf.len as usize) };
-            ::pgrx::serde_cbor::from_slice(slice).ok()
+            ::pgrx::serde_cbor::from_slice(slice).expect("Failed to deserialize CBOR data")
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1014,15 +1014,15 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             use ::pgrx::datum::{FromDatum, IntoDatum};
             let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
             todo!("Debugging buffer: {:?}", buf);
-            let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
-                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            };
-            unsafe {
-                let Some(object) = FromDatum::from_datum(datum, false) else {
-                    ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
-                };
-                object
-            }
+            // let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
+            //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+            // };
+            // unsafe {
+            //     let Some(object) = FromDatum::from_datum(datum, false) else {
+            //         ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
+            //     };
+            //     object
+            // }
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -822,6 +822,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         panic!("DieselPGRX can only be derived for structs, not enums");
     };
 
+    let number_of_attributes: i32 = attribute_names.len() as i32;
+
     let mut writers: Vec<Ident> = Vec::new();
     let mut readers: Vec<Ident> = Vec::new();
 
@@ -1003,6 +1005,13 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
                 let mut cursor = Cursor::new(bytes);
 
+                // Composite types start with field count
+                let number_of_attributes = cursor
+                    .read_i32::<BigEndian>()
+                    .expect("failed to read number of attributes");
+
+                assert_eq!(number_of_attributes, #number_of_attributes);
+
                 #(
                     let #attribute_names = cursor.#readers::<BigEndian>().unwrap();
                 )*
@@ -1018,6 +1027,11 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 use std::io::Write;
                 use byteorder::{WriteBytesExt, BigEndian};
                 let mut buffer = Vec::new();
+
+                // Composite types start with field count
+                buffer
+                    .write_i32::<BigEndian>(#number_of_attributes)
+                    .expect("failed to write number of attributes");
 
                 #(
                     buffer.#writers::<BigEndian>(input.#attribute_names).unwrap();

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -957,7 +957,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
-                internal.get().map(|slice| {
+                internal.get().map(|slice: Vec<u8>| {
                     serde_cbor::from_slice(&slice).ok()
                 }).flatten()
             }

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1011,10 +1011,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         pub fn #funcname_recv #generics(
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
-            // use ::pgrx::datum::{FromDatum, IntoDatum};
-            // let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
-            //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            // };
+            use ::pgrx::datum::{FromDatum, IntoDatum};
+            let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
+                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+            };
             // unsafe {
             //     let Some(object) = FromDatum::from_datum(datum, false) else {
             //         ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -991,6 +991,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
+                use std::io::Cursor;
                 use byteorder::{ReadBytesExt, BigEndian};
                 let string_info = unsafe {
                     let data = internal.get_mut::<::pgrx::pg_sys::StringInfoData>();

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -995,7 +995,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
             pub fn #funcname_recv #generics(
                 internal: ::pgrx::datum::Internal,
-                oid: Oid,
+                oid: ::pgrx::pg_sys::Oid,
                 typmod: i32
             ) -> #name #generics {
                 use std::io::Cursor;
@@ -1005,11 +1005,9 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 let string_info = unsafe {
                     let Some(data) = internal.get_mut::<::pgrx::pg_sys::StringInfoData>() else {
                         pgrx::error!("internal input pointer is NULL");
-                        unreachable!()
                     };
                     let Some(string_info) = ::pgrx::StringInfo::from_pg(data) else {
                         pgrx::error!("failed to create StringInfo from internal");
-                        unreachable!()
                     };
                     string_info
                 };

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -954,34 +954,6 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 bytes.push(0); // terminate
                 ::pgrx::ffi::CString::from_vec_with_nul(bytes).unwrap()
             }
-
-            #[doc(hidden)]
-            #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
-            pub fn #funcname_recv #generics(
-                internal: ::pgrx::datum::Internal,
-            ) -> #name #generics {
-                use ::pgrx::datum::{FromDatum, IntoDatum};
-                let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
-                    ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-                };
-                let Some(object) = unsafe{ #name::from_datum(datum, false) else {
-                    ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
-                } };
-
-                object
-            }
-            #[doc(hidden)]
-            #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
-            pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
-                use ::pgrx::datum::{FromDatum, IntoDatum};
-                let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
-                    ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-                }
-                let Some(serialized): Option<Vec<u8>> = unsafe{ #name::from_datum(datum, false) else {
-                    ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
-                } };
-                serialized
-            }
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {
         // otherwise if it's InOutFuncs our _in/_out functions use an owned type instance
@@ -1030,6 +1002,38 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             }
         });
     }
+
+    // At this time, the `PostgresTypeAttribute` does not impact the way we generate
+    // the `recv` and `send` functions.
+    stream.extend(quote! {
+        #[doc(hidden)]
+        #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
+        pub fn #funcname_recv #generics(
+            internal: ::pgrx::datum::Internal,
+        ) -> #name #generics {
+            use ::pgrx::datum::{FromDatum, IntoDatum};
+            let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
+                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+            };
+            let Some(object) = unsafe{ #name::from_datum(datum, false) else {
+                ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
+            } };
+
+            object
+        }
+        #[doc(hidden)]
+        #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
+        pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
+            use ::pgrx::datum::{FromDatum, IntoDatum};
+            let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
+                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+            }
+            let Some(serialized): Option<Vec<u8>> = unsafe{ #name::from_datum(datum, false) else {
+                ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
+            } };
+            serialized
+        }
+    });
 
     let sql_graph_entity_item = sql_gen::PostgresTypeDerive::from_derive_input(ast)?;
     sql_graph_entity_item.to_tokens(&mut stream);

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1013,10 +1013,14 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
 
-            // We can cast the buffer into a varlena:
-            unsafe {
-                ::pgrx::datum::cbor_decode(std::mem::transmute(buf))
-            }
+            // We cast 
+            let data: &[u8] = unsafe { ::core::slice::from_raw_parts(buf.data as *mut u8, buf.len as usize) };
+            todo!("The received data is: {:?}, with buffer: {:?}", data, buf);
+
+            // // We can cast the buffer into a varlena:
+            // unsafe {
+            //     ::pgrx::datum::cbor_decode(std::mem::transmute(buf.data))
+            // }
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -957,8 +957,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
-                internal.get().map(|slice: Vec<u8>| {
-                    serde_cbor::from_slice(&slice).ok()
+                internal.get().map(|slice: &[u8]| {
+                    serde_cbor::from_slice(slice).ok()
                 }).flatten()
             }
             

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -15,7 +15,7 @@ use std::collections::HashSet;
 use proc_macro2::Ident;
 use quote::{format_ident, quote, ToTokens};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, Attribute, Data, DeriveInput, Item, ItemImpl, Type};
+use syn::{parse_macro_input, Attribute, Data, DeriveInput, Item, ItemImpl};
 
 use operators::{deriving_postgres_eq, deriving_postgres_hash, deriving_postgres_ord};
 use pgrx_sql_entity_graph as sql_gen;
@@ -975,7 +975,6 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
                 object
             }
-            
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
             pub fn #funcname_send #generics(input: #name #generics) -> ::pgrx::datum::Internal {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1016,7 +1016,12 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             let mut serialized = ::pgrx::StringInfo::new();
 
             serialized.push_bytes(&[0u8; ::pgrx::pg_sys::VARHDRSZ]); // reserve space for the header
-            serialized.push_bytes(buf.data);
+            serialized.push_bytes(unsafe {
+                core::slice::from_raw_parts(
+                    buf.data as *const u8,
+                    buf.len as usize
+                )
+            });
 
             let size = serialized.len();
             let varlena = serialized.into_char_ptr();

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -956,22 +956,18 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(input: ::pgrx::pg_sys::PgInput) -> ::pgrx::datum::PgVarlena<#name #generics> {
-                use ::pgrx::datum::varlena::cbor_encode;
-                use ::pgrx::datum::PgVarlena;
-
-                let value: #name #generics = unsafe { cbor_decode(input.0 as *mut _) };
-                PgVarlena::from(value)
+            pub fn #funcname_recv #generics(input: *mut ::pgrx::pg_sys::varlena) -> #name #generics {
+                use ::pgrx::datum::varlena::cbor_decode;
+            
+                unsafe { cbor_decode(input) }
             }
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_send #generics(input: ::pgrx::datum::PgVarlena<#name #generics>) -> ::pgrx::pg_sys::PgOutput {
-                use ::pgrx::datum::varlena::cbor_decode;
-                use ::pgrx::pg_sys::PgOutput;
-
-                let ptr = unsafe { cbor_encode(&*input) }; // pass a reference to the inner type
-                unsafe { PgOutput::from_varlena(ptr) }
+            pub fn #funcname_send #generics(input: #name #generics) -> *const ::pgrx::pg_sys::varlena {
+                use ::pgrx::datum::varlena::cbor_encode;
+            
+                unsafe { cbor_encode(&*input) }
             }
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -957,8 +957,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
-                internal.get().map(|slice: &[u8]| {
-                    serde_cbor::from_slice(slice).ok()
+                internal.get().map(|bytes: &Vec<u8>| {
+                    serde_cbor::from_slice(&bytes).ok()
                 }).flatten()
             }
             

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1015,7 +1015,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             let mut serialized = StringInfo::new();
 
-            serialized.push_bytes(&[0u8; pg_sys::VARHDRSZ]); // reserve space for the header
+            serialized.push_bytes(&[0u8; ::pgrx::pg_sys::VARHDRSZ]); // reserve space for the header
             serialized.push_bytes(buf.data);
 
             let size = serialized.len();

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1015,8 +1015,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
                 #(
                     let #attribute_names = cursor.#readers::<BigEndian>().expect(
-                        "failed to read {} from internal input",
-                        #string_attribute_names
+                        &format!(
+                            "failed to read {} from internal input",
+                            #string_attribute_names
+                        )
                     );
                 )*
 
@@ -1039,8 +1041,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
                 #(
                     buffer.#writers::<BigEndian>(input.#attribute_names).expect(
-                        "failed to write {} to internal output",
-                        #string_attribute_names
+                        &format!(
+                            "failed to write {} to internal output",
+                            #string_attribute_names
+                        )
                     );
                 )*
 

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1016,6 +1016,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
                 let mut cursor = Cursor::new(bytes);
 
+                // Maybe we should skip the first 4 bytes which are
+                // the varlena header?
+                cursor.set_position(4);
+
                 #(
                     let #attribute_names = cursor.#readers::<BigEndian>().expect(
                         &format!(

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1016,7 +1016,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             let slice_i8: &[i8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len as usize) };
             // We transmute the data from &[i8] to &[u8]:
             let slice_u8: &[u8] = unsafe { ::core::mem::transmute(slice_i8) };
-            serde_cbor::from_slice(slice_u8).expect("failed to decode CBOR")
+            ::pgrx::serde_cbor::from_slice(slice_u8).expect("failed to decode CBOR")
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1003,52 +1003,57 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         });
     }
 
-    // At this time, the `PostgresTypeAttribute` does not impact the way we generate
-    // the `recv` and `send` functions.
-    stream.extend(quote! {
-        #[doc(hidden)]
-        #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
-        pub fn #funcname_recv #generics(
-            internal: ::pgrx::datum::Internal,
-        ) -> #name #generics {
-            let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
+    if args.contains(&PostgresTypeAttribute::pg_binary_protocol) {
+        // At this time, the `PostgresTypeAttribute` does not impact the way we generate
+        // the `recv` and `send` functions.
+        stream.extend(quote! {
+            #[doc(hidden)]
+            #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
+            pub fn #funcname_recv #generics(
+                internal: ::pgrx::datum::Internal,
+            ) -> #name #generics {
+                let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
 
-            let mut serialized = ::pgrx::StringInfo::new();
+                let mut serialized = ::pgrx::StringInfo::new();
 
-            serialized.push_bytes(&[0u8; ::pgrx::pg_sys::VARHDRSZ]); // reserve space for the header
-            serialized.push_bytes(unsafe {
-                core::slice::from_raw_parts(
-                    buf.data as *const u8,
-                    buf.len as usize
-                )
-            });
+                serialized.push_bytes(&[0u8; ::pgrx::pg_sys::VARHDRSZ]); // reserve space for the header
+                serialized.push_bytes(unsafe {
+                    core::slice::from_raw_parts(
+                        buf.data as *const u8,
+                        buf.len as usize
+                    )
+                });
 
-            let size = serialized.len();
-            let varlena = serialized.into_char_ptr();
+                let size = serialized.len();
+                let varlena = serialized.into_char_ptr();
 
-            unsafe{
-                ::pgrx::set_varsize_4b(varlena as *mut ::pgrx::pg_sys::varlena, size as i32);
-                buf.cursor = buf.len;
-                ::pgrx::datum::cbor_decode(varlena as *mut ::pgrx::pg_sys::varlena)
+                unsafe{
+                    ::pgrx::set_varsize_4b(varlena as *mut ::pgrx::pg_sys::varlena, size as i32);
+                    buf.cursor = buf.len;
+                    ::pgrx::datum::cbor_decode(varlena as *mut ::pgrx::pg_sys::varlena)
+                }
             }
-        }
-        #[doc(hidden)]
-        #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
-        pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
-            use ::pgrx::datum::{FromDatum, IntoDatum};
-            let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
-                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            };
-            unsafe {
-                let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
-                    ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
+            #[doc(hidden)]
+            #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
+            pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
+                use ::pgrx::datum::{FromDatum, IntoDatum};
+                let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
+                    ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
                 };
-                serialized
+                unsafe {
+                    let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
+                        ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
+                    };
+                    serialized
+                }
             }
-        }
-    });
+        });
+    }
 
-    let sql_graph_entity_item = sql_gen::PostgresTypeDerive::from_derive_input(ast)?;
+    let sql_graph_entity_item = sql_gen::PostgresTypeDerive::from_derive_input(
+        ast,
+        args.contains(&PostgresTypeAttribute::InOutFuncs),
+    )?;
     sql_graph_entity_item.to_tokens(&mut stream);
 
     Ok(stream)
@@ -1145,6 +1150,7 @@ fn impl_guc_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
 enum PostgresTypeAttribute {
     InOutFuncs,
+    pg_binary_protocol,
     PgVarlenaInOutFuncs,
     Default,
     ManualFromIntoDatum,
@@ -1159,6 +1165,9 @@ fn parse_postgres_type_args(attributes: &[Attribute]) -> HashSet<PostgresTypeAtt
         match path.as_str() {
             "inoutfuncs" => {
                 categorized_attributes.insert(PostgresTypeAttribute::InOutFuncs);
+            }
+            "pg_binary_protocol" => {
+                categorized_attributes.insert(PostgresTypeAttribute::pg_binary_protocol);
             }
             "pgvarlena_inoutfuncs" => {
                 categorized_attributes.insert(PostgresTypeAttribute::PgVarlenaInOutFuncs);

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1019,8 +1019,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 let Some(object) = FromDatum::from_datum(datum, false) else {
                     ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
                 };
+                object
             }
-            todo!("implement `recv` function for `{}`", stringify!(#name))
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -956,15 +956,17 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(input: *mut ::pgrx::pg_sys::varlena) -> #name #generics {
+            pub fn #funcname_recv #generics(input: *mut ::pgrx::pg_sys::varlena) -> ::pgrx::datum::PgVarlena<#name #generics> {
                 use ::pgrx::datum::varlena::cbor_decode;
+                use ::pgrx::datum::PgVarlena;
             
-                unsafe { cbor_decode(input) }
+                let val: #name #generics = unsafe { cbor_decode(input) };
+                PgVarlena::from(val)
             }
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_send #generics(input: #name #generics) -> *const ::pgrx::pg_sys::varlena {
+            pub fn #funcname_send #generics(input: ::pgrx::datum::PgVarlena<#name #generics>) -> *const ::pgrx::pg_sys::varlena {
                 use ::pgrx::datum::varlena::cbor_encode;
             
                 unsafe { cbor_encode(&*input) }

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1011,30 +1011,32 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         pub fn #funcname_recv #generics(
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
-            use ::pgrx::datum::{FromDatum, IntoDatum};
-            let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
-                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            };
-            unsafe {
-                let Some(object) = #name::from_datum(datum, false) else {
-                    ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
-                };
-                object
-            }
+            // use ::pgrx::datum::{FromDatum, IntoDatum};
+            // let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
+            //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+            // };
+            // unsafe {
+            //     let Some(object) = FromDatum::from_datum(datum, false) else {
+            //         ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
+            //     };
+            //     object
+            // }
+            todo!("implement `recv` function for `{}`", stringify!(#name))
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
         pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
-            use ::pgrx::datum::{FromDatum, IntoDatum};
-            let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
-                ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
-            };
-            unsafe {
-                let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
-                    ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
-                };
-                serialized
-            }
+            // use ::pgrx::datum::{FromDatum, IntoDatum};
+            // let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
+            //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+            // };
+            // unsafe {
+            //     let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
+            //         ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
+            //     };
+            //     serialized
+            // }
+            todo!("implement `send` function for `{}`", stringify!(#name))
         }
     });
 

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1002,15 +1002,16 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 use byteorder::{ReadBytesExt, BigEndian};
 
                 let _ = (oid, typmod);
-                let Some(string_info) = unsafe {
+                let string_info = unsafe {
                     let Some(data) = internal.get_mut::<::pgrx::pg_sys::StringInfoData>() else {
                         pgrx::error!("internal input pointer is NULL");
                         unreachable!()
                     };
-                    ::pgrx::StringInfo::from_pg(data)
-                } else {
-                    pgrx::error!("failed to create StringInfo from internal");
-                    unreachable!()
+                    let Some(string_info) = ::pgrx::StringInfo::from_pg(data) else {
+                        pgrx::error!("failed to create StringInfo from internal");
+                        unreachable!()
+                    };
+                    string_info
                 };
 
                 let bytes = string_info.as_bytes();

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1013,7 +1013,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };
 
-            let mut serialized = StringInfo::new();
+            let mut serialized = ::pgrx::StringInfo::new();
 
             serialized.push_bytes(&[0u8; ::pgrx::pg_sys::VARHDRSZ]); // reserve space for the header
             serialized.push_bytes(buf.data);

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -698,7 +698,7 @@ fn impl_postgres_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     stream.extend(quote! {
         impl ::pgrx::datum::FromDatum for #enum_ident {
             #[inline]
-            unsafe fn from_polymorphic_datum(datum: ::pgrx::pg_sys::Datum, is_null: bool, typeoid: ::pgrx::pg_sys::Oid) -> Option<#enum_ident> {
+            unsafe fn from_polymorphic_datum(datum: ::pgrx::pg_sys::Datum, is_null: bool, _typeoid: ::pgrx::pg_sys::Oid) -> Option<#enum_ident> {
                 if is_null {
                     None
                 } else {
@@ -808,42 +808,6 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     let funcname_out = Ident::new(&format!("{name}_out").to_lowercase(), name.span());
     let funcname_recv = Ident::new(&format!("{name}_recv").to_lowercase(), name.span());
     let funcname_send = Ident::new(&format!("{name}_send").to_lowercase(), name.span());
-
-    // We retrieve the list of attributes from the struct.
-    let attribute_names: Vec<Ident> = if let syn::Data::Struct(data) = &ast.data {
-        data.fields.iter().map(|field| field.ident.clone().unwrap()).collect()
-    } else {
-        panic!("DieselPGRX can only be derived for structs, not enums");
-    };
-    let string_attribute_names: Vec<String> = attribute_names.iter().map(|i| i.to_string()).collect();
-
-    let attribute_types: Vec<Type> = if let syn::Data::Struct(data) = &ast.data {
-        data.fields.iter().map(|field| field.ty.clone()).collect()
-    } else {
-        panic!("DieselPGRX can only be derived for structs, not enums");
-    };
-
-    let number_of_attributes: i32 = attribute_names.len() as i32;
-
-    let mut writers: Vec<Ident> = Vec::new();
-    let mut readers: Vec<Ident> = Vec::new();
-
-    attribute_types.iter().for_each(|ty| {
-        match ty {
-            syn::Type::Path(type_path) => {
-                let segment = &type_path.path.segments.last().unwrap().ident;
-                let segment_name = segment.to_string();
-                match segment_name.as_str() {
-                    "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" => {
-                        writers.push(Ident::new(&format!("write_{segment_name}"), segment.span()));
-                        readers.push(Ident::new(&format!("read_{segment_name}"), segment.span()));
-                    }
-                    _ => panic!("Unsupported type: {}", segment),
-                }
-            },
-            _ => panic!("Unsupported type format"),
-        }
-    });
 
     let mut args = parse_postgres_type_args(&ast.attrs);
     let mut stream = proc_macro2::TokenStream::new();
@@ -995,62 +959,28 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
             pub fn #funcname_recv #generics(
                 internal: ::pgrx::datum::Internal,
-                oid: ::pgrx::pg_sys::Oid,
-                typmod: i32
             ) -> #name #generics {
-                use std::io::Cursor;
-                use byteorder::{ReadBytesExt, BigEndian};
-
-                let _ = (oid, typmod);
-                let string_info = unsafe {
-                    let Some(data) = internal.get_mut::<::pgrx::pg_sys::StringInfoData>() else {
-                        pgrx::error!("internal input pointer is NULL");
-                    };
-                    let Some(string_info) = ::pgrx::StringInfo::from_pg(data) else {
-                        pgrx::error!("failed to create StringInfo from internal");
-                    };
-                    string_info
+                use ::pgrx::datum::{FromDatum, IntoDatum};
+                let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
+                    ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
+                };
+                // In order to satisfy the `from_polymorphic_datum` method signature,
+                // we create a dummy Oid which is afterwards ignored in the `from_polymorphic_datum` method.
+                // This is safe because the Oid is not used in any way for the implementation
+                // of the current function.
+                let dummy_oid = ::pgrx::pg_sys::Oid::from(0);
+                let Some(object) = #name::from_polymorphic_datum(datum, false, dummy_oid) else {
+                    ::pgrx::error!("Failed to CBOR-deserialize Datum to type `{}`.", stringify!(#name));
                 };
 
-                let bytes = string_info.as_bytes();
-
-                let mut cursor = Cursor::new(bytes);
-
-                // Maybe we should skip the first 4 bytes which are
-                // the varlena header?
-                cursor.set_position(4);
-
-                #(
-                    let #attribute_names = cursor.#readers::<BigEndian>().expect(
-                        &format!(
-                            "failed to read {} from internal input",
-                            #string_attribute_names
-                        )
-                    );
-                )*
-
-                #name {
-                    #(#attribute_names),*
-                }
+                object
             }
             
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
-            pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
-                use std::io::Write;
-                use byteorder::{WriteBytesExt, BigEndian};
-                let mut buffer = Vec::new();
-
-                #(
-                    buffer.#writers::<BigEndian>(input.#attribute_names).expect(
-                        &format!(
-                            "failed to write {} to internal output",
-                            #string_attribute_names
-                        )
-                    );
-                )*
-
-                buffer
+            pub fn #funcname_send #generics(input: #name #generics) -> ::pgrx::datum::Internal {
+                use ::pgrx::datum::IntoDatum;
+                ::pgrx::datum::::from(input.into_datum())
             }
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -956,15 +956,10 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
-                let string_info = unsafe {
-                    let data = internal.get_mut::<::pgrx::pg_sys::StringInfoData>();
-                    ::pgrx::StringInfo::from_pg(data.expect("internal input pointer is NULL"))
-                }
-                .expect("failed to create StringInfo from internal");
-
-                let bytes = string_info.as_bytes();
-                serde_cbor::from_slice(bytes).expect("failed to decode from CBOR")
+            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
+                internal.get().map(|slice| {
+                    serde_cbor::from_slice(&slice).ok()
+                }).flatten()
             }
             
             #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -957,9 +957,9 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
-                internal.get().map(|bytes: &Vec<u8>| {
+                unsafe{internal.get().map(|bytes: &Vec<u8>| {
                     serde_cbor::from_slice(&bytes).ok()
-                }).flatten()
+                }).flatten()}
             }
             
             #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -956,7 +956,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
+            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
                 let string_info = unsafe {
                     let data = internal.get_mut::<::pgrx::pg_sys::StringInfoData>();
                     ::pgrx::StringInfo::from_pg(data.expect("internal input pointer is NULL"))
@@ -964,7 +964,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 .expect("failed to create StringInfo from internal");
 
                 let bytes = string_info.as_bytes();
-                serde_cbor::from_slice(bytes).expect("failed to decode from CBOR")
+                serde_cbor::from_slice(bytes).ok()
             }
             
             #[doc(hidden)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -806,6 +806,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     let has_lifetimes = generics.lifetimes().next();
     let funcname_in = Ident::new(&format!("{name}_in").to_lowercase(), name.span());
     let funcname_out = Ident::new(&format!("{name}_out").to_lowercase(), name.span());
+    let funcname_recv = Ident::new(&format!("{name}_recv").to_lowercase(), name.span());
+    let funcname_send = Ident::new(&format!("{name}_send").to_lowercase(), name.span());
     let mut args = parse_postgres_type_args(&ast.attrs);
     let mut stream = proc_macro2::TokenStream::new();
 
@@ -950,6 +952,26 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 let mut bytes = json_to_vec(&input).unwrap();
                 bytes.push(0); // terminate
                 ::pgrx::ffi::CString::from_vec_with_nul(bytes).unwrap()
+            }
+
+            #[doc(hidden)]
+            #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
+            pub fn #funcname_recv #generics(input: ::pgrx::pg_sys::PgInput) -> ::pgrx::datum::PgVarlena<#name #generics> {
+                use ::pgrx::datum::varlena::cbor_encode;
+                use ::pgrx::datum::PgVarlena;
+
+                let value: #name #generics = unsafe { cbor_decode(input.0 as *mut _) };
+                PgVarlena::from(value)
+            }
+
+            #[doc(hidden)]
+            #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
+            pub fn #funcname_send #generics(input: ::pgrx::datum::PgVarlena<#name #generics>) -> ::pgrx::pg_sys::PgOutput {
+                use ::pgrx::datum::varlena::cbor_decode;
+                use ::pgrx::pg_sys::PgOutput;
+
+                let ptr = unsafe { cbor_encode(&*input) }; // pass a reference to the inner type
+                unsafe { PgOutput::from_varlena(ptr) }
             }
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1013,7 +1013,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
         ) -> #name #generics {
             use ::pgrx::datum::{FromDatum, IntoDatum};
             let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
-            let data: &[u8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len) };
+            let data: &[i8] = unsafe { ::core::slice::from_raw_parts(buf.data, buf.len as usize) };
             todo!("Debugging buffer: {:?}", data);
             // let Some(datum): Option<::pgrx::pg_sys::Datum> = internal.into_datum() else {
             //     ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -781,6 +781,7 @@ Optionally accepts the following attributes:
 
 * `inoutfuncs(some_in_fn, some_out_fn)`: Define custom in/out functions for the type.
 * `pgvarlena_inoutfuncs(some_in_fn, some_out_fn)`: Define custom in/out functions for the `PgVarlena` of this type.
+* `pg_binary_protocol`: Use the binary protocol for this type.
 * `pgrx(alignment = "<align>")`: Derive Postgres alignment from Rust type. One of `"on"`, or `"off"`.
 * `sql`: Same arguments as [`#[pgrx(sql = ..)]`](macro@pgrx).
 */

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1015,12 +1015,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             // We cast 
             let data: &[u8] = unsafe { ::core::slice::from_raw_parts(buf.data as *mut u8, buf.len as usize) };
-            todo!("The received data is: {:?}, with buffer: {:?}", data, buf);
-
-            // // We can cast the buffer into a varlena:
-            // unsafe {
-            //     ::pgrx::datum::cbor_decode(std::mem::transmute(buf.data))
-            // }
+            ::pgrx::datum::cbor_decode(buf.data as *mut pg_sys::varlena)
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1012,8 +1012,11 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             internal: ::pgrx::datum::Internal,
         ) -> #name #generics {
             let buf = unsafe { internal.get_mut::<pgrx::pg_sys::StringInfoData>().unwrap() };
-            let slice = unsafe { ::core::slice::from_raw_parts(buf.data as *const u8, buf.len as usize) };
-            ::pgrx::serde_cbor::from_slice(slice).expect("Failed to deserialize CBOR data")
+
+            // We can cast the buffer into a varlena:
+            unsafe {
+                ::pgrx::datum::cbor_decode(std::mem::transmute(buf))
+            }
         }
         #[doc(hidden)]
         #[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -958,7 +958,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
                 let ptr = internal.get().expect("internal input pointer is NULL");
-                let string_info = unsafe { StringInfo::from_pg(ptr as *mut pgrx::pg_sys::StringInfoData) };
+                let string_info = unsafe { ::pgrx::StringInfo::from_pg(ptr as *mut ::pgrx::pg_sys::StringInfoData) };
                 let bytes = unsafe { std::slice::from_raw_parts(string_info.data as *const u8, string_info.len as usize) };
 
                 serde_cbor::from_slice(bytes).expect("failed to decode from CBOR")

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -15,7 +15,7 @@ use std::collections::HashSet;
 use proc_macro2::Ident;
 use quote::{format_ident, quote, ToTokens};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, Attribute, Data, DeriveInput, Item, ItemImpl};
+use syn::{parse_macro_input, Attribute, Data, DeriveInput, Item, ItemImpl, Type};
 
 use operators::{deriving_postgres_eq, deriving_postgres_hash, deriving_postgres_ord};
 use pgrx_sql_entity_graph as sql_gen;
@@ -808,6 +808,40 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
     let funcname_out = Ident::new(&format!("{name}_out").to_lowercase(), name.span());
     let funcname_recv = Ident::new(&format!("{name}_recv").to_lowercase(), name.span());
     let funcname_send = Ident::new(&format!("{name}_send").to_lowercase(), name.span());
+
+    // We retrieve the list of attributes from the struct.
+    let attribute_names: Vec<Ident> = if let syn::Data::Struct(data) = &ast.data {
+        data.fields.iter().map(|field| field.ident.clone().unwrap()).collect()
+    } else {
+        panic!("DieselPGRX can only be derived for structs, not enums");
+    };
+
+    let attribute_types: Vec<Type> = if let syn::Data::Struct(data) = &ast.data {
+        data.fields.iter().map(|field| field.ty.clone()).collect()
+    } else {
+        panic!("DieselPGRX can only be derived for structs, not enums");
+    };
+
+    let mut writers: Vec<Ident> = Vec::new();
+    let mut readers: Vec<Ident> = Vec::new();
+
+    attribute_types.iter().for_each(|ty| {
+        match ty {
+            syn::Type::Path(type_path) => {
+                let segment = &type_path.path.segments.last().unwrap().ident;
+                let segment_name = segment.to_string();
+                match segment_name.as_str() {
+                    "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" => {
+                        writers.push(Ident::new(&format!("write_{segment_name}"), segment.span()));
+                        readers.push(Ident::new(&format!("read_{segment_name}"), segment.span()));
+                    }
+                    _ => panic!("Unsupported type: {}", segment),
+                }
+            },
+            _ => panic!("Unsupported type format"),
+        }
+    });
+
     let mut args = parse_postgres_type_args(&ast.attrs);
     let mut stream = proc_macro2::TokenStream::new();
 
@@ -956,7 +990,8 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
 
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
-            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> Option<#name #generics> {
+            pub fn #funcname_recv #generics(internal: ::pgrx::datum::Internal) -> #name #generics {
+                use byteorder::{ReadBytesExt, BigEndian};
                 let string_info = unsafe {
                     let data = internal.get_mut::<::pgrx::pg_sys::StringInfoData>();
                     ::pgrx::StringInfo::from_pg(data.expect("internal input pointer is NULL"))
@@ -964,13 +999,30 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
                 .expect("failed to create StringInfo from internal");
 
                 let bytes = string_info.as_bytes();
-                serde_cbor::from_slice(bytes).ok()
+
+                let mut cursor = Cursor::new(bytes);
+
+                #(
+                    let #attribute_names = cursor.#readers::<BigEndian>().unwrap();
+                )*
+
+                #name {
+                    #(#attribute_names),*
+                }
             }
             
             #[doc(hidden)]
             #[::pgrx::pgrx_macros::pg_extern(immutable, parallel_safe)]
             pub fn #funcname_send #generics(input: #name #generics) -> Vec<u8> {
-                serde_cbor::to_vec(&input).expect("failed to encode to CBOR")
+                use std::io::Write;
+                use byteorder::{WriteBytesExt, BigEndian};
+                let mut buffer = Vec::new();
+
+                #(
+                    buffer.#writers::<BigEndian>(input.#attribute_names).unwrap();
+                )*
+
+                buffer
             }
         });
     } else if args.contains(&PostgresTypeAttribute::InOutFuncs) {

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -255,10 +255,15 @@ impl ToSql for SqlGraphEntity {
                             && item.full_path.ends_with(in_fn);
                         let is_out_fn = item.full_path.starts_with(out_fn_module_path)
                             && item.full_path.ends_with(out_fn);
-                        let is_receive_fn = item.full_path.starts_with(receive_fn_module_path)
-                            && item.full_path.ends_with(receive_fn);
-                        let is_send_fn = item.full_path.starts_with(send_fn_module_path)
-                            && item.full_path.ends_with(send_fn);
+                        let is_receive_fn =
+                            receive_fn_module_path.as_ref().is_some_and(|receive_fn_module_path| {
+                                item.full_path.starts_with(receive_fn_module_path)
+                            }) && receive_fn
+                                .is_some_and(|receive_fn| item.full_path.ends_with(receive_fn));
+                        let is_send_fn =
+                            send_fn_module_path.as_ref().is_some_and(|send_fn_module_path| {
+                                item.full_path.starts_with(send_fn_module_path)
+                            }) && send_fn.is_some_and(|send_fn| item.full_path.ends_with(send_fn));
                         is_in_fn || is_out_fn || is_receive_fn || is_send_fn
                     })
                 {

--- a/pgrx-sql-entity-graph/src/lib.rs
+++ b/pgrx-sql-entity-graph/src/lib.rs
@@ -241,6 +241,10 @@ impl ToSql for SqlGraphEntity {
                             in_fn_module_path,
                             out_fn,
                             out_fn_module_path,
+                            receive_fn,
+                            receive_fn_module_path,
+                            send_fn,
+                            send_fn_module_path,
                             ..
                         }) = &context.graph[neighbor]
                         else {
@@ -251,7 +255,11 @@ impl ToSql for SqlGraphEntity {
                             && item.full_path.ends_with(in_fn);
                         let is_out_fn = item.full_path.starts_with(out_fn_module_path)
                             && item.full_path.ends_with(out_fn);
-                        is_in_fn || is_out_fn
+                        let is_receive_fn = item.full_path.starts_with(receive_fn_module_path)
+                            && item.full_path.ends_with(receive_fn);
+                        let is_send_fn = item.full_path.starts_with(send_fn_module_path)
+                            && item.full_path.ends_with(send_fn);
+                        is_in_fn || is_out_fn || is_receive_fn || is_send_fn
                     })
                 {
                     Ok(String::default())

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -242,7 +242,7 @@ impl ToSql for PostgresTypeEntity {
             .externs
             .iter()
             .find(|(k, _v)| k.full_path == receive_fn_path)
-            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn: {}`.", receive_fn_path))?;
+            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn: {}`, but found {out_fn_path}.", receive_fn_path))?;
 
         let (receive_fn_graph_index, receive_fn_entity) = context
             .graph

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -105,10 +105,10 @@ pub struct PostgresTypeEntity {
     pub in_fn_module_path: String,
     pub out_fn: &'static str,
     pub out_fn_module_path: String,
-    pub receive_fn: Option<&'static str>,
-    pub receive_fn_module_path: Option<String>,
-    pub send_fn: Option<&'static str>,
-    pub send_fn_module_path: Option<String>,
+    pub receive_fn: &'static str,
+    pub receive_fn_module_path: String,
+    pub send_fn: &'static str,
+    pub send_fn_module_path: String,
     pub to_sql_config: ToSqlConfigEntity,
     pub alignment: Option<usize>,
 }
@@ -226,102 +226,76 @@ impl ToSql for PostgresTypeEntity {
         let out_fn_sql = out_fn_entity.to_sql(context)?;
 
         // Handle binary protocol functions if they exist
-        let mut receive_fn_sql = String::new();
-        let receive_fn_clause = match (receive_fn, receive_fn_module_path) {
-            (Some(func_name), Some(module_path)) => {
-                let receive_fn_module_path = if !module_path.is_empty() {
-                    module_path.clone()
-                } else {
-                    module_path.to_string() // Presume a local
-                };
-
-                let receive_fn_path = format!(
-                    "{receive_fn_module_path}{maybe_colons}{func_name}",
-                    maybe_colons = if !receive_fn_module_path.is_empty() { "::" } else { "" }
-                );
-
-                // Find the receive function in the context
-                let (_, _) = context
-                    .externs
-                    .iter()
-                    .find(|(k, _v)| k.full_path == receive_fn_path)
-                    .ok_or_else(|| {
-                        eyre::eyre!("Did not find `receive_fn: {}`.", receive_fn_path)
-                    })?;
-
-                let (receive_fn_graph_index, receive_fn_entity) = context
-                    .graph
-                    .neighbors_undirected(self_index)
-                    .find_map(|neighbor| match &context.graph[neighbor] {
-                        SqlGraphEntity::Function(func) if func.full_path == receive_fn_path => {
-                            Some((neighbor, func))
-                        }
-                        _ => None,
-                    })
-                    .ok_or_else(|| eyre!("Could not find receive_fn graph entity."))?;
-
-                receive_fn_sql = receive_fn_entity.to_sql(context)?;
-
-                format!(
-                    ",\n\tRECEIVE = {}{}",
-                    context.schema_prefix_for(&receive_fn_graph_index),
-                    func_name
-                )
-            }
-            _ => String::new(),
+        let receive_fn_module_path = if !receive_fn_module_path.is_empty() {
+            receive_fn_module_path.clone()
+        } else {
+            receive_fn_module_path.to_string() // Presume a local
         };
 
-        let mut send_fn_sql = String::new();
-        let send_fn_clause = match (send_fn, send_fn_module_path) {
-            (Some(func_name), Some(module_path)) => {
-                let send_fn_module_path = if !module_path.is_empty() {
-                    module_path.clone()
-                } else {
-                    module_path.to_string() // Presume a local
-                };
+        let receive_fn_path = format!(
+            "{receive_fn_module_path}{maybe_colons}{receive_fn}",
+            maybe_colons = if !receive_fn_module_path.is_empty() { "::" } else { "" }
+        );
 
-                let send_fn_path = format!(
-                    "{send_fn_module_path}{maybe_colons}{func_name}",
-                    maybe_colons = if !send_fn_module_path.is_empty() { "::" } else { "" }
-                );
+        // Find the receive function in the context
+        let (_, _) = context
+            .externs
+            .iter()
+            .find(|(k, _v)| k.full_path == receive_fn_path)
+            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn: {}`.", receive_fn_path))?;
 
-                // Find the send function in the context
-                let (_, _) = context
-                    .externs
-                    .iter()
-                    .find(|(k, _v)| k.full_path == send_fn_path)
-                    .ok_or_else(|| eyre::eyre!("Did not find `send_fn: {}`.", send_fn_path))?;
+        let (receive_fn_graph_index, receive_fn_entity) = context
+            .graph
+            .neighbors_undirected(self_index)
+            .find_map(|neighbor| match &context.graph[neighbor] {
+                SqlGraphEntity::Function(func) if func.full_path == receive_fn_path => {
+                    Some((neighbor, func))
+                }
+                _ => None,
+            })
+            .ok_or_else(|| eyre!("Could not find receive_fn graph entity."))?;
 
-                let (send_fn_graph_index, send_fn_entity) = context
-                    .graph
-                    .neighbors_undirected(self_index)
-                    .find_map(|neighbor| match &context.graph[neighbor] {
-                        SqlGraphEntity::Function(func) if func.full_path == send_fn_path => {
-                            Some((neighbor, func))
-                        }
-                        _ => None,
-                    })
-                    .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
+        let receive_fn_sql = receive_fn_entity.to_sql(context)?;
 
-                send_fn_sql = send_fn_entity.to_sql(context)?;
+        let receive_fn_clause = format!(
+            ",\n\tRECEIVE = {}{}",
+            context.schema_prefix_for(&receive_fn_graph_index),
+            receive_fn
+        );
 
-                format!(
-                    ",\n\tSEND = {}{}",
-                    context.schema_prefix_for(&send_fn_graph_index),
-                    func_name
-                )
-            }
-            _ => String::new(),
+        let send_fn_module_path = if !send_fn_module_path.is_empty() {
+            send_fn_module_path.clone()
+        } else {
+            send_fn_module_path.to_string() // Presume a local
         };
 
-        println!("in_fn_sql: {in_fn_sql}");
-        println!("out_fn_sql: {out_fn_sql}");
-        if !receive_fn_sql.is_empty() {
-            println!("receive_fn_sql: {receive_fn_sql}");
-        }
-        if !send_fn_sql.is_empty() {
-            println!("send_fn_sql: {send_fn_sql}");
-        }
+        let send_fn_path = format!(
+            "{send_fn_module_path}{maybe_colons}{send_fn}",
+            maybe_colons = if !send_fn_module_path.is_empty() { "::" } else { "" }
+        );
+
+        // Find the send function in the context
+        let (_, _) = context
+            .externs
+            .iter()
+            .find(|(k, _v)| k.full_path == send_fn_path)
+            .ok_or_else(|| eyre::eyre!("Did not find `send_fn: {}`.", send_fn_path))?;
+
+        let (send_fn_graph_index, send_fn_entity) = context
+            .graph
+            .neighbors_undirected(self_index)
+            .find_map(|neighbor| match &context.graph[neighbor] {
+                SqlGraphEntity::Function(func) if func.full_path == send_fn_path => {
+                    Some((neighbor, func))
+                }
+                _ => None,
+            })
+            .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
+
+        let send_fn_sql = send_fn_entity.to_sql(context)?;
+
+        let send_fn_clause =
+            format!(",\n\tSEND = {}{}", context.schema_prefix_for(&send_fn_graph_index), send_fn);
 
         let shell_type = format!(
             "\n\

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -229,7 +229,7 @@ impl ToSql for PostgresTypeEntity {
         let receive_fn_module_path = if !receive_fn_module_path.is_empty() {
             receive_fn_module_path.clone()
         } else {
-            receive_fn_module_path.to_string() // Presume a local
+            module_path.to_string() // Presume a local
         };
 
         let receive_fn_path = format!(
@@ -266,7 +266,7 @@ impl ToSql for PostgresTypeEntity {
         let send_fn_module_path = if !send_fn_module_path.is_empty() {
             send_fn_module_path.clone()
         } else {
-            send_fn_module_path.to_string() // Presume a local
+            module_path.to_string() // Presume a local
         };
 
         let send_fn_path = format!(

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -242,9 +242,9 @@ impl ToSql for PostgresTypeEntity {
             .externs
             .iter()
             .find(|(k, _v)| k.full_path == receive_fn_path)
-            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn: {}`, but found {out_fn_path}.", receive_fn_path))?;
+            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn: {}`.", receive_fn_path))?;
 
-        let (receive_fn_graph_index, receive_fn_entity) = context
+        let (receive_fn_graph_index, _) = context
             .graph
             .neighbors_undirected(self_index)
             .find_map(|neighbor| match &context.graph[neighbor] {
@@ -254,8 +254,6 @@ impl ToSql for PostgresTypeEntity {
                 _ => None,
             })
             .ok_or_else(|| eyre!("Could not find receive_fn graph entity."))?;
-
-        let receive_fn_sql = receive_fn_entity.to_sql(context)?;
 
         let send_fn_module_path = if !send_fn_module_path.is_empty() {
             send_fn_module_path.clone()
@@ -275,7 +273,7 @@ impl ToSql for PostgresTypeEntity {
             .find(|(k, _v)| k.full_path == send_fn_path)
             .ok_or_else(|| eyre::eyre!("Did not find `send_fn: {}`.", send_fn_path))?;
 
-        let (send_fn_graph_index, send_fn_entity) = context
+        let (send_fn_graph_index, _) = context
             .graph
             .neighbors_undirected(self_index)
             .find_map(|neighbor| match &context.graph[neighbor] {
@@ -285,8 +283,6 @@ impl ToSql for PostgresTypeEntity {
                 _ => None,
             })
             .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
-
-        let send_fn_sql = send_fn_entity.to_sql(context)?;
 
         let shell_type = format!(
             "\n\
@@ -322,7 +318,7 @@ impl ToSql for PostgresTypeEntity {
                 CREATE TYPE {schema}{name} (\n\
                     \tINTERNALLENGTH = variable,\n\
                     \tINPUT = {schema_prefix_in_fn}{in_fn}, /* {in_fn_path} */\n\
-                    \tOUTPUT = {schema_prefix_out_fn}{out_fn}, /* {out_fn_path} */
+                    \tOUTPUT = {schema_prefix_out_fn}{out_fn}, /* {out_fn_path} */\n\
                     \tRECEIVE = {schema_prefix_receive_fn}{receive_fn}, /* {receive_fn_path} */\n\
                     \tSEND = {schema_prefix_send_fn}{send_fn}, /* {send_fn_path} */\n\
                     \tSTORAGE = extended{alignment}\n\
@@ -340,10 +336,6 @@ impl ToSql for PostgresTypeEntity {
             + &in_fn_sql
             + "\n"
             + &out_fn_sql
-            + "\n"
-            + &receive_fn_sql
-            + "\n"
-            + &send_fn_sql
             + "\n"
             + &materialized_type;
 

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -257,12 +257,6 @@ impl ToSql for PostgresTypeEntity {
 
         let receive_fn_sql = receive_fn_entity.to_sql(context)?;
 
-        let receive_fn_clause = format!(
-            ",\n\tRECEIVE = {}{}",
-            context.schema_prefix_for(&receive_fn_graph_index),
-            receive_fn
-        );
-
         let send_fn_module_path = if !send_fn_module_path.is_empty() {
             send_fn_module_path.clone()
         } else {
@@ -293,9 +287,6 @@ impl ToSql for PostgresTypeEntity {
             .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
 
         let send_fn_sql = send_fn_entity.to_sql(context)?;
-
-        let send_fn_clause =
-            format!(",\n\tSEND = {}{}", context.schema_prefix_for(&send_fn_graph_index), send_fn);
 
         let shell_type = format!(
             "\n\
@@ -331,13 +322,17 @@ impl ToSql for PostgresTypeEntity {
                 CREATE TYPE {schema}{name} (\n\
                     \tINTERNALLENGTH = variable,\n\
                     \tINPUT = {schema_prefix_in_fn}{in_fn}, /* {in_fn_path} */\n\
-                    \tOUTPUT = {schema_prefix_out_fn}{out_fn}, /* {out_fn_path} */{receive_fn_clause}{send_fn_clause}\n\
+                    \tOUTPUT = {schema_prefix_out_fn}{out_fn}, /* {out_fn_path} */
+                    \tRECEIVE = {schema_prefix_receive_fn}{receive_fn}, /* {receive_fn_path} */\n\
+                    \tSEND = {schema_prefix_send_fn}{send_fn}, /* {send_fn_path} */\n\
                     \tSTORAGE = extended{alignment}\n\
                 );\
             ",
             schema = context.schema_prefix_for(&self_index),
             schema_prefix_in_fn = context.schema_prefix_for(&in_fn_graph_index),
             schema_prefix_out_fn = context.schema_prefix_for(&out_fn_graph_index),
+            schema_prefix_receive_fn = context.schema_prefix_for(&receive_fn_graph_index),
+            schema_prefix_send_fn = context.schema_prefix_for(&send_fn_graph_index),
         };
 
         let result = shell_type

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -105,10 +105,10 @@ pub struct PostgresTypeEntity {
     pub in_fn_module_path: String,
     pub out_fn: &'static str,
     pub out_fn_module_path: String,
-    pub receive_fn: &'static str,
-    pub receive_fn_module_path: String,
-    pub send_fn: &'static str,
-    pub send_fn_module_path: String,
+    pub receive_fn: Option<&'static str>,
+    pub receive_fn_module_path: Option<String>,
+    pub send_fn: Option<&'static str>,
+    pub send_fn_module_path: Option<String>,
     pub to_sql_config: ToSqlConfigEntity,
     pub alignment: Option<usize>,
 }
@@ -226,65 +226,82 @@ impl ToSql for PostgresTypeEntity {
         let out_fn_sql = out_fn_entity.to_sql(context)?;
 
         // Handle binary protocol functions if they exist
-        let receive_fn_module_path = if !receive_fn_module_path.is_empty() {
-            receive_fn_module_path.clone()
-        } else {
-            module_path.to_string() // Presume a local
-        };
 
-        let receive_fn_path = format!(
-            "{receive_fn_module_path}{maybe_colons}{receive_fn}",
-            maybe_colons = if !receive_fn_module_path.is_empty() { "::" } else { "" }
-        );
+        let receive_fn_graph_index_and_receive_fn_sql = receive_fn_module_path
+            .as_ref()
+            .zip(*receive_fn)
+            .map(|(receive_fn_module_path, receive_fn)| {
+                let receive_fn_module_path = if !receive_fn_module_path.is_empty() {
+                    receive_fn_module_path.clone()
+                } else {
+                    module_path.to_string() // Presume a local
+                };
+                let receive_fn_path = format!(
+                    "{receive_fn_module_path}{maybe_colons}{receive_fn}",
+                    maybe_colons = if !receive_fn_module_path.is_empty() { "::" } else { "" }
+                );
 
-        // Find the receive function in the context
-        let (_, _index) = context
-            .externs
-            .iter()
-            .find(|(k, _v)| k.full_path == receive_fn_path)
-            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn`: {receive_fn_path}."))?;
+                // Find the receive function in the context
+                let (_, _index) = context
+                    .externs
+                    .iter()
+                    .find(|(k, _v)| k.full_path == receive_fn_path)
+                    .ok_or_else(|| eyre::eyre!("Did not find `receive_fn`: {receive_fn_path}."))?;
 
-        let (receive_fn_graph_index, receive_fn_entity) = context
-            .graph
-            .neighbors_undirected(self_index)
-            .find_map(|neighbor| match &context.graph[neighbor] {
-                SqlGraphEntity::Function(func) if func.full_path == receive_fn_path => {
-                    Some((neighbor, func))
-                }
-                _ => None,
+                let (receive_fn_graph_index, receive_fn_entity) = context
+                    .graph
+                    .neighbors_undirected(self_index)
+                    .find_map(|neighbor| match &context.graph[neighbor] {
+                        SqlGraphEntity::Function(func) if func.full_path == receive_fn_path => {
+                            Some((neighbor, func))
+                        }
+                        _ => None,
+                    })
+                    .ok_or_else(|| eyre!("Could not find receive_fn graph entity."))?;
+                let receive_fn_sql = receive_fn_entity.to_sql(context)?;
+
+                Ok::<_, eyre::Report>((receive_fn_graph_index, receive_fn_sql, receive_fn_path))
             })
-            .ok_or_else(|| eyre!("Could not find receive_fn graph entity."))?;
-        let receive_fn_sql = receive_fn_entity.to_sql(context)?;
+            .transpose()?;
 
-        let send_fn_module_path = if !send_fn_module_path.is_empty() {
-            send_fn_module_path.clone()
-        } else {
-            module_path.to_string() // Presume a local
-        };
+        // Handle send function for the binary protocol if it exists
 
-        let send_fn_path = format!(
-            "{send_fn_module_path}{maybe_colons}{send_fn}",
-            maybe_colons = if !send_fn_module_path.is_empty() { "::" } else { "" }
-        );
+        let send_fn_graph_index_and_send_fn_sql = send_fn_module_path
+            .as_ref()
+            .zip(*send_fn)
+            .map(|(send_fn_module_path, send_fn)| {
+                let send_fn_module_path = if !send_fn_module_path.is_empty() {
+                    send_fn_module_path.clone()
+                } else {
+                    module_path.to_string() // Presume a local
+                };
+                let send_fn_path = format!(
+                    "{send_fn_module_path}{maybe_colons}{send_fn}",
+                    maybe_colons = if !send_fn_module_path.is_empty() { "::" } else { "" }
+                );
 
-        // Find the send function in the context
-        let (_, _index) = context
-            .externs
-            .iter()
-            .find(|(k, _v)| k.full_path == send_fn_path)
-            .ok_or_else(|| eyre::eyre!("Did not find `send_fn: {}`.", send_fn_path))?;
+                // Find the send function in the context
+                let (_, _index) = context
+                    .externs
+                    .iter()
+                    .find(|(k, _v)| k.full_path == send_fn_path)
+                    .ok_or_else(|| eyre::eyre!("Did not find `send_fn: {}`.", send_fn_path))?;
 
-        let (send_fn_graph_index, send_fn_entity) = context
-            .graph
-            .neighbors_undirected(self_index)
-            .find_map(|neighbor| match &context.graph[neighbor] {
-                SqlGraphEntity::Function(func) if func.full_path == send_fn_path => {
-                    Some((neighbor, func))
-                }
-                _ => None,
+                let (send_fn_graph_index, send_fn_entity) = context
+                    .graph
+                    .neighbors_undirected(self_index)
+                    .find_map(|neighbor| match &context.graph[neighbor] {
+                        SqlGraphEntity::Function(func) if func.full_path == send_fn_path => {
+                            Some((neighbor, func))
+                        }
+                        _ => None,
+                    })
+                    .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
+                let send_fn_sql = send_fn_entity.to_sql(context)?;
+
+                Ok::<_, eyre::Report>((send_fn_graph_index, send_fn_sql, send_fn_path))
             })
-            .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
-        let send_fn_sql = send_fn_entity.to_sql(context)?;
+            .transpose()?;
 
         let shell_type = format!(
             "\n\
@@ -313,6 +330,29 @@ impl ToSql for PostgresTypeEntity {
             })
             .unwrap_or_default();
 
+        let (receive_send_attributes, receive_send_sql) = receive_fn_graph_index_and_receive_fn_sql
+            .zip(send_fn_graph_index_and_send_fn_sql)
+            .map(|((receive_fn_graph_index, receive_fn_sql, receive_fn_path), (send_fn_graph_index, send_fn_sql, send_fn_path))| {
+                let receive_fn = receive_fn.unwrap();
+                let send_fn = send_fn.unwrap();
+                (
+                    format! {
+                        "\
+                        \tRECEIVE = {schema_prefix_receive_fn}{receive_fn}, /* {receive_fn_path} */\n\
+                        \tSEND = {schema_prefix_send_fn}{send_fn}, /* {send_fn_path} */\n\
+                        ",
+                        schema_prefix_receive_fn = context.schema_prefix_for(&receive_fn_graph_index),
+                        schema_prefix_send_fn = context.schema_prefix_for(&send_fn_graph_index),
+                    },
+                    format! {
+                        "\n\
+                        {receive_fn_sql}\n\
+                        {send_fn_sql}\n\
+                        "
+                    }
+                )
+            }).unwrap_or_default();
+
         let materialized_type = format! {
             "\n\
                 -- {file}:{line}\n\
@@ -321,16 +361,13 @@ impl ToSql for PostgresTypeEntity {
                     \tINTERNALLENGTH = variable,\n\
                     \tINPUT = {schema_prefix_in_fn}{in_fn}, /* {in_fn_path} */\n\
                     \tOUTPUT = {schema_prefix_out_fn}{out_fn}, /* {out_fn_path} */\n\
-                    \tRECEIVE = {schema_prefix_receive_fn}{receive_fn}, /* {receive_fn_path} */\n\
-                    \tSEND = {schema_prefix_send_fn}{send_fn}, /* {send_fn_path} */\n\
+                    {receive_send_attributes}\
                     \tSTORAGE = extended{alignment}\n\
                 );\
             ",
             schema = context.schema_prefix_for(&self_index),
             schema_prefix_in_fn = context.schema_prefix_for(&in_fn_graph_index),
-            schema_prefix_out_fn = context.schema_prefix_for(&out_fn_graph_index),
-            schema_prefix_receive_fn = context.schema_prefix_for(&receive_fn_graph_index),
-            schema_prefix_send_fn = context.schema_prefix_for(&send_fn_graph_index),
+            schema_prefix_out_fn = context.schema_prefix_for(&out_fn_graph_index)
         };
 
         let result = shell_type
@@ -338,10 +375,7 @@ impl ToSql for PostgresTypeEntity {
             + &in_fn_sql
             + "\n"
             + &out_fn_sql
-            + "\n"
-            + &receive_fn_sql
-            + "\n"
-            + &send_fn_sql
+            + &receive_send_sql
             + "\n"
             + &materialized_type;
 

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -225,8 +225,6 @@ impl ToSql for PostgresTypeEntity {
             .ok_or_else(|| eyre!("Could not find out_fn graph entity."))?;
         let out_fn_sql = out_fn_entity.to_sql(context)?;
 
-        // Handle binary protocol functions if they exist
-
         let receive_fn_graph_index_and_receive_fn_sql = receive_fn_module_path
             .as_ref()
             .zip(*receive_fn)
@@ -263,8 +261,6 @@ impl ToSql for PostgresTypeEntity {
                 Ok::<_, eyre::Report>((receive_fn_graph_index, receive_fn_sql, receive_fn_path))
             })
             .transpose()?;
-
-        // Handle send function for the binary protocol if it exists
 
         let send_fn_graph_index_and_send_fn_sql = send_fn_module_path
             .as_ref()

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -105,6 +105,10 @@ pub struct PostgresTypeEntity {
     pub in_fn_module_path: String,
     pub out_fn: &'static str,
     pub out_fn_module_path: String,
+    pub receive_fn: Option<&'static str>,
+    pub receive_fn_module_path: Option<String>,
+    pub send_fn: Option<&'static str>,
+    pub send_fn_module_path: Option<String>,
     pub to_sql_config: ToSqlConfigEntity,
     pub alignment: Option<usize>,
 }
@@ -152,6 +156,10 @@ impl ToSql for PostgresTypeEntity {
             out_fn,
             out_fn_module_path,
             in_fn,
+            receive_fn,
+            receive_fn_module_path,
+            send_fn,
+            send_fn_module_path,
             alignment,
             ..
         }) = item_node
@@ -217,8 +225,103 @@ impl ToSql for PostgresTypeEntity {
             .ok_or_else(|| eyre!("Could not find out_fn graph entity."))?;
         let out_fn_sql = out_fn_entity.to_sql(context)?;
 
+        // Handle binary protocol functions if they exist
+        let mut receive_fn_sql = String::new();
+        let receive_fn_clause = match (receive_fn, receive_fn_module_path) {
+            (Some(func_name), Some(module_path)) => {
+                let receive_fn_module_path = if !module_path.is_empty() {
+                    module_path.clone()
+                } else {
+                    module_path.to_string() // Presume a local
+                };
+
+                let receive_fn_path = format!(
+                    "{receive_fn_module_path}{maybe_colons}{func_name}",
+                    maybe_colons = if !receive_fn_module_path.is_empty() { "::" } else { "" }
+                );
+
+                // Find the receive function in the context
+                let (_, _) = context
+                    .externs
+                    .iter()
+                    .find(|(k, _v)| k.full_path == receive_fn_path)
+                    .ok_or_else(|| {
+                        eyre::eyre!("Did not find `receive_fn: {}`.", receive_fn_path)
+                    })?;
+
+                let (receive_fn_graph_index, receive_fn_entity) = context
+                    .graph
+                    .neighbors_undirected(self_index)
+                    .find_map(|neighbor| match &context.graph[neighbor] {
+                        SqlGraphEntity::Function(func) if func.full_path == receive_fn_path => {
+                            Some((neighbor, func))
+                        }
+                        _ => None,
+                    })
+                    .ok_or_else(|| eyre!("Could not find receive_fn graph entity."))?;
+
+                receive_fn_sql = receive_fn_entity.to_sql(context)?;
+
+                format!(
+                    ",\n\tRECEIVE = {}{}",
+                    context.schema_prefix_for(&receive_fn_graph_index),
+                    func_name
+                )
+            }
+            _ => String::new(),
+        };
+
+        let mut send_fn_sql = String::new();
+        let send_fn_clause = match (send_fn, send_fn_module_path) {
+            (Some(func_name), Some(module_path)) => {
+                let send_fn_module_path = if !module_path.is_empty() {
+                    module_path.clone()
+                } else {
+                    module_path.to_string() // Presume a local
+                };
+
+                let send_fn_path = format!(
+                    "{send_fn_module_path}{maybe_colons}{func_name}",
+                    maybe_colons = if !send_fn_module_path.is_empty() { "::" } else { "" }
+                );
+
+                // Find the send function in the context
+                let (_, _) = context
+                    .externs
+                    .iter()
+                    .find(|(k, _v)| k.full_path == send_fn_path)
+                    .ok_or_else(|| eyre::eyre!("Did not find `send_fn: {}`.", send_fn_path))?;
+
+                let (send_fn_graph_index, send_fn_entity) = context
+                    .graph
+                    .neighbors_undirected(self_index)
+                    .find_map(|neighbor| match &context.graph[neighbor] {
+                        SqlGraphEntity::Function(func) if func.full_path == send_fn_path => {
+                            Some((neighbor, func))
+                        }
+                        _ => None,
+                    })
+                    .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
+
+                send_fn_sql = send_fn_entity.to_sql(context)?;
+
+                format!(
+                    ",\n\tSEND = {}{}",
+                    context.schema_prefix_for(&send_fn_graph_index),
+                    func_name
+                )
+            }
+            _ => String::new(),
+        };
+
         println!("in_fn_sql: {in_fn_sql}");
         println!("out_fn_sql: {out_fn_sql}");
+        if !receive_fn_sql.is_empty() {
+            println!("receive_fn_sql: {receive_fn_sql}");
+        }
+        if !send_fn_sql.is_empty() {
+            println!("send_fn_sql: {send_fn_sql}");
+        }
 
         let shell_type = format!(
             "\n\
@@ -254,7 +357,7 @@ impl ToSql for PostgresTypeEntity {
                 CREATE TYPE {schema}{name} (\n\
                     \tINTERNALLENGTH = variable,\n\
                     \tINPUT = {schema_prefix_in_fn}{in_fn}, /* {in_fn_path} */\n\
-                    \tOUTPUT = {schema_prefix_out_fn}{out_fn}, /* {out_fn_path} */\n\
+                    \tOUTPUT = {schema_prefix_out_fn}{out_fn}, /* {out_fn_path} */{receive_fn_clause}{send_fn_clause}\n\
                     \tSTORAGE = extended{alignment}\n\
                 );\
             ",
@@ -263,6 +366,18 @@ impl ToSql for PostgresTypeEntity {
             schema_prefix_out_fn = context.schema_prefix_for(&out_fn_graph_index),
         };
 
-        Ok(shell_type + "\n" + &in_fn_sql + "\n" + &out_fn_sql + "\n" + &materialized_type)
+        let result = shell_type
+            + "\n"
+            + &in_fn_sql
+            + "\n"
+            + &out_fn_sql
+            + "\n"
+            + &receive_fn_sql
+            + "\n"
+            + &send_fn_sql
+            + "\n"
+            + &materialized_type;
+
+        Ok(result)
     }
 }

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -238,13 +238,13 @@ impl ToSql for PostgresTypeEntity {
         );
 
         // Find the receive function in the context
-        let (_, _) = context
+        let (_, _index) = context
             .externs
             .iter()
             .find(|(k, _v)| k.full_path == receive_fn_path)
-            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn: {}`.", receive_fn_path))?;
+            .ok_or_else(|| eyre::eyre!("Did not find `receive_fn`: {receive_fn_path}."))?;
 
-        let (receive_fn_graph_index, _) = context
+        let (receive_fn_graph_index, receive_fn_entity) = context
             .graph
             .neighbors_undirected(self_index)
             .find_map(|neighbor| match &context.graph[neighbor] {
@@ -254,6 +254,7 @@ impl ToSql for PostgresTypeEntity {
                 _ => None,
             })
             .ok_or_else(|| eyre!("Could not find receive_fn graph entity."))?;
+        let receive_fn_sql = receive_fn_entity.to_sql(context)?;
 
         let send_fn_module_path = if !send_fn_module_path.is_empty() {
             send_fn_module_path.clone()
@@ -267,13 +268,13 @@ impl ToSql for PostgresTypeEntity {
         );
 
         // Find the send function in the context
-        let (_, _) = context
+        let (_, _index) = context
             .externs
             .iter()
             .find(|(k, _v)| k.full_path == send_fn_path)
             .ok_or_else(|| eyre::eyre!("Did not find `send_fn: {}`.", send_fn_path))?;
 
-        let (send_fn_graph_index, _) = context
+        let (send_fn_graph_index, send_fn_entity) = context
             .graph
             .neighbors_undirected(self_index)
             .find_map(|neighbor| match &context.graph[neighbor] {
@@ -283,6 +284,7 @@ impl ToSql for PostgresTypeEntity {
                 _ => None,
             })
             .ok_or_else(|| eyre!("Could not find send_fn graph entity."))?;
+        let send_fn_sql = send_fn_entity.to_sql(context)?;
 
         let shell_type = format!(
             "\n\
@@ -336,6 +338,10 @@ impl ToSql for PostgresTypeEntity {
             + &in_fn_sql
             + "\n"
             + &out_fn_sql
+            + "\n"
+            + &receive_fn_sql
+            + "\n"
+            + &send_fn_sql
             + "\n"
             + &materialized_type;
 

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -217,6 +217,9 @@ impl ToSql for PostgresTypeEntity {
             .ok_or_else(|| eyre!("Could not find out_fn graph entity."))?;
         let out_fn_sql = out_fn_entity.to_sql(context)?;
 
+        println!("in_fn_sql: {in_fn_sql}");
+        println!("out_fn_sql: {out_fn_sql}");
+
         let shell_type = format!(
             "\n\
                 -- {file}:{line}\n\

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -55,8 +55,8 @@ pub struct PostgresTypeDerive {
     generics: Generics,
     in_fn: Ident,
     out_fn: Ident,
-    receive_fn: Ident,
-    send_fn: Ident,
+    receive_fn: Option<Ident>,
+    send_fn: Option<Ident>,
     to_sql_config: ToSqlConfig,
     alignment: Alignment,
 }
@@ -67,8 +67,8 @@ impl PostgresTypeDerive {
         generics: Generics,
         in_fn: Ident,
         out_fn: Ident,
-        receive_fn: Ident,
-        send_fn: Ident,
+        receive_fn: Option<Ident>,
+        send_fn: Option<Ident>,
         to_sql_config: ToSqlConfig,
         alignment: Alignment,
     ) -> Result<CodeEnrichment<Self>, syn::Error> {
@@ -89,6 +89,7 @@ impl PostgresTypeDerive {
 
     pub fn from_derive_input(
         derive_input: DeriveInput,
+        pg_binary_protocol: bool,
     ) -> Result<CodeEnrichment<Self>, syn::Error> {
         match derive_input.data {
             syn::Data::Struct(_) | syn::Data::Enum(_) => {}
@@ -106,14 +107,18 @@ impl PostgresTypeDerive {
             &format!("{}_out", derive_input.ident).to_lowercase(),
             derive_input.ident.span(),
         );
-        let funcname_receive = Ident::new(
-            &format!("{}_recv", derive_input.ident).to_lowercase(),
-            derive_input.ident.span(),
-        );
-        let funcname_send = Ident::new(
-            &format!("{}_send", derive_input.ident).to_lowercase(),
-            derive_input.ident.span(),
-        );
+        let funcname_receive = (pg_binary_protocol).then(|| {
+            Ident::new(
+                &format!("{}_recv", derive_input.ident).to_lowercase(),
+                derive_input.ident.span(),
+            )
+        });
+        let funcname_send = (pg_binary_protocol).then(|| {
+            Ident::new(
+                &format!("{}_send", derive_input.ident).to_lowercase(),
+                derive_input.ident.span(),
+            )
+        });
         let alignment = Alignment::from_attributes(derive_input.attrs.as_slice())?;
         Self::new(
             derive_input.ident,
@@ -152,8 +157,40 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
 
         let in_fn = &self.in_fn;
         let out_fn = &self.out_fn;
-        let receive_fn = &self.receive_fn;
-        let send_fn = &self.send_fn;
+        let stringify_receive_fn = self
+            .receive_fn
+            .as_ref()
+            .map(|f| quote! { Some(stringify!(#f)) })
+            .unwrap_or_else(|| quote! { None });
+        let stringify_send_fn = self
+            .send_fn
+            .as_ref()
+            .map(|f| quote! { Some(stringify!(#f)) })
+            .unwrap_or_else(|| quote! { None });
+        let receive_fn_module_path = self
+            .receive_fn
+            .as_ref()
+            .map(|f| {
+                quote! {
+                    let in_fn = stringify!(#f);
+                    let mut path_items: Vec<_> = in_fn.split("::").collect();
+                    let _ = path_items.pop(); // Drop the one we don't want.
+                    path_items.join("::")
+                }
+            })
+            .unwrap_or_else(|| quote! { None });
+        let send_fn_module_path = self
+            .send_fn
+            .as_ref()
+            .map(|f| {
+                quote! {
+                    let out_fn = stringify!(#f);
+                    let mut path_items: Vec<_> = out_fn.split("::").collect();
+                    let _ = path_items.pop(); // Drop the one we don't want.
+                    path_items.join("::")
+                }
+            })
+            .unwrap_or_else(|| quote! { None });
 
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_type_{}", self.name);
 
@@ -224,20 +261,10 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
                     },
-                    receive_fn: stringify!(#receive_fn),
-                    receive_fn_module_path: {
-                        let recv_fn = stringify!(#receive_fn);
-                        let mut path_items: Vec<_> = recv_fn.split("::").collect();
-                        let _ = path_items.pop(); // Drop the one we don't want.
-                        path_items.join("::")
-                    },
-                    send_fn: stringify!(#send_fn),
-                    send_fn_module_path: {
-                        let send_fn = stringify!(#send_fn);
-                        let mut path_items: Vec<_> = send_fn.split("::").collect();
-                        let _ = path_items.pop(); // Drop the one we don't want.
-                        path_items.join("::")
-                    },
+                    receive_fn: #stringify_receive_fn,
+                    receive_fn_module_path: #receive_fn_module_path,
+                    send_fn: #stringify_send_fn,
+                    send_fn_module_path: #send_fn_module_path,
                     to_sql_config: #to_sql_config,
                     alignment: #alignment,
                 };
@@ -252,11 +279,16 @@ impl ToRustCodeTokens for PostgresTypeDerive {}
 impl Parse for CodeEnrichment<PostgresTypeDerive> {
     fn parse(input: ParseStream) -> Result<Self, syn::Error> {
         let ItemStruct { attrs, ident, generics, .. } = input.parse()?;
+
+        let pg_binary_protocol = attrs.iter().any(|a| a.path().is_ident("pg_binary_protocol"));
+
         let to_sql_config = ToSqlConfig::from_attributes(attrs.as_slice())?.unwrap_or_default();
         let in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
         let out_fn = Ident::new(&format!("{}_out", ident).to_lowercase(), ident.span());
-        let receive_fn = Ident::new(&format!("{}_recv", ident).to_lowercase(), ident.span());
-        let send_fn = Ident::new(&format!("{}_send", ident).to_lowercase(), ident.span());
+        let receive_fn = (pg_binary_protocol)
+            .then(|| Ident::new(&format!("{}_recv", ident).to_lowercase(), ident.span()));
+        let send_fn = (pg_binary_protocol)
+            .then(|| Ident::new(&format!("{}_send", ident).to_lowercase(), ident.span()));
         let alignment = Alignment::from_attributes(attrs.as_slice())?;
         PostgresTypeDerive::new(
             ident,

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -171,24 +171,24 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
             .receive_fn
             .as_ref()
             .map(|f| {
-                quote! {
+                quote! {{
                     let in_fn = stringify!(#f);
                     let mut path_items: Vec<_> = in_fn.split("::").collect();
                     let _ = path_items.pop(); // Drop the one we don't want.
                     path_items.join("::")
-                }
+                }}
             })
             .unwrap_or_else(|| quote! { None });
         let send_fn_module_path = self
             .send_fn
             .as_ref()
             .map(|f| {
-                quote! {
+                quote! {{
                     let out_fn = stringify!(#f);
                     let mut path_items: Vec<_> = out_fn.split("::").collect();
                     let _ = path_items.pop(); // Drop the one we don't want.
                     path_items.join("::")
-                }
+                }}
             })
             .unwrap_or_else(|| quote! { None });
 

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -75,7 +75,16 @@ impl PostgresTypeDerive {
         if !to_sql_config.overrides_default() {
             crate::ident_is_acceptable_to_postgres(&name)?;
         }
-        Ok(CodeEnrichment(Self { generics, name, in_fn, out_fn, receive_fn, send_fn, to_sql_config, alignment }))
+        Ok(CodeEnrichment(Self {
+            generics,
+            name,
+            in_fn,
+            out_fn,
+            receive_fn,
+            send_fn,
+            to_sql_config,
+            alignment,
+        }))
     }
 
     pub fn from_derive_input(
@@ -249,6 +258,15 @@ impl Parse for CodeEnrichment<PostgresTypeDerive> {
         let receive_fn = Ident::new(&format!("{}_recv", ident).to_lowercase(), ident.span());
         let send_fn = Ident::new(&format!("{}_send", ident).to_lowercase(), ident.span());
         let alignment = Alignment::from_attributes(attrs.as_slice())?;
-        PostgresTypeDerive::new(ident, generics, in_fn, out_fn, receive_fn, send_fn, to_sql_config, alignment)
+        PostgresTypeDerive::new(
+            ident,
+            generics,
+            in_fn,
+            out_fn,
+            receive_fn,
+            send_fn,
+            to_sql_config,
+            alignment,
+        )
     }
 }

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -55,6 +55,8 @@ pub struct PostgresTypeDerive {
     generics: Generics,
     in_fn: Ident,
     out_fn: Ident,
+    receive_fn: Option<Ident>,
+    send_fn: Option<Ident>,
     to_sql_config: ToSqlConfig,
     alignment: Alignment,
 }
@@ -65,13 +67,15 @@ impl PostgresTypeDerive {
         generics: Generics,
         in_fn: Ident,
         out_fn: Ident,
+        receive_fn: Option<Ident>,
+        send_fn: Option<Ident>,
         to_sql_config: ToSqlConfig,
         alignment: Alignment,
     ) -> Result<CodeEnrichment<Self>, syn::Error> {
         if !to_sql_config.overrides_default() {
             crate::ident_is_acceptable_to_postgres(&name)?;
         }
-        Ok(CodeEnrichment(Self { generics, name, in_fn, out_fn, to_sql_config, alignment }))
+        Ok(CodeEnrichment(Self { generics, name, in_fn, out_fn, receive_fn, send_fn, to_sql_config, alignment }))
     }
 
     pub fn from_derive_input(
@@ -93,12 +97,22 @@ impl PostgresTypeDerive {
             &format!("{}_out", derive_input.ident).to_lowercase(),
             derive_input.ident.span(),
         );
+        let funcname_receive = Ident::new(
+            &format!("{}_recv", derive_input.ident).to_lowercase(),
+            derive_input.ident.span(),
+        );
+        let funcname_send = Ident::new(
+            &format!("{}_send", derive_input.ident).to_lowercase(),
+            derive_input.ident.span(),
+        );
         let alignment = Alignment::from_attributes(derive_input.attrs.as_slice())?;
         Self::new(
             derive_input.ident,
             derive_input.generics,
             funcname_in,
             funcname_out,
+            Some(funcname_receive),
+            Some(funcname_send),
             to_sql_config,
             alignment,
         )
@@ -129,6 +143,8 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
 
         let in_fn = &self.in_fn;
         let out_fn = &self.out_fn;
+        let receive_fn = &self.receive_fn;
+        let send_fn = &self.send_fn;
 
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_type_{}", self.name);
 
@@ -199,6 +215,20 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
                     },
+                    receive_fn: #receive_fn.as_ref().map(|recv_fn| stringify!(recv_fn)),
+                    receive_fn_module_path: #receive_fn.as_ref().map(|recv_fn| {
+                        let recv_fn = stringify!(recv_fn);
+                        let mut path_items: Vec<_> = recv_fn.split("::").collect();
+                        let _ = path_items.pop(); // Drop the one we don't want.
+                        path_items.join("::")
+                    }),
+                    send_fn: #send_fn.as_ref().map(|send_fn| stringify!(#send_fn)),
+                    send_fn_module_path: #send_fn.as_ref().map(|send_fn| {
+                        let send_fn = stringify!(#send_fn);
+                        let mut path_items: Vec<_> = send_fn.split("::").collect();
+                        let _ = path_items.pop(); // Drop the one we don't want.
+                        path_items.join("::")
+                    }),
                     to_sql_config: #to_sql_config,
                     alignment: #alignment,
                 };
@@ -216,7 +246,9 @@ impl Parse for CodeEnrichment<PostgresTypeDerive> {
         let to_sql_config = ToSqlConfig::from_attributes(attrs.as_slice())?.unwrap_or_default();
         let in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
         let out_fn = Ident::new(&format!("{}_out", ident).to_lowercase(), ident.span());
+        let receive_fn = Some(Ident::new(&format!("{}_recv", ident).to_lowercase(), ident.span()));
+        let send_fn = Some(Ident::new(&format!("{}_send", ident).to_lowercase(), ident.span()));
         let alignment = Alignment::from_attributes(attrs.as_slice())?;
-        PostgresTypeDerive::new(ident, generics, in_fn, out_fn, to_sql_config, alignment)
+        PostgresTypeDerive::new(ident, generics, in_fn, out_fn, receive_fn, send_fn, to_sql_config, alignment)
     }
 }

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -215,20 +215,20 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
                     },
-                    receive_fn: Some(stringify!(#receive_fn)),
-                    receive_fn_module_path: Some({
+                    receive_fn: stringify!(#receive_fn),
+                    receive_fn_module_path: {
                         let recv_fn = stringify!(#receive_fn);
                         let mut path_items: Vec<_> = recv_fn.split("::").collect();
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
-                    }),
-                    send_fn: Some(stringify!(#send_fn)),
-                    send_fn_module_path: Some({
+                    },
+                    send_fn: stringify!(#send_fn),
+                    send_fn_module_path: {
                         let send_fn = stringify!(#send_fn);
                         let mut path_items: Vec<_> = send_fn.split("::").collect();
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
-                    }),
+                    },
                     to_sql_config: #to_sql_config,
                     alignment: #alignment,
                 };

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -215,15 +215,15 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
                     },
-                    receive_fn: #receive_fn.as_ref().map(|recv_fn| stringify!(#receive_fn)),
-                    receive_fn_module_path: #receive_fn.as_ref().map(|recv_fn| {
+                    receive_fn: Some(stringify!(#receive_fn)),
+                    receive_fn_module_path: Some({
                         let recv_fn = stringify!(#receive_fn);
                         let mut path_items: Vec<_> = recv_fn.split("::").collect();
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
                     }),
-                    send_fn: #send_fn.as_ref().map(|send_fn| stringify!(#send_fn)),
-                    send_fn_module_path: #send_fn.as_ref().map(|send_fn| {
+                    send_fn: Some(stringify!(#send_fn)),
+                    send_fn_module_path: Some({
                         let send_fn = stringify!(#send_fn);
                         let mut path_items: Vec<_> = send_fn.split("::").collect();
                         let _ = path_items.pop(); // Drop the one we don't want.

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -55,8 +55,8 @@ pub struct PostgresTypeDerive {
     generics: Generics,
     in_fn: Ident,
     out_fn: Ident,
-    receive_fn: Option<Ident>,
-    send_fn: Option<Ident>,
+    receive_fn: Ident,
+    send_fn: Ident,
     to_sql_config: ToSqlConfig,
     alignment: Alignment,
 }
@@ -67,8 +67,8 @@ impl PostgresTypeDerive {
         generics: Generics,
         in_fn: Ident,
         out_fn: Ident,
-        receive_fn: Option<Ident>,
-        send_fn: Option<Ident>,
+        receive_fn: Ident,
+        send_fn: Ident,
         to_sql_config: ToSqlConfig,
         alignment: Alignment,
     ) -> Result<CodeEnrichment<Self>, syn::Error> {
@@ -111,8 +111,8 @@ impl PostgresTypeDerive {
             derive_input.generics,
             funcname_in,
             funcname_out,
-            Some(funcname_receive),
-            Some(funcname_send),
+            funcname_receive,
+            funcname_send,
             to_sql_config,
             alignment,
         )
@@ -215,9 +215,9 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
                     },
-                    receive_fn: #receive_fn.as_ref().map(|recv_fn| stringify!(recv_fn)),
+                    receive_fn: #receive_fn.as_ref().map(|recv_fn| stringify!(#receive_fn)),
                     receive_fn_module_path: #receive_fn.as_ref().map(|recv_fn| {
-                        let recv_fn = stringify!(recv_fn);
+                        let recv_fn = stringify!(#receive_fn);
                         let mut path_items: Vec<_> = recv_fn.split("::").collect();
                         let _ = path_items.pop(); // Drop the one we don't want.
                         path_items.join("::")
@@ -246,8 +246,8 @@ impl Parse for CodeEnrichment<PostgresTypeDerive> {
         let to_sql_config = ToSqlConfig::from_attributes(attrs.as_slice())?.unwrap_or_default();
         let in_fn = Ident::new(&format!("{}_in", ident).to_lowercase(), ident.span());
         let out_fn = Ident::new(&format!("{}_out", ident).to_lowercase(), ident.span());
-        let receive_fn = Some(Ident::new(&format!("{}_recv", ident).to_lowercase(), ident.span()));
-        let send_fn = Some(Ident::new(&format!("{}_send", ident).to_lowercase(), ident.span()));
+        let receive_fn = Ident::new(&format!("{}_recv", ident).to_lowercase(), ident.span());
+        let send_fn = Ident::new(&format!("{}_send", ident).to_lowercase(), ident.span());
         let alignment = Alignment::from_attributes(attrs.as_slice())?;
         PostgresTypeDerive::new(ident, generics, in_fn, out_fn, receive_fn, send_fn, to_sql_config, alignment)
     }

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -171,24 +171,24 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
             .receive_fn
             .as_ref()
             .map(|f| {
-                quote! {{
+                quote! {Some({
                     let in_fn = stringify!(#f);
                     let mut path_items: Vec<_> = in_fn.split("::").collect();
                     let _ = path_items.pop(); // Drop the one we don't want.
                     path_items.join("::")
-                }}
+                })}
             })
             .unwrap_or_else(|| quote! { None });
         let send_fn_module_path = self
             .send_fn
             .as_ref()
             .map(|f| {
-                quote! {{
+                quote! {Some({
                     let out_fn = stringify!(#f);
                     let mut path_items: Vec<_> = out_fn.split("::").collect();
                     let _ = path_items.pop(); // Drop the one we don't want.
                     path_items.join("::")
-                }}
+                })}
             })
             .unwrap_or_else(|| quote! { None });
 

--- a/pgrx-tests/src/tests/aggregate_tests.rs
+++ b/pgrx-tests/src/tests/aggregate_tests.rs
@@ -12,6 +12,7 @@ use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Default, Debug, PostgresType, Serialize, Deserialize)]
+#[pg_binary_protocol]
 pub struct DemoSum {
     count: i32,
 }
@@ -64,6 +65,7 @@ impl Aggregate for DemoSum {
 }
 
 #[derive(Copy, Clone, Default, Debug, PostgresType, Serialize, Deserialize)]
+#[pg_binary_protocol]
 pub struct DemoPercentileDisc;
 
 #[pg_aggregate]
@@ -105,11 +107,13 @@ mod demo_schema {
     use serde::{Deserialize, Serialize};
 
     #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
+    #[pg_binary_protocol]
     pub struct DemoState {
         pub sum: i32,
     }
 }
 #[derive(Copy, Clone, Default, Debug, PostgresType, Serialize, Deserialize)]
+#[pg_binary_protocol]
 pub struct DemoCustomState;
 
 // demonstrate we can properly support an STYPE with a pg_schema

--- a/pgrx-tests/src/tests/fcinfo_tests.rs
+++ b/pgrx-tests/src/tests/fcinfo_tests.rs
@@ -137,6 +137,7 @@ fn fcinfo_not_named_no_arg(fcinfo: pg_sys::FunctionCallInfo) -> i32 {
 }
 
 #[derive(PostgresType, Serialize, Deserialize, Debug, PartialEq)]
+#[pg_binary_protocol]
 #[inoutfuncs]
 pub struct NullStrict {}
 
@@ -153,6 +154,7 @@ impl InOutFuncs for NullStrict {
 }
 
 #[derive(PostgresType, Serialize, Deserialize, Debug, PartialEq)]
+#[pg_binary_protocol]
 #[inoutfuncs]
 pub struct NullError {}
 

--- a/pgrx-tests/src/tests/pg_cast_tests.rs
+++ b/pgrx-tests/src/tests/pg_cast_tests.rs
@@ -30,6 +30,7 @@ mod pg_catalog {
     }
 
     #[derive(PostgresType, Serialize, Deserialize)]
+    #[pg_binary_protocol]
     struct TestCastType;
 
     #[pg_cast(implicit, immutable)]

--- a/pgrx-tests/src/tests/postgres_type_tests.rs
+++ b/pgrx-tests/src/tests/postgres_type_tests.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
+#[pg_binary_protocol]
 #[pgvarlena_inoutfuncs]
 pub struct VarlenaType {
     a: f32,
@@ -39,6 +40,7 @@ impl PgVarlenaInOutFuncs for VarlenaType {
 }
 
 #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
+#[pg_binary_protocol]
 #[pgvarlena_inoutfuncs]
 pub enum VarlenaEnumType {
     A,
@@ -71,6 +73,7 @@ impl PgVarlenaInOutFuncs for VarlenaEnumType {
 }
 
 #[derive(Serialize, Deserialize, PostgresType)]
+#[pg_binary_protocol]
 #[inoutfuncs]
 pub struct CustomTextFormatSerializedType {
     a: f32,
@@ -105,6 +108,7 @@ fn fn_takes_option(input: Option<CustomTextFormatSerializedType>) -> String {
 }
 
 #[derive(Serialize, Deserialize, PostgresType)]
+#[pg_binary_protocol]
 #[inoutfuncs]
 pub enum CustomTextFormatSerializedEnumType {
     A,
@@ -140,6 +144,7 @@ fn fn_takes_option_enum(input: Option<CustomTextFormatSerializedEnumType>) -> St
 }
 
 #[derive(Serialize, Deserialize, PostgresType)]
+#[pg_binary_protocol]
 pub struct JsonType {
     a: f32,
     b: f32,
@@ -147,6 +152,7 @@ pub struct JsonType {
 }
 
 #[derive(Serialize, Deserialize, PostgresType)]
+#[pg_binary_protocol]
 #[serde(tag = "type")]
 pub enum JsonEnumType {
     E1 { a: f32 },

--- a/pgrx-tests/src/tests/result_tests.rs
+++ b/pgrx-tests/src/tests/result_tests.rs
@@ -19,6 +19,7 @@ use serde::*;
 //
 
 #[derive(Debug, Serialize, Deserialize, PostgresType)]
+#[pg_binary_protocol]
 pub struct ResultTestsA;
 
 #[pg_extern]

--- a/pgrx-tests/src/tests/roundtrip_tests.rs
+++ b/pgrx-tests/src/tests/roundtrip_tests.rs
@@ -4,6 +4,7 @@ use rand::distr::{Alphanumeric, StandardUniform};
 use rand::Rng;
 
 #[derive(pgrx::PostgresType, Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[pg_binary_protocol]
 pub struct RandomData {
     i: u64,
     s: String,

--- a/pgrx-tests/src/tests/schema_tests.rs
+++ b/pgrx-tests/src/tests/schema_tests.rs
@@ -25,17 +25,21 @@ mod test_schema {
     fn func_generated_with_custom_sql() {}
 
     #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    #[pg_binary_protocol]
     pub struct TestType(pub u64);
 
     #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    #[pg_binary_protocol]
     #[pgrx(sql = false)]
     pub struct ElidedType(pub u64);
 
     #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    #[pg_binary_protocol]
     #[pgrx(sql = generate_type)]
     pub struct OtherType(pub u64);
 
     #[derive(Debug, PostgresType, Serialize, Deserialize)]
+    #[pg_binary_protocol]
     #[pgrx(sql = "CREATE TYPE test_schema.ManuallyRenderedType;")]
     pub struct OverriddenType(pub u64);
 

--- a/pgrx/src/aggregate.rs
+++ b/pgrx/src/aggregate.rs
@@ -29,6 +29,7 @@ use serde::{Serialize, Deserialize};
 // pg_module_magic!(); // Uncomment this outside of docs!
 
 #[derive(Copy, Clone, Default, PostgresType, Serialize, Deserialize)]
+#[pg_binary_protocol]
 pub struct DemoSum {
     count: i32,
 }
@@ -221,6 +222,7 @@ Sometimes it's useful to have aggregates share state, or use some other type for
 # use serde::{Serialize, Deserialize};
 #
 #[derive(Copy, Clone, Default, PostgresType, Serialize, Deserialize)]
+#[pg_binary_protocol]
 pub struct DemoSumState {
     count: i32,
 }

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -401,8 +401,8 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
-    todo!("cbor_decode stops here!");
     let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
+    todo!("cbor_decode stops here 2!");
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);
     let slice = std::slice::from_raw_parts(data as *const u8, len);

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -401,6 +401,7 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
+    todo!("cbor_decode stops here!");
     let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -401,8 +401,8 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
+    todo!("received input: {:?}", input);
     let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
-    todo!("cbor_decode stops here 2!");
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);
     let slice = std::slice::from_raw_parts(data as *const u8, len);

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -401,9 +401,7 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
-    let dereferenced_varlena = *input;
-    let slice = unsafe{dereferenced_varlena.vl_dat.as_slice()};
-    todo!("received input: {:?}, {:?}", dereferenced_varlena, slice);
+    todo!("received input: {:?}, {:?}", *input);
     let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -401,7 +401,9 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
-    todo!("received input: {:?}", *input);
+    let dereferenced_varlena = *input;
+    let slice = unsafe{dereferenced_varlena.vl_dat.as_slice()};
+    todo!("received input: {:?}, {:?}", dereferenced_varlena, slice);
     let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -401,7 +401,7 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
-    todo!("received input: {:?}", input);
+    todo!("received input: {:?}", *input);
     let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -401,7 +401,6 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
-    todo!("received input: {:?}, {:?}", *input);
     let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -132,8 +132,6 @@ pub use pg_sys::{
     info, log, notice, warning, FATAL, PANIC,
 };
 
-pub use serde_cbor;
-
 #[doc(hidden)]
 pub use pgrx_sql_entity_graph;
 

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -131,6 +131,9 @@ pub use pg_sys::{
     check_for_interrupts, debug1, debug2, debug3, debug4, debug5, ereport, error, function_name,
     info, log, notice, warning, FATAL, PANIC,
 };
+
+pub use serde_cbor;
+
 #[doc(hidden)]
 pub use pgrx_sql_entity_graph;
 


### PR DESCRIPTION
This PR generally addresses issues such as #2060, #1446, #1364, and https://github.com/pksunkara/pgx_ulid/issues/27, and supersedes PR #887.

- [x] Introduces the generation of the `SEND` and `RECEIVE` bindings.
- [x] Introduces the generation of the `*_recv` and `*_send` functions in rust, based on the existing `serde_cbor`-based methods [`cbor_encode`](https://github.com/pgcentralfoundation/pgrx/blob/231acce2448ce7df2b9f01cb0962077122a0cf83/pgrx/src/datum/varlena.rs#L380-L397) and [`cbor_decode`](https://github.com/pgcentralfoundation/pgrx/blob/231acce2448ce7df2b9f01cb0962077122a0cf83/pgrx/src/datum/varlena.rs#L399-L409)
- [x] Introduces the `#[pg_binary_protocol]` decorator to be used alongside the `PostgresType` derive

This PR is not API breaking, as even if people have created functions with naming clashes they would still need to add the attribute on the interested structs.

Many thanks to @YohDeadfall and @zommiommy for their help in understanding better pgrx internals and postgres's binary protocol.

## The generated Rust & SQL

Given a custom rust type such as:

```rust
#[derive(serde::Serialize, serde::Deserialize, pgrx::PostgresType)]
#[pg_binary_protocol]
pub struct PositiveU32 {
    pub field: i32,
}
```

The resulting generated rust bindings look like:

```rust
#[doc(hidden)]
#[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
pub fn positiveu32_recv(
    internal: ::pgrx::datum::Internal,
) -> PositiveU32 {
    let buf = unsafe { internal.get_mut::<::pgrx::pg_sys::StringInfoData>().unwrap() };

    let mut serialized = ::pgrx::StringInfo::new();

    serialized.push_bytes(&[0u8; ::pgrx::pg_sys::VARHDRSZ]);
    serialized.push_bytes(unsafe {
        core::slice::from_raw_parts(
            buf.data as *const u8,
            buf.len as usize
        )
    });

    let size = serialized.len();
    let varlena = serialized.into_char_ptr();

    unsafe{
        ::pgrx::set_varsize_4b(varlena as *mut ::pgrx::pg_sys::varlena, size as i32);
        buf.cursor = buf.len;
        ::pgrx::datum::cbor_decode(varlena as *mut ::pgrx::pg_sys::varlena)
    }
}
#[doc(hidden)]
#[::pgrx::pgrx_macros::pg_extern(immutable, strict, parallel_safe)]
pub fn positiveu32_send(input: PositiveU32) -> Vec<u8> {
    use ::pgrx::datum::{FromDatum, IntoDatum};
    let Some(datum): Option<::pgrx::pg_sys::Datum> = input.into_datum() else {
        ::pgrx::error!("Datum of type `{}` is unexpectedly NULL.", stringify!(#name));
    };
    unsafe {
        let Some(serialized): Option<Vec<u8>> = FromDatum::from_datum(datum, false) else {
            ::pgrx::error!("Failed to CBOR-serialize Datum to type `{}`.", stringify!(#name));
        };
        serialized
    }
}
```

And the associated generated SQL looks like:

```sql
/* <begin connected objects> */
/*
This file is auto generated by pgrx.

The ordering of items is not stable, it is driven by a dependency graph.
*/
/* </end connected objects> */

/* <begin connected objects> */
-- utils/diesel-pgrx/example_extension/src/lib.rs:16
-- example_extension::PositiveU32
CREATE TYPE PositiveU32;

-- utils/diesel-pgrx/example_extension/src/lib.rs:16
-- example_extension::positiveu32_in
CREATE  FUNCTION "positiveu32_in"(
	"input" cstring /* core::option::Option<&core::ffi::c_str::CStr> */
) RETURNS PositiveU32 /* core::option::Option<example_extension::PositiveU32> */
IMMUTABLE PARALLEL SAFE
LANGUAGE c /* Rust */
AS 'MODULE_PATHNAME', 'positiveu32_in_wrapper';

-- utils/diesel-pgrx/example_extension/src/lib.rs:16
-- example_extension::positiveu32_out
CREATE  FUNCTION "positiveu32_out"(
	"input" PositiveU32 /* example_extension::PositiveU32 */
) RETURNS cstring /* alloc::ffi::c_str::CString */
IMMUTABLE STRICT PARALLEL SAFE
LANGUAGE c /* Rust */
AS 'MODULE_PATHNAME', 'positiveu32_out_wrapper';

-- utils/diesel-pgrx/example_extension/src/lib.rs:16
-- example_extension::positiveu32_recv
CREATE  FUNCTION "positiveu32_recv"(
	"internal" internal /* pgrx::datum::internal::Internal */
) RETURNS PositiveU32 /* example_extension::PositiveU32 */
IMMUTABLE STRICT PARALLEL SAFE
LANGUAGE c /* Rust */
AS 'MODULE_PATHNAME', 'positiveu32_recv_wrapper';

-- utils/diesel-pgrx/example_extension/src/lib.rs:16
-- example_extension::positiveu32_send
CREATE  FUNCTION "positiveu32_send"(
	"input" PositiveU32 /* example_extension::PositiveU32 */
) RETURNS bytea /* alloc::vec::Vec<u8> */
IMMUTABLE STRICT PARALLEL SAFE
LANGUAGE c /* Rust */
AS 'MODULE_PATHNAME', 'positiveu32_send_wrapper';


-- utils/diesel-pgrx/example_extension/src/lib.rs:16
-- example_extension::PositiveU32
CREATE TYPE PositiveU32 (
	INTERNALLENGTH = variable,
	INPUT = positiveu32_in, /* example_extension::positiveu32_in */
	OUTPUT = positiveu32_out, /* example_extension::positiveu32_out */
	RECEIVE = positiveu32_recv, /* example_extension::positiveu32_recv */
	SEND = positiveu32_send, /* example_extension::positiveu32_send */
	STORAGE = extended
);
/* </end connected objects> */
```

## On Diesel traits

I use [`diesel`](https://docs.rs/diesel/latest/diesel/) extensively in my projects, and it uses the binary protocol to send data to PostgreSQL. This PR makes it possible to use Postgres's binary protocol with `pgrx` type, so I can now implement diesel's [`ToSql`](https://docs.rs/diesel/latest/diesel/serialize/trait.ToSql.html) and [`FromSql`](https://docs.rs/diesel/latest/diesel/deserialize/trait.FromSql.html) traits as follows:

```rust
#[derive(
    Debug, diesel::FromSqlRow, diesel::AsExpression,
    serde::Serialize, serde::Deserialize, pgrx::PostgresType
)]
#[pg_binary_protocol]
#[diesel(sql_type = MyCustomTypeDiesel)]
pub struct MyCustomType {
    pub field1: String,
    pub field2: i32,
}

#[derive(
    Debug, Clone, Copy, Default, diesel::query_builder::QueryId, diesel::sql_types::SqlType,
)]
#[diesel(postgres_type(name = "my_custom_type"))]
pub struct MyCustomTypeDiesel;

impl diesel::serialize::ToSql<MyCustomTypeDiesel, diesel::pg::Pg> for MyCustomType
{
    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, diesel::pg::Pg>) -> diesel::serialize::Result {
        use std::io::Write;
        serde_cbor::to_writer(out, self)?;
        Ok(diesel::serialize::IsNull::No)
    }
}

impl diesel::deserialize::FromSql<MyCustomTypeDiesel, diesel::pg::Pg> for MyCustomType
{
    fn from_sql(raw: diesel::pg::PgValue<'_>) -> diesel::deserialize::Result<Self> {
        Ok(serde_cbor::from_slice(raw.as_bytes())?)
    }
}
```
 
*P.S. Sorry for the very small commits, but I could only figure out how to compile pgrx inside a Docker and therefore to test it in there I had to push every single small test edit.*

*P.P.S I have also tried to add support for fixed-size types, but there is too much varlena-specific methods at this time and the amount of code it would be needed for that makes it necessarily a separate PR*