### PR TITLE
teach `#[pg_cast]` to support 3-argument CAST functions

### DIFF
--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -482,20 +482,6 @@ impl ToSql for PgExternEntity {
                 }
                 Err(err) => return Err(err.into()),
             };
-            if self.metadata.arguments.len() != 1 {
-                return Err(eyre!(
-                    "PG cast function ({}) must have exactly one argument, got {}",
-                    self.name,
-                    self.metadata.arguments.len()
-                ));
-            }
-            if self.fn_args.len() != 1 {
-                return Err(eyre!(
-                    "PG cast function ({}) must have exactly one argument, got {}",
-                    self.name,
-                    self.fn_args.len()
-                ));
-            }
             let source_arg = self
                 .metadata
                 .arguments

--- a/pgrx-tests/src/tests/pg_cast_tests.rs
+++ b/pgrx-tests/src/tests/pg_cast_tests.rs
@@ -38,6 +38,18 @@ mod pg_catalog {
         // look, it's just a test, okay?
         true
     }
+
+    // there is a 3-arg version of CAST functions that pass through the user-provided "type modifier"
+    // and if it's an explicit cast or not.  This function itself is enough to test that we can generate
+    // the proper code for the function
+    #[pg_cast]
+    fn testcasttype_to_testcasttype(
+        i: TestCastType,
+        _typmod: i32,
+        _is_explicit: bool,
+    ) -> TestCastType {
+        i
+    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]


### PR DESCRIPTION
CAST functions can have 1 argument or 3 arguments where the latter is the source type plus the type modifier ("typmod") and explicit context for the destination type.

This changes `#[pg_cast]` to blindly support any number of arguments on the function to which it's attached and then Postgres will sort it out during DDL playback.