### PR TITLE
chore: consolidate package settings in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@
 #LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "cargo-pgrx",
     "pgrx",
@@ -51,6 +51,13 @@ exclude = [
     "pgrx-examples/versioned_so",
 ]
 
+[workspace.package]
+authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage = "https://github.com/pgcentralfoundation/pgrx/"
+version = "0.15.0"
 
 [workspace.metadata.local-install]
 cargo-pgrx = { path = "cargo-pgrx" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/pgcentralfoundation/pgrx/"
 homepage = "https://github.com/pgcentralfoundation/pgrx/"
+# TODO: all crates should use this version rather than copy it
+#   See https://github.com/pgcentralfoundation/pgrx/pull/2100 comments
 version = "0.15.0"
 
 [workspace.metadata.local-install]

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "cargo-pgrx"
-version.workspace = true
+version = "0.15.0"
 authors.workspace = true
 license.workspace = true
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,18 +10,18 @@
 
 [package]
 name = "cargo-pgrx"
-version = "0.15.0"
-authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"
-homepage = "https://github.com/pgcentralfoundation/pgrx/"
-repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/cargo-pgrx"
 categories = ["development-tools::cargo-plugins", "command-line-utilities", "database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 readme = "README.md"
 exclude = ["*.png"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 pgrx-pg-config.workspace = true

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version.workspace = true
+version = "0.15.0"
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.15.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 homepage = "https://github.com/pgcentralfoundation/pgrx"
 repository = "https://github.com/pgcentralfoundation/pgrx"
 documentation = "https://docs.rs/pgrx-bindgen"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version.workspace = true
+version = "0.15.0"
 authors.workspace = true
 license.workspace = true
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,15 +10,15 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.15.0"
-authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Proc Macros for 'pgrx'"
-homepage = "https://github.com/pgcentralfoundation/pgrx/"
-repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/pgrx-macros"
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
 
 [lib]
 proc-macro = true

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-config"
-version.workspace = true
+version = "0.15.0"
 authors.workspace = true
 license.workspace = true
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,15 +10,15 @@
 
 [package]
 name = "pgrx-pg-config"
-version = "0.15.0"
-authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "A Postgres pg_config wrapper for 'pgrx'"
-homepage = "https://github.com/pgcentralfoundation/pgrx/"
-repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/pgrx-pg-config"
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version.workspace = true
+version = "0.15.0"
 authors.workspace = true
 license.workspace = true
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,15 +10,15 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.15.0"
-authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"
-homepage = "https://github.com/pgcentralfoundation/pgrx/"
-repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/pgrx-pg-sys"
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "README.md", "include/*", "pgrx-cshim.c", "bindgen.rs"]
 build = "bindgen.rs"
 

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,15 +10,15 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.15.0"
-authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Sql Entity Graph for `pgrx`"
-homepage = "https://github.com/pgcentralfoundation/pgrx/"
-repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/pgrx-sql-entity-graph"
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "README.md"]
 
 [features]

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version.workspace = true
+version = "0.15.0"
 authors.workspace = true
 license.workspace = true
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version.workspace = true
+version = "0.15.0"
 authors.workspace = true
 license.workspace = true
 description = "Test framework for 'pgrx'-based Postgres extensions"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,15 +10,15 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.15.0"
-authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Test framework for 'pgrx'-based Postgres extensions"
-homepage = "https://github.com/pgcentralfoundation/pgrx/"
-repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/pgrx-tests"
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "README.md", "!**/tests/**/*"]
 
 [lib]

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version.workspace = true
+version = "0.15.0"
 authors.workspace = true
 license.workspace = true
 description = "pgrx:  A Rust framework for creating Postgres extensions"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,17 +10,17 @@
 
 [package]
 name = "pgrx"
-version = "0.15.0"
-authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
-license = "MIT"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "pgrx:  A Rust framework for creating Postgres extensions"
-homepage = "https://github.com/pgcentralfoundation/pgrx/"
-repository = "https://github.com/pgcentralfoundation/pgrx/"
+homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/pgrx"
 categories = ["database"]
 keywords = ["database", "postgres", "postgresql", "extension"]
 readme = "../README.md"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*"]
 
 [lib]


### PR DESCRIPTION
allow the same version, edition, and other settings to be centrally managed. Also bump to the newer workspace resolver to simplify future 2024 migration