### PR TITLE
improve pg_magic_func

### DIFF
--- a/cargo-pgrx/src/command/info.rs
+++ b/cargo-pgrx/src/command/info.rs
@@ -78,7 +78,7 @@ impl CommandExecute for Info {
     }
 }
 
-fn version(ver: &str) -> Cow<str> {
+fn version(ver: &str) -> Cow<'_, str> {
     if ver.starts_with("pg") {
         Cow::Borrowed(ver)
     } else {

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -594,7 +594,7 @@ fn compute_sql(package_name: &str, manifest: &Manifest) -> eyre::Result<()> {
     Ok(())
 }
 
-fn parse_object(data: &[u8]) -> object::Result<object::File> {
+fn parse_object(data: &[u8]) -> object::Result<object::File<'_>> {
     let kind = object::FileKind::parse(data)?;
 
     match kind {

--- a/cargo-pgrx/src/templates/lib_rs
+++ b/cargo-pgrx/src/templates/lib_rs
@@ -1,6 +1,6 @@
 use pgrx::prelude::*;
 
-::pgrx::pg_module_magic!(c"{name}", pgrx::pg_sys::PG_VERSION);
+::pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn hello_{name}() -> &'static str {{

--- a/pgrx-examples/aggregate/src/lib.rs
+++ b/pgrx-examples/aggregate/src/lib.rs
@@ -14,7 +14,7 @@ use pgrx::StringInfo;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-pgrx::pg_module_magic!(c"aggregate", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[derive(Copy, Clone, PostgresType, Serialize, Deserialize)]
 #[pgvarlena_inoutfuncs]

--- a/pgrx-examples/arrays/src/lib.rs
+++ b/pgrx-examples/arrays/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use serde::*;
 
-pgrx::pg_module_magic!(c"arrays", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn sq_euclid_pgrx(a: Array<f32>, b: Array<f32>) -> f32 {

--- a/pgrx-examples/bad_ideas/src/lib.rs
+++ b/pgrx-examples/bad_ideas/src/lib.rs
@@ -14,7 +14,7 @@ use std::io::{Read, Write};
 use std::panic::catch_unwind;
 use std::process::Command;
 
-pgrx::pg_module_magic!(c"bad_ideas", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn panic(s: &str) -> bool {

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
     this background worker
 */
 
-pgrx::pg_module_magic!(c"bgworker", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {

--- a/pgrx-examples/bytea/src/lib.rs
+++ b/pgrx-examples/bytea/src/lib.rs
@@ -11,7 +11,7 @@ use libflate::gzip::{Decoder, Encoder};
 use pgrx::prelude::*;
 use std::io::{Read, Write};
 
-pgrx::pg_module_magic!(c"bytea", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 /// gzip bytes.  Postgres will automatically convert `text`/`varchar` data into `bytea`
 #[pg_extern]

--- a/pgrx-examples/composite_type/src/lib.rs
+++ b/pgrx-examples/composite_type/src/lib.rs
@@ -23,7 +23,7 @@ using composite types.
 use pgrx::{opname, pg_operator, prelude::*};
 
 // All `pgrx` extensions will do this:
-pgrx::pg_module_magic!(c"composite_type", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 /* Composite types must be defined either before they are used.
 

--- a/pgrx-examples/custom_libname/src/lib.rs
+++ b/pgrx-examples/custom_libname/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"custom_libname", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn hello_custom_libname() -> &'static str {

--- a/pgrx-examples/custom_sql/src/lib.rs
+++ b/pgrx-examples/custom_sql/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pgrx::pg_module_magic!(c"custom_sql", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_schema]
 mod home {

--- a/pgrx-examples/custom_types/src/lib.rs
+++ b/pgrx-examples/custom_types/src/lib.rs
@@ -16,7 +16,7 @@ mod hstore_clone;
 mod ordered;
 mod rust_enum;
 
-pgrx::pg_module_magic!(c"custom_types", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[cfg(test)]
 pub mod pg_test {

--- a/pgrx-examples/datetime/src/lib.rs
+++ b/pgrx-examples/datetime/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use rand::Rng;
 
-pgrx::pg_module_magic!(c"datetime", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern(name = "to_iso_string", immutable, parallel_safe)]
 fn to_iso_string(tsz: TimestampWithTimeZone) -> String {

--- a/pgrx-examples/errors/src/lib.rs
+++ b/pgrx-examples/errors/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 use pgrx::{error, info, warning, PgRelation, FATAL, PANIC};
 
-pgrx::pg_module_magic!(c"errors", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn array_with_null_and_panic(input: Vec<Option<i32>>) -> i64 {

--- a/pgrx-examples/nostd/src/lib.rs
+++ b/pgrx-examples/nostd/src/lib.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use alloc::string::String;
 
-pgrx::pg_module_magic!(c"nostd", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 /// standard Rust equality/comparison derives
 #[derive(Eq, PartialEq, Ord, Hash, PartialOrd)]

--- a/pgrx-examples/numeric/src/lib.rs
+++ b/pgrx-examples/numeric/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::assign_op_pattern)]
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"numeric", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn add_numeric(a: Numeric<1000, 33>, b: Numeric<1000, 33>) -> Numeric<1000, 33> {

--- a/pgrx-examples/operators/src/lib.rs
+++ b/pgrx-examples/operators/src/lib.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 mod derived;
 mod pgvarlena;
 
-pgrx::pg_module_magic!(c"operators", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[derive(PostgresType, Serialize, Deserialize, Eq, PartialEq)]
 pub struct MyType {

--- a/pgrx-examples/pgtrybuilder/src/lib.rs
+++ b/pgrx-examples/pgtrybuilder/src/lib.rs
@@ -10,7 +10,7 @@
 use pgrx::pg_sys::panic::CaughtError;
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"pgtrybuilder", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn is_valid_number(i: i32) -> i32 {

--- a/pgrx-examples/range/src/lib.rs
+++ b/pgrx-examples/range/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"range", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn range(s: i32, e: i32) -> pgrx::Range<i32> {

--- a/pgrx-examples/schemas/src/lib.rs
+++ b/pgrx-examples/schemas/src/lib.rs
@@ -13,7 +13,7 @@
 use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
-pgrx::pg_module_magic!(c"schemas", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[derive(PostgresType, Serialize, Deserialize)]
 pub struct MyType(pub(crate) String);

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -15,7 +15,7 @@ use pgrx::{pg_shmem_init, warning};
 use serde::*;
 use std::sync::atomic::Ordering;
 
-pgrx::pg_module_magic!(c"shmem", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 // types behind a `LwLock` must derive/implement `Copy` and `Clone`
 #[derive(Copy, Clone)]

--- a/pgrx-examples/spi/src/lib.rs
+++ b/pgrx-examples/spi/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"spi", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 extension_sql!(
     r#"

--- a/pgrx-examples/spi_srf/src/lib.rs
+++ b/pgrx-examples/spi_srf/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"spi_srf", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 extension_sql!(
     r#"

--- a/pgrx-examples/srf/src/lib.rs
+++ b/pgrx-examples/srf/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"srf", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn generate_series(start: i64, finish: i64, step: default!(i64, 1)) -> SetOfIterator<'static, i64> {

--- a/pgrx-examples/strings/src/lib.rs
+++ b/pgrx-examples/strings/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"strings", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn return_static() -> &'static str {

--- a/pgrx-examples/triggers/src/lib.rs
+++ b/pgrx-examples/triggers/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"triggers", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[derive(thiserror::Error, Debug)]
 enum TriggerError {

--- a/pgrx-examples/versioned_custom_libname_so/src/lib.rs
+++ b/pgrx-examples/versioned_custom_libname_so/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"versioned_custom_libname_so", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn hello_versioned_custom_libname_so() -> &'static str {

--- a/pgrx-examples/versioned_so/src/lib.rs
+++ b/pgrx-examples/versioned_so/src/lib.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
-pgrx::pg_module_magic!(c"versioned_so", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 #[pg_extern]
 fn hello_versioned_so() -> &'static str {

--- a/pgrx-examples/wal_decoder/src/lib.rs
+++ b/pgrx-examples/wal_decoder/src/lib.rs
@@ -4,7 +4,7 @@ use serde::ser::{SerializeStruct, Serializer};
 use serde::Serialize;
 use std::alloc::{alloc, dealloc, Layout};
 
-pgrx::pg_module_magic!(c"wal_decoder", pgrx::pg_sys::PG_VERSION);
+pgrx::pg_module_magic!(name, version);
 
 // An Action describe a change that occurred on a table
 #[derive(Serialize)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -967,7 +967,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[::pgrx::pgrx_macros::pg_extern(immutable,parallel_safe)]
             pub fn #funcname_in #generics(input: Option<&::core::ffi::CStr>) -> Option<#name #generics> {
                 input.map_or_else(|| {
-                    for m in <#name as ::pgrx::inoutfuncs::InOutFuncs>::NULL_ERROR_MESSAGE {
+                    if let Some(m) = <#name as ::pgrx::inoutfuncs::InOutFuncs>::NULL_ERROR_MESSAGE {
                         ::pgrx::pg_sys::error!("{m}");
                     }
                     None
@@ -990,7 +990,7 @@ fn impl_postgres_type(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream>
             #[::pgrx::pgrx_macros::pg_extern(immutable,parallel_safe)]
             pub fn #funcname_in #generics(input: Option<&::core::ffi::CStr>) -> Option<::pgrx::datum::PgVarlena<#name #generics>> {
                 input.map_or_else(|| {
-                    for m in <#name as ::pgrx::inoutfuncs::PgVarlenaInOutFuncs>::NULL_ERROR_MESSAGE {
+                    if let Some(m) = <#name as ::pgrx::inoutfuncs::PgVarlenaInOutFuncs>::NULL_ERROR_MESSAGE {
                         ::pgrx::pg_sys::error!("{m}");
                     }
                     None

--- a/pgrx-pg-sys/src/include.rs
+++ b/pgrx-pg-sys/src/include.rs
@@ -5,6 +5,7 @@
 #[cfg(all(feature = "pg13", not(docsrs)))]
 pub(crate) mod pg13 {
     #![allow(clippy::all)]
+    #![allow(unknown_lints, unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/pg13.rs"));
 }
 #[cfg(all(feature = "pg13", docsrs))]
@@ -13,6 +14,7 @@ pub(crate) mod pg13;
 #[cfg(all(feature = "pg14", not(docsrs)))]
 pub(crate) mod pg14 {
     #![allow(clippy::all)]
+    #![allow(unknown_lints, unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/pg14.rs"));
 }
 #[cfg(all(feature = "pg14", docsrs))]
@@ -21,6 +23,7 @@ pub(crate) mod pg14;
 #[cfg(all(feature = "pg15", not(docsrs)))]
 pub(crate) mod pg15 {
     #![allow(clippy::all)]
+    #![allow(unknown_lints, unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/pg15.rs"));
 }
 #[cfg(all(feature = "pg15", docsrs))]
@@ -29,6 +32,7 @@ pub(crate) mod pg15;
 #[cfg(all(feature = "pg16", not(docsrs)))]
 pub(crate) mod pg16 {
     #![allow(clippy::all)]
+    #![allow(unknown_lints, unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/pg16.rs"));
 }
 #[cfg(all(feature = "pg16", docsrs))]
@@ -37,6 +41,7 @@ pub(crate) mod pg16;
 #[cfg(all(feature = "pg17", not(docsrs)))]
 pub(crate) mod pg17 {
     #![allow(clippy::all)]
+    #![allow(unknown_lints, unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/pg17.rs"));
 }
 #[cfg(all(feature = "pg17", docsrs))]
@@ -45,6 +50,7 @@ pub(crate) mod pg17;
 #[cfg(all(feature = "pg18", not(docsrs)))]
 pub(crate) mod pg18 {
     #![allow(clippy::all)]
+    #![allow(unknown_lints, unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/pg18.rs"));
 }
 #[cfg(all(feature = "pg18", docsrs))]

--- a/pgrx-tests/src/lib.rs
+++ b/pgrx-tests/src/lib.rs
@@ -19,7 +19,7 @@ pub use framework::*;
 pub mod proptest;
 
 #[cfg(any(test, feature = "pg_test"))]
-pgrx::pg_module_magic!();
+pgrx::pg_module_magic!(name, version);
 
 #[cfg(test)]
 pub mod pg_test {

--- a/pgrx-tests/src/tests/hooks_tests.rs
+++ b/pgrx-tests/src/tests/hooks_tests.rs
@@ -7,6 +7,8 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+#![allow(deprecated, static_mut_refs)]
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {

--- a/pgrx-tests/src/tests/trigger_tests.rs
+++ b/pgrx-tests/src/tests/trigger_tests.rs
@@ -74,7 +74,9 @@ mod tests {
         }
 
         #[pg_trigger]
-        fn signature_aliased_both(_trigger: AliasedBorrowedPgTrigger) -> AliasedTriggerResult<'_> {
+        fn signature_aliased_both(
+            _trigger: AliasedBorrowedPgTrigger<'_>,
+        ) -> AliasedTriggerResult<'_> {
             unimplemented!("Only testing signature compiles")
         }
     }

--- a/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.rs
+++ b/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.rs
@@ -3,7 +3,7 @@ use pgrx::prelude::*;
 #[pg_extern]
 fn returns_tuple_with_lifetime(
     value: &'static str,
-) -> TableIterator<(name!(a, &'static str), name!(b, Option<&'static str>))> {
+) -> TableIterator<'static, (name!(a, &'static str), name!(b, Option<&'static str>))> {
     TableIterator::once((value, Some(value)))
 }
 

--- a/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.stderr
+++ b/pgrx-tests/tests/compile-fail/table-iterators-arent-immortal.stderr
@@ -1,17 +1,5 @@
-warning: elided lifetime has a name
- --> tests/compile-fail/table-iterators-arent-immortal.rs:6:19
-  |
-6 | ) -> TableIterator<(name!(a, &'static str), name!(b, Option<&'static str>))> {
-  |                   ^ this elided lifetime gets resolved as `'static`
-  |
-  = note: `#[warn(elided_named_lifetimes)]` on by default
-help: consider specifying it explicitly
-  |
-6 | ) -> TableIterator<'static, (name!(a, &'static str), name!(b, Option<&'static str>))> {
-  |                    ++++++++
-
 error[E0521]: borrowed data escapes outside of function
- --> tests/compile-fail/table-iterators-arent-immortal.rs:6:78
+ --> tests/compile-fail/table-iterators-arent-immortal.rs:6:87
   |
 3 |   #[pg_extern]
   |   ------------
@@ -19,8 +7,8 @@ error[E0521]: borrowed data escapes outside of function
   |   lifetime `'fcx` defined here
   |   in this procedural macro expansion
 ...
-6 |   ) -> TableIterator<(name!(a, &'static str), name!(b, Option<&'static str>))> {
-  |  ______________________________________________________________________________^
+6 |   ) -> TableIterator<'static, (name!(a, &'static str), name!(b, Option<&'static str>))> {
+  |  _______________________________________________________________________________________^
 7 | |     TableIterator::once((value, Some(value)))
 8 | | }
   | | ^

--- a/pgrx/src/datum/into.rs
+++ b/pgrx/src/datum/into.rs
@@ -378,7 +378,7 @@ impl<'a> IntoDatum for &'a [u8] {
             // and the `dest` was freshly allocated, thus non-overlapping
             std::ptr::copy_nonoverlapping(
                 self.as_ptr(),
-                addr_of_mut!((*varattrib_4b).va_data).cast::<u8>(),
+                addr_of_mut!((&mut *varattrib_4b).va_data).cast::<u8>(),
                 self.len(),
             );
 

--- a/pgrx/src/fn_call.rs
+++ b/pgrx/src/fn_call.rs
@@ -410,7 +410,7 @@ fn lookup_fn(fname: &str, args: &[&dyn FnCallArg]) -> Result<pg_sys::Oid> {
 
 /// Parses an arbitrary string as if it is a SQL identifier.  If it's not, [`FnCallError::InvalidIdentifier`]
 /// is returned
-fn parse_sql_ident(ident: &str) -> Result<Array<&str>> {
+fn parse_sql_ident(ident: &str) -> Result<Array<'_, &str>> {
     unsafe {
         direct_function_call::<Array<&str>>(
             pg_sys::parse_ident,

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -176,26 +176,15 @@ const _: () = {
 /// <div class="example-wrap" style="display:inline-block">
 /// <pre class="ignore" style="white-space:normal;font:inherit;">
 ///
-/// **Note**: Every [`pgrx`][crate] extension **must** have this macro called at top level (usually `src/lib.rs`) to be valid. You can use `pg_module_magic!()` or `pg_module_magic!(name, version)`
+/// **Note**: Every [`pgrx`][crate] extension **must** have this macro called at top level (usually `src/lib.rs`) to be valid. You can use `pg_module_magic!()`, `pg_module_magic!(name, version)` or `pg_module_magic!(name = c"custom_name", version = c"1.0.0")`
 ///
 /// </pre></div>
 ///
 /// This calls [`pg_magic_func!()`](pg_magic_func).
 #[macro_export]
 macro_rules! pg_module_magic {
-    () => {
-        $crate::pg_magic_func!();
-
-        // A marker function which must exist in the root of the extension for proper linking by the
-        // "pgrx_embed" binary during `cargo-pgrx schema` generation.
-        #[inline(never)] /* we don't want DCE to remove this as it *could* cause the compiler to decide to not link to us */
-        #[doc(hidden)]
-        pub fn __pgrx_marker() {
-            // noop
-        }
-    };
-    ($name:expr, $version:expr) => {
-        $crate::pg_magic_func!($name, $version);
+    ($($key:ident $(= $value:expr)?),*) => {
+        $crate::pg_magic_func!($($key $(= $value)?),*);
 
         // A marker function which must exist in the root of the extension for proper linking by the
         // "pgrx_embed" binary during `cargo-pgrx schema` generation.
@@ -241,169 +230,132 @@ macro_rules! pg_module_magic {
 /// [Dynamic Loading]: https://www.postgresql.org/docs/current/xfunc-c.html#XFUNC-C-DYNLOAD
 #[macro_export]
 macro_rules! pg_magic_func {
-    () => {
-        #[no_mangle]
+    ($($key:ident $(= $value: expr)?),*) => {
+        #[unsafe(no_mangle)]
         #[allow(non_snake_case, unexpected_cfgs)]
         #[doc(hidden)]
-        pub extern "C-unwind" fn Pg_magic_func() -> &'static ::pgrx::pg_sys::Pg_magic_struct {
-            #[cfg(any(
-                feature = "pg13",
-                feature = "pg14",
-                feature = "pg15",
-                feature = "pg16",
-                feature = "pg17"
-            ))]
-            {
-                static MY_MAGIC: ::pgrx::pg_sys::Pg_magic_struct =
-                    ::pgrx::pg_sys::Pg_magic_struct {
-                        len: ::core::mem::size_of::<::pgrx::pg_sys::Pg_magic_struct>() as i32,
-                        version: ::pgrx::pg_sys::PG_VERSION_NUM as i32 / 100,
-                        funcmaxargs: ::pgrx::pg_sys::FUNC_MAX_ARGS as i32,
-                        indexmaxkeys: ::pgrx::pg_sys::INDEX_MAX_KEYS as i32,
-                        namedatalen: ::pgrx::pg_sys::NAMEDATALEN as i32,
-                        float8byval: cfg!(target_pointer_width = "64") as i32,
-                        #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
-                        abi_extra: {
-                            // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then we'll
-                            // raise a compilation error unless the `unsafe-postgres` feature is set
-                            let magic = ::pgrx::pg_sys::FMGR_ABI_EXTRA.to_bytes_with_nul();
-                            let mut abi = [0 as ::pgrx::ffi::c_char; 32];
-                            let mut i = 0;
-                            while i < magic.len() {
-                                abi[i] = magic[i] as ::pgrx::ffi::c_char;
-                                i += 1;
-                            }
-                            abi
-                        },
-                    };
+        pub extern "C" fn Pg_magic_func() -> &'static ::pgrx::pg_sys::Pg_magic_struct {
+            #[repr(transparent)]
+            struct AssertSync<T>(T);
+            unsafe impl<T> Sync for AssertSync<T> {}
 
-                // since Postgres calls this first, register our panic handler now
-                // so we don't unwind into C / Postgres
-                ::pgrx::pg_sys::panic::register_pg_guard_panic_hook();
+            // since Postgres calls this first, register our panic handler now
+            // so we don't unwind into C / Postgres
+            ::pgrx::pg_sys::panic::register_pg_guard_panic_hook();
 
-                // return the magic
-                &MY_MAGIC
-            }
-
-            #[cfg(feature = "pg18")]
-            {
-                struct PgMagicstruct(::pgrx::pg_sys::Pg_magic_struct);
-                unsafe impl Sync for PgMagicstruct {}
-                static MY_MAGIC: PgMagicstruct = PgMagicstruct(::pgrx::pg_sys::Pg_magic_struct {
-                    len: ::core::mem::size_of::<::pgrx::pg_sys::Pg_magic_struct>() as i32,
+            static MY_MAGIC: AssertSync<::pgrx::pg_sys::Pg_magic_struct> = {
+                let len = ::core::mem::size_of::<::pgrx::pg_sys::Pg_magic_struct>() as i32;
+                let version = ::pgrx::pg_sys::PG_VERSION_NUM as i32 / 100;
+                let funcmaxargs = ::pgrx::pg_sys::FUNC_MAX_ARGS as i32;
+                let indexmaxkeys = ::pgrx::pg_sys::INDEX_MAX_KEYS as i32;
+                let namedatalen = ::pgrx::pg_sys::NAMEDATALEN as i32;
+                let float8byval = cfg!(target_pointer_width = "64") as i32;
+                #[cfg(not(any(feature = "pg13", feature = "pg14")))]
+                let abi_extra = {
+                    // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then we'll
+                    // raise a compilation error unless the `unsafe-postgres` feature is set
+                    let magic = ::pgrx::pg_sys::FMGR_ABI_EXTRA.to_bytes_with_nul();
+                    let mut abi = [0 as ::pgrx::ffi::c_char; 32];
+                    let mut i = 0;
+                    while i < magic.len() {
+                        abi[i] = magic[i] as ::pgrx::ffi::c_char;
+                        i += 1;
+                    }
+                    abi
+                };
+                let mut magic = ::pgrx::pg_sys::Pg_magic_struct {
+                    len,
+                    #[cfg(not(feature = "pg18"))]
+                    version,
+                    #[cfg(not(feature = "pg18"))]
+                    funcmaxargs,
+                    #[cfg(not(feature = "pg18"))]
+                    indexmaxkeys,
+                    #[cfg(not(feature = "pg18"))]
+                    namedatalen,
+                    #[cfg(not(feature = "pg18"))]
+                    float8byval,
+                    #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
+                    abi_extra,
+                    #[cfg(feature = "pg18")]
                     abi_fields: ::pgrx::pg_sys::Pg_abi_values {
-                        version: ::pgrx::pg_sys::PG_VERSION_NUM as i32 / 100,
-                        funcmaxargs: ::pgrx::pg_sys::FUNC_MAX_ARGS as i32,
-                        indexmaxkeys: ::pgrx::pg_sys::INDEX_MAX_KEYS as i32,
-                        namedatalen: ::pgrx::pg_sys::NAMEDATALEN as i32,
-                        float8byval: cfg!(target_pointer_width = "64") as i32,
-                        abi_extra: {
-                            // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then we'll
-                            // raise a compilation error unless the `unsafe-postgres` feature is set
-                            let magic = ::pgrx::pg_sys::FMGR_ABI_EXTRA.to_bytes_with_nul();
-                            let mut abi = [0 as ::pgrx::ffi::c_char; 32];
-                            let mut i = 0;
-                            while i < magic.len() {
-                                abi[i] = magic[i] as ::pgrx::ffi::c_char;
-                                i += 1;
-                            }
-                            abi
-                        },
+                        version,
+                        funcmaxargs,
+                        indexmaxkeys,
+                        namedatalen,
+                        float8byval,
+                        abi_extra,
                     },
-                    name: std::ptr::null(),
-                    version: std::ptr::null(),
-                });
-
-                // since Postgres calls this first, register our panic handler now
-                // so we don't unwind into C / Postgres
-                ::pgrx::pg_sys::panic::register_pg_guard_panic_hook();
-
-                // return the magic
-                &MY_MAGIC.0
-            }
-        }
-    };
-
-    ($name:expr, $version:expr) => {
-        #[no_mangle]
-        #[allow(non_snake_case, unexpected_cfgs)]
-        #[doc(hidden)]
-        pub extern "C-unwind" fn Pg_magic_func() -> &'static ::pgrx::pg_sys::Pg_magic_struct {
-            #[cfg(any(
-                feature = "pg13",
-                feature = "pg14",
-                feature = "pg15",
-                feature = "pg16",
-                feature = "pg17"
-            ))]
-            {
-                static MY_MAGIC: ::pgrx::pg_sys::Pg_magic_struct =
-                    ::pgrx::pg_sys::Pg_magic_struct {
-                        len: ::core::mem::size_of::<::pgrx::pg_sys::Pg_magic_struct>() as i32,
-                        version: ::pgrx::pg_sys::PG_VERSION_NUM as i32 / 100,
-                        funcmaxargs: ::pgrx::pg_sys::FUNC_MAX_ARGS as i32,
-                        indexmaxkeys: ::pgrx::pg_sys::INDEX_MAX_KEYS as i32,
-                        namedatalen: ::pgrx::pg_sys::NAMEDATALEN as i32,
-                        float8byval: cfg!(target_pointer_width = "64") as i32,
-                        #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
-                        abi_extra: {
-                            // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then we'll
-                            // raise a compilation error unless the `unsafe-postgres` feature is set
-                            let magic = ::pgrx::pg_sys::FMGR_ABI_EXTRA.to_bytes_with_nul();
-                            let mut abi = [0 as ::pgrx::ffi::c_char; 32];
-                            let mut i = 0;
-                            while i < magic.len() {
-                                abi[i] = magic[i] as ::pgrx::ffi::c_char;
-                                i += 1;
-                            }
-                            abi
-                        },
+                    #[cfg(feature = "pg18")]
+                    name: ::core::ptr::null(),
+                    #[cfg(feature = "pg18")]
+                    version: ::core::ptr::null(),
+                };
+                #[allow(unused_macros)]
+                macro_rules! field_update {
+                    (name) => {
+                        field_update!(name = {
+                            const RAW: &str = env!("CARGO_PKG_NAME");
+                            const BUFFER: [u8; RAW.len() + 1] = {
+                                let mut buffer = [0u8; RAW.len() + 1];
+                                let mut i = 0_usize;
+                                while i < RAW.len() {
+                                    buffer[i] = RAW.as_bytes()[i];
+                                    i += 1;
+                                }
+                                buffer
+                            };
+                            const STR: &::core::ffi::CStr =
+                                if let Ok(s) = ::core::ffi::CStr::from_bytes_with_nul(&BUFFER) {
+                                    s
+                                } else {
+                                    panic!("there are null characters in CARGO_PKG_NAME")
+                                };
+                            const { STR }
+                        });
                     };
+                    (version) => {
+                        field_update!(name = {
+                            const RAW: &str = env!("CARGO_PKG_VERSION");
+                            const BUFFER: [u8; RAW.len() + 1] = {
+                                let mut buffer = [0u8; RAW.len() + 1];
+                                let mut i = 0_usize;
+                                while i < RAW.len() {
+                                    buffer[i] = RAW.as_bytes()[i];
+                                    i += 1;
+                                }
+                                buffer
+                            };
+                            const STR: &::core::ffi::CStr =
+                                if let Ok(s) = ::core::ffi::CStr::from_bytes_with_nul(&BUFFER) {
+                                    s
+                                } else {
+                                panic!("there are null characters in CARGO_CRATE_VERSION")
+                             };
+                            const { STR }
+                        });
+                    };
+                    (name = $name:expr) => {
+                        let name: &'static ::core::ffi::CStr = $name;
+                        #[cfg(feature = "pg18")]
+                        {
+                            magic.name = ::core::ffi::CStr::as_ptr($name);
+                        }
+                    };
+                    (version = $version:expr) => {
+                        let version: &'static ::core::ffi::CStr = $version;
+                        #[cfg(feature = "pg18")]
+                        {
+                            magic.version = ::core::ffi::CStr::as_ptr($version);
+                        }
+                    };
+                }
+                $(field_update!($key $(= $value)?);)*
+                AssertSync(magic)
+            };
 
-                // since Postgres calls this first, register our panic handler now
-                // so we don't unwind into C / Postgres
-                ::pgrx::pg_sys::panic::register_pg_guard_panic_hook();
-
-                // return the magic
-                &MY_MAGIC
-            }
-
-            #[cfg(feature = "pg18")]
-            {
-                struct PgMagicstruct(::pgrx::pg_sys::Pg_magic_struct);
-                unsafe impl Sync for PgMagicstruct {}
-                static MY_MAGIC: PgMagicstruct = PgMagicstruct(::pgrx::pg_sys::Pg_magic_struct {
-                    len: ::core::mem::size_of::<::pgrx::pg_sys::Pg_magic_struct>() as i32,
-                    abi_fields: ::pgrx::pg_sys::Pg_abi_values {
-                        version: ::pgrx::pg_sys::PG_VERSION_NUM as i32 / 100,
-                        funcmaxargs: ::pgrx::pg_sys::FUNC_MAX_ARGS as i32,
-                        indexmaxkeys: ::pgrx::pg_sys::INDEX_MAX_KEYS as i32,
-                        namedatalen: ::pgrx::pg_sys::NAMEDATALEN as i32,
-                        float8byval: cfg!(target_pointer_width = "64") as i32,
-                        abi_extra: {
-                            // we'll use what the bindings tell us, but if it ain't "PostgreSQL" then we'll
-                            // raise a compilation error unless the `unsafe-postgres` feature is set
-                            let magic = ::pgrx::pg_sys::FMGR_ABI_EXTRA.to_bytes_with_nul();
-                            let mut abi = [0 as ::pgrx::ffi::c_char; 32];
-                            let mut i = 0;
-                            while i < magic.len() {
-                                abi[i] = magic[i] as ::pgrx::ffi::c_char;
-                                i += 1;
-                            }
-                            abi
-                        },
-                    },
-                    name: $name.as_ptr(),
-                    version: $version.as_ptr(),
-                });
-
-                // since Postgres calls this first, register our panic handler now
-                // so we don't unwind into C / Postgres
-                ::pgrx::pg_sys::panic::register_pg_guard_panic_hook();
-
-                // return the magic
-                &MY_MAGIC.0
-            }
+            // return the magic
+            &MY_MAGIC.0
         }
     };
 }

--- a/pgrx/src/lwlock.rs
+++ b/pgrx/src/lwlock.rs
@@ -51,7 +51,7 @@ impl<T> PgLwLock<T> {
     }
 
     /// Obtain a shared lock (which comes with `&T` access)
-    pub fn share(&self) -> PgLwLockShareGuard<T> {
+    pub fn share(&self) -> PgLwLockShareGuard<'_, T> {
         unsafe {
             let shared = self.inner.get().read().as_ref().expect("PgLwLock was not initialized");
             pg_sys::LWLockAcquire((*shared).lock_ptr, pg_sys::LWLockMode::LW_SHARED);
@@ -60,7 +60,7 @@ impl<T> PgLwLock<T> {
     }
 
     /// Obtain an exclusive lock (which comes with `&mut T` access)
-    pub fn exclusive(&self) -> PgLwLockExclusiveGuard<T> {
+    pub fn exclusive(&self) -> PgLwLockExclusiveGuard<'_, T> {
         unsafe {
             let shared = self.inner.get().read().as_ref().expect("PgLwLock was not initialized");
             pg_sys::LWLockAcquire((*shared).lock_ptr, pg_sys::LWLockMode::LW_EXCLUSIVE);

--- a/pgrx/src/rel.rs
+++ b/pgrx/src/rel.rs
@@ -235,7 +235,7 @@ impl PgRelation {
     /// // assert that the tuple descriptor has 12 attributes
     /// assert_eq!(tupdesc.len(), 12);
     /// ```
-    pub fn tuple_desc(&self) -> PgTupleDesc {
+    pub fn tuple_desc(&self) -> PgTupleDesc<'_> {
         PgTupleDesc::from_relation(self)
     }
 

--- a/pgrx/src/spi/cursor.rs
+++ b/pgrx/src/spi/cursor.rs
@@ -72,7 +72,7 @@ impl SpiCursor<'_> {
     /// Fetch up to `count` rows from the cursor, moving forward
     ///
     /// If `fetch` runs off the end of the available rows, an empty [`SpiTupleTable`] is returned.
-    pub fn fetch(&mut self, count: libc::c_long) -> SpiResult<SpiTupleTable> {
+    pub fn fetch(&mut self, count: libc::c_long) -> SpiResult<SpiTupleTable<'_>> {
         // SAFETY: no concurrent access
         unsafe {
             pg_sys::SPI_tuptable = std::ptr::null_mut();

--- a/pgrx/src/tupdesc.rs
+++ b/pgrx/src/tupdesc.rs
@@ -142,7 +142,7 @@ impl<'a> PgTupleDesc<'a> {
     }
 
     /// wrap the `pg_sys::TupleDesc` contained by the specified `PgRelation`
-    pub fn from_relation(parent: &PgRelation) -> PgTupleDesc {
+    pub fn from_relation(parent: &PgRelation) -> PgTupleDesc<'_> {
         PgTupleDesc {
             // SAFETY:  `parent` is a Rust reference, and as such its rd_att attribute will be property initialized
             tupdesc: Some(unsafe { PgBox::from_pg(parent.rd_att) }),
@@ -232,7 +232,7 @@ impl<'a> PgTupleDesc<'a> {
     }
 
     /// Iterate over our attributes
-    pub fn iter(&self) -> TupleDescIterator {
+    pub fn iter(&self) -> TupleDescIterator<'_> {
         TupleDescIterator { tupdesc: self, curr: 0 }
     }
 


### PR DESCRIPTION
Based on #2087, to make CI happy.

This patch

1. changes the syntax from `pgrx::pg_module_magic!(c"NAME", c"VERSION")` to `pgrx::pg_module_magic!(name = c"NAME", version = c"VERSION")`
2. allows `pgrx::pg_module_magic!(name, version)` to fill the name and version by package name and version  in magic struct
3. allows `pgrx::pg_module_magic!(name, version = c"1.0.0")` to fill the name by package name and the version by specifying one in magic struct
4. allows `pgrx::pg_module_magic!()` to fill the name and version with null pointers in magic struct
5. checks type of `name` and `version`, in order to avoid misuse since `str::as_ptr` also exists