### PR TITLE
Updated Fedora to latest in CI

### DIFF
--- a/.github/docker/Dockerfile.fedora
+++ b/.github/docker/Dockerfile.fedora
@@ -7,7 +7,7 @@
 # Note that "PG_MAJOR_VER" build arg in the build step must match the
 # "--features pgXX" in the run step
 
-ARG FEDORA_VER=40
+ARG FEDORA_VER=42
 FROM fedora:${FEDORA_VER}
 ARG FEDORA_VER
 ENV FEDORA_VER=${FEDORA_VER}


### PR DESCRIPTION
Fedore 40 has reached EOL, so our CI is broken now. The latest supported version is 42.