### PR TITLE
WIP: Adding support for contrib/intarray style fast-allocated arrays

### DIFF
--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -183,6 +183,11 @@ fn validate_cstring_array<'a>(
     Ok(true)
 }
 
+#[pg_extern]
+fn int_array_roundtrip(arr: Array<i32>) -> Array<i32> {
+    arr
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
@@ -503,6 +508,87 @@ mod tests {
         assert_eq!(a.get(3), Some(None));
         assert_eq!(a.get(4), Some(Some(String::from("the fifth element"))));
         assert_eq!(a.get(5), None);
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_int_array_roundtrip_test() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Vec<i32>>("SELECT int_array_roundtrip(ARRAY[1, 2, 3, 4, 5])")?;
+
+        assert_eq!(a, Some(vec![1, 2, 3, 4, 5]));
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_array_new_from_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Spi::get_one::<Array<i8>>("SELECT ARRAY[1, 2, 3, 4, 5]::\"char\"[]")?
+            .expect("spi result was NULL");
+        let b = Array::<i8>::new_from_slice(&[1, 2, 3, 4, 5]).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, b.as_slice()?);
+
+        let a = Spi::get_one::<Array<i16>>("SELECT ARRAY[1, 2, 3, 4, 5]::smallint[]")?
+            .expect("spi result was NULL");
+        let b = Array::<i16>::new_from_slice(&[1, 2, 3, 4, 5]).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, b.as_slice()?);
+
+        let a = Spi::get_one::<Array<i32>>("SELECT ARRAY[1, 2, 3, 4, 5]::integer[]")?
+            .expect("spi result was NULL");
+        let b = Array::<i32>::new_from_slice(&[1, 2, 3, 4, 5]).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, b.as_slice()?);
+
+        let a = Spi::get_one::<Array<i64>>("SELECT ARRAY[1, 2, 3, 4, 5]::bigint[]")?
+            .expect("spi result was NULL");
+        let b = Array::<i64>::new_from_slice(&[1, 2, 3, 4, 5]).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, b.as_slice()?);
+
+        let a = Spi::get_one::<Array<f32>>("SELECT ARRAY[1.0, 2.0, 3.0, 4.0, 5.0]::float4[]")?
+            .expect("spi result was NULL");
+        let b = Array::<f32>::new_from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0])
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, b.as_slice()?);
+
+        let a = Spi::get_one::<Array<f64>>("SELECT ARRAY[1.0, 2.0, 3.0, 4.0, 5.0]::float8[]")?
+            .expect("spi result was NULL");
+        let b = Array::<f64>::new_from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0])
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, b.as_slice()?);
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_new_array_with_len() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Array::<i8>::new_with_len(5).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[0, 0, 0, 0, 0]);
+
+        let a = Array::<i16>::new_with_len(5).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[0, 0, 0, 0, 0]);
+
+        let a = Array::<i32>::new_with_len(5).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[0, 0, 0, 0, 0]);
+
+        let a = Array::<i64>::new_with_len(5).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[0, 0, 0, 0, 0]);
+
+        let a = Array::<f32>::new_with_len(5).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[0.0, 0.0, 0.0, 0.0, 0.0]);
+
+        let a = Array::<f64>::new_with_len(5).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[0.0, 0.0, 0.0, 0.0, 0.0]);
 
         Ok(())
     }

--- a/pgrx-tests/src/tests/array_tests.rs
+++ b/pgrx-tests/src/tests/array_tests.rs
@@ -195,6 +195,7 @@ mod tests {
     use crate as pgrx_tests;
 
     use super::ArrayTestEnum;
+    use pgrx::array::ArrayAllocError;
     use pgrx::prelude::*;
     use pgrx::Json;
     use serde_json::json;
@@ -589,6 +590,111 @@ mod tests {
         let a = Array::<f64>::new_with_len(5).expect("failed to create array");
 
         assert_eq!(a.as_slice()?, &[0.0, 0.0, 0.0, 0.0, 0.0]);
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_new_array_from_iter() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Array::<i8>::new_from_iter(vec![1, 2, 3, 4, 5].into_iter(), 5)
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<i16>::new_from_iter(vec![1, 2, 3, 4, 5].into_iter(), 5)
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<i32>::new_from_iter(vec![1, 2, 3, 4, 5].into_iter(), 5)
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<i64>::new_from_iter(vec![1, 2, 3, 4, 5].into_iter(), 5)
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<f32>::new_from_iter(vec![1.0, 2.0, 3.0, 4.0, 5.0].into_iter(), 5)
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        let a = Array::<f64>::new_from_iter(vec![1.0, 2.0, 3.0, 4.0, 5.0].into_iter(), 5)
+            .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        // a more complex iter
+        let iter = vec![1i32, 2, 3].into_iter().chain(vec![4i32, 5].into_iter());
+        let a = Array::<i32>::new_from_iter(iter, 5).expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        // make sure the expected allocated len matches the enumerated len
+        let a = Array::<i32>::new_from_iter(vec![1, 2, 3, 4, 5].into_iter(), 3);
+
+        assert_eq!(a.err(), Some(ArrayAllocError::IterLenMismatch(3, 5))); // expected 3, saw 5
+
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_new_array_with_init_fn() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Array::<i8>::new_with_init_fn(5, |slice| {
+            for (i, elem) in slice.iter_mut().enumerate() {
+                *elem = (i + 1) as i8;
+            }
+        })
+        .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<i16>::new_with_init_fn(5, |slice| {
+            for (i, elem) in slice.iter_mut().enumerate() {
+                *elem = (i + 1) as i16;
+            }
+        })
+        .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<i32>::new_with_init_fn(5, |slice| {
+            for (i, elem) in slice.iter_mut().enumerate() {
+                *elem = (i + 1) as i32;
+            }
+        })
+        .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<i64>::new_with_init_fn(5, |slice| {
+            for (i, elem) in slice.iter_mut().enumerate() {
+                *elem = (i + 1) as i64;
+            }
+        })
+        .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1, 2, 3, 4, 5]);
+
+        let a = Array::<f32>::new_with_init_fn(5, |slice| {
+            for (i, elem) in slice.iter_mut().enumerate() {
+                *elem = (i + 1) as f32;
+            }
+        })
+        .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        let a = Array::<f64>::new_with_init_fn(5, |slice| {
+            for (i, elem) in slice.iter_mut().enumerate() {
+                *elem = (i + 1) as f64;
+            }
+        })
+        .expect("failed to create array");
+
+        assert_eq!(a.as_slice()?, &[1.0, 2.0, 3.0, 4.0, 5.0]);
 
         Ok(())
     }

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -8,7 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![allow(clippy::precedence)]
-use crate::datum::{Array, IntoDatum, UnboxDatum};
+use crate::datum::{Array, ArrayFastAllocSubType};
 use crate::toast::{Toast, Toasty};
 use crate::{layout, pg_sys, set_varsize_4b, varlena, PgMemoryContexts};
 use bitvec::ptr::{self as bitptr, BitPtr, BitPtrError, Mut};
