### PR TITLE
chore: prepare for 2024 edition

### DIFF
--- a/articles/forging-sql-from-rust.md
+++ b/articles/forging-sql-from-rust.md
@@ -237,7 +237,7 @@ During the proc macro expansion process, we can append the [`proc_macro2::TokenS
 struct Floof { boof: usize }
 
 // We should extend the TokenStream with something like
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __pgrx_internals_type_Floof()
 -> pgrx::datum::inventory::SqlGraphEntity {
     todo!()
@@ -253,7 +253,7 @@ pub fn floof_from_boof(boof: usize) -> Floof {
 }
 
 // We should extend the TokenStream with something like
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn __pgrx_internals_fn_floof_from_boof()
 -> pgrx::datum::inventory::SqlGraphEntity {
     todo!()
@@ -473,7 +473,7 @@ struct Floof { boof: usize }
 The above gets parsed and new tokens are quasi-quoted atop this template like this:
 
 ```rust
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn  #inventory_fn_name() -> pgrx::datum::inventory::SqlGraphEntity {
     let mut mappings = Default::default();
     <#name #ty_generics as pgrx::datum::WithTypeIds>::register_with_refs(
@@ -498,7 +498,7 @@ pub extern "C" fn  #inventory_fn_name() -> pgrx::datum::inventory::SqlGraphEntit
 The proc macro passes will make it into:
 
 ```rust
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn  __pgrx_internals_type_Floof() -> pgrx::datum::inventory::SqlGraphEntity {
     let mut mappings = Default::default();
     <Floof as pgrx::datum::WithTypeIds>::register_with_refs(
@@ -544,7 +544,7 @@ Types such as `Vec<T>` require a type to be `Sized`, `pgrx::datum::Array<T>` req
 ```rust
 // This doesn't work
 syn::parse_quote! {
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn  #inventory_fn_name() -> pgrx::datum::inventory::SqlGraphEntity {
         let mut mappings = Default::default();
         #hypothetical_if_some_type_impls_sized_block {

--- a/cargo-pgrx/src/env.rs
+++ b/cargo-pgrx/src/env.rs
@@ -17,7 +17,9 @@ pub(crate) fn cargo() -> std::process::Command {
 pub(crate) fn initialize() {
     match (std::env::var_os("CARGO_PGRX"), std::env::current_exe()) {
         (None, Ok(path)) => {
-            std::env::set_var("CARGO_PGRX", path);
+            unsafe {
+                std::env::set_var("CARGO_PGRX", path);
+            }
             // TODO: Should we set `CARGO_PGRX_{CARGO,RUSTC}` to `RUSTC`/`CARGO`
             // if unset, then prefer those? The issue with `RUSTC`/`CARGO` vars
             // is that they are unset if something invokes e.g. `cargo`

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -213,7 +213,7 @@ pub(crate) fn get_package_manifest(
 
 pub(crate) fn all_pg_in_both_tomls<'a>(
     manifest: &'a Manifest,
-    pgrx: &Pgrx,
+    pgrx: &'a Pgrx,
 ) -> impl Iterator<Item = eyre::Result<PgConfig>> + 'a {
     // Maybe eventually warn when the Cargo.toml has a version our config.toml doesn't,
     // as it makes sense to further constrain support from the version set pgrx supports,

--- a/cargo-pgrx/src/templates/bgworker_lib_rs
+++ b/cargo-pgrx/src/templates/bgworker_lib_rs
@@ -31,7 +31,7 @@ pub extern "C-unwind" fn _PG_init() {{
 }}
 
 #[pg_guard]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C-unwind" fn background_worker_main(arg: pg_sys::Datum) {{
     let arg = unsafe {{ i32::from_datum(arg, false) }};
 

--- a/docs/src/extension/install.md
+++ b/docs/src/extension/install.md
@@ -16,7 +16,7 @@ C code? In MY Rust? Well, it's more likely than you think, but this is not actua
 Postgres thinks every language that compiles to machine code and can be dlopened and called is "C".
 Rust does not disagree: your Rust functions, exposed by `#[pg_extern]`, will look something like
 ```rust
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn your_fn_wrapper(
     fcinfo: pg_sys::FunctionCallInfo
 ) -> pg_sys::Datum {

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -39,7 +39,7 @@ pub extern "C-unwind" fn _PG_init() {
 }
 
 #[pg_guard]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C-unwind" fn background_worker_main(arg: pg_sys::Datum) {
     let arg = unsafe { i32::from_polymorphic_datum(arg, false, pg_sys::INT4OID) };
 

--- a/pgrx-examples/wal_decoder/src/lib.rs
+++ b/pgrx-examples/wal_decoder/src/lib.rs
@@ -196,7 +196,7 @@ impl Serialize for Tuple {
 
 // Initialize the output plugin
 #[allow(non_snake_case)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[pg_guard]
 pub unsafe extern "C-unwind" fn _PG_output_plugin_init(cb_ptr: *mut pg_sys::OutputPluginCallbacks) {
     let mut callbacks = unsafe { PgBox::from_pg(cb_ptr) };

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -31,8 +31,11 @@ macro_rules! format_ident {
 pub fn extern_block(block: ItemForeignMod) -> proc_macro2::TokenStream {
     let mut stream = proc_macro2::TokenStream::new();
 
+    let unsafety = &block.unsafety;
+    let abi = &block.abi;
+    let abi = quote! { #unsafety #abi };
     for item in block.items.into_iter() {
-        stream.extend(foreign_item(item, &block.abi));
+        stream.extend(foreign_item(item, &abi));
     }
 
     stream
@@ -58,7 +61,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
             GenericParam::Const(_) => true,
         })
     {
-        panic!("#[pg_guard] for function with generic parameters must not be combined with #[no_mangle]");
+        panic!("#[pg_guard] for function with generic parameters must not be combined with #[unsafe(no_mangle)]");
     }
 
     // but for the inner function (the one we're wrapping) we don't need any kind of
@@ -82,7 +85,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     } else if input_func_name == "_PG_init" || input_func_name == "_PG_fini" {
         quote! {
             #[allow(non_snake_case)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
         }
     } else {
         quote! {}
@@ -121,7 +124,10 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     })
 }
 
-fn foreign_item(item: ForeignItem, abi: &syn::Abi) -> syn::Result<proc_macro2::TokenStream> {
+fn foreign_item(
+    item: ForeignItem,
+    abi: &proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
     match item {
         ForeignItem::Fn(func) => {
             if func.sig.variadic.is_some() {
@@ -135,7 +141,10 @@ fn foreign_item(item: ForeignItem, abi: &syn::Abi) -> syn::Result<proc_macro2::T
     }
 }
 
-fn foreign_item_fn(func: &ForeignItemFn, abi: &syn::Abi) -> syn::Result<proc_macro2::TokenStream> {
+fn foreign_item_fn(
+    func: &ForeignItemFn,
+    abi: &proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
     let func_name = func.sig.ident.clone();
     let arg_list = rename_arg_list(&func.sig)?;
     let arg_list_with_types = rename_arg_list_with_types(&func.sig)?;
@@ -170,7 +179,7 @@ fn foreign_item_fn(func: &ForeignItemFn, abi: &syn::Abi) -> syn::Result<proc_mac
 
 fn foreign_item_static(
     variable: &ForeignItemStatic,
-    abi: &syn::Abi,
+    abi: &proc_macro2::TokenStream,
 ) -> syn::Result<proc_macro2::TokenStream> {
     let link = quote! { #[cfg_attr(target_os = "windows", link(name = "postgres"))] };
     Ok(quote! {

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -923,11 +923,14 @@ fn from_empty_env() -> eyre::Result<()> {
     let pg_config = PgConfig::from_env();
     assert!(pg_config.is_err());
 
-    // but now we can
-    std::env::set_var("PGRX_PG_CONFIG_AS_ENV", "true");
-    std::env::set_var("PGRX_PG_CONFIG_VERSION", "PostgresSQL 15.1");
-    std::env::set_var("PGRX_PG_CONFIG_INCLUDEDIR-SERVER", "/path/to/server/headers");
-    std::env::set_var("PGRX_PG_CONFIG_CPPFLAGS", "some cpp flags");
+    // SAFETY: set_var in 2024th edition requires unsafe due to sync issues
+    unsafe {
+        // but now we can
+        std::env::set_var("PGRX_PG_CONFIG_AS_ENV", "true");
+        std::env::set_var("PGRX_PG_CONFIG_VERSION", "PostgresSQL 15.1");
+        std::env::set_var("PGRX_PG_CONFIG_INCLUDEDIR-SERVER", "/path/to/server/headers");
+        std::env::set_var("PGRX_PG_CONFIG_CPPFLAGS", "some cpp flags");
+    }
 
     let pg_config = PgConfig::from_env().unwrap();
     assert_eq!(pg_config.major_version()?, 15, "Major version should match");

--- a/pgrx-pg-sys/src/cshim.rs
+++ b/pgrx-pg-sys/src/cshim.rs
@@ -4,7 +4,7 @@
 use crate as pg_sys;
 
 #[pgrx_macros::pg_guard]
-extern "C-unwind" {
+unsafe extern "C-unwind" {
     #[link_name = "SpinLockInit__pgrx_cshim"]
     pub fn SpinLockInit(lock: *mut pg_sys::slock_t);
     #[link_name = "SpinLockAcquire__pgrx_cshim"]

--- a/pgrx-pg-sys/src/lib.rs
+++ b/pgrx-pg-sys/src/lib.rs
@@ -44,4 +44,4 @@ mod seal {
 // (https://github.com/pgcentralfoundation/pgrx/issues/730).
 #[cfg(target_os = "linux")]
 #[link(name = "resolv")]
-extern "C" {}
+unsafe extern "C" {}

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -107,7 +107,7 @@ pub unsafe fn GetMemoryChunkContext(pointer: *mut std::os::raw::c_void) -> pg_sy
     #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
     {
         #[pgrx_macros::pg_guard]
-        extern "C-unwind" {
+        unsafe extern "C-unwind" {
             #[link_name = "GetMemoryChunkContext"]
             pub fn extern_fn(pointer: *mut std::os::raw::c_void) -> pg_sys::MemoryContext;
         }

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -395,7 +395,7 @@ where
         GuardAction::Return(r) => r,
         GuardAction::ReThrow => {
             #[cfg_attr(target_os = "windows", link(name = "postgres"))]
-            extern "C-unwind" {
+            unsafe extern "C-unwind" {
                 fn pg_re_throw() -> !;
             }
             unsafe {
@@ -510,7 +510,7 @@ fn do_ereport(ereport: ErrorReportWithLevel) {
     //
 
     #[cfg_attr(target_os = "windows", link(name = "postgres"))]
-    extern "C-unwind" {
+    unsafe extern "C-unwind" {
         fn errcode(sqlerrcode: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
         fn errmsg(fmt: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
         fn errdetail(fmt: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
@@ -520,7 +520,7 @@ fn do_ereport(ereport: ErrorReportWithLevel) {
 
     // we only allocate file, lineno and funcname if `errstart` returns true
     #[cfg_attr(target_os = "windows", link(name = "postgres"))]
-    extern "C-unwind" {
+    unsafe extern "C-unwind" {
         fn errstart(elevel: ::std::os::raw::c_int, domain: *const ::std::os::raw::c_char) -> bool;
         fn errfinish(
             filename: *const ::std::os::raw::c_char,

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -680,7 +680,7 @@ impl ToEntityGraphTokens for PgAggregate {
         let to_sql_config = &self.to_sql_config;
 
         quote! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {
@@ -749,7 +749,7 @@ fn get_target_ident(path: &Path) -> Result<Ident, syn::Error> {
 
 fn get_target_path(item_impl: &ItemImpl) -> Result<Path, syn::Error> {
     let target_ident = match &*item_impl.self_ty {
-        syn::Type::Path(ref type_path) => {
+        syn::Type::Path(type_path) => {
             let last_segment = type_path.path.segments.last().ok_or_else(|| {
                 syn::Error::new(
                     type_path.span(),
@@ -902,7 +902,7 @@ fn get_const_litstr(item: &ImplItemConst) -> syn::Result<Option<String>> {
 }
 
 fn remap_self_to_target(ty: &mut syn::Type, target: &syn::Ident) {
-    if let Type::Path(ref mut ty_path) = ty {
+    if let Type::Path(ty_path) = ty {
         for segment in ty_path.path.segments.iter_mut() {
             if segment.ident == "Self" {
                 segment.ident = target.clone()

--- a/pgrx-sql-entity-graph/src/extension_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/mod.rs
@@ -96,7 +96,7 @@ impl ToEntityGraphTokens for ExtensionSqlFile {
         let creates_iter = creates.iter();
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_sql_{}", name.clone());
         quote! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {
@@ -193,7 +193,7 @@ impl ToEntityGraphTokens for ExtensionSql {
 
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_sql_{}", name.value());
         quote! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -9,7 +9,7 @@ use syn::{self, spanned::Spanned, ItemFn};
 pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
     let finfo_name = format_ident!("pg_finfo_{ident}");
     let tokens = quote! {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[doc(hidden)]
         pub extern "C" fn #finfo_name() -> &'static ::pgrx::pg_sys::Pg_finfo_record {
             const V1_API: ::pgrx::pg_sys::Pg_finfo_record = ::pgrx::pg_sys::Pg_finfo_record { api_version: 1 };
@@ -31,7 +31,7 @@ pub fn finfo_v1_extern_c(
     let synthetic = synthetic.located_at(original.sig.span());
 
     let tokens = quote_spanned! { synthetic =>
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[doc(hidden)]
         pub unsafe extern "C-unwind" fn #wrapper_symbol(#fcinfo: ::pgrx::pg_sys::FunctionCallInfo) -> ::pgrx::pg_sys::Datum {
             #contents

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -358,7 +358,7 @@ impl PgExtern {
 
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_fn_{}", ident);
         quote_spanned! { self.func.sig.span() =>
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/pg_extern/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/returning.rs
@@ -259,9 +259,9 @@ impl Returning {
                 let used_ty = UsedType::new(syn::Type::Reference(ty_ref.clone()))?;
                 Ok(Returning::Type(used_ty))
             }
-            syn::Type::Macro(ref mut type_macro) => Self::parse_type_macro(type_macro),
-            syn::Type::Paren(ref mut type_paren) => match &mut *type_paren.elem {
-                syn::Type::Macro(ref mut type_macro) => Self::parse_type_macro(type_macro),
+            syn::Type::Macro(type_macro) => Self::parse_type_macro(type_macro),
+            syn::Type::Paren(type_paren) => match &mut *type_paren.elem {
+                syn::Type::Macro(type_macro) => Self::parse_type_macro(type_macro),
                 other => Err(syn::Error::new(
                     other.span(),
                     format!("Got unknown return type (type_paren): {type_paren:?}"),

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -113,7 +113,7 @@ impl ToEntityGraphTokens for PgTrigger {
         let to_sql_config = &self.to_sql_config;
 
         quote! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(unknown_lints, clippy::no_mangle_with_rust_abi, nonstandard_style)]
             pub extern "Rust" fn #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_enum/mod.rs
@@ -137,7 +137,7 @@ impl ToEntityGraphTokens for PostgresEnum {
                 }
             }
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(unknown_lints, clippy::no_mangle_with_rust_abi, nonstandard_style)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/postgres_hash/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_hash/mod.rs
@@ -102,7 +102,7 @@ impl ToEntityGraphTokens for PostgresHash {
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_hash_{}", self.name);
         let to_sql_config = &self.to_sql_config;
         quote! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(nonstandard_style, unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/postgres_ord/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_ord/mod.rs
@@ -103,7 +103,7 @@ impl ToEntityGraphTokens for PostgresOrd {
         let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_ord_{}", self.name);
         let to_sql_config = &self.to_sql_config;
         quote! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(nonstandard_style, unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/postgres_type/entity.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/entity.rs
@@ -61,7 +61,7 @@ impl Alignment {
 
         let attr = attr.parse_args::<PgrxAttribute>()?;
         for arg in attr.args.iter() {
-            let PgrxArg::NameValue(ref nv) = arg;
+            let PgrxArg::NameValue(nv) = arg;
             if !nv.path.is_ident("alignment") {
                 continue;
             }

--- a/pgrx-sql-entity-graph/src/postgres_type/mod.rs
+++ b/pgrx-sql-entity-graph/src/postgres_type/mod.rs
@@ -213,7 +213,7 @@ impl ToEntityGraphTokens for PostgresTypeDerive {
             }
 
 
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(nonstandard_style, unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/schema/mod.rs
+++ b/pgrx-sql-entity-graph/src/schema/mod.rs
@@ -80,7 +80,7 @@ impl Schema {
         let sql_graph_entity_fn_name =
             quote::format_ident!("__pgrx_internals_schema_{ident}_{postfix}");
         quote! {
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             #[doc(hidden)]
             #[allow(unknown_lints, clippy::no_mangle_with_rust_abi)]
             pub extern "Rust" fn  #sql_graph_entity_fn_name() -> ::pgrx::pgrx_sql_entity_graph::SqlGraphEntity {

--- a/pgrx-sql-entity-graph/src/to_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/mod.rs
@@ -94,7 +94,7 @@ impl ToSqlConfig {
 
         let attr = attr.parse_args::<PgrxAttribute>()?;
         for arg in attr.args.iter() {
-            let PgrxArg::NameValue(ref nv) = arg;
+            let PgrxArg::NameValue(nv) = arg;
             if !nv.path.is_ident("sql") {
                 continue;
             }

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -147,7 +147,7 @@ impl UsedType {
                                     syn::GenericArgument::Type(inner_ty) => {
                                         match inner_ty {
                                             // Result<$Type<T>>
-                                            syn::Type::Path(ref inner_type_path) => {
+                                            syn::Type::Path(inner_type_path) => {
                                                 let path = &inner_type_path.path;
                                                 let last_segment =
                                                     path.segments.last().ok_or(syn::Error::new(
@@ -210,7 +210,7 @@ impl UsedType {
                                     syn::GenericArgument::Type(inner_ty) => {
                                         match inner_ty {
                                             // Option<VariadicArray<T>>
-                                            syn::Type::Path(ref inner_type_path) => {
+                                            syn::Type::Path(inner_type_path) => {
                                                 let path = &inner_type_path.path;
                                                 let last_segment =
                                                     path.segments.last().ok_or(syn::Error::new(

--- a/pgrx-tests/src/tests/anyelement_tests.rs
+++ b/pgrx-tests/src/tests/anyelement_tests.rs
@@ -15,10 +15,9 @@ mod tests {
 
     #[pg_test]
     fn test_anyelement_arg() -> Result<(), pgrx::spi::Error> {
-        let element = Spi::get_one_with_args::<AnyElement>("SELECT anyelement_arg($1);", unsafe {
-            &[DatumWithOid::new(123, AnyElement::type_oid())]
-        })?
-        .map(|e| e.datum());
+        let oid = unsafe { DatumWithOid::new(123, AnyElement::type_oid()) };
+        let element = Spi::get_one_with_args::<AnyElement>("SELECT anyelement_arg($1);", &[oid])?
+            .map(|e| e.datum());
 
         assert_eq!(element, 123.into_datum());
 

--- a/pgrx-tests/src/tests/bgworker_tests.rs
+++ b/pgrx-tests/src/tests/bgworker_tests.rs
@@ -10,7 +10,7 @@
 use pgrx::prelude::*;
 
 #[pg_guard]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C-unwind" fn bgworker(arg: pg_sys::Datum) {
     use pgrx::bgworkers::*;
     use std::time::Duration;
@@ -41,7 +41,7 @@ pub extern "C-unwind" fn bgworker(arg: pg_sys::Datum) {
 }
 
 #[pg_guard]
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Here we test that `BackgroundWorker::transaction` can return data from the closure
 pub extern "C-unwind" fn bgworker_return_value(arg: pg_sys::Datum) {
     use pgrx::bgworkers::*;
@@ -75,7 +75,7 @@ pub extern "C-unwind" fn bgworker_return_value(arg: pg_sys::Datum) {
 }
 
 #[pg_guard]
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// Simple background worker that waits to be terminated; used to test behaviour in case of worker slots exhaustion
 pub extern "C-unwind" fn bgworker_sleep() {
     use pgrx::bgworkers::*;

--- a/pgrx-tests/src/tests/pg_guard_tests.rs
+++ b/pgrx-tests/src/tests/pg_guard_tests.rs
@@ -18,7 +18,7 @@ fn extern_func() -> bool {
 // This ensures that parameterized function compiles when it has `pg_guard` attached to it
 #[pg_guard]
 // Uncommenting the line below will make it fail to compile
-// #[no_mangle]
+// #[unsafe(no_mangle)]
 extern "C-unwind" fn extern_func_impl<T>() -> bool {
     let _ = PhantomData::<T>;
     true
@@ -27,7 +27,7 @@ extern "C-unwind" fn extern_func_impl<T>() -> bool {
 // This ensures that non-parameterized function compiles when it has `pg_guard` attached to it
 // and [no_mangle]
 #[pg_guard]
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C-unwind" fn extern_func_impl_1() -> bool {
     true
 }
@@ -35,7 +35,7 @@ extern "C-unwind" fn extern_func_impl_1() -> bool {
 // This ensures that lifetime-parameterized function compiles when it has `pg_guard` attached to it
 // and [no_mangle]
 #[pg_guard]
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(unused_lifetimes, clippy::extra_unused_lifetimes)]
 extern "C-unwind" fn extern_func_impl_2<'a>() -> bool {
     let _ = PhantomData::<&'a ()>;

--- a/pgrx-tests/src/tests/schema_tests.rs
+++ b/pgrx-tests/src/tests/schema_tests.rs
@@ -47,7 +47,7 @@ mod test_schema {
         entity: &SqlGraphEntity,
         _context: &PgrxSql,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        if let SqlGraphEntity::Function(ref func) = entity {
+        if let SqlGraphEntity::Function(func) = entity {
             Ok(format!(
                 "\
                 CREATE FUNCTION test_schema.\"func_generated_with_custom_name\"() RETURNS void\n\
@@ -65,7 +65,7 @@ mod test_schema {
         entity: &SqlGraphEntity,
         _context: &PgrxSql,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        if let SqlGraphEntity::Type(ref ty) = entity {
+        if let SqlGraphEntity::Type(ty) = entity {
             Ok(format!(
                 "\n\
                 CREATE TYPE test_schema.Custom{name};\

--- a/pgrx/src/toast.rs
+++ b/pgrx/src/toast.rs
@@ -45,8 +45,8 @@ impl<T: Toasty> Deref for Toast<T> {
 impl<T: Toasty> DerefMut for Toast<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
-            Toast::Stale(ref mut t) => t,
-            Toast::Fresh(ref mut t) => t,
+            Toast::Stale(t) => t,
+            Toast::Fresh(t) => t,
         }
     }
 }


### PR DESCRIPTION
I got edition 2024 to compile with these changes, but there are still quiet a few [warnings](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html) that should be fixed separatelly. As such, this PR only focuses on the required code changes to migrate to 2024 edition, but without the actual migration (i.e. it should still work in 2021)