### PR TITLE
add pg_guard_ffi_boundary to direct_pg_extern_function_call_as_datum

### DIFF
--- a/pgrx-tests/src/tests/fcinfo_tests.rs
+++ b/pgrx-tests/src/tests/fcinfo_tests.rs
@@ -83,6 +83,11 @@ fn returns_none() -> Option<i32> {
 }
 
 #[pg_extern]
+fn panics() -> Option<i32> {
+    panic!("an error message")
+}
+
+#[pg_extern]
 fn returns_null() -> Nullable<i32> {
     Nullable::Null
 }
@@ -306,6 +311,14 @@ mod tests {
     unsafe fn test_returns_none() {
         let result = direct_pg_extern_function_call::<i32>(super::returns_none_wrapper, &[]);
         assert!(result.is_none())
+    }
+
+    #[pg_test]
+    unsafe fn test_panics() {
+        let r = std::panic::catch_unwind(|| {
+            direct_pg_extern_function_call::<i32>(super::panics_wrapper, &[])
+        });
+        assert!(r.is_err());
     }
 
     #[pg_test]

--- a/pgrx/src/fcinfo.rs
+++ b/pgrx/src/fcinfo.rs
@@ -14,6 +14,7 @@
 
 use crate::{pg_sys, void_mut_ptr, FromDatum, PgBox, PgMemoryContexts};
 use core::{ptr, slice};
+use pgrx_pg_sys::ffi::pg_guard_ffi_boundary;
 
 /// A macro for specifying default argument values so they get properly translated to SQL in
 /// `CREATE FUNCTION` statements
@@ -379,7 +380,7 @@ pub unsafe fn direct_pg_extern_function_call_as_datum(
     func: unsafe extern "C-unwind" fn(pg_sys::FunctionCallInfo) -> pg_sys::Datum,
     args: &[Option<pg_sys::Datum>],
 ) -> Option<pg_sys::Datum> {
-    direct_function_call_as_datum_internal(|fcinfo| func(fcinfo), args)
+    direct_function_call_as_datum_internal(|fcinfo| pg_guard_ffi_boundary(|| func(fcinfo)), args)
 }
 
 #[inline]


### PR DESCRIPTION
Theoretically, this results in undefined behavior when an error occurs, but in practice, it only leads to resource leaks.

This bug is caught through `#[deny(ffi_unwind_calls)]`. During this process, I found that the `pgrx::hooks` also lack proper `pg_guard_ffi_boundary`. However, since they are already deprecated, we should remove them instead of fixing them.