@@ -378,9 +378,7 @@ impl RawArray {
     /// Slightly faster than new_array_type_with_len(0)
     pub fn new_empty_array_type<T>() -> Result<RawArray, ArrayAllocError>
     where
-        T: IntoDatum,
-        T: UnboxDatum,
-        T: Sized,
+        T: ArrayFastAllocSubType,
     {
         unsafe {
             let array_type = pg_sys::construct_empty_array(T::type_oid());
@@ -393,9 +391,7 @@ impl RawArray {
     /// Rustified version of new_intArrayType(int num) from https://github.com/postgres/postgres/blob/master/contrib/intarray/_int_tool.c#L219
     pub fn new_array_type_with_len<T>(len: usize) -> Result<RawArray, ArrayAllocError>
     where
-        T: IntoDatum,
-        T: UnboxDatum,
-        T: Sized,
+        T: ArrayFastAllocSubType,
     {
         if len == 0 {
             return Self::new_empty_array_type::<T>();

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -431,4 +431,6 @@ impl Toasty for RawArray {
 pub enum ArrayAllocError {
     #[error("Failed to allocate memory for Array")]
     MemoryAllocationFailed,
+    #[error("Expected len {0}, found {1}")]
+    IterLenMismatch(usize, usize),
 }

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -8,13 +8,14 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![allow(clippy::precedence)]
-use crate::datum::Array;
+use crate::datum::{Array, IntoDatum, UnboxDatum};
 use crate::toast::{Toast, Toasty};
-use crate::{layout, pg_sys, varlena};
+use crate::{layout, pg_sys, set_varsize_4b, varlena, PgMemoryContexts};
 use bitvec::ptr::{self as bitptr, BitPtr, BitPtrError, Mut};
 use bitvec::slice::BitSlice;
 use core::ptr::{self, NonNull};
 use core::slice;
+use pgrx_pg_sys::ArrayType;
 
 mod port;
 
@@ -373,10 +374,65 @@ impl RawArray {
         let ptr = self.ptr.as_ptr().cast::<u8>();
         ptr.wrapping_add(unsafe { varlena::varsize_any(ptr.cast()) })
     }
+
+    /// Slightly faster than new_array_type_with_len(0)
+    pub fn new_empty_array_type<T>() -> Result<RawArray, ArrayAllocError>
+    where
+        T: IntoDatum,
+        T: UnboxDatum,
+        T: Sized,
+    {
+        unsafe {
+            let array_type = pg_sys::construct_empty_array(T::type_oid());
+            let array_type =
+                NonNull::new(array_type).ok_or(ArrayAllocError::MemoryAllocationFailed)?;
+            Ok(RawArray::from_ptr(array_type))
+        }
+    }
+
+    /// Rustified version of new_intArrayType(int num) from https://github.com/postgres/postgres/blob/master/contrib/intarray/_int_tool.c#L219
+    pub fn new_array_type_with_len<T>(len: usize) -> Result<RawArray, ArrayAllocError>
+    where
+        T: IntoDatum,
+        T: UnboxDatum,
+        T: Sized,
+    {
+        if len == 0 {
+            return Self::new_empty_array_type::<T>();
+        }
+        let elem_size = std::mem::size_of::<T>();
+        let nbytes: usize = port::ARR_OVERHEAD_NONULLS(1) + elem_size * len;
+
+        unsafe {
+            let array_type = PgMemoryContexts::For(pg_sys::CurrentMemoryContext).palloc0(nbytes)
+                as *mut ArrayType;
+            if array_type.is_null() {
+                return Err(ArrayAllocError::MemoryAllocationFailed);
+            }
+            set_varsize_4b(array_type as *mut pg_sys::varlena, nbytes as i32);
+            (*array_type).ndim = 1;
+            (*array_type).dataoffset = 0; /* marker for no null bitmap */
+            (*array_type).elemtype = T::type_oid();
+
+            let ndims = port::ARR_DIMS(array_type);
+            *ndims = len as i32; // equivalent of ARR_DIMS(r)[0] = num;
+            let arr_lbound = port::ARR_LBOUND(array_type);
+            *arr_lbound = 1;
+
+            let array_type = NonNull::new_unchecked(array_type);
+            Ok(RawArray::from_ptr(array_type))
+        }
+    }
 }
 
 impl Toasty for RawArray {
     unsafe fn drop_toast(&mut self) {
         unsafe { pg_sys::pfree(self.ptr.as_ptr().cast()) }
     }
+}
+
+#[derive(thiserror::Error, Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ArrayAllocError {
+    #[error("Failed to allocate memory for Array")]
+    MemoryAllocationFailed,
 }

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -388,7 +388,7 @@ impl RawArray {
         }
     }
 
-    /// Rustified version of new_intArrayType(int num) from https://github.com/postgres/postgres/blob/master/contrib/intarray/_int_tool.c#L219
+    /// Rustified version of new_intArrayType(int num) from [https://github.com/postgres/postgres/blob/master/contrib/intarray/_int_tool.c#L219]
     pub fn new_array_type_with_len<T>(len: usize) -> Result<RawArray, ArrayAllocError>
     where
         T: ArrayFastAllocSubType,

--- a/pgrx/src/array/port.rs
+++ b/pgrx/src/array/port.rs
@@ -126,3 +126,22 @@ pub(super) unsafe fn ARR_DATA_PTR(a: *mut pg_sys::ArrayType) -> *mut u8 {
 
     unsafe { a.cast::<u8>().add(ARR_DATA_OFFSET(a)) }
 }
+
+/// Returns a pointer to the lower bounds of the array.
+/// # Safety
+/// Does a field access, but doesn't deref out of bounds of ArrayType.  The caller asserts that
+/// `a` is a properly allocated [`pg_sys::ArrayType`]
+///
+/// [`pg_sys::ArrayType`] is typically allocated past its size, and its somewhere in that region
+/// that the returned pointer points, so don't attempt to `pfree` it.
+#[inline(always)]
+pub(super) unsafe fn ARR_LBOUND(a: *mut pg_sys::ArrayType) -> *mut i32 {
+    //  #define ARR_LBOUND(a) \
+    //        ((int *) (((char *) (a)) + sizeof(ArrayType) + \
+    //                  sizeof(int) * ARR_NDIM(a)))
+
+    a.cast::<u8>()
+        .add(std::mem::size_of::<pg_sys::ArrayType>())
+        .add(std::mem::size_of::<i32>() * ((*a).ndim as usize))
+        .cast::<i32>()
+}

--- a/pgrx/src/array/port.rs
+++ b/pgrx/src/array/port.rs
@@ -127,7 +127,7 @@ pub(super) unsafe fn ARR_DATA_PTR(a: *mut pg_sys::ArrayType) -> *mut u8 {
     unsafe { a.cast::<u8>().add(ARR_DATA_OFFSET(a)) }
 }
 
-/// Returns a pointer to the lower bounds of the array.
+/// Returns a pointer to the list of lower bounds given by Postgres as a series of integers
 /// # Safety
 /// Does a field access, but doesn't deref out of bounds of ArrayType.  The caller asserts that
 /// `a` is a properly allocated [`pg_sys::ArrayType`]
@@ -141,7 +141,7 @@ pub(super) unsafe fn ARR_LBOUND(a: *mut pg_sys::ArrayType) -> *mut i32 {
     //                  sizeof(int) * ARR_NDIM(a)))
 
     a.cast::<u8>()
-        .add(std::mem::size_of::<pg_sys::ArrayType>())
-        .add(std::mem::size_of::<i32>() * ((*a).ndim as usize))
+        .add(mem::size_of::<pg_sys::ArrayType>())
+        .add(mem::size_of::<i32>() * ((*a).ndim as usize))
         .cast::<i32>()
 }

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -20,9 +20,9 @@ use crate::datum::{Range, RangeSubType};
 use crate::heap_tuple::PgHeapTuple;
 use crate::layout::PassBy;
 use crate::nullable::Nullable;
-use crate::pg_sys;
 use crate::pgbox::*;
 use crate::rel::PgRelation;
+use crate::{pg_sys, Array};
 use crate::{PgBox, PgMemoryContexts};
 
 use core::marker::PhantomData;
@@ -592,6 +592,19 @@ unsafe impl<T> BoxRet for Vec<T>
 where
     T: IntoDatum,
 {
+    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
+        match self.into_datum() {
+            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
+            None => fcinfo.return_null(),
+        }
+    }
+}
+
+unsafe impl<'mcx, T: UnboxDatum> BoxRet for Array<'mcx, T>
+where
+    T: IntoDatum,
+{
+    #[inline]
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
         match self.into_datum() {
             Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -664,7 +664,7 @@ fn as_mut_slice<'a, T: Sized>(array: &'a mut Array<'_, T>) -> Result<&'a mut [T]
     Ok(slice)
 }
 
-/// Creates an Array<`a, T> with zero-elements
+/// Creates an `Array<'a, T>` with zero-elements
 /// Slightly faster than new_array_with_len(0)
 pub fn new_empty_array<'a, T: Sized>() -> Result<Array<'a, T>, ArrayAllocError>
 where
@@ -679,7 +679,7 @@ where
     }
 }
 
-/// Creates an Array<T> of a fixed len, with 0 for all elements
+/// Creates an `Array<T>` of a fixed len, with 0 for all elements
 /// Uses a single PG allocation rather than
 #[inline(always)]
 pub fn new_array_with_len<'a, T: Sized>(len: usize) -> Result<Array<'a, T>, ArrayAllocError>

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![allow(clippy::question_mark)]
 use super::{unbox, UnboxDatum};
-use crate::array::RawArray;
+use crate::array::{ArrayAllocError, RawArray};
 use crate::nullable::{
     BitSliceNulls, IntoNullableIterator, MaybeStrictNulls, NullLayout, Nullable, NullableContainer,
 };
@@ -424,6 +424,31 @@ impl Array<'_, f64> {
     pub fn as_slice(&self) -> Result<&[f64], ArraySliceError> {
         as_slice(self)
     }
+
+    /// Returns a mutable slice of `f64`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> Result<&mut [f64], ArraySliceError> {
+        as_mut_slice(self)
+    }
+}
+
+impl<'mcx> Array<'mcx, f64> {
+    #[inline]
+    pub fn new_with_len(len: usize) -> Result<Array<'mcx, f64>, ArrayAllocError> {
+        new_array_with_len(len)
+    }
+
+    #[inline(always)]
+    pub fn new_from_slice(slice: &'_ [f64]) -> Result<Array<'mcx, f64>, ArrayAllocError> {
+        let mut array = Self::new_with_len(slice.len())?;
+        array.as_mut_slice().unwrap().copy_from_slice(slice);
+        Ok(array)
+    }
 }
 
 impl Array<'_, f32> {
