### PR TITLE
Added a missing `#[doc(hidden)]`

### DIFF
--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -477,6 +477,7 @@ fn compute_codegen(
         out
     };
     Ok(quote::quote! {
+        #[doc(hidden)]
         pub fn main() {
             #inputs
             #build


### PR DESCRIPTION
This very small PR resolves clippy's `error: missing documentation for a function` when you set `missing_docs = "forbid"` in a project.