### PR TITLE
improve shmem api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,16 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-traits"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707f750b93bd1b739cf9ddf85f8fe7c97a4a62c60ccf8b6f232514bd9103bedc"
-dependencies = [
- "cfg-if",
- "rustc_version",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,15 +1154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,16 +1162,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2007,11 +1978,9 @@ dependencies = [
 name = "pgrx"
 version = "0.15.0"
 dependencies = [
- "atomic-traits",
  "bitflags 2.9.0",
  "bitvec",
  "enum-map",
- "heapless",
  "libc",
  "once_cell",
  "pgrx-macros",
@@ -2581,15 +2550,6 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -30,7 +30,7 @@ pgrx::pg_module_magic!(name, version);
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
-    if unsafe { pgrx::pg_sys::IsUnderPostmaster } {
+    if unsafe { !pgrx::pg_sys::process_shared_preload_libraries_in_progress } {
         pgrx::error!("this extension must be loaded via shared_preload_libraries.");
     }
     BackgroundWorkerBuilder::new("Background Worker Example")

--- a/pgrx-examples/bgworker/src/lib.rs
+++ b/pgrx-examples/bgworker/src/lib.rs
@@ -30,6 +30,9 @@ pgrx::pg_module_magic!(name, version);
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
+    if unsafe { pgrx::pg_sys::IsUnderPostmaster } {
+        pgrx::error!("this extension must be loaded via shared_preload_libraries.");
+    }
     BackgroundWorkerBuilder::new("Background Worker Example")
         .set_function("background_worker_main")
         .set_library("bgworker")
@@ -84,4 +87,13 @@ pub extern "C-unwind" fn background_worker_main(arg: pg_sys::Datum) {
     }
 
     log!("Goodbye from inside the {} BGWorker! ", BackgroundWorker::get_name());
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {}
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        vec!["shared_preload_libraries='bgworker'"]
+    }
 }

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -29,15 +29,41 @@ pub struct Pgtest {
 
 unsafe impl PGRXSharedMemory for Pgtest {}
 
-static DEQUE: PgLwLock<heapless::Deque<Pgtest, 400>> = PgLwLock::new(c"shmem_deque");
-static VEC: PgLwLock<heapless::Vec<Pgtest, 400>> = PgLwLock::new(c"shmem_vec");
-static HASH: PgLwLock<heapless::FnvIndexMap<i32, i32, 4>> = PgLwLock::new(c"shmem_hash");
-static STRUCT: PgLwLock<Pgtest> = PgLwLock::new(c"shmem_struct");
-static PRIMITIVE: PgLwLock<i32> = PgLwLock::new(c"shmem_primtive");
-static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = PgAtomic::new(c"shmem_atomic");
+#[derive(Default)]
+#[repr(transparent)]
+pub struct AssertPGRXSharedMemory<T>(T);
+
+impl<T> std::ops::Deref for AssertPGRXSharedMemory<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for AssertPGRXSharedMemory<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+unsafe impl<T> PGRXSharedMemory for AssertPGRXSharedMemory<T> {}
+
+static DEQUE: PgLwLock<AssertPGRXSharedMemory<heapless::Deque<Pgtest, 400>>> =
+    unsafe { PgLwLock::new(c"shmem_deque") };
+static VEC: PgLwLock<AssertPGRXSharedMemory<heapless::Vec<Pgtest, 400>>> =
+    unsafe { PgLwLock::new(c"shmem_vec") };
+static HASH: PgLwLock<AssertPGRXSharedMemory<heapless::FnvIndexMap<i32, i32, 4>>> =
+    unsafe { PgLwLock::new(c"shmem_hash") };
+static STRUCT: PgLwLock<Pgtest> = unsafe { PgLwLock::new(c"shmem_struct") };
+static PRIMITIVE: PgLwLock<i32> = unsafe { PgLwLock::new(c"shmem_primtive") };
+static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = unsafe { PgAtomic::new(c"shmem_atomic") };
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
+    if unsafe { pgrx::pg_sys::IsUnderPostmaster } {
+        pgrx::error!("this extension must be loaded via shared_preload_libraries.");
+    }
     pg_shmem_init!(DEQUE);
     pg_shmem_init!(VEC);
     pg_shmem_init!(HASH);
@@ -156,4 +182,13 @@ fn atomic_get() -> bool {
 #[pg_extern]
 fn atomic_set(value: bool) -> bool {
     ATOMIC.get().swap(value, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {}
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        vec!["shared_preload_libraries='shmem'"]
+    }
 }

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -61,7 +61,7 @@ static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = unsafe { PgAtomic::new(
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
-    if unsafe { pgrx::pg_sys::IsUnderPostmaster } {
+    if unsafe { !pgrx::pg_sys::process_shared_preload_libraries_in_progress } {
         pgrx::error!("this extension must be loaded via shared_preload_libraries.");
     }
     pg_shmem_init!(DEQUE);

--- a/pgrx-examples/shmem/src/lib.rs
+++ b/pgrx-examples/shmem/src/lib.rs
@@ -29,26 +29,6 @@ pub struct Pgtest {
 
 unsafe impl PGRXSharedMemory for Pgtest {}
 
-#[derive(Default)]
-#[repr(transparent)]
-pub struct AssertPGRXSharedMemory<T>(T);
-
-impl<T> std::ops::Deref for AssertPGRXSharedMemory<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T> std::ops::DerefMut for AssertPGRXSharedMemory<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        &mut self.0
-    }
-}
-
-unsafe impl<T> PGRXSharedMemory for AssertPGRXSharedMemory<T> {}
-
 static DEQUE: PgLwLock<AssertPGRXSharedMemory<heapless::Deque<Pgtest, 400>>> =
     unsafe { PgLwLock::new(c"shmem_deque") };
 static VEC: PgLwLock<AssertPGRXSharedMemory<heapless::Vec<Pgtest, 400>>> =
@@ -64,9 +44,9 @@ pub extern "C-unwind" fn _PG_init() {
     if unsafe { !pgrx::pg_sys::process_shared_preload_libraries_in_progress } {
         pgrx::error!("this extension must be loaded via shared_preload_libraries.");
     }
-    pg_shmem_init!(DEQUE);
-    pg_shmem_init!(VEC);
-    pg_shmem_init!(HASH);
+    pg_shmem_init!(DEQUE = unsafe { AssertPGRXSharedMemory::new(Default::default()) });
+    pg_shmem_init!(VEC = unsafe { AssertPGRXSharedMemory::new(Default::default()) });
+    pg_shmem_init!(HASH = unsafe { AssertPGRXSharedMemory::new(Default::default()) });
     pg_shmem_init!(STRUCT);
     pg_shmem_init!(PRIMITIVE);
     pg_shmem_init!(ATOMIC);

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -77,12 +77,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     let func_name = func.sig.ident.clone();
     let func_name = format_ident!("{}", func_name);
 
-    let prolog = if input_func_name == "__pgrx_private_shmem_hook"
-        || input_func_name == "__pgrx_private_shmem_request_hook"
-    {
-        // we do not want "no_mangle" on these functions
-        quote! {}
-    } else if input_func_name == "_PG_init" || input_func_name == "_PG_fini" {
+    let prolog = if input_func_name == "_PG_init" || input_func_name == "_PG_fini" {
         quote! {
             #[allow(non_snake_case)]
             #[unsafe(no_mangle)]

--- a/pgrx-tests/src/tests/shmem_tests.rs
+++ b/pgrx-tests/src/tests/shmem_tests.rs
@@ -8,17 +8,25 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
-use pgrx::{pg_shmem_init, PgAtomic, PgLwLock, PgSharedMemoryInitialization};
+use pgrx::{pg_shmem_init, PgAtomic, PgLwLock};
 use std::sync::atomic::AtomicBool;
 
-static ATOMIC: PgAtomic<AtomicBool> = PgAtomic::new(c"pgrx_tests_atomic");
-static LWLOCK: PgLwLock<bool> = PgLwLock::new(c"pgrx_tests_lwlock");
+#[cfg(feature = "cshim")]
+use pgrx::spinlock::PgSpinLock;
+
+static ATOMIC: PgAtomic<AtomicBool> = unsafe { PgAtomic::new(c"pgrx_tests_atomic") };
+static LWLOCK: PgLwLock<bool> = unsafe { PgLwLock::new(c"pgrx_tests_lwlock") };
+
+#[cfg(feature = "cshim")]
+static SPINLOCK: PgAtomic<PgSpinLock<usize>> = unsafe { PgAtomic::new(c"pgrx_tests_spinlock") };
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
     // This ensures that this functionality works across PostgreSQL versions
     pg_shmem_init!(ATOMIC);
     pg_shmem_init!(LWLOCK);
+    #[cfg(feature = "cshim")]
+    pg_shmem_init!(SPINLOCK = PgSpinLock::new(0));
 }
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
@@ -26,12 +34,12 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
 
-    use super::LWLOCK;
     use pgrx::prelude::*;
 
     #[pg_test]
     #[should_panic(expected = "cache lookup failed for type 0")]
     pub fn test_behaves_normally_when_elog_while_holding_lock() {
+        use super::LWLOCK;
         // Hold lock
         let _lock = LWLOCK.exclusive();
         // Call into pg_guarded postgres function which internally reports an error
@@ -40,6 +48,7 @@ mod tests {
 
     #[pg_test]
     pub fn test_lock_is_released_on_drop() {
+        use super::LWLOCK;
         let lock = LWLOCK.exclusive();
         drop(lock);
         let _lock = LWLOCK.exclusive();
@@ -47,10 +56,23 @@ mod tests {
 
     #[pg_test]
     pub fn test_lock_is_released_on_unwind() {
+        use super::LWLOCK;
         let _res = std::panic::catch_unwind(|| {
             let _lock = LWLOCK.exclusive();
             panic!("get out")
         });
         let _lock = LWLOCK.exclusive();
+    }
+
+    #[cfg(feature = "cshim")]
+    #[pg_test]
+    pub fn test_spinlock() {
+        use super::SPINLOCK;
+        for i in 0..10 {
+            let mut lock = SPINLOCK.get().lock();
+            assert!(*lock == i);
+            *lock = i + 1;
+            drop(lock);
+        }
     }
 }

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -58,10 +58,8 @@ uuid = { version = "1.16.0", features = ["v4"] } # PgLwLock and shmem
 enum-map = "2.7.3"
 
 # exposed in public API
-atomic-traits = "0.4.0" # PgAtomic and shmem init
 bitflags = "2.9.0" # BackgroundWorker
 bitvec = "1.0" # processing array nullbitmaps
-heapless = "0.8" # shmem and PgLwLock
 libc.workspace = true # FFI type compat
 seahash = "4.1.0" # derive(PostgresHash)
 serde.workspace = true # impls on pub types

--- a/pgrx/src/atomics.rs
+++ b/pgrx/src/atomics.rs
@@ -7,43 +7,78 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-#![deny(unsafe_op_in_unsafe_fn)]
+
+use crate::{PGRXSharedMemory, PgSharedMemoryInitialization};
 use std::cell::UnsafeCell;
 use std::ffi::CStr;
 
 pub struct PgAtomic<T> {
     name: &'static CStr,
-    inner: UnsafeCell<*mut T>,
+    inner: UnsafeCell<*mut Shared<T>>,
 }
 
+unsafe impl<T: PGRXSharedMemory> Sync for PgAtomic<T> {}
+
 impl<T> PgAtomic<T> {
-    pub const fn new(name: &'static CStr) -> Self {
+    /// Create a pointer of an atomic that points to nothing.
+    ///
+    /// # Safety
+    ///
+    /// * Caller must be confident that there are no name conflicts.
+    pub const unsafe fn new(name: &'static CStr) -> Self {
         Self { name, inner: UnsafeCell::new(std::ptr::null_mut()) }
     }
 
-    pub fn name(&self) -> &'static CStr {
+    /// Get the name of the shared memory.
+    pub const fn name(&self) -> &'static CStr {
         self.name
     }
 }
 
-impl<T> PgAtomic<T>
-where
-    T: atomic_traits::Atomic + Default,
-{
-    /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    pub unsafe fn attach(&self, value: *mut T) {
-        unsafe {
-            *self.inner.get() = value;
-        }
-    }
-
+impl<T: PGRXSharedMemory> PgAtomic<T> {
+    /// Obtain the reference (which comes with `&T` access).
     pub fn get(&self) -> &T {
         unsafe {
             let shared = self.inner.get().read().as_ref().expect("PgAtomic was not initialized");
-            shared
+            &shared.data
         }
     }
 }
 
-unsafe impl<T> Send for PgAtomic<T> where T: atomic_traits::Atomic + Default {}
-unsafe impl<T> Sync for PgAtomic<T> where T: atomic_traits::Atomic + Default {}
+impl<T: PGRXSharedMemory> PgSharedMemoryInitialization for PgAtomic<T> {
+    type Value = T;
+
+    unsafe fn on_shmem_request(&'static self) {
+        unsafe {
+            crate::pg_sys::RequestAddinShmemSpace(size_of::<Shared<T>>());
+        }
+    }
+
+    unsafe fn on_shmem_startup(&'static self, value: T) {
+        unsafe {
+            use crate::pg_sys;
+
+            let shm_name = self.name;
+            let addin_shmem_init_lock = &raw mut (*pg_sys::MainLWLockArray.add(21)).lock;
+            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode::LW_EXCLUSIVE);
+
+            let mut found = false;
+            let fv_shmem =
+                pg_sys::ShmemInitStruct(shm_name.as_ptr(), size_of::<Shared<T>>(), &mut found)
+                    .cast::<Shared<T>>();
+            assert!(fv_shmem.is_aligned(), "shared memory is not aligned");
+            if !found {
+                fv_shmem.write(Shared { data: value });
+            }
+
+            *self.inner.get() = fv_shmem;
+
+            pg_sys::LWLockRelease(addin_shmem_init_lock);
+        }
+    }
+}
+
+#[repr(transparent)]
+struct Shared<T> {
+    data: T,
+}

--- a/pgrx/src/lwlock.rs
+++ b/pgrx/src/lwlock.rs
@@ -7,13 +7,13 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-#![allow(clippy::needless_borrow)]
-use crate::pg_sys;
+
+use crate::{PGRXSharedMemory, PgSharedMemoryInitialization};
 use core::ops::{Deref, DerefMut};
 use std::cell::UnsafeCell;
 use std::ffi::CStr;
 
-/// A Rust locking mechanism which uses a PostgreSQL LWLock to lock the data
+/// A Rust locking mechanism which uses a PostgreSQL LWLock to lock the data.
 ///
 /// This type of lock allows a number of readers or at most one writer at any
 /// point in time. The write portion of this lock typically allows modification
@@ -32,59 +32,96 @@ use std::ffi::CStr;
 /// PostgreSQL cleanly.
 pub struct PgLwLock<T> {
     name: &'static CStr,
-    inner: UnsafeCell<*mut PgLwLockShared<T>>,
+    inner: UnsafeCell<*mut Shared<T>>,
 }
 
-unsafe impl<T: Send> Send for PgLwLock<T> {}
-unsafe impl<T: Send + Sync> Sync for PgLwLock<T> {}
+unsafe impl<T: PGRXSharedMemory> Sync for PgLwLock<T> {}
 
 impl<T> PgLwLock<T> {
-    /// Create an empty lock which can be created as a global with None as a
-    /// sentinel value
-    pub const fn new(name: &'static CStr) -> Self {
-        PgLwLock { name, inner: UnsafeCell::new(std::ptr::null_mut()) }
+    /// Create a pointer of a lock that points to nothing.
+    ///
+    /// # Safety
+    ///
+    /// * Caller must be confident that there are no name conflicts.
+    pub const unsafe fn new(name: &'static CStr) -> Self {
+        Self { name, inner: UnsafeCell::new(std::ptr::null_mut()) }
     }
 
-    /// Get the name of the PgLwLock
-    pub fn name(&self) -> &'static CStr {
+    /// Get the name of the atomic.
+    pub const fn name(&self) -> &'static CStr {
         self.name
     }
+}
 
-    /// Obtain a shared lock (which comes with `&T` access)
+impl<T: PGRXSharedMemory> PgLwLock<T> {
+    /// Obtain a shared lock (which comes with `&T` access).
     pub fn share(&self) -> PgLwLockShareGuard<'_, T> {
         unsafe {
             let shared = self.inner.get().read().as_ref().expect("PgLwLock was not initialized");
-            pg_sys::LWLockAcquire(shared.lock_ptr, pg_sys::LWLockMode::LW_SHARED);
-            PgLwLockShareGuard { data: &*shared.data.get(), lock: shared.lock_ptr }
+            crate::pg_sys::LWLockAcquire(shared.lock, crate::pg_sys::LWLockMode::LW_SHARED);
+            PgLwLockShareGuard { data: &*shared.data.get(), lock: shared.lock }
         }
     }
 
-    /// Obtain an exclusive lock (which comes with `&mut T` access)
+    /// Obtain an exclusive lock (which comes with `&mut T` access).
     pub fn exclusive(&self) -> PgLwLockExclusiveGuard<'_, T> {
         unsafe {
             let shared = self.inner.get().read().as_ref().expect("PgLwLock was not initialized");
-            pg_sys::LWLockAcquire(shared.lock_ptr, pg_sys::LWLockMode::LW_EXCLUSIVE);
-            PgLwLockExclusiveGuard { data: &mut *shared.data.get(), lock: shared.lock_ptr }
+            crate::pg_sys::LWLockAcquire(shared.lock, crate::pg_sys::LWLockMode::LW_EXCLUSIVE);
+            PgLwLockExclusiveGuard { data: &mut *shared.data.get(), lock: shared.lock }
+        }
+    }
+}
+
+impl<T: PGRXSharedMemory> PgSharedMemoryInitialization for PgLwLock<T> {
+    type Value = T;
+
+    unsafe fn on_shmem_request(&'static self) {
+        unsafe {
+            crate::pg_sys::RequestAddinShmemSpace(size_of::<Shared<T>>());
+            crate::pg_sys::RequestNamedLWLockTranche(self.name.as_ptr(), 1);
         }
     }
 
-    /// Attach an empty PgLwLock lock to a LWLock, and wrap T
-    /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    pub unsafe fn attach(&self, value: *mut PgLwLockShared<T>) {
-        *self.inner.get() = value;
+    unsafe fn on_shmem_startup(&'static self, value: T) {
+        unsafe {
+            use crate::pg_sys;
+
+            let shm_name = self.name;
+            let addin_shmem_init_lock = &raw mut (*pg_sys::MainLWLockArray.add(21)).lock;
+            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode::LW_EXCLUSIVE);
+
+            let mut found = false;
+            let fv_shmem =
+                pg_sys::ShmemInitStruct(shm_name.as_ptr(), size_of::<Shared<T>>(), &mut found)
+                    .cast::<Shared<T>>();
+            assert!(fv_shmem.is_aligned(), "shared memory is not aligned");
+            if !found {
+                fv_shmem.write(Shared {
+                    data: UnsafeCell::new(value),
+                    lock: &raw mut (*pg_sys::GetNamedLWLockTranche(shm_name.as_ptr())).lock,
+                });
+            }
+
+            *self.inner.get() = fv_shmem;
+
+            pg_sys::LWLockRelease(addin_shmem_init_lock);
+        }
     }
 }
 
 #[repr(C)]
-pub struct PgLwLockShared<T> {
-    pub data: UnsafeCell<T>,
-    pub lock_ptr: *mut pg_sys::LWLock,
+struct Shared<T> {
+    data: UnsafeCell<T>,
+    lock: *mut crate::pg_sys::LWLock,
 }
 
 pub struct PgLwLockShareGuard<'a, T> {
     data: &'a T,
-    lock: *mut pg_sys::LWLock,
+    lock: *mut crate::pg_sys::LWLock,
 }
+
+unsafe impl<T: PGRXSharedMemory> Sync for PgLwLockShareGuard<'_, T> {}
 
 impl<T> Drop for PgLwLockShareGuard<'_, T> {
     fn drop(&mut self) {
@@ -96,27 +133,32 @@ impl<T> Drop for PgLwLockShareGuard<'_, T> {
 impl<T> Deref for PgLwLockShareGuard<'_, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &T {
-        &self.data
+        self.data
     }
 }
 
 pub struct PgLwLockExclusiveGuard<'a, T> {
     data: &'a mut T,
-    lock: *mut pg_sys::LWLock,
+    lock: *mut crate::pg_sys::LWLock,
 }
+
+unsafe impl<T: PGRXSharedMemory> Sync for PgLwLockExclusiveGuard<'_, T> {}
 
 impl<T> Deref for PgLwLockExclusiveGuard<'_, T> {
     type Target = T;
 
+    #[inline]
     fn deref(&self) -> &T {
-        &self.data
+        self.data
     }
 }
 
 impl<T> DerefMut for PgLwLockExclusiveGuard<'_, T> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        &mut self.data
+        self.data
     }
 }
 
@@ -135,9 +177,9 @@ impl<T> Drop for PgLwLockExclusiveGuard<'_, T> {
 /// on (sub)transaction abort anyway.
 ///
 /// SAFETY: the given lock must be valid
-unsafe fn release_unless_elog_unwinding(lock: *mut pg_sys::LWLock) {
+unsafe fn release_unless_elog_unwinding(lock: *mut crate::pg_sys::LWLock) {
     // SAFETY: mut static access is ok from a single (main) thread.
-    if pg_sys::InterruptHoldoffCount > 0 {
-        pg_sys::LWLockRelease(lock);
+    if crate::pg_sys::InterruptHoldoffCount > 0 {
+        crate::pg_sys::LWLockRelease(lock);
     }
 }

--- a/pgrx/src/shmem.rs
+++ b/pgrx/src/shmem.rs
@@ -65,7 +65,7 @@ macro_rules! pg_shmem_init {
             unsafe extern "C-unwind" fn on_shmem_request() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_REQUEST_HOOK {
-                        i();
+                        ::pgrx::pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| i());
                     }
                     $crate::shmem::PgSharedMemoryInitialization::on_shmem_request(&$var);
                 }
@@ -81,7 +81,7 @@ macro_rules! pg_shmem_init {
             unsafe extern "C-unwind" fn on_shmem_startup() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_STARTUP_HOOK {
-                        i();
+                        ::pgrx::pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| i());
                     }
                     $crate::shmem::PgSharedMemoryInitialization::on_shmem_startup(&$var, $e);
                 }

--- a/pgrx/src/shmem.rs
+++ b/pgrx/src/shmem.rs
@@ -65,8 +65,10 @@ macro_rules! pg_shmem_init {
             unsafe extern "C-unwind" fn on_shmem_request() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_REQUEST_HOOK {
-                        ::pgrx::pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| i());
+                        $crate::pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| i());
                     }
+                }
+                unsafe {
                     $crate::shmem::PgSharedMemoryInitialization::on_shmem_request(&$var);
                 }
             }
@@ -78,12 +80,16 @@ macro_rules! pg_shmem_init {
             pg_sys::shmem_startup_hook = Some(on_shmem_startup);
 
             #[pg_guard]
+            #[forbid(unsafe_op_in_unsafe_fn)]
             unsafe extern "C-unwind" fn on_shmem_startup() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_STARTUP_HOOK {
-                        ::pgrx::pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| i());
+                        $crate::pg_sys::submodules::ffi::pg_guard_ffi_boundary(|| i());
                     }
-                    $crate::shmem::PgSharedMemoryInitialization::on_shmem_startup(&$var, $e);
+                }
+                let value = $e;
+                unsafe {
+                    $crate::shmem::PgSharedMemoryInitialization::on_shmem_startup(&$var, value);
                 }
             }
         }