@@ -436,6 +461,31 @@ impl Array<'_, f32> {
     #[inline]
     pub fn as_slice(&self) -> Result<&[f32], ArraySliceError> {
         as_slice(self)
+    }
+
+    /// Returns a mutable slice of `f32`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> Result<&mut [f32], ArraySliceError> {
+        as_mut_slice(self)
+    }
+}
+
+impl<'mcx> Array<'mcx, f32> {
+    #[inline]
+    pub fn new_with_len(len: usize) -> Result<Array<'mcx, f32>, ArrayAllocError> {
+        new_array_with_len(len)
+    }
+
+    #[inline(always)]
+    pub fn new_from_slice(slice: &'_ [f32]) -> Result<Array<'mcx, f32>, ArrayAllocError> {
+        let mut array = Self::new_with_len(slice.len())?;
+        array.as_mut_slice().unwrap().copy_from_slice(slice);
+        Ok(array)
     }
 }
 
@@ -451,6 +501,31 @@ impl Array<'_, i64> {
     pub fn as_slice(&self) -> Result<&[i64], ArraySliceError> {
         as_slice(self)
     }
+
+    /// Returns a mutable slice of `i64`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> Result<&mut [i64], ArraySliceError> {
+        as_mut_slice(self)
+    }
+}
+
+impl<'mcx> Array<'mcx, i64> {
+    #[inline]
+    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i64>, ArrayAllocError> {
+        new_array_with_len(len)
+    }
+
+    #[inline(always)]
+    pub fn new_from_slice(slice: &'_ [i64]) -> Result<Array<'mcx, i64>, ArrayAllocError> {
+        let mut array = Self::new_with_len(slice.len())?;
+        array.as_mut_slice().unwrap().copy_from_slice(slice);
+        Ok(array)
+    }
 }
 
 impl Array<'_, i32> {
@@ -463,6 +538,31 @@ impl Array<'_, i32> {
     #[inline]
     pub fn as_slice(&self) -> Result<&[i32], ArraySliceError> {
         as_slice(self)
+    }
+
+    /// Returns a mutable slice of `i32`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> Result<&mut [i32], ArraySliceError> {
+        as_mut_slice(self)
+    }
+}
+
+impl<'mcx> Array<'mcx, i32> {
+    #[inline]
+    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i32>, ArrayAllocError> {
+        new_array_with_len(len)
+    }
+
+    #[inline(always)]
+    pub fn new_from_slice(slice: &'_ [i32]) -> Result<Array<'mcx, i32>, ArrayAllocError> {
+        let mut array = Self::new_with_len(slice.len())?;
+        array.as_mut_slice().unwrap().copy_from_slice(slice);
+        Ok(array)
     }
 }
 
@@ -477,6 +577,31 @@ impl Array<'_, i16> {
     pub fn as_slice(&self) -> Result<&[i16], ArraySliceError> {
         as_slice(self)
     }
+
+    /// Returns a mutable slice of `i16`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> Result<&mut [i16], ArraySliceError> {
+        as_mut_slice(self)
+    }
+}
+
+impl<'mcx> Array<'mcx, i16> {
+    #[inline]
+    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i16>, ArrayAllocError> {
+        new_array_with_len(len)
+    }
+
+    #[inline(always)]
+    pub fn new_from_slice(slice: &'_ [i16]) -> Result<Array<'mcx, i16>, ArrayAllocError> {
+        let mut array = Self::new_with_len(slice.len())?;
+        array.as_mut_slice().unwrap().copy_from_slice(slice);
+        Ok(array)
+    }
 }
 
 impl Array<'_, i8> {
@@ -490,6 +615,31 @@ impl Array<'_, i8> {
     pub fn as_slice(&self) -> Result<&[i8], ArraySliceError> {
         as_slice(self)
     }
+
+    /// Returns a mutable slice of `i8`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> Result<&mut [i8], ArraySliceError> {
+        as_mut_slice(self)
+    }
+}
+
+impl<'mcx> Array<'mcx, i8> {
+    #[inline]
+    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i8>, ArrayAllocError> {
+        new_array_with_len(len)
+    }
+
+    #[inline(always)]
+    pub fn new_from_slice(slice: &'_ [i8]) -> Result<Array<'mcx, i8>, ArrayAllocError> {
+        let mut array = Self::new_with_len(slice.len())?;
+        array.as_mut_slice().unwrap().copy_from_slice(slice);
+        Ok(array)
+    }
 }
 
 #[inline(always)]
@@ -501,6 +651,52 @@ fn as_slice<'a, T: Sized>(array: &'a Array<'_, T>) -> Result<&'a [T], ArraySlice
     let slice =
         unsafe { std::slice::from_raw_parts(array.raw.data_ptr() as *const _, array.len()) };
     Ok(slice)
+}
+
+#[inline(always)]
+fn as_mut_slice<'a, T: Sized>(array: &'a mut Array<'_, T>) -> Result<&'a mut [T], ArraySliceError> {
+    if array.contains_nulls() {
+        return Err(ArraySliceError::ContainsNulls);
+    }
+
+    let slice =
+        unsafe { std::slice::from_raw_parts_mut(array.raw.data_ptr() as *mut _, array.len()) };
+    Ok(slice)
+}
+
+/// Creates an Array<`a, T> with zero-elements
+/// Slightly faster than new_array_with_len(0)
+pub fn new_empty_array<'a, T: Sized>() -> Result<Array<'a, T>, ArrayAllocError>
+where
+    T: IntoDatum,
+    T: UnboxDatum,
+{
+    unsafe {
+        let raw_array = RawArray::new_empty_array_type::<T>()?;
+        let datum: pgrx_pg_sys::Datum = pg_sys::Datum::from(raw_array.into_ptr().as_ptr());
+        Array::<'a, T>::from_polymorphic_datum(datum, false, pg_sys::get_array_type(T::type_oid()))
+            .ok_or(ArrayAllocError::MemoryAllocationFailed)
+    }
+}
+
+/// Creates an Array<T> of a fixed len, with 0 for all elements
+/// Uses a single PG allocation rather than
+#[inline(always)]
+pub fn new_array_with_len<'a, T: Sized>(len: usize) -> Result<Array<'a, T>, ArrayAllocError>
+where
+    T: IntoDatum,
+    T: UnboxDatum,
+{
+    if len == 0 {
+        return new_empty_array();
+    }
+
+    let raw_array = RawArray::new_array_type_with_len::<T>(len)?;
+    let datum: pgrx_pg_sys::Datum = pg_sys::Datum::from(raw_array.into_ptr().as_ptr());
+    unsafe {
+        Array::<'a, T>::from_polymorphic_datum(datum, false, pg_sys::get_array_type(T::type_oid()))
+            .ok_or(ArrayAllocError::MemoryAllocationFailed)
+    }
 }
 
 mod casper {
@@ -946,7 +1142,7 @@ impl<T: IntoDatum> IntoDatum for Array<'_, T> {
     #[inline]
     fn into_datum(self) -> Option<pg_sys::Datum> {
         let array_type = self.into_array_type();
-        let datum = pg_sys::Datum::from(array_type);
+        let datum: pgrx_pg_sys::Datum = pg_sys::Datum::from(array_type);
         Some(datum)
     }
 

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -1349,7 +1349,7 @@ where
     }
 }
 
