### PR TITLE
teach `#[pg_extern]` about a SUPPORT function

### DIFF
--- a/pgrx-sql-entity-graph/src/extern_args.rs
+++ b/pgrx-sql-entity-graph/src/extern_args.rs
@@ -28,6 +28,7 @@ pub enum ExternArgs {
     ParallelRestricted,
     ShouldPanic(String),
     Schema(String),
+    Support(PositioningRef),
     Name(String),
     Cost(String),
     Requires(Vec<PositioningRef>),
@@ -47,6 +48,7 @@ impl core::fmt::Display for ExternArgs {
             ExternArgs::SecurityDefiner => write!(f, "SECURITY DEFINER"),
             ExternArgs::SecurityInvoker => write!(f, "SECURITY INVOKER"),
             ExternArgs::ParallelRestricted => write!(f, "PARALLEL RESTRICTED"),
+            ExternArgs::Support(item) => write!(f, "{item}"),
             ExternArgs::ShouldPanic(_) => Ok(()),
             ExternArgs::NoGuard => Ok(()),
             ExternArgs::Schema(_) => Ok(()),
@@ -72,45 +74,13 @@ impl ToTokens for ExternArgs {
             ExternArgs::ParallelSafe => tokens.append(format_ident!("ParallelSafe")),
             ExternArgs::ParallelUnsafe => tokens.append(format_ident!("ParallelUnsafe")),
             ExternArgs::ParallelRestricted => tokens.append(format_ident!("ParallelRestricted")),
-            ExternArgs::ShouldPanic(_s) => {
-                tokens.append_all(
-                    quote! {
-                        Error(String::from("#_s"))
-                    }
-                    .to_token_stream(),
-                );
-            }
-            ExternArgs::Schema(_s) => {
-                tokens.append_all(
-                    quote! {
-                        Schema(String::from("#_s"))
-                    }
-                    .to_token_stream(),
-                );
-            }
-            ExternArgs::Name(_s) => {
-                tokens.append_all(
-                    quote! {
-                        Name(String::from("#_s"))
-                    }
-                    .to_token_stream(),
-                );
-            }
-            ExternArgs::Cost(_s) => {
-                tokens.append_all(
-                    quote! {
-                        Cost(String::from("#_s"))
-                    }
-                    .to_token_stream(),
-                );
-            }
+            ExternArgs::ShouldPanic(_s) => tokens.append_all(quote! { Error(String::from("#_s")) }),
+            ExternArgs::Schema(_s) => tokens.append_all(quote! { Schema(String::from("#_s")) }),
+            ExternArgs::Support(item) => tokens.append_all(quote! { Support(#item) }),
+            ExternArgs::Name(_s) => tokens.append_all(quote! { Name(String::from("#_s")) }),
+            ExternArgs::Cost(_s) => tokens.append_all(quote! { Cost(String::from("#_s")) }),
             ExternArgs::Requires(items) => {
-                tokens.append_all(
-                    quote! {
-                        Requires(vec![#(#items),*])
-                    }
-                    .to_token_stream(),
-                );
+                tokens.append_all(quote! { Requires(vec![#(#items),*]) })
             }
         }
     }

--- a/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/attribute.rs
@@ -39,6 +39,7 @@ pub enum Attribute {
     ParallelRestricted,
     ShouldPanic(syn::LitStr),
     Schema(syn::LitStr),
+    Support(PositioningRef),
     Name(syn::LitStr),
     Cost(syn::Expr),
     Requires(Punctuated<PositioningRef, Token![,]>),
@@ -81,6 +82,9 @@ impl Attribute {
             }
             Attribute::Schema(s) => {
                 quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::Schema(String::from(#s)) }
+            }
+            Attribute::Support(item) => {
+                quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::Support(#item) }
             }
             Attribute::Name(s) => {
                 quote! { ::pgrx::pgrx_sql_entity_graph::ExternArgs::Name(String::from(#s)) }
@@ -131,6 +135,9 @@ impl ToTokens for Attribute {
             Attribute::Schema(s) => {
                 quote! { schema = #s }
             }
+            Attribute::Support(item) => {
+                quote! { support = #item }
+            }
             Attribute::Name(s) => {
                 quote! { name = #s }
             }
@@ -175,6 +182,11 @@ impl Parse for Attribute {
                 let _eq: Token![=] = input.parse()?;
                 let literal: syn::LitStr = input.parse()?;
                 Attribute::Schema(literal)
+            }
+            "support" => {
+                let _eq: Token![=] = input.parse()?;
+                let item: PositioningRef = input.parse()?;
+                Self::Support(item)
             }
             "name" => {
                 let _eq: Token![=] = input.parse()?;

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -77,6 +77,18 @@ impl SqlGraphIdentifier for PgExternEntity {
     }
 }
 
+impl PgExternEntity {
+    fn sql_name(&self, context: &PgrxSql) -> String {
+        let self_index = context.externs[self];
+        let schema = self
+            .schema
+            .map(|schema| format!("{schema}."))
+            .unwrap_or_else(|| context.schema_prefix_for(&self_index));
+
+        format!("{schema}\"{}\"", self.name)
+    }
+}
+
 impl ToSql for PgExternEntity {
     fn to_sql(&self, context: &PgrxSql) -> eyre::Result<String> {
         let self_index = context.externs[self];
@@ -126,15 +138,15 @@ impl ToSql for PgExternEntity {
                         let buf = format!("\
                                             \t\"{pattern}\" {variadic}{schema_prefix}{sql_type}{default}{maybe_comma}/* {type_name} */\
                                         ",
-                                            pattern = arg.pattern,
-                                            schema_prefix = context.schema_prefix_for(&graph_index),
-                                            // First try to match on [`TypeId`] since it's most reliable.
-                                            sql_type = argument_sql,
-                                            default = if let Some(def) = arg.used_ty.default { format!(" DEFAULT {def}") } else { String::from("") },
-                                            variadic = if metadata_argument.variadic { "VARIADIC " } else { "" },
-                                            maybe_comma = if needs_comma { ", " } else { " " },
-                                            type_name = metadata_argument.type_name,
-                                    );
+                                          pattern = arg.pattern,
+                                          schema_prefix = context.schema_prefix_for(&graph_index),
+                                          // First try to match on [`TypeId`] since it's most reliable.
+                                          sql_type = argument_sql,
+                                          default = if let Some(def) = arg.used_ty.default { format!(" DEFAULT {def}") } else { String::from("") },
+                                          variadic = if metadata_argument.variadic { "VARIADIC " } else { "" },
+                                          maybe_comma = if needs_comma { ", " } else { " " },
+                                          type_name = metadata_argument.type_name,
+                        );
                         args.push(buf);
                     }
                     Ok(SqlMapping::Composite { array_brackets }) => {
@@ -150,15 +162,15 @@ impl ToSql for PgExternEntity {
                         let buf = format!("\
                             \t\"{pattern}\" {variadic}{schema_prefix}{sql_type}{default}{maybe_comma}/* {type_name} */\
                         ",
-                            pattern = arg.pattern,
-                            schema_prefix = context.schema_prefix_for(&graph_index),
-                            // First try to match on [`TypeId`] since it's most reliable.
-                            sql_type = sql,
-                            default = if let Some(def) = arg.used_ty.default { format!(" DEFAULT {def}") } else { String::from("") },
-                            variadic = if metadata_argument.variadic { "VARIADIC " } else { "" },
-                            maybe_comma = if needs_comma { ", " } else { " " },
-                            type_name = metadata_argument.type_name,
-                    );
+                                          pattern = arg.pattern,
+                                          schema_prefix = context.schema_prefix_for(&graph_index),
+                                          // First try to match on [`TypeId`] since it's most reliable.
+                                          sql_type = sql,
+                                          default = if let Some(def) = arg.used_ty.default { format!(" DEFAULT {def}") } else { String::from("") },
+                                          variadic = if metadata_argument.variadic { "VARIADIC " } else { "" },
+                                          maybe_comma = if needs_comma { ", " } else { " " },
+                                          type_name = metadata_argument.type_name,
+                        );
                         args.push(buf);
                     }
                     Ok(SqlMapping::Skip) => (),
@@ -199,11 +211,11 @@ impl ToSql for PgExternEntity {
                     .ok_or_else(|| eyre!("Could not find return type in graph."))?;
                 let metadata_retval = self.metadata.retval.clone();
                 let sql_type = match metadata_retval.return_sql {
-                        Ok(Returns::SetOf(SqlMapping::As(ref sql))) => sql.clone(),
-                        Ok(Returns::SetOf(SqlMapping::Composite { array_brackets })) => fmt::with_array_brackets(ty.composite_type.unwrap().into(), array_brackets),
-                        Ok(_other) => return Err(eyre!("Got non-setof mapped/composite return variant SQL in what macro-expansion thought was a setof")),
-                        Err(err) => return Err(err).wrap_err("Error mapping return SQL"),
-                    };
+                    Ok(Returns::SetOf(SqlMapping::As(ref sql))) => sql.clone(),
+                    Ok(Returns::SetOf(SqlMapping::Composite { array_brackets })) => fmt::with_array_brackets(ty.composite_type.unwrap().into(), array_brackets),
+                    Ok(_other) => return Err(eyre!("Got non-setof mapped/composite return variant SQL in what macro-expansion thought was a setof")),
+                    Err(err) => return Err(err).wrap_err("Error mapping return SQL"),
+                };
                 format!(
                     "RETURNS SETOF {schema_prefix}{sql_type} /* {full_path} */",
                     schema_prefix = context.schema_prefix_for(&graph_index),
@@ -214,21 +226,21 @@ impl ToSql for PgExternEntity {
                 let mut items = String::new();
                 let metadata_retval = self.metadata.retval.clone();
                 let metadata_retval_sqls: Vec<String> = match metadata_retval.return_sql {
-                        Ok(Returns::Table(variants)) => {
-                            variants.iter().enumerate().map(|(idx, variant)| {
-                                match variant {
-                                    SqlMapping::As(sql) => sql.clone(),
-                                    SqlMapping::Composite { array_brackets } => {
-                                        let composite = table_items[idx].ty.composite_type.unwrap();
-                                        fmt::with_array_brackets(composite.into(), *array_brackets)
-                                    },
-                                    SqlMapping::Skip => todo!(),
+                    Ok(Returns::Table(variants)) => {
+                        variants.iter().enumerate().map(|(idx, variant)| {
+                            match variant {
+                                SqlMapping::As(sql) => sql.clone(),
+                                SqlMapping::Composite { array_brackets } => {
+                                    let composite = table_items[idx].ty.composite_type.unwrap();
+                                    fmt::with_array_brackets(composite.into(), *array_brackets)
                                 }
-                            }).collect()
-                        },
-                        Ok(_other) => return Err(eyre!("Got non-table return variant SQL in what macro-expansion thought was a table")),
-                        Err(err) => return Err(err).wrap_err("Error mapping return SQL"),
-                    };
+                                SqlMapping::Skip => todo!(),
+                            }
+                        }).collect()
+                    }
+                    Ok(_other) => return Err(eyre!("Got non-table return variant SQL in what macro-expansion thought was a table")),
+                    Err(err) => return Err(err).wrap_err("Error mapping return SQL"),
+                };
 
                 for (idx, returning::PgExternReturnEntityIteratedItem { ty, name: col_name }) in
                     table_items.iter().enumerate()
@@ -283,7 +295,22 @@ impl ToSql for PgExternEntity {
                 let mut retval = extern_attrs
                     .iter()
                     .filter(|attr| **attr != ExternArgs::CreateOrReplace)
-                    .map(|attr| attr.to_string().to_uppercase())
+                    .map(|attr| {
+                        if matches!(attr, ExternArgs::Support(..)) {
+                            let support_fn_name = attr.to_string();
+
+                            let support_fn_name =
+                            if let Some(entity) = context.find_matching_fn(&support_fn_name) {
+                                entity.sql_name(context)
+                            } else {
+                                panic!("cannot locate SUPPORT function `{support_fn_name}` attached to function `{}`", self.full_path)
+                            };
+
+                            format!("SUPPORT {support_fn_name}")
+                        } else {
+                            attr.to_string().to_uppercase()
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .join(" ");
                 retval.push('\n');
@@ -297,11 +324,13 @@ impl ToSql for PgExternEntity {
                 .extern_attrs
                 .iter()
                 .filter_map(|x| match x {
-                    ExternArgs::Requires(requirements) => Some(requirements),
+                    ExternArgs::Requires(requirements) => Some(requirements.clone()),
+                    ExternArgs::Support(support_fn) => Some(vec![support_fn.clone()]),
                     _ => None,
                 })
                 .flatten()
                 .collect::<Vec<_>>();
+
             if !requires_attrs.is_empty() {
                 format!(
                     "-- requires:\n{}\n",
@@ -436,14 +465,14 @@ impl ToSql for PgExternEntity {
                                                         {optionals}\
                                                     );\
                                                     ",
-                                                    opname = op.opname.unwrap(),
-                                                    left_name = left_arg.type_name,
-                                                    right_name = right_arg.type_name,
-                                                    schema_prefix_left = context.schema_prefix_for(&left_arg_graph_index),
-                                                    schema_prefix_right = context.schema_prefix_for(&right_arg_graph_index),
-                                                    maybe_comma = if !optionals.is_empty() { "," } else { "" },
-                                                    optionals = if !optionals.is_empty() { optionals.join(",\n") + "\n" } else { "".to_string() },
-                                            );
+                                       opname = op.opname.unwrap(),
+                                       left_name = left_arg.type_name,
+                                       right_name = right_arg.type_name,
+                                       schema_prefix_left = context.schema_prefix_for(&left_arg_graph_index),
+                                       schema_prefix_right = context.schema_prefix_for(&right_arg_graph_index),
+                                       maybe_comma = if !optionals.is_empty() { "," } else { "" },
+                                       optionals = if !optionals.is_empty() { optionals.join(",\n") + "\n" } else { "".to_string() },
+            );
             ext_sql += &operator_sql
         };
         if let Some(cast) = &self.cast {
@@ -534,16 +563,16 @@ impl ToSql for PgExternEntity {
                                                     )\n\
                                                     WITH FUNCTION {function_name}{optional};\
                                                     ",
-                                                    file = self.file,
-                                                    line = self.line,
-                                                    name = self.name,
-                                                    module_path = self.module_path,
-                                                    schema_prefix_source = context.schema_prefix_for(&source_arg_graph_index),
-                                                    source_name = source_arg.type_name,
-                                                    schema_prefix_target = context.schema_prefix_for(&target_arg_graph_index),
-                                                    target_name = target_arg.type_name,
-                                                    function_name = self.name,
-                                            );
+                                   file = self.file,
+                                   line = self.line,
+                                   name = self.name,
+                                   module_path = self.module_path,
+                                   schema_prefix_source = context.schema_prefix_for(&source_arg_graph_index),
+                                   source_name = source_arg.type_name,
+                                   schema_prefix_target = context.schema_prefix_for(&target_arg_graph_index),
+                                   target_name = target_arg.type_name,
+                                   function_name = self.name,
+            );
             ext_sql += &cast_sql
         };
         Ok(ext_sql)

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -461,6 +461,10 @@ impl PgrxSql {
             String::from("MODULE_PATHNAME")
         }
     }
+
+    pub fn find_matching_fn(&self, name: &str) -> Option<&PgExternEntity> {
+        self.externs.keys().find(|key| key.full_path.ends_with(name))
+    }
 }
 
 fn build_base_edges(
@@ -832,6 +836,20 @@ fn connect_externs(
                         } else {
                             return Err(eyre!("Could not find `requires` target: {:?}", requires));
                         }
+                    }
+                }
+                crate::ExternArgs::Support(support_fn) => {
+                    if let Some(target) = find_positioning_ref_target(
+                        support_fn,
+                        types,
+                        enums,
+                        externs,
+                        schemas,
+                        extension_sqls,
+                        triggers,
+                    ) {
+                        graph.add_edge(*target, index, SqlGraphRequires::By);
+                        has_explicit_requires = true
                     }
                 }
                 crate::ExternArgs::Schema(declared_schema_name) => {

--- a/pgrx-tests/src/tests/pg_extern_tests.rs
+++ b/pgrx-tests/src/tests/pg_extern_tests.rs
@@ -1,3 +1,4 @@
+use pgrx::Internal;
 //LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
 //LICENSE
 //LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
@@ -9,6 +10,17 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use pgrx::prelude::*;
 
+#[pg_schema]
+mod support_fn_schema {
+    use pgrx::Internal;
+    use pgrx_macros::pg_extern;
+
+    #[pg_extern]
+    fn test_support_fn(i: Internal) -> Internal {
+        i
+    }
+}
+
 #[pg_extern(immutable)]
 fn returns_tuple_with_attributes(
 ) -> TableIterator<'static, (name!(arg, String), name!(arg2, String))> {
@@ -18,6 +30,21 @@ fn returns_tuple_with_attributes(
 // Check we can map a `fdw_handler`
 #[pg_extern]
 fn fdw_handler_return() -> PgBox<pg_sys::FdwRoutine> {
+    unimplemented!("Not a functional test, just a signature test for SQL generation. Feel free to make a functional test!")
+}
+
+#[pg_extern(support = support_fn_schema::test_support_fn)]
+fn test_using_support_fn_in_other_module() {
+    unimplemented!("Not a functional test, just a signature test for SQL generation. Feel free to make a functional test!")
+}
+
+#[pg_extern]
+fn local_support_fn(i: Internal) -> Internal {
+    i
+}
+
+#[pg_extern(support = local_support_fn)]
+fn test_using_support_fn() {
     unimplemented!("Not a functional test, just a signature test for SQL generation. Feel free to make a functional test!")
 }
 


### PR DESCRIPTION
This adds a new attribute to `#[pg_extern]` called `support` with a value that is a Rust path to another function to act as the `SUPPORT` support function.