@@ -193,3 +199,31 @@ pub trait PgSharedMemoryInitialization {
     /// * Be called from inside PostgreSQL `shmem_startup_hook`.
     unsafe fn on_shmem_startup(&'static self, value: Self::Value);
 }
+
+#[repr(transparent)]
+pub struct AssertPGRXSharedMemory<T>(T);
+
+impl<T> AssertPGRXSharedMemory<T> {
+    pub const unsafe fn new(value: T) -> Self {
+        Self(value)
+    }
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> std::ops::Deref for AssertPGRXSharedMemory<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for AssertPGRXSharedMemory<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+unsafe impl<T> PGRXSharedMemory for AssertPGRXSharedMemory<T> {}

--- a/pgrx/src/shmem.rs
+++ b/pgrx/src/shmem.rs
@@ -7,14 +7,6 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-#![deny(unsafe_op_in_unsafe_fn)]
-use crate::lwlock::*;
-use crate::{pg_sys, PgAtomic};
-use std::cell::UnsafeCell;
-use std::hash::Hash;
-
-/// Custom types that want to participate in shared memory must implement this marker trait
-pub unsafe trait PGRXSharedMemory {}
 
 /// In order to store a type in Postgres Shared Memory, it must be passed to
 /// `pg_shmem_init!()` during `_PG_init()`.
@@ -29,19 +21,20 @@ pub unsafe trait PGRXSharedMemory {}
 /// Custom types need to also implement the `PGRXSharedMemory` trait.
 ///
 /// > Extensions that use shared memory **must** be loaded via `postgresql.conf`'s
-/// > `shared_preload_libraries` configuration setting.  
+/// > `shared_preload_libraries` configuration setting.
 ///
 /// # Example
 ///
 /// ```rust,no_run
 /// use pgrx::prelude::*;
 /// use pgrx::{PgAtomic, PgLwLock, pg_shmem_init, PgSharedMemoryInitialization};
+/// use std::sync::atomic::AtomicBool;
 ///
-/// // primitive types must be protected behind a `PgLwLock`
-/// static PRIMITIVE: PgLwLock<i32> = PgLwLock::new(c"primitive");
+/// // Primitive types must be protected behind a `PgLwLock`.
+/// static PRIMITIVE: PgLwLock<i32> = unsafe { PgLwLock::new(c"primitive") };
 ///
-/// // Rust atomics can be used without locks, wrapped in a `PgAtomic`
-/// static ATOMIC: PgAtomic<std::sync::atomic::AtomicBool> = PgAtomic::new(c"atomic");
+/// // Rust atomics can be used without locks, wrapped in a `PgAtomic`.
+/// static ATOMIC: PgAtomic<AtomicBool> = unsafe { PgAtomic::new(c"atomic") };
 ///
 /// #[pg_guard]
 /// pub extern "C-unwind" fn _PG_init() {
@@ -49,46 +42,32 @@ pub unsafe trait PGRXSharedMemory {}
 ///     pg_shmem_init!(ATOMIC);
 /// }
 /// ```
-#[cfg(not(any(feature = "pg15", feature = "pg16", feature = "pg17", feature = "pg18")))]
 #[macro_export]
 macro_rules! pg_shmem_init {
-    ($thing:expr) => {
-        $thing.pg_init();
-
-        unsafe {
-            static mut PREV_SHMEM_STARTUP_HOOK: Option<unsafe extern "C-unwind" fn()> = None;
-            PREV_SHMEM_STARTUP_HOOK = pg_sys::shmem_startup_hook;
-            pg_sys::shmem_startup_hook = Some(__pgrx_private_shmem_hook);
-
-            #[pg_guard]
-            extern "C-unwind" fn __pgrx_private_shmem_hook() {
-                unsafe {
-                    if let Some(i) = PREV_SHMEM_STARTUP_HOOK {
-                        i();
-                    }
-                    $thing.shmem_init();
-                }
-            }
-        }
+    ($var:ident) => {
+        $crate::pg_shmem_init!($var = Default::default())
     };
-}
+    ($var:ident = $e:expr) => {
+        $crate::pg_sys::submodules::thread_check::check_active_thread();
 
-#[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17", feature = "pg18"))]
-#[macro_export]
-macro_rules! pg_shmem_init {
-    ($thing:expr) => {
+        #[cfg(any(feature = "pg13", feature = "pg14"))]
+        unsafe {
+            $crate::shmem::PgSharedMemoryInitialization::on_shmem_request(&$var);
+        }
+
+        #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17", feature = "pg18"))]
         unsafe {
             static mut PREV_SHMEM_REQUEST_HOOK: Option<unsafe extern "C-unwind" fn()> = None;
             PREV_SHMEM_REQUEST_HOOK = pg_sys::shmem_request_hook;
-            pg_sys::shmem_request_hook = Some(__pgrx_private_shmem_request_hook);
+            pg_sys::shmem_request_hook = Some(on_shmem_request);
 
             #[pg_guard]
-            extern "C-unwind" fn __pgrx_private_shmem_request_hook() {
+            unsafe extern "C-unwind" fn on_shmem_request() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_REQUEST_HOOK {
                         i();
                     }
-                    $thing.pg_init();
+                    $crate::shmem::PgSharedMemoryInitialization::on_shmem_request(&$var);
                 }
             }
         }
@@ -96,185 +75,121 @@ macro_rules! pg_shmem_init {
         unsafe {
             static mut PREV_SHMEM_STARTUP_HOOK: Option<unsafe extern "C-unwind" fn()> = None;
             PREV_SHMEM_STARTUP_HOOK = pg_sys::shmem_startup_hook;
-            pg_sys::shmem_startup_hook = Some(__pgrx_private_shmem_hook);
+            pg_sys::shmem_startup_hook = Some(on_shmem_startup);
 
             #[pg_guard]
-            extern "C-unwind" fn __pgrx_private_shmem_hook() {
+            unsafe extern "C-unwind" fn on_shmem_startup() {
                 unsafe {
                     if let Some(i) = PREV_SHMEM_STARTUP_HOOK {
                         i();
                     }
-                    $thing.shmem_init();
+                    $crate::shmem::PgSharedMemoryInitialization::on_shmem_startup(&$var, $e);
                 }
             }
         }
     };
 }
 
-/// A trait that types can implement to provide their own Postgres Shared Memory initialization process
-pub trait PgSharedMemoryInitialization {
-    /// Automatically called when the an extension is loaded.  If using the `pg_shmem_init!()` macro
-    /// in `_PG_init()`, this is called automatically
-    fn pg_init(&'static self);
-
-    /// Automatically called by the `pg_shmem_init!()` macro, when Postgres is initializing its
-    /// shared memory system
-    /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    unsafe fn shmem_init(&'static self);
-}
-
-impl<T> PgSharedMemoryInitialization for PgLwLock<T>
-where
-    T: Default + PGRXSharedMemory + 'static,
-{
-    fn pg_init(&'static self) {
-        PgSharedMem::pg_init_locked(self);
-    }
-
-    /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    unsafe fn shmem_init(&'static self) {
-        unsafe {
-            PgSharedMem::shmem_init_locked(self);
-        }
-    }
-}
-
-impl<T> PgSharedMemoryInitialization for PgAtomic<T>
-where
-    T: atomic_traits::Atomic + Default,
-{
-    fn pg_init(&'static self) {
-        PgSharedMem::pg_init_atomic(self);
-    }
-
-    /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    unsafe fn shmem_init(&'static self) {
-        unsafe {
-            PgSharedMem::shmem_init_atomic(self);
-        }
-    }
-}
-
-/// This struct contains methods to drive creation of types in shared memory
-pub struct PgSharedMem {}
-
-impl PgSharedMem {
-    /// Must be run from PG_init, use for types which are guarded by a LWLock
-    pub fn pg_init_locked<T: Default + PGRXSharedMemory>(lock: &PgLwLock<T>) {
-        unsafe {
-            pg_sys::RequestAddinShmemSpace(std::mem::size_of::<PgLwLockShared<T>>());
-            pg_sys::RequestNamedLWLockTranche(lock.name().as_ptr(), 1);
-        }
-    }
-
-    /// Must be run from _PG_init for atomics
-    pub fn pg_init_atomic<T: atomic_traits::Atomic + Default>(_atomic: &PgAtomic<T>) {
-        unsafe {
-            pg_sys::RequestAddinShmemSpace(std::mem::size_of::<T>());
-        }
-    }
-
-    /// Must be run from the shared memory init hook, use for types which are guarded by a `LWLock`
-    /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    pub unsafe fn shmem_init_locked<T: Default + PGRXSharedMemory>(lock: &PgLwLock<T>) {
-        unsafe {
-            let shm_name = lock.name();
-            let addin_shmem_init_lock = &raw mut (*pg_sys::MainLWLockArray.add(21)).lock;
-            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode::LW_EXCLUSIVE);
-
-            let mut found = false;
-            let fv_shmem = pg_sys::ShmemInitStruct(
-                shm_name.as_ptr(),
-                std::mem::size_of::<PgLwLockShared<T>>(),
-                &mut found,
-            )
-            .cast::<PgLwLockShared<T>>();
-            if !found {
-                fv_shmem.write(PgLwLockShared {
-                    data: UnsafeCell::new(T::default()),
-                    lock_ptr: &raw mut (*pg_sys::GetNamedLWLockTranche(shm_name.as_ptr())).lock,
-                });
-            }
-
-            lock.attach(fv_shmem);
-            pg_sys::LWLockRelease(addin_shmem_init_lock);
-        }
-    }
-
-    /// Must be run from the shared memory init hook, use for rust atomics behind `PgAtomic`
-    /// SAFETY: Must only be called from inside the Postgres shared memory init hook
-    pub unsafe fn shmem_init_atomic<T: atomic_traits::Atomic + Default>(atomic: &PgAtomic<T>) {
-        unsafe {
-            let shm_name = atomic.name();
-            let addin_shmem_init_lock = &raw mut (*pg_sys::MainLWLockArray.add(21)).lock;
-            pg_sys::LWLockAcquire(addin_shmem_init_lock, pg_sys::LWLockMode::LW_EXCLUSIVE);
-
-            let mut found = false;
-            let fv_shmem =
-                pg_sys::ShmemInitStruct(shm_name.as_ptr(), std::mem::size_of::<T>(), &mut found)
-                    .cast::<T>();
-            if !found {
-                fv_shmem.write(T::default());
-            }
-
-            atomic.attach(fv_shmem);
-            pg_sys::LWLockRelease(addin_shmem_init_lock);
-        }
-    }
-}
+/// Types for which it is safe to transfer and share references between PostgreSQL processes.
+pub unsafe trait PGRXSharedMemory {}
 
 unsafe impl PGRXSharedMemory for bool {}
-unsafe impl PGRXSharedMemory for char {}
-unsafe impl PGRXSharedMemory for str {}
-unsafe impl PGRXSharedMemory for () {}
+
 unsafe impl PGRXSharedMemory for i8 {}
-unsafe impl PGRXSharedMemory for i16 {}
-unsafe impl PGRXSharedMemory for i32 {}
-unsafe impl PGRXSharedMemory for i64 {}
-unsafe impl PGRXSharedMemory for i128 {}
+
 unsafe impl PGRXSharedMemory for u8 {}
+
+unsafe impl PGRXSharedMemory for i16 {}
+
 unsafe impl PGRXSharedMemory for u16 {}
+
+unsafe impl PGRXSharedMemory for i32 {}
+
 unsafe impl PGRXSharedMemory for u32 {}
+
+unsafe impl PGRXSharedMemory for i64 {}
+
 unsafe impl PGRXSharedMemory for u64 {}
+
+unsafe impl PGRXSharedMemory for i128 {}
+
 unsafe impl PGRXSharedMemory for u128 {}
-unsafe impl PGRXSharedMemory for usize {}
+
 unsafe impl PGRXSharedMemory for isize {}
+
+unsafe impl PGRXSharedMemory for usize {}
+
+#[cfg(target_has_atomic = "8")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicBool {}
+
+#[cfg(target_has_atomic = "8")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicI8 {}
+
+#[cfg(target_has_atomic = "8")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicU8 {}
+
+#[cfg(target_has_atomic = "16")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicI16 {}
+
+#[cfg(target_has_atomic = "16")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicU16 {}
+
+#[cfg(target_has_atomic = "32")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicI32 {}
+
+#[cfg(target_has_atomic = "32")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicU32 {}
+
+#[cfg(target_has_atomic = "64")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicI64 {}
+
+#[cfg(target_has_atomic = "64")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicU64 {}
+
+#[cfg(target_has_atomic = "ptr")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicIsize {}
+
+#[cfg(target_has_atomic = "ptr")]
+unsafe impl PGRXSharedMemory for std::sync::atomic::AtomicUsize {}
+
+unsafe impl PGRXSharedMemory for char {}
+
 unsafe impl PGRXSharedMemory for f32 {}
+
 unsafe impl PGRXSharedMemory for f64 {}
-unsafe impl<T> PGRXSharedMemory for [T] where T: PGRXSharedMemory + Default {}
-unsafe impl<A, B> PGRXSharedMemory for (A, B)
-where
-    A: PGRXSharedMemory + Default,
-    B: PGRXSharedMemory + Default,
-{
+
+unsafe impl PGRXSharedMemory for str {}
+
+unsafe impl<T: PGRXSharedMemory> PGRXSharedMemory for [T] {}
+
+unsafe impl<const N: usize, T: PGRXSharedMemory> PGRXSharedMemory for [T; N] {}
+
+macro_rules! impl_pg_sync_for_tuple {
+    ($($t:ident),*) => {
+        unsafe impl<$($t,)*> PGRXSharedMemory for ($($t,)*) where $($t: PGRXSharedMemory,)* {}
+    };
 }
-unsafe impl<A, B, C> PGRXSharedMemory for (A, B, C)
-where
-    A: PGRXSharedMemory + Default,
-    B: PGRXSharedMemory + Default,
-    C: PGRXSharedMemory + Default,
-{
-}
-unsafe impl<A, B, C, D> PGRXSharedMemory for (A, B, C, D)
-where
-    A: PGRXSharedMemory + Default,
-    B: PGRXSharedMemory + Default,
-    C: PGRXSharedMemory + Default,
-    D: PGRXSharedMemory + Default,
-{
-}
-unsafe impl<A, B, C, D, E> PGRXSharedMemory for (A, B, C, D, E)
-where
-    A: PGRXSharedMemory + Default,
-    B: PGRXSharedMemory + Default,
-    C: PGRXSharedMemory + Default,
-    D: PGRXSharedMemory + Default,
-    E: PGRXSharedMemory + Default,
-{
-}
-unsafe impl<T, const N: usize> PGRXSharedMemory for heapless::Vec<T, N> {}
-unsafe impl<T, const N: usize> PGRXSharedMemory for heapless::Deque<T, N> {}
-unsafe impl<K: Eq + Hash, V: Default, S, const N: usize> PGRXSharedMemory
-    for heapless::IndexMap<K, V, S, N>
-{
+
+impl_pg_sync_for_tuple!();
+impl_pg_sync_for_tuple!(A);
+impl_pg_sync_for_tuple!(A, B);
+impl_pg_sync_for_tuple!(A, B, C);
+impl_pg_sync_for_tuple!(A, B, C, D);
+impl_pg_sync_for_tuple!(A, B, C, D, E);
+impl_pg_sync_for_tuple!(A, B, C, D, E, F);
+
+/// A trait that types can implement to provide their own Postgres Shared Memory initialization process.
+pub trait PgSharedMemoryInitialization {
+    type Value: PGRXSharedMemory;
+
+    /// # Safety
+    ///
+    /// * Be called from inside PostgreSQL `shmem_request_hook`.
+    /// * For PostgreSQL 13, 14, it could be called at any time.
+    unsafe fn on_shmem_request(&'static self);
+
+    /// # Safety
+    ///
+    /// * Be called from inside PostgreSQL `shmem_startup_hook`.
+    unsafe fn on_shmem_startup(&'static self, value: Self::Value);
 }

--- a/pgrx/src/spinlock.rs
+++ b/pgrx/src/spinlock.rs
@@ -7,9 +7,11 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use crate::pg_sys;
+
+use crate::{pg_sys, PGRXSharedMemory};
 use core::mem::MaybeUninit;
-use std::{cell::UnsafeCell, marker::PhantomData};
+use core::ops::{Deref, DerefMut};
+use std::cell::UnsafeCell;
 
 /// A Rust locking mechanism which uses a PostgreSQL `slock_t` to lock the data.
 ///
@@ -29,18 +31,17 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 ///     https://github.com/postgres/postgres/blob/1f0c4fa255253d223447c2383ad2b384a6f05854/src/include/storage/spin.h
 #[doc(alias = "slock_t")]
 pub struct PgSpinLock<T> {
-    item: UnsafeCell<T>,
+    data: UnsafeCell<T>,
     lock: UnsafeCell<pg_sys::slock_t>,
 }
 
-// `PgSpinLock` is basically a `Mutex`, so we just need `T` to be `Send` to get
-// `Send` and `Sync`.
-unsafe impl<T: Send> Send for PgSpinLock<T> {}
-unsafe impl<T: Send> Sync for PgSpinLock<T> {}
+unsafe impl<T: PGRXSharedMemory> Sync for PgSpinLock<T> {}
+unsafe impl<T: PGRXSharedMemory> PGRXSharedMemory for PgSpinLock<T> {}
 
 impl<T> PgSpinLock<T> {
     /// Create a new [`PgSpinLock`]. See the type documentation for more info.
     #[inline]
+    #[doc(alias = "SpinLockInit")]
     pub fn new(value: T) -> Self {
         let mut slock = MaybeUninit::zeroed();
         // Safety: We initialize the `slock_t` before use (and it was likely
@@ -48,10 +49,12 @@ impl<T> PgSpinLock<T> {
         // it's probably a primitive integer).
         unsafe {
             pg_sys::SpinLockInit(slock.as_mut_ptr());
-            Self { item: UnsafeCell::new(value), lock: UnsafeCell::new(slock.assume_init()) }
+            Self { data: UnsafeCell::new(value), lock: UnsafeCell::new(slock.assume_init()) }
         }
     }
+}
 
+impl<T: PGRXSharedMemory> PgSpinLock<T> {
     /// Returns true if the spinlock is locked, and false otherwise.
     #[inline]
     #[doc(alias = "SpinLockFree")]
@@ -65,8 +68,10 @@ impl<T> PgSpinLock<T> {
     #[inline]
     #[doc(alias = "SpinLockAcquire")]
     pub fn lock(&self) -> PgSpinLockGuard<'_, T> {
-        unsafe { pg_sys::SpinLockAcquire(self.lock.get()) };
-        PgSpinLockGuard { lock: self, _marker: PhantomData }
+        unsafe {
+            pg_sys::SpinLockAcquire(self.lock.get());
+            PgSpinLockGuard { data: &mut *self.data.get(), lock: self.lock.get() }
+        }
     }
 }
 
@@ -75,33 +80,32 @@ impl<T> PgSpinLock<T> {
 ///
 /// See the documentation of [`PgSpinLock`] for more information.
 pub struct PgSpinLockGuard<'a, T: 'a> {
-    lock: &'a PgSpinLock<T>,
-    // For !Send, variance, etc.
-    _marker: PhantomData<*mut T>,
+    data: &'a mut T,
+    lock: *mut pg_sys::slock_t,
 }
 
-unsafe impl<T: Sync> Sync for PgSpinLockGuard<'_, T> {}
+unsafe impl<T: PGRXSharedMemory> Sync for PgSpinLockGuard<'_, T> {}
 
 impl<T> Drop for PgSpinLockGuard<'_, T> {
     #[inline]
+    #[doc(alias = "SpinLockRelease")]
     fn drop(&mut self) {
-        unsafe { pg_sys::SpinLockRelease(self.lock.lock.get()) };
+        unsafe { pg_sys::SpinLockRelease(self.lock) };
     }
 }
 
-impl<T> core::ops::Deref for PgSpinLockGuard<'_, T> {
+impl<T> Deref for PgSpinLockGuard<'_, T> {
     type Target = T;
+
     #[inline]
     fn deref(&self) -> &T {
-        // Safety: The guard's existence enforces that the lock is locked.
-        unsafe { &*self.lock.item.get() }
+        self.data
     }
 }
 
-impl<T> core::ops::DerefMut for PgSpinLockGuard<'_, T> {
+impl<T> DerefMut for PgSpinLockGuard<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        // Safety: The guard's existence enforces that the lock is locked.
-        unsafe { &mut *self.lock.item.get() }
+        self.data
     }
 }


### PR DESCRIPTION
closes #2106

1. `heapless` is removed due to unsoundness
2. `atomic_traits` is removed due to unsoundness
3. `PgAtomic::new` and `PgLwLock::new` is marked unsafe; caller must be confident that there are no name conflicts (including `pg_shmem_init` is called for a variable twice)
4. `unsafe impl<T: PGRXSharedMemory> PGRXSharedMemory for PgSpinLock<T> {}`, in order to allow it work on shared memory
5. `pg_shmem_init!(ATOMIC = AtomicUsize::new(0));` is allowed now
6. checks if the pointer to the allocated shared memory is properly aligned

It breaks api.