-/// This trait allows for arrays of certain numeric types to use Array<T>'s single allocation strategy
+/// This trait allows for arrays of certain numeric types to use Array&lt;T&gt;'s single allocation strategy
 pub trait ArrayFastAllocSubType: Sized + UnboxDatum + IntoDatum {}
 
 // for char

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -1349,7 +1349,7 @@ where
     }
 }
 
-/// This trait allows for arrays of certain numeric types to use Array&lt;T&gt;'s single allocation strategy
+/// This trait allows for arrays of certain numeric types to use `Array<T>`'s single allocation strategy
 pub trait ArrayFastAllocSubType: Sized + UnboxDatum + IntoDatum {}
 
 // for char

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -666,10 +666,9 @@ fn as_mut_slice<'a, T: Sized>(array: &'a mut Array<'_, T>) -> Result<&'a mut [T]
 
 /// Creates an `Array<'a, T>` with zero-elements
 /// Slightly faster than new_array_with_len(0)
-pub fn new_empty_array<'a, T: Sized>() -> Result<Array<'a, T>, ArrayAllocError>
+pub fn new_empty_array<'a, T>() -> Result<Array<'a, T>, ArrayAllocError>
 where
-    T: IntoDatum,
-    T: UnboxDatum,
+    T: ArrayFastAllocSubType,
 {
     unsafe {
         let raw_array = RawArray::new_empty_array_type::<T>()?;
@@ -680,12 +679,11 @@ where
 }
 
 /// Creates an `Array<T>` of a fixed len, with 0 for all elements
-/// Uses a single PG allocation rather than
+/// Uses a single PG allocation rather than pg_sys::accumArrayResult(..)
 #[inline(always)]
-pub fn new_array_with_len<'a, T: Sized>(len: usize) -> Result<Array<'a, T>, ArrayAllocError>
+pub fn new_array_with_len<'a, T>(len: usize) -> Result<Array<'a, T>, ArrayAllocError>
 where
-    T: IntoDatum,
-    T: UnboxDatum,
+    T: ArrayFastAllocSubType,
 {
     if len == 0 {
         return new_empty_array();
@@ -1350,3 +1348,19 @@ where
         true
     }
 }
+
+/// This trait allows for arrays of certain numeric types to use Array<T>'s single allocation strategy
+pub trait ArrayFastAllocSubType: Sized + UnboxDatum + IntoDatum {}
+
+// for char
+impl ArrayFastAllocSubType for i8 {}
+// for smallint
+impl ArrayFastAllocSubType for i16 {}
+// for integer
+impl ArrayFastAllocSubType for i32 {}
+// for bigint
+impl ArrayFastAllocSubType for i64 {}
+// for real
+impl ArrayFastAllocSubType for f32 {}
+// for double precision
+impl ArrayFastAllocSubType for f64 {}

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -543,42 +543,6 @@ pub enum ArraySliceError {
     ContainsNulls,
 }
 
-impl<'mcx> Array<'mcx, i32> {
-    // #[inline]
-    // pub fn new_with_len(len: usize) -> Result<Array<'mcx, i32>, ArrayAllocError> {
-    //     new_array_with_len(len)
-    // }
-
-    // #[inline(always)]
-    // pub fn new_from_slice(slice: &'_ [i32]) -> Result<Array<'mcx, i32>, ArrayAllocError> {
-    //     let mut array = Self::new_with_len(slice.len())?;
-    //     array.as_mut_slice().unwrap().copy_from_slice(slice);
-    //     Ok(array)
-    // }
-
-    // #[inline(always)]
-    // pub fn new_from_iter<I>(iter: I, iter_len: usize) -> Result<Array<'mcx, i32>, ArrayAllocError>
-    // where
-    //     I: Iterator<Item = i32>,
-    // {
-    //     Self::new_from_iter(iter, iter_len)
-    //     let mut array = Self::new_with_len(iter_len)?;
-    //     let slice = array.as_mut_slice().unwrap();
-    //     let mut count = 0;
-    //     for (idx, item) in iter.enumerate() {
-    //         if idx >= iter_len {
-    //             return Err(ArrayAllocError::IterLenMismatch(iter_len, idx + iter.count()));
-    //         }
-    //         slice[idx] = item;
-    //         count += 1;
-    //     }
-    //     if count != iter_len {
-    //         return Err(ArrayAllocError::IterLenMismatch(iter_len, count));
-    //     }
-    //     Ok(array)
-    // }
-}
-
 mod casper {
     use super::UnboxDatum;
     use crate::layout::Align;

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -351,6 +351,137 @@ impl<T> Array<'_, T> {
     }
 }
 
