### PR TITLE
pg18 support: add header and implement `#define`

### DIFF
--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -161,7 +161,6 @@ pub fn main() -> eyre::Result<()> {
     }
 
     let compile_cshim = env_tracked("CARGO_FEATURE_CSHIM").as_deref() == Some("1");
-
     let is_for_release =
         env_tracked("PGRX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE").as_deref() == Some("1");
 
@@ -897,6 +896,9 @@ fn add_blocklists(bind: bindgen::Builder) -> bindgen::Builder {
         .blocklist_function("raw_expression_tree_walker")
         .blocklist_function("type_is_array")
         .blocklist_function("varsize_any")
+        // we define these ourselves b/c Postgres is schizophrenic about them across versions
+        .blocklist_function("PageValidateSpecialPointer")
+        .blocklist_function("PageIsValid")
         // it's defined twice on Windows, so use PGERROR instead
         .blocklist_item("ERROR")
         // it causes strange linker errors for PostgreSQL 14 on Windows

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -75,6 +75,7 @@
 #include "commands/defrem.h"
 #include "commands/event_trigger.h"
 #include "commands/explain.h"
+#include "commands/explain_format.h"
 #include "commands/extension.h"
 #include "commands/prepare.h"
 #include "commands/proclang.h"

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -479,6 +479,15 @@ pub unsafe fn raw_expression_tree_walker(
     crate::raw_expression_tree_walker_impl(node, walker, context)
 }
 
+#[cfg(feature = "pg18")]
+pub unsafe fn expression_tree_mutator(
+    node: *mut crate::Node,
+    mutator: crate::tree_mutator_callback,
+    context: *mut ::core::ffi::c_void,
+) -> *mut crate::Node {
+    crate::expression_tree_mutator_impl(node, mutator, context)
+}
+
 #[inline(always)]
 pub unsafe fn MemoryContextSwitchTo(context: crate::MemoryContext) -> crate::MemoryContext {
     let old = crate::CurrentMemoryContext;
@@ -611,6 +620,22 @@ pub unsafe fn PageGetSpecialSize(page: pg_sys::Page) -> u16 {
 #[inline(always)]
 #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
 pub unsafe fn PageGetSpecialPointer(page: pg_sys::Page) -> *mut ::core::ffi::c_char {
+    /*
+    #define PageGetSpecialPointer(page) \
+    ( \
+        PageValidateSpecialPointer(page), \
+        ((page) + ((PageHeader) (page))->pd_special) \
+    )
+    */
+    let page_header = page as *mut pg_sys::PageHeaderData;
+    page.add((*page_header).pd_special as usize) as *mut ::core::ffi::c_char
+}
+
+#[allow(non_snake_case)]
+#[inline(always)]
+#[cfg(feature = "pg18")]
+pub unsafe fn PageGetSpecialPointer(page: pg_sys::Page) -> *mut ::core::ffi::c_char {
+    crate::PageValidateSpecialPointer(page);
     // #define PageGetSpecialPointer(page) \
     // ((char *) ((char *) (page) + ((PageHeader) (page))->pd_special))
     let page_header = page as *mut pg_sys::PageHeaderData;

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -1,4 +1,5 @@
 use crate as pg_sys;
+use crate::BLCKSZ;
 use core::mem::offset_of;
 use core::str::FromStr;
 
@@ -520,8 +521,7 @@ pub unsafe fn ItemIdGetOffset(item_id: pg_sys::ItemId) -> u32 {
 
 #[allow(non_snake_case)]
 #[inline(always)]
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
-pub unsafe fn PageIsValid(page: pg_sys::Page) -> bool {
+pub const unsafe fn PageIsValid(page: pg_sys::Page) -> bool {
     // #define PageIsValid(page) PointerIsValid(page)
     !page.is_null()
 }
@@ -616,9 +616,43 @@ pub unsafe fn PageGetSpecialSize(page: pg_sys::Page) -> u16 {
     PageGetPageSize(page) as u16 - (*page_header).pd_special
 }
 
+/// line pointer(s) do not count as part of header
+pub const unsafe fn SizeOfPageHeaderData() -> usize {
+    /*
+       #define SizeOfPageHeaderData (offsetof(PageHeaderData, pd_linp))
+    */
+    offset_of!(pg_sys::PageHeaderData, pd_linp)
+}
+
+/// Using assertions, validate that the page special pointer is OK.
+///
+/// This is intended to catch use of the pointer before page initialization.
+/// It is implemented as a function due to the limitations of the MSVC
+/// compiler, which choked on doing all these tests within another macro.  We
+/// return true so that AssertMacro() can be used while still getting the
+/// specifics from the macro failure within this function.
 #[allow(non_snake_case)]
 #[inline(always)]
-#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15"))]
+pub const unsafe fn PageValidateSpecialPointer(page: pg_sys::Page) -> bool {
+    // static inline bool
+    // PageValidateSpecialPointer(Page page)
+    // {
+    //     Assert(PageIsValid(page));
+    //     Assert(((PageHeader) (page))->pd_special <= BLCKSZ);
+    //     Assert(((PageHeader) (page))->pd_special >= SizeOfPageHeaderData);
+    //
+    //     return true;
+    // }
+    assert!(PageIsValid(page));
+    let page = page as *mut pg_sys::PageHeaderData;
+    assert!((*page).pd_special <= BLCKSZ as _);
+    assert!((*page).pd_special >= SizeOfPageHeaderData() as _);
+    true
+}
+
+#[allow(non_snake_case)]
+#[inline(always)]
+#[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg18"))]
 pub unsafe fn PageGetSpecialPointer(page: pg_sys::Page) -> *mut ::core::ffi::c_char {
     /*
     #define PageGetSpecialPointer(page) \
@@ -627,17 +661,9 @@ pub unsafe fn PageGetSpecialPointer(page: pg_sys::Page) -> *mut ::core::ffi::c_c
         ((page) + ((PageHeader) (page))->pd_special) \
     )
     */
-    let page_header = page as *mut pg_sys::PageHeaderData;
-    page.add((*page_header).pd_special as usize) as *mut ::core::ffi::c_char
-}
 
-#[allow(non_snake_case)]
-#[inline(always)]
-#[cfg(feature = "pg18")]
-pub unsafe fn PageGetSpecialPointer(page: pg_sys::Page) -> *mut ::core::ffi::c_char {
-    crate::PageValidateSpecialPointer(page);
-    // #define PageGetSpecialPointer(page) \
-    // ((char *) ((char *) (page) + ((PageHeader) (page))->pd_special))
+    assert!(PageValidateSpecialPointer(page));
+
     let page_header = page as *mut pg_sys::PageHeaderData;
     page.add((*page_header).pd_special as usize) as *mut ::core::ffi::c_char
 }


### PR DESCRIPTION
There's a number of new headers and some symbols got shifted around.  

At least one downstream project (`pg_search`) needs these changes.