### PR TITLE
filter out unrecognized attributes in PostgresGucEnum

### DIFF
--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -615,7 +615,7 @@ fn pgrx_embed_name(manifest: &Manifest) -> eyre::Result<String> {
         .ok_or_else(|| eyre!("Failed to find a pgrx_embed binary."))
 }
 
-fn parse_object(data: &[u8]) -> object::Result<object::File> {
+fn parse_object(data: &[u8]) -> object::Result<object::File<'_>> {
     let kind = object::FileKind::parse(data)?;
 
     match kind {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1081,6 +1081,12 @@ fn impl_guc_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         Hidden(bool),
     }
 
+    impl GucEnumAttribute {
+        fn is_guc_enum_attribute(attribute: &str) -> bool {
+            matches!(attribute, "name" | "hidden")
+        }
+    }
+
     impl Parse for GucEnumAttribute {
         fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
             let ident: Ident = input.parse()?;
@@ -1110,17 +1116,26 @@ fn impl_guc_enum(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         let mut name = None;
         let mut hidden = None;
         for attr in variant.attrs.iter() {
-            let tokens = attr.meta.require_name_value()?.to_token_stream();
-            let pair: GucEnumAttribute = syn::parse2(tokens)?;
-            match pair {
-                GucEnumAttribute::Name(value) => {
-                    if name.replace(value).is_some() {
-                        return Err(syn::Error::new(ast.span(), "too many #[name] attributes"));
-                    }
-                }
-                GucEnumAttribute::Hidden(value) => {
-                    if hidden.replace(value).is_some() {
-                        return Err(syn::Error::new(ast.span(), "too many #[hidden] attributes"));
+            if let Some(ident) = attr.path().get_ident() {
+                if GucEnumAttribute::is_guc_enum_attribute(&ident.to_string()) {
+                    let pair: GucEnumAttribute = syn::parse2(attr.meta.to_token_stream())?;
+                    match pair {
+                        GucEnumAttribute::Name(value) => {
+                            if name.replace(value).is_some() {
+                                return Err(syn::Error::new(
+                                    ast.span(),
+                                    "too many #[name] attributes",
+                                ));
+                            }
+                        }
+                        GucEnumAttribute::Hidden(value) => {
+                            if hidden.replace(value).is_some() {
+                                return Err(syn::Error::new(
+                                    ast.span(),
+                                    "too many #[hidden] attributes",
+                                ));
+                            }
+                        }
                     }
                 }
             }

--- a/pgrx-tests/src/tests/guc_tests.rs
+++ b/pgrx-tests/src/tests/guc_tests.rs
@@ -152,6 +152,7 @@ mod tests {
         enum TestEnum {
             One,
             Two,
+            #[doc = "three"]
             Three,
             #[name = c"five"]
             Four,


### PR DESCRIPTION
fix: document on GUC enum is not accepted by `PostgresGucEnum`, eg.

```rust
#[derive(PostgresGucEnum, Clone, Copy)]
enum TestEnum {
    /// One
    One,
    /// Two
    Two,
    /// Three
    Three,
}
// `PostgresGucEnum` emit errors because it accepts `name` and `hidden` only (excluding `doc`)
```

This bug is reported in discord by #theory, thank you!