+impl<'mcx, T> Array<'mcx, T>
+where
+    T: ArrayFastAllocSubType,
+{
+    /// Returns a mutable slice of `T`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    ///
+    /// # Safety
+    /// Use internally only for array construction,
+    /// We don't want to pass around a mutable reference to array data which we didn't specifically create
+    #[inline(always)]
+    pub(crate) fn as_mut_slice(&mut self) -> Result<&mut [T], ArraySliceError> {
+        if self.contains_nulls() {
+            return Err(ArraySliceError::ContainsNulls);
+        }
+        let slice =
+            unsafe { std::slice::from_raw_parts_mut(self.raw.data_ptr() as *mut _, self.len()) };
+        Ok(slice)
+    }
+
+    // Returns a slice of `T`s which comprise this [`Array`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
+    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
+    #[inline]
+    pub fn as_slice(&self) -> Result<&[T], ArraySliceError> {
+        if self.contains_nulls() {
+            return Err(ArraySliceError::ContainsNulls);
+        }
+
+        let slice =
+            unsafe { std::slice::from_raw_parts(self.raw.data_ptr() as *const _, self.len()) };
+        Ok(slice)
+    }
+
+    /// Creates an `Array<'a, T>` with zero-elements
+    /// Slightly faster than new_array_with_len(0)
+    pub fn new_empty_array<'a>() -> Result<Array<'a, T>, ArrayAllocError>
+    where
+        T: ArrayFastAllocSubType,
+    {
+        unsafe {
+            let raw_array = RawArray::new_empty_array_type::<T>()?;
+            let datum: pgrx_pg_sys::Datum = pg_sys::Datum::from(raw_array.into_ptr().as_ptr());
+            Array::<'a, T>::from_polymorphic_datum(
+                datum,
+                false,
+                pg_sys::get_array_type(T::type_oid()),
+            )
+            .ok_or(ArrayAllocError::MemoryAllocationFailed)
+        }
+    }
+
+    /// Creates an `Array<'a, T>` of a fixed len, with 0 for all elements
+    /// Uses a single PG allocation rather than pg_sys::accumArrayResult(..)
+    pub fn new_with_len<'a>(len: usize) -> Result<Array<'a, T>, ArrayAllocError>
+    where
+        T: ArrayFastAllocSubType,
+    {
+        if len == 0 {
+            return Self::new_empty_array();
+        }
+
+        let raw_array = RawArray::new_array_type_with_len::<T>(len)?;
+        let datum: pgrx_pg_sys::Datum = pg_sys::Datum::from(raw_array.into_ptr().as_ptr());
+        unsafe {
+            Array::<'a, T>::from_polymorphic_datum(
+                datum,
+                false,
+                pg_sys::get_array_type(T::type_oid()),
+            )
+            .ok_or(ArrayAllocError::MemoryAllocationFailed)
+        }
+    }
+
+    /// Constructs an `Array<'a, T>` with a single allocation and enumerating the iter
+    ///
+    /// iter_len must equal the total length of the iter.  You must know the iter_len ahead of time to prevent multiple enumerations/allocations
+    ///
+    /// # Errors
+    /// Returns a [`ArrayAllocError::IterLenMismatch`] iter's total len != iter_len
+    pub fn new_from_iter<'a, I>(iter: I, iter_len: usize) -> Result<Array<'a, T>, ArrayAllocError>
+    where
+        T: ArrayFastAllocSubType,
+        I: Iterator<Item = T>,
+    {
+        let mut array = Self::new_with_len(iter_len)?;
+        let slice = array.as_mut_slice().unwrap();
+        let mut count = 0;
+        for (idx, item) in iter.enumerate() {
+            if idx < iter_len {
+                slice[idx] = item;
+            }
+            count += 1;
+        }
+        if count != iter_len {
+            return Err(ArrayAllocError::IterLenMismatch(iter_len, count));
+        }
+        Ok(array)
+    }
+
+    /// Constructs an `Array<'a, T>` with a single allocation and copy_from_slice
+    pub fn new_from_slice<'a>(slice: &[T]) -> Result<Array<'a, T>, ArrayAllocError>
+    where
+        T: ArrayFastAllocSubType,
+    {
+        let mut array = Self::new_with_len(slice.len())?;
+        let array_slice = array.as_mut_slice().unwrap();
+        array_slice.copy_from_slice(slice);
+        Ok(array)
+    }
+
+    /// Constructs an `Array<'a, T>` with a single allocation and running init_fn on the Array's `&mut [T]`
+    pub fn new_with_init_fn<'a, F>(len: usize, init_fn: F) -> Result<Array<'a, T>, ArrayAllocError>
+    where
+        T: ArrayFastAllocSubType,
+        F: FnOnce(&mut [T]) -> (),
+    {
+        let mut array = Self::new_with_len(len)?;
+        let slice = array.as_mut_slice().unwrap();
+        init_fn(slice);
+        Ok(array)
+    }
+}
+
 /// Adapter to use `Nullable<T>` for array iteration.
 pub struct NullableArrayIterator<'mcx, T>
 where
