### PR TITLE
Include libpq/libpq-be.h

### DIFF
--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -49,6 +49,7 @@ jobs:
             build-essential \
             llvm-14-dev libclang-14-dev clang-14 \
             gcc \
+            libkrb5-dev \
             libssl-dev \
             libz-dev \
             make \
@@ -85,6 +86,9 @@ jobs:
         run: |
           cargo --version
           pg_config --version
+
+      - name: pg_config details
+        run: pg_config
 
       - name: Install cargo pgrx
         run: cd cargo-pgrx && cargo install --path . --debug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,6 +142,7 @@ jobs:
             build-essential \
             llvm-14-dev libclang-14-dev clang-14 \
             gcc \
+            libkrb5-dev \
             libssl-dev \
             libz-dev \
             make \

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -95,6 +95,7 @@
 #include "foreign/foreign.h"
 #include "jit/jit.h"
 #include "lib/stringinfo.h"
+#include "libpq/libpq-be.h"
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -95,6 +95,7 @@
 #include "foreign/foreign.h"
 #include "jit/jit.h"
 #include "lib/stringinfo.h"
+#include "libpq/libpq-be.h"
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -96,6 +96,7 @@
 #include "foreign/foreign.h"
 #include "jit/jit.h"
 #include "lib/stringinfo.h"
+#include "libpq/libpq-be.h"
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -97,6 +97,7 @@
 #include "foreign/foreign.h"
 #include "jit/jit.h"
 #include "lib/stringinfo.h"
+#include "libpq/libpq-be.h"
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -97,6 +97,7 @@
 #include "foreign/foreign.h"
 #include "jit/jit.h"
 #include "lib/stringinfo.h"
+#include "libpq/libpq-be.h"
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -96,6 +96,7 @@
 #include "foreign/foreign.h"
 #include "jit/jit.h"
 #include "lib/stringinfo.h"
+#include "libpq/libpq-be.h"
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"

--- a/pgrx-pg-sys/src/lib.rs
+++ b/pgrx-pg-sys/src/lib.rs
@@ -45,3 +45,12 @@ mod seal {
 #[cfg(target_os = "linux")]
 #[link(name = "resolv")]
 unsafe extern "C" {}
+
+// Link to the builtin crypto libraries on Windows.
+// This is necessary only when Postgres is built --with-openssl, but what Windows distribution isn't?
+//
+// See: https://github.com/postgres/postgres/blob/REL_17_0/meson.build#L1321
+#[cfg(target_os = "windows")]
+#[link(name = "ssl")]
+#[link(name = "crypto")]
+unsafe extern "C" {}


### PR DESCRIPTION
I want to read `database_name` and `user_name` from `MyProcPort`. These fields inform the [`%u` and `%d`  escapes](https://github.com/postgres/postgres/blob/REL_17_0/src/backend/utils/error/elog.c#L2910-L2941) of [log_line_prefix](https://www.postgresql.org/docs/17/runtime-config-logging.html#GUC-LOG-LINE-PREFIX). Without this, the binding for Port is:

```rust
pub struct Port {
    _unused: [u8; 0],
}
```