### PR TITLE
fix name_data_to_str

### DIFF
--- a/pgrx-pg-sys/src/submodules/utils.rs
+++ b/pgrx-pg-sys/src/submodules/utils.rs
@@ -10,11 +10,15 @@
 //! General utility functions
 use crate as pg_sys;
 
-/// Converts a `pg_sys::NameData` struct into a `&str`.  
+/// Converts a `pg_sys::NameData` struct into a `&str`.
 ///
 /// This is a zero-copy operation and the returned `&str` is tied to the lifetime
 /// of the provided `pg_sys::NameData`
 #[inline]
 pub fn name_data_to_str(name_data: &pg_sys::NameData) -> &str {
-    unsafe { core::ffi::CStr::from_ptr(name_data.data.as_ptr()) }.to_str().unwrap()
+    fn transmute<const N: usize>(x: &[core::ffi::c_char; N]) -> &[core::ffi::c_uchar; N] {
+        unsafe { std::mem::transmute(x) }
+    }
+
+    core::ffi::CStr::from_bytes_until_nul(transmute(&name_data.data)).unwrap().to_str().unwrap()
 }


### PR DESCRIPTION
`nameData.data` is not a private field, so in this example

```rust
name_data_to_str(&NameData { data: [1; _] })
```

Miri reports UB.

Here `CStr::from_bytes_until_nul` is used to replace `CStr::from_ptr`.