@@ -412,289 +543,40 @@ pub enum ArraySliceError {
     ContainsNulls,
 }
 
-#[cfg(target_pointer_width = "64")]
-impl Array<'_, f64> {
-    /// Returns a slice of `f64`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_slice(&self) -> Result<&[f64], ArraySliceError> {
-        as_slice(self)
-    }
-
-    /// Returns a mutable slice of `f64`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> Result<&mut [f64], ArraySliceError> {
-        as_mut_slice(self)
-    }
-}
-
-impl<'mcx> Array<'mcx, f64> {
-    #[inline]
-    pub fn new_with_len(len: usize) -> Result<Array<'mcx, f64>, ArrayAllocError> {
-        new_array_with_len(len)
-    }
-
-    #[inline(always)]
-    pub fn new_from_slice(slice: &'_ [f64]) -> Result<Array<'mcx, f64>, ArrayAllocError> {
-        let mut array = Self::new_with_len(slice.len())?;
-        array.as_mut_slice().unwrap().copy_from_slice(slice);
-        Ok(array)
-    }
-}
-
-impl Array<'_, f32> {
-    /// Returns a slice of `f32`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_slice(&self) -> Result<&[f32], ArraySliceError> {
-        as_slice(self)
-    }
-
-    /// Returns a mutable slice of `f32`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> Result<&mut [f32], ArraySliceError> {
-        as_mut_slice(self)
-    }
-}
-
-impl<'mcx> Array<'mcx, f32> {
-    #[inline]
-    pub fn new_with_len(len: usize) -> Result<Array<'mcx, f32>, ArrayAllocError> {
-        new_array_with_len(len)
-    }
-
-    #[inline(always)]
-    pub fn new_from_slice(slice: &'_ [f32]) -> Result<Array<'mcx, f32>, ArrayAllocError> {
-        let mut array = Self::new_with_len(slice.len())?;
-        array.as_mut_slice().unwrap().copy_from_slice(slice);
-        Ok(array)
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl Array<'_, i64> {
-    /// Returns a slice of `i64`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_slice(&self) -> Result<&[i64], ArraySliceError> {
-        as_slice(self)
-    }
-
-    /// Returns a mutable slice of `i64`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> Result<&mut [i64], ArraySliceError> {
-        as_mut_slice(self)
-    }
-}
-
-impl<'mcx> Array<'mcx, i64> {
-    #[inline]
-    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i64>, ArrayAllocError> {
-        new_array_with_len(len)
-    }
-
-    #[inline(always)]
-    pub fn new_from_slice(slice: &'_ [i64]) -> Result<Array<'mcx, i64>, ArrayAllocError> {
-        let mut array = Self::new_with_len(slice.len())?;
-        array.as_mut_slice().unwrap().copy_from_slice(slice);
-        Ok(array)
-    }
-}
-
-impl Array<'_, i32> {
-    /// Returns a slice of `i32`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_slice(&self) -> Result<&[i32], ArraySliceError> {
-        as_slice(self)
-    }
-
-    /// Returns a mutable slice of `i32`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> Result<&mut [i32], ArraySliceError> {
-        as_mut_slice(self)
-    }
-}
-
 impl<'mcx> Array<'mcx, i32> {
-    #[inline]
-    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i32>, ArrayAllocError> {
-        new_array_with_len(len)
-    }
+    // #[inline]
+    // pub fn new_with_len(len: usize) -> Result<Array<'mcx, i32>, ArrayAllocError> {
+    //     new_array_with_len(len)
+    // }
 
-    #[inline(always)]
-    pub fn new_from_slice(slice: &'_ [i32]) -> Result<Array<'mcx, i32>, ArrayAllocError> {
-        let mut array = Self::new_with_len(slice.len())?;
-        array.as_mut_slice().unwrap().copy_from_slice(slice);
-        Ok(array)
-    }
-}
+    // #[inline(always)]
+    // pub fn new_from_slice(slice: &'_ [i32]) -> Result<Array<'mcx, i32>, ArrayAllocError> {
+    //     let mut array = Self::new_with_len(slice.len())?;
+    //     array.as_mut_slice().unwrap().copy_from_slice(slice);
+    //     Ok(array)
+    // }
 
-impl Array<'_, i16> {
-    /// Returns a slice of `i16`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_slice(&self) -> Result<&[i16], ArraySliceError> {
-        as_slice(self)
-    }
-
-    /// Returns a mutable slice of `i16`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> Result<&mut [i16], ArraySliceError> {
-        as_mut_slice(self)
-    }
-}
-
-impl<'mcx> Array<'mcx, i16> {
-    #[inline]
-    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i16>, ArrayAllocError> {
-        new_array_with_len(len)
-    }
-
-    #[inline(always)]
-    pub fn new_from_slice(slice: &'_ [i16]) -> Result<Array<'mcx, i16>, ArrayAllocError> {
-        let mut array = Self::new_with_len(slice.len())?;
-        array.as_mut_slice().unwrap().copy_from_slice(slice);
-        Ok(array)
-    }
-}
-
-impl Array<'_, i8> {
-    /// Returns a slice of `i8`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_slice(&self) -> Result<&[i8], ArraySliceError> {
-        as_slice(self)
-    }
-
-    /// Returns a mutable slice of `i8`s which comprise this [`Array`].
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ArraySliceError::ContainsNulls`] error if this [`Array`] contains one or more
-    /// SQL "NULL" values.  In this case, you'd likely want to fallback to using [`Array::iter()`].
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> Result<&mut [i8], ArraySliceError> {
-        as_mut_slice(self)
-    }
-}
-
-impl<'mcx> Array<'mcx, i8> {
-    #[inline]
-    pub fn new_with_len(len: usize) -> Result<Array<'mcx, i8>, ArrayAllocError> {
-        new_array_with_len(len)
-    }
-
-    #[inline(always)]
-    pub fn new_from_slice(slice: &'_ [i8]) -> Result<Array<'mcx, i8>, ArrayAllocError> {
-        let mut array = Self::new_with_len(slice.len())?;
-        array.as_mut_slice().unwrap().copy_from_slice(slice);
-        Ok(array)
-    }
-}
-
-#[inline(always)]
-fn as_slice<'a, T: Sized>(array: &'a Array<'_, T>) -> Result<&'a [T], ArraySliceError> {
-    if array.contains_nulls() {
-        return Err(ArraySliceError::ContainsNulls);
-    }
-
-    let slice =
-        unsafe { std::slice::from_raw_parts(array.raw.data_ptr() as *const _, array.len()) };
-    Ok(slice)
-}
-
-#[inline(always)]
-fn as_mut_slice<'a, T: Sized>(array: &'a mut Array<'_, T>) -> Result<&'a mut [T], ArraySliceError> {
-    if array.contains_nulls() {
-        return Err(ArraySliceError::ContainsNulls);
-    }
-
-    let slice =
-        unsafe { std::slice::from_raw_parts_mut(array.raw.data_ptr() as *mut _, array.len()) };
-    Ok(slice)
-}
-
-/// Creates an `Array<'a, T>` with zero-elements
-/// Slightly faster than new_array_with_len(0)
-pub fn new_empty_array<'a, T>() -> Result<Array<'a, T>, ArrayAllocError>
-where
-    T: ArrayFastAllocSubType,
-{
-    unsafe {
-        let raw_array = RawArray::new_empty_array_type::<T>()?;
-        let datum: pgrx_pg_sys::Datum = pg_sys::Datum::from(raw_array.into_ptr().as_ptr());
-        Array::<'a, T>::from_polymorphic_datum(datum, false, pg_sys::get_array_type(T::type_oid()))
-            .ok_or(ArrayAllocError::MemoryAllocationFailed)
-    }
-}
-
-/// Creates an `Array<T>` of a fixed len, with 0 for all elements
-/// Uses a single PG allocation rather than pg_sys::accumArrayResult(..)
-#[inline(always)]
-pub fn new_array_with_len<'a, T>(len: usize) -> Result<Array<'a, T>, ArrayAllocError>
-where
-    T: ArrayFastAllocSubType,
-{
-    if len == 0 {
-        return new_empty_array();
-    }
-
-    let raw_array = RawArray::new_array_type_with_len::<T>(len)?;
-    let datum: pgrx_pg_sys::Datum = pg_sys::Datum::from(raw_array.into_ptr().as_ptr());
-    unsafe {
-        Array::<'a, T>::from_polymorphic_datum(datum, false, pg_sys::get_array_type(T::type_oid()))
-            .ok_or(ArrayAllocError::MemoryAllocationFailed)
-    }
+    // #[inline(always)]
+    // pub fn new_from_iter<I>(iter: I, iter_len: usize) -> Result<Array<'mcx, i32>, ArrayAllocError>
+    // where
+    //     I: Iterator<Item = i32>,
+    // {
+    //     Self::new_from_iter(iter, iter_len)
+    //     let mut array = Self::new_with_len(iter_len)?;
+    //     let slice = array.as_mut_slice().unwrap();
+    //     let mut count = 0;
+    //     for (idx, item) in iter.enumerate() {
+    //         if idx >= iter_len {
+    //             return Err(ArrayAllocError::IterLenMismatch(iter_len, idx + iter.count()));
+    //         }
+    //         slice[idx] = item;
+    //         count += 1;
+    //     }
+    //     if count != iter_len {
+    //         return Err(ArrayAllocError::IterLenMismatch(iter_len, count));
+    //     }
+    //     Ok(array)
+    // }
 }
 
 mod casper {
@@ -1350,7 +1232,7 @@ where
 }
 
 /// This trait allows for arrays of certain numeric types to use `Array<T>`'s single allocation strategy
-pub trait ArrayFastAllocSubType: Sized + UnboxDatum + IntoDatum {}
+pub trait ArrayFastAllocSubType: Sized + UnboxDatum + IntoDatum + Copy {}
 
 // for char
 impl ArrayFastAllocSubType for i8 {}
@@ -1359,8 +1241,10 @@ impl ArrayFastAllocSubType for i16 {}
 // for integer
 impl ArrayFastAllocSubType for i32 {}
 // for bigint
+#[cfg(target_pointer_width = "64")]
 impl ArrayFastAllocSubType for i64 {}
 // for real
 impl ArrayFastAllocSubType for f32 {}
 // for double precision
+#[cfg(target_pointer_width = "64")]
 impl ArrayFastAllocSubType for f64 {}


### PR DESCRIPTION
## Faster arrays!
Now that `Array<T>` is stable, this PR ports in performance enhancements for creating PostgreSQL `int[]` arrays—based on the optimizations found in PostgreSQL’s `contrib/intarray` extension (specifically [`new_intArrayType(int num)`](https://github.com/postgres/postgres/blob/master/contrib/intarray/_int_tool.c#L224)).

The goal is to significantly speed up the conversion from `&[i32]` to a PostgreSQL `ArrayType` Datum.

## Background

Currently, to return a PostgreSQL `int[]` from a Rust function, we typically return a `Vec<i32>`, which then gets converted to a Datum via `array_datum_from_iter(..)`  
([implementation here](https://github.com/pgcentralfoundation/pgrx/blob/c0de15d29d2ef175f3b56b630f85af09448094e5/pgrx/src/datum/array.rs#L1017)).

This approach uses:
- `pg_sys::initArrayResult`
- `pg_sys::accumArrayResult`
- `pg_sys::makeArrayResult`

These APIs build a varlena array by accumulating values and repeatedly reallocating memory as the capacity grows. For larger arrays, this results in substantial performance overhead.

## Optimization

PostgreSQL's `contrib/intarray` takes a different approach for fixed-size datums: it pre-allocates the entire array up front and directly `memcpy`s the data into `ARR_DATA_PTR`. This avoids the need for reallocations and is **much faster**.

## What I've added

- Implemented `BoxRet` for `Array<'a, T>` when `T` is a fixed-size numeric type (`i8`, `i16`, `i32`, `f32`, `f64`)
  - Enables using `Array<T>` directly as a return type from `#[pg_extern]` functions.
- Adds optimized allocation logic for these numeric types
  - Pre-allocates the full `ArrayType`
  - Uses `memcpy`-like behavior for fast construction from slices
- Adds helper functions for:
  - Creating empty arrays
  - Creating `Array<T>` from `&[T]`

## Benchmarks

I've benchmarked two approaches for turning `Vec<i32> -> Array<i32>`:
1. The current `array_datum_from_iter(..)`
2. The new fast pre-allocated method

Each test used 10,000 rows of randomly generated `int[]` in a temp table, work_mem = '1GB'.  I used Instant::now() to time only the microseconds needed to convert and accumulated all those timings

```
    #[pg_extern]
    fn accum_alloc(input: Vec<i32>) -> i32 {
        let start = std::time::Instant::now();
        let array = input.into_datum().unwrap();  // this uses array_datum_from_iter(..)
        let duration = start.elapsed();
        duration.subsec_micros() as i32
    }
    
    #[pg_extern]
    fn fast_alloc(input: Vec<i32>) -> i32 {
        let start = std::time::Instant::now();
        let array = Array::<i32>::new_from_slice(input.as_slice()).expect("couldn't allocate");
        let duration = start.elapsed();
        duration.subsec_micros() as i32
    }
```

| Row Count | int[] Length | accum_alloc (total μs) | fast_alloc (total μs) | Improvement |
|-----------|--------------|----------------------------------|------------------------|-------------|
| 10,000    | 10           | 16,933.00                        | 2,120.00               | 8.0×        |
| 10,000    | 100          | 155,352.00                       | 10,228.00              | 15.2×       |
| 10,000    | 1,000        | 1,375,613.00                     | 30,443.00              | 45.2×       |
| 10,000    | 10,000       | 13,666,835.00                    | 251,825.00             | 54.3×       |

It's been a while since I contributed, so I'm a little rusty on matching the teams style/conventions, and as usual lifetime differences between PG allocated and rust allocated still escape me.  I'm sure the ergonomics of the new Array<T> functions could be improved.  Am I doing anything the wrong way here?