### PR TITLE
add cfi directives to call_closure_with_sigsetjmp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,16 +467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cee-scape"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d67dfb052149f779f77e9ce089cea126e00657e8f0d11dafc7901fde4291101"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,7 +2035,6 @@ dependencies = [
 name = "pgrx-pg-sys"
 version = "0.16.0"
 dependencies = [
- "cee-scape",
  "libc",
  "pgrx-bindgen",
  "pgrx-macros",

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -50,10 +50,6 @@ serde.workspace = true # impls on pub types
 # polyfill until #![feature(strict_provenance)] stabilizes
 sptr = "0.3"
 
-[target.'cfg(all(any(target_os = "linux", target_os = "macos"), any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-# Safer `sigsetjmp` and `siglongjmp`
-cee-scape = "0.2"
-
 [build-dependencies]
 pgrx-bindgen.workspace = true
 

--- a/pgrx-pg-sys/src/submodules/ffi.rs
+++ b/pgrx-pg-sys/src/submodules/ffi.rs
@@ -9,14 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![deny(unsafe_op_in_unsafe_fn)]
 
-#[cfg(not(all(
-    any(target_os = "linux", target_os = "macos"),
-    any(target_arch = "x86_64", target_arch = "aarch64")
-)))]
-mod cee_scape {
-    #[cfg(not(feature = "cshim"))]
-    compile_error!("target platform cannot work without feature cshim");
-
+mod sjlj {
     use libc::{c_int, c_void};
     use std::marker::PhantomData;
 
@@ -26,30 +19,259 @@ mod cee_scape {
         _neither_send_nor_sync: PhantomData<*const u8>,
     }
 
+    #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+    #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(feature = "cshim")]
+    unsafe extern "C-unwind" {
+        unsafe fn call_closure_with_sigsetjmp(
+            savemask: c_int,
+            closure_env_ptr: *mut c_void,
+            closure_code: extern "C-unwind" fn(
+                jbuf: *const SigJmpBufFields,
+                env_ptr: *mut c_void,
+            ) -> c_int,
+        ) -> c_int;
+    }
+
+    #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+    #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+    #[cfg(not(all(target_os = "macos", target_arch = "x86_64")))]
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(feature = "cshim"))]
+    compile_error!("target platform is not supported without feature `cshim`");
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    #[unsafe(naked)]
+    unsafe extern "C-unwind" fn call_closure_with_sigsetjmp(
+        savemask: c_int,
+        closure_env_ptr: *mut c_void,
+        closure_code: extern "C-unwind" fn(
+            jbuf: *const SigJmpBufFields,
+            env_ptr: *mut c_void,
+        ) -> c_int,
+    ) -> c_int {
+        #[link(name = "c")]
+        unsafe extern "C-unwind" {
+            #[link_name = "__sigsetjmp"]
+            unsafe fn sigsetjmp();
+        }
+        core::arch::naked_asm!(
+            "    .cfi_startproc",
+            "    push    rbp",
+            "    .cfi_def_cfa_offset 16",
+            "    .cfi_offset rbp, -16",
+            "    mov    rbp, rsp",
+            "    .cfi_def_cfa_register rbp",
+            "    push    r14",
+            "    push    rbx",
+            "    sub    rsp, 208",
+            "    .cfi_offset rbx, -32",
+            "    .cfi_offset r14, -24",
+            "    mov    rbx, rdx",
+            "    mov    r14, rsi",
+            "    mov    esi, edi",
+            "    lea    rdi, [rbp - 224]",
+            "    call    {}",
+            "    mov    ecx, eax",
+            "    test    eax, eax",
+            "    jne    2f",
+            "    lea    rdi, [rbp - 224]",
+            "    mov    rsi, r14",
+            "    call    rbx",
+            "    mov    ecx, eax",
+            "2:",
+            "    mov    eax, ecx",
+            "    add    rsp, 208",
+            "    pop    rbx",
+            "    pop    r14",
+            "    pop    rbp",
+            "    .cfi_def_cfa rsp, 8",
+            "    ret",
+            "    .cfi_endproc",
+            sym sigsetjmp,
+        );
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    #[unsafe(naked)]
+    unsafe extern "C-unwind" fn call_closure_with_sigsetjmp(
+        savemask: c_int,
+        closure_env_ptr: *mut c_void,
+        closure_code: extern "C-unwind" fn(
+            jbuf: *const SigJmpBufFields,
+            env_ptr: *mut c_void,
+        ) -> c_int,
+    ) -> c_int {
+        #[link(name = "c")]
+        unsafe extern "C-unwind" {
+            #[link_name = "__sigsetjmp"]
+            unsafe fn sigsetjmp();
+        }
+        core::arch::naked_asm!(
+            "    .cfi_startproc",
+            "    sub    sp, sp, #368",
+            "    .cfi_def_cfa_offset 368",
+            "    stp    x29, x30, [sp, #320]",
+            "    str    x28, [sp, #336]",
+            "    stp    x20, x19, [sp, #352]",
+            "    add    x29, sp, #320",
+            "    .cfi_def_cfa w29, 48",
+            "    .cfi_offset w19, -8",
+            "    .cfi_offset w20, -16",
+            "    .cfi_offset w28, -32",
+            "    .cfi_offset w30, -40",
+            "    .cfi_offset w29, -48",
+            "    mov    x20, x1",
+            "    mov    w1, w0",
+            "    add    x0, sp, #8",
+            "    mov    x19, x2",
+            "    bl    {}",
+            "    mov    w1, w0",
+            "    cbnz    w0, 2f",
+            "    add    x0, sp, #8",
+            "    mov    x1, x20",
+            "    blr    x19",
+            "    mov    w1, w0",
+            "2:",
+            "    mov    w0, w1",
+            "    .cfi_def_cfa wsp, 368",
+            "    ldp    x20, x19, [sp, #352]",
+            "    ldr    x28, [sp, #336]",
+            "    ldp    x29, x30, [sp, #320]",
+            "    add    sp, sp, #368",
+            "    .cfi_def_cfa_offset 0",
+            "    .cfi_restore w19",
+            "    .cfi_restore w20",
+            "    .cfi_restore w28",
+            "    .cfi_restore w30",
+            "    .cfi_restore w29",
+            "    ret",
+            "    .cfi_endproc",
+            sym sigsetjmp,
+        );
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    #[unsafe(naked)]
+    unsafe extern "C-unwind" fn call_closure_with_sigsetjmp(
+        savemask: c_int,
+        closure_env_ptr: *mut c_void,
+        closure_code: extern "C-unwind" fn(
+            jbuf: *const SigJmpBufFields,
+            env_ptr: *mut c_void,
+        ) -> c_int,
+    ) -> c_int {
+        #[link(name = "c")]
+        unsafe extern "C-unwind" {
+            #[link_name = "sigsetjmp"]
+            unsafe fn sigsetjmp();
+        }
+        core::arch::naked_asm!(
+            "    .cfi_startproc",
+            "    push    rbp",
+            "    .cfi_def_cfa_offset 16",
+            "    .cfi_offset rbp, -16",
+            "    mov    rbp, rsp",
+            "    .cfi_def_cfa_register rbp",
+            "    push    r14",
+            "    push    rbx",
+            "    sub    rsp, 160",
+            "    .cfi_offset rbx, -32",
+            "    .cfi_offset r14, -24",
+            "    mov    rbx, rdx",
+            "    mov    r14, rsi",
+            "    mov    esi, edi",
+            "    lea    rdi, [rbp - 176]",
+            "    call    {}",
+            "    mov    ecx, eax",
+            "    test    eax, eax",
+            "    jne    2f",
+            "    lea    rdi, [rbp - 176]",
+            "    mov    rsi, r14",
+            "    call    rbx",
+            "    mov    ecx, eax",
+            "2:",
+            "    mov    eax, ecx",
+            "    add    rsp, 160",
+            "    pop    rbx",
+            "    pop    r14",
+            "    pop    rbp",
+            "    ret",
+            "    .cfi_endproc",
+            sym sigsetjmp,
+        );
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[unsafe(naked)]
+    unsafe extern "C-unwind" fn call_closure_with_sigsetjmp(
+        savemask: c_int,
+        closure_env_ptr: *mut c_void,
+        closure_code: extern "C-unwind" fn(
+            jbuf: *const SigJmpBufFields,
+            env_ptr: *mut c_void,
+        ) -> c_int,
+    ) -> c_int {
+        #[link(name = "c")]
+        unsafe extern "C-unwind" {
+            #[link_name = "sigsetjmp"]
+            unsafe fn sigsetjmp();
+        }
+        core::arch::naked_asm!(
+            "    .cfi_startproc",
+            "    sub    sp, sp, #240",
+            "    .cfi_def_cfa_offset 240",
+            "    stp    x20, x19, [sp, #208]",
+            "    stp    x29, x30, [sp, #224]",
+            "    add    x29, sp, #224",
+            "    .cfi_def_cfa w29, 16",
+            "    .cfi_offset w30, -8",
+            "    .cfi_offset w29, -16",
+            "    .cfi_offset w19, -24",
+            "    .cfi_offset w20, -32",
+            "    mov    x19, x2",
+            "    mov    x20, x1",
+            "    mov    x1, x0",
+            "    add    x0, sp, #12",
+            "    bl    {}",
+            "    mov    x1, x0",
+            "    cbnz    w0, 2f",
+            "    add    x0, sp, #12",
+            "    mov    x1, x20",
+            "    blr    x19",
+            "    mov    x1, x0",
+            "2:",
+            "    mov    x0, x1",
+            "    .cfi_def_cfa wsp, 240",
+            "    ldp    x29, x30, [sp, #224]",
+            "    ldp    x20, x19, [sp, #208]",
+            "    add    sp, sp, #240",
+            "    .cfi_def_cfa_offset 0",
+            "    .cfi_restore w30",
+            "    .cfi_restore w29",
+            "    .cfi_restore w19",
+            "    .cfi_restore w20",
+            "    ret",
+            "    .cfi_endproc",
+            sym sigsetjmp,
+        );
+    }
+
     pub fn call_with_sigsetjmp<F>(savemask: bool, mut callback: F) -> c_int
     where
-        F: for<'a> FnOnce(&'a SigJmpBufFields) -> c_int,
+        F: FnOnce(*const SigJmpBufFields) -> c_int,
     {
-        extern "C-unwind" {
-            fn call_closure_with_sigsetjmp(
-                savemask: c_int,
-                closure_env_ptr: *mut c_void,
-                closure_code: extern "C-unwind" fn(
-                    jbuf: *const SigJmpBufFields,
-                    env_ptr: *mut c_void,
-                ) -> c_int,
-            ) -> c_int;
-        }
-
         extern "C-unwind" fn call_from_c_to_rust<F>(
             jbuf: *const SigJmpBufFields,
             closure_env_ptr: *mut c_void,
         ) -> c_int
         where
-            F: for<'a> FnOnce(&'a SigJmpBufFields) -> c_int,
+            F: FnOnce(*const SigJmpBufFields) -> c_int,
         {
             let closure_env_ptr: *mut F = closure_env_ptr as *mut F;
-            unsafe { (closure_env_ptr.read())(&*jbuf) }
+            unsafe { (closure_env_ptr.read())(jbuf) }
         }
 
         let savemask: libc::c_int = if savemask { 1 } else { 0 };
@@ -66,7 +288,7 @@ mod cee_scape {
     }
 }
 
-use cee_scape::{call_with_sigsetjmp, SigJmpBufFields};
+use sjlj::call_with_sigsetjmp;
 
 /**
 Given a closure that is assumed to be a wrapped Postgres `extern "C-unwind"` function, [pg_guard_ffi_boundary]
@@ -174,7 +396,7 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
         let jump_value = call_with_sigsetjmp(false, |jump_buffer| {
             // Make Postgres' error-handling system aware of our new
             // setjmp/longjmp restore point.
-            pg_sys::PG_exception_stack = std::mem::transmute(jump_buffer as *const SigJmpBufFields);
+            pg_sys::PG_exception_stack = std::mem::transmute(jump_buffer);
 
             // execute the closure, which will be a wrapped internal Postgres function
             result.write(f());

--- a/pgrx-tests/tests/compile-fail/eq-for-postgres_hash.stderr
+++ b/pgrx-tests/tests/compile-fail/eq-for-postgres_hash.stderr
@@ -31,6 +31,8 @@ error[E0277]: the trait bound `BrokenType: std::hash::Hash` is not satisfied
   |
 4 | #[derive(Serialize, Deserialize, PostgresType, PostgresHash)]
   |                                                ^^^^^^^^^^^^ the trait `std::hash::Hash` is not implemented for `BrokenType`
+5 | pub struct BrokenType {
+  |            ---------- required by a bound introduced by this call
   |
 note: required by a bound in `brokentype_hash`
  --> tests/compile-fail/eq-for-postgres_hash.rs:4:48
@@ -51,6 +53,8 @@ error[E0277]: the trait bound `BrokenType: std::cmp::Eq` is not satisfied
   |
 4 | #[derive(Serialize, Deserialize, PostgresType, PostgresHash)]
   |                                                ^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `BrokenType`
+5 | pub struct BrokenType {
+  |            ---------- required by a bound introduced by this call
   |
 note: required by a bound in `brokentype_hash`
  --> tests/compile-fail/eq-for-postgres_hash.rs:4:48

--- a/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-cursor.stderr
+++ b/pgrx-tests/tests/compile-fail/escaping-spiclient-1209-cursor.stderr
@@ -1,19 +1,19 @@
 error: lifetime may not live long enough
-  --> tests/compile-fail/escaping-spiclient-1209-cursor.rs:9:9
-   |
-8  |       let mut res = Spi::connect(|c| {
+ --> tests/compile-fail/escaping-spiclient-1209-cursor.rs:9:9
+  |
+ 8 |       let mut res = Spi::connect(|c| {
    |                                   -- return type of closure is SpiTupleTable<'2>
    |                                   |
    |                                   has type `&SpiClient<'1>`
-9  | /         c.open_cursor("select 'hello world' from generate_series(1, 1000)", &[])
+ 9 | /         c.open_cursor("select 'hello world' from generate_series(1, 1000)", &[])
 10 | |             .fetch(1000)
 11 | |             .unwrap()
    | |_____________________^ returning this value requires that `'1` must outlive `'2`
 
 error[E0515]: cannot return value referencing temporary value
-  --> tests/compile-fail/escaping-spiclient-1209-cursor.rs:9:9
-   |
-9  |           c.open_cursor("select 'hello world' from generate_series(1, 1000)", &[])
+ --> tests/compile-fail/escaping-spiclient-1209-cursor.rs:9:9
+  |
+ 9 |           c.open_cursor("select 'hello world' from generate_series(1, 1000)", &[])
    |           ^-----------------------------------------------------------------------
    |           |
    |  _________temporary value created here

--- a/pgrx-tests/tests/compile-fail/total-eq-for-postgres_eq.stderr
+++ b/pgrx-tests/tests/compile-fail/total-eq-for-postgres_eq.stderr
@@ -13,10 +13,10 @@ help: consider annotating `BrokenType` with `#[derive(Eq)]`
   |
 
 error[E0277]: the trait bound `BrokenType: std::cmp::Eq` is not satisfied
- --> tests/compile-fail/total-eq-for-postgres_eq.rs:4:59
+ --> tests/compile-fail/total-eq-for-postgres_eq.rs:5:12
   |
-4 | #[derive(Serialize, Deserialize, PartialEq, PostgresType, PostgresEq)]
-  |                                                           ^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `BrokenType`
+5 | pub struct BrokenType {
+  |            ^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `BrokenType`
   |
 note: required by a bound in `brokentype_eq`
  --> tests/compile-fail/total-eq-for-postgres_eq.rs:4:59
@@ -25,7 +25,7 @@ note: required by a bound in `brokentype_eq`
   |                                                           ^^^^^^^^^^ required by this bound in `brokentype_eq`
 5 | pub struct BrokenType {
   |            ---------- required by a bound in this function
-  = note: this error originates in the attribute macro `::pgrx::pgrx_macros::pg_operator` which comes from the expansion of the derive macro `PostgresEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `PostgresEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `BrokenType` with `#[derive(Eq)]`
   |
 5 + #[derive(Eq)]

--- a/pgrx-tests/tests/todo/busted-exotic-signature.stderr
+++ b/pgrx-tests/tests/todo/busted-exotic-signature.stderr
@@ -1,20 +1,20 @@
 error[E0277]: the trait bound `Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/busted-exotic-signature.rs:12:9
-   |
-10 |     #[pg_extern]
-   |     ------------ in this procedural macro expansion
-11 |     fn exotic_signature(
-12 |         _cats: pgrx::default!(
-   |         ^^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>`
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
-   = note: required for `Option<Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>>` to implement `ArgAbi<'_>`
+ --> tests/todo/busted-exotic-signature.rs:12:9
+  |
+ 10 |     #[pg_extern]
+    |     ------------ in this procedural macro expansion
+ 11 |     fn exotic_signature(
+ 12 |         _cats: pgrx::default!(
+    |         ^^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
+    = note: required for `Option<Vec<Option<PgHeapTuple<'_, AllocatedByRust>>>>` to implement `ArgAbi<'_>`
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/todo/composite-types-broken-on-spi.stderr
+++ b/pgrx-tests/tests/todo/composite-types-broken-on-spi.stderr
@@ -1,63 +1,63 @@
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/composite-types-broken-on-spi.rs:60:9
-   |
-58 |     #[pg_extern]
-   |     ------------ in this procedural macro expansion
-59 |     fn sum_scritches_for_names_strict_optional_items(
-60 |         dogs: Vec<Option<pgrx::composite_type!("Dog")>>,
-   |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ --> tests/todo/composite-types-broken-on-spi.rs:60:9
+  |
+ 58 |     #[pg_extern]
+    |     ------------ in this procedural macro expansion
+ 59 |     fn sum_scritches_for_names_strict_optional_items(
+ 60 |         dogs: Vec<Option<pgrx::composite_type!("Dog")>>,
+    |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/composite-types-broken-on-spi.rs:77:9
-   |
-75 |     #[pg_extern]
-   |     ------------ in this procedural macro expansion
-76 |     fn sum_scritches_for_names_default_optional_items(
-77 |         dogs: pgrx::default!(
-   |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ --> tests/todo/composite-types-broken-on-spi.rs:77:9
+  |
+ 75 |     #[pg_extern]
+    |     ------------ in this procedural macro expansion
+ 76 |     fn sum_scritches_for_names_default_optional_items(
+ 77 |         dogs: pgrx::default!(
+    |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/composite-types-broken-on-spi.rs:97:9
-   |
-95 |     #[pg_extern]
-   |     ------------ in this procedural macro expansion
-96 |     fn sum_scritches_for_names_optional_items(
-97 |         dogs: Option<Vec<Option<pgrx::composite_type!("Dog")>>>,
-   |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
-   = note: required for `Option<Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>>` to implement `ArgAbi<'_>`
+ --> tests/todo/composite-types-broken-on-spi.rs:97:9
+  |
+ 95 |     #[pg_extern]
+    |     ------------ in this procedural macro expansion
+ 96 |     fn sum_scritches_for_names_optional_items(
+ 97 |         dogs: Option<Vec<Option<pgrx::composite_type!("Dog")>>>,
+    |         ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
+    = note: required for `Option<Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>>` to implement `ArgAbi<'_>`
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Array<'_, pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>` is not an iterator
    --> tests/todo/composite-types-broken-on-spi.rs:125:20
@@ -87,46 +87,46 @@ error[E0277]: `Array<'_, pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>`
             but trait `IntoIterator` is implemented for it
 
 error[E0308]: mismatched types
-  --> tests/todo/composite-types-broken-on-spi.rs:11:5
-   |
-11 |     #[pg_extern]
-   |     ^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
-              found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
+ --> tests/todo/composite-types-broken-on-spi.rs:11:5
+  |
+ 11 |     #[pg_extern]
+    |     ^^^^^^^^^^^^ one type is more general than the other
+    |
+    = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
+               found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
 note: the lifetime requirement is introduced here
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/todo/composite-types-broken-on-spi.rs:28:5
-   |
-28 |     #[pg_extern]
-   |     ^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
-              found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
+ --> tests/todo/composite-types-broken-on-spi.rs:28:5
+  |
+ 28 |     #[pg_extern]
+    |     ^^^^^^^^^^^^ one type is more general than the other
+    |
+    = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
+               found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
 note: the lifetime requirement is introduced here
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/todo/composite-types-broken-on-spi.rs:44:5
-   |
-44 |     #[pg_extern]
-   |     ^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
-              found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
+ --> tests/todo/composite-types-broken-on-spi.rs:44:5
+  |
+ 44 |     #[pg_extern]
+    |     ^^^^^^^^^^^^ one type is more general than the other
+    |
+    = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
+               found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
 note: the lifetime requirement is introduced here
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/todo/random-vec-strs-arent-okay.stderr
+++ b/pgrx-tests/tests/todo/random-vec-strs-arent-okay.stderr
@@ -1,19 +1,19 @@
 error[E0277]: the trait bound `Vec<Option<&str>>: ArgAbi<'_>` is not satisfied
  --> tests/todo/random-vec-strs-arent-okay.rs:8:5
   |
-5 | #[pg_extern]
-  | ------------ in this procedural macro expansion
+  5 | #[pg_extern]
+    | ------------ in this procedural macro expansion
 ...
-8 |     args: default!(Vec<Option<&'a str>>, "ARRAY[]::text[]"),
-  |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<&str>>`
-  |
-  = help: the following other types implement trait `ArgAbi<'fcx>`:
-            Vec<Option<T>>
-            Vec<T>
-            Vec<u8>
+  8 |     args: default!(Vec<Option<&'a str>>, "ARRAY[]::text[]"),
+    |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<&str>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
- --> $WORKSPACE/pgrx/src/callconv.rs
-  |
-  |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-  |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/todo/roundtrip-tests.stderr
+++ b/pgrx-tests/tests/todo/roundtrip-tests.stderr
@@ -2,12 +2,15 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> tests/todo/roundtrip-tests.rs:69:21
    |
 22 |             fn $fname(i: $rtype) -> $rtype {
-   |             - - help: consider introducing lifetime `'a` here: `<'a>`
-   |             |
-   |             lifetime `'a` is missing in item created through this procedural macro
+   |             - lifetime `'a` is missing in item created through this procedural macro
 ...
 69 |         Vec<Option<&'a str>>,
    |                     ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+22 |             fn<'a> $fname(i: $rtype) -> $rtype {
+   |               ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> tests/todo/roundtrip-tests.rs:69:21
@@ -21,11 +24,13 @@ error[E0261]: use of undeclared lifetime name `'a`
 error[E0261]: use of undeclared lifetime name `'a`
   --> tests/todo/roundtrip-tests.rs:69:21
    |
-67 |         rt_array_refstr,
-   |                        - help: consider introducing lifetime `'a` here: `<'a>`
-68 |         test_rt_array_refstr,
 69 |         Vec<Option<&'a str>>,
    |                     ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+67 |         rt_array_refstr<'a>,
+   |                        ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> tests/todo/roundtrip-tests.rs:69:21
@@ -42,141 +47,147 @@ error[E0261]: use of undeclared lifetime name `'a`
 error[E0261]: use of undeclared lifetime name `'a`
   --> tests/todo/roundtrip-tests.rs:69:21
    |
-68 |         test_rt_array_refstr,
-   |                             - help: consider introducing lifetime `'a` here: `<'a>`
 69 |         Vec<Option<&'a str>>,
    |                     ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+68 |         test_rt_array_refstr<'a>,
+   |                             ++++
 
 error[E0277]: the trait bound `Vec<Option<&[u8]>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/roundtrip-tests.rs:22:23
-   |
-22 |               fn $fname(i: $rtype) -> $rtype {
-   |                         ^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<&[u8]>>`
+ --> tests/todo/roundtrip-tests.rs:22:23
+  |
+ 22 |               fn $fname(i: $rtype) -> $rtype {
+    |                         ^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<&[u8]>>`
 ...
-52 | /     roundtrip!(
-53 | |         rt_array_bytea,
-54 | |         test_rt_array_bytea,
-55 | |         Vec<Option<&[u8]>>,
-...  |
-64 | |     );
-   | |_____- in this macro invocation
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ 52 | /     roundtrip!(
+ 53 | |         rt_array_bytea,
+ 54 | |         test_rt_array_bytea,
+ 55 | |         Vec<Option<&[u8]>>,
+...   |
+ 64 | |     );
+    | |_____- in this macro invocation
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<&[u8]>>: FromDatum` is not satisfied
-  --> tests/todo/roundtrip-tests.rs:36:38
-   |
-36 |                   let result: $rtype = Spi::get_one_with_args(
-   |  ______________________________________^
-37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-38 | |                     &[value.into()],
-39 | |                 )?
-   | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&[u8]>>`
+ --> tests/todo/roundtrip-tests.rs:36:38
+  |
+ 36 |                   let result: $rtype = Spi::get_one_with_args(
+    |  ______________________________________^
+ 37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
+ 38 | |                     &[value.into()],
+ 39 | |                 )?
+    | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&[u8]>>`
 ...
-52 | /     roundtrip!(
-53 | |         rt_array_bytea,
-54 | |         test_rt_array_bytea,
-55 | |         Vec<Option<&[u8]>>,
-...  |
-64 | |     );
-   | |_____- in this macro invocation
-   |
-   = help: the following other types implement trait `FromDatum`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ 52 | /     roundtrip!(
+ 53 | |         rt_array_bytea,
+ 54 | |         test_rt_array_bytea,
+ 55 | |         Vec<Option<&[u8]>>,
+...   |
+ 64 | |     );
+    | |_____- in this macro invocation
+    |
+    = help: the following other types implement trait `FromDatum`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::Spi::get_one_with_args`
-  --> $WORKSPACE/pgrx/src/spi.rs
-   |
-   |     pub fn get_one_with_args<'mcx, A: FromDatum + IntoDatum>(
-   |                                       ^^^^^^^^^ required by this bound in `Spi::get_one_with_args`
-   = note: this error originates in the macro `roundtrip_test` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/spi.rs
+    |
+    |     pub fn get_one_with_args<'mcx, A: FromDatum + IntoDatum>(
+    |                                       ^^^^^^^^^ required by this bound in `Spi::get_one_with_args`
+    = note: this error originates in the macro `roundtrip_test` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0284]: type annotations needed: cannot satisfy `for<'arr> <Option<&str> as UnboxDatum>::As<'arr> == Option<&str>`
-  --> tests/todo/roundtrip-tests.rs:36:38
-   |
-36 |                   let result: $rtype = Spi::get_one_with_args(
-   |  ______________________________________^
-37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-38 | |                     &[value.into()],
-39 | |                 )?
-   | |_________________^ cannot satisfy `for<'arr> <Option<&str> as UnboxDatum>::As<'arr> == Option<&str>`
+error[E0277]: the trait bound `Vec<Option<&str>>: FromDatum` is not satisfied
+ --> tests/todo/roundtrip-tests.rs:36:38
+  |
+ 36 |                   let result: $rtype = Spi::get_one_with_args(
+    |  ______________________________________^
+ 37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
+ 38 | |                     &[value.into()],
+ 39 | |                 )?
+    | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&str>>`
 ...
-66 | /     roundtrip!(
-67 | |         rt_array_refstr,
-68 | |         test_rt_array_refstr,
-69 | |         Vec<Option<&'a str>>,
-70 | |         vec![None, Some("foo"), Some("bar"), None, Some("baz"), None]
-71 | |     );
-   | |_____- in this macro invocation
-   |
-   = note: required for `Vec<Option<&str>>` to implement `FromDatum`
+ 66 | /     roundtrip!(
+ 67 | |         rt_array_refstr,
+ 68 | |         test_rt_array_refstr,
+ 69 | |         Vec<Option<&'a str>>,
+ 70 | |         vec![None, Some("foo"), Some("bar"), None, Some("baz"), None]
+ 71 | |     );
+    | |_____- in this macro invocation
+    |
+    = help: the following other types implement trait `FromDatum`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::Spi::get_one_with_args`
-  --> $WORKSPACE/pgrx/src/spi.rs
-   |
-   |     pub fn get_one_with_args<'mcx, A: FromDatum + IntoDatum>(
-   |                                       ^^^^^^^^^ required by this bound in `Spi::get_one_with_args`
-   = note: this error originates in the macro `roundtrip_test` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/spi.rs
+    |
+    |     pub fn get_one_with_args<'mcx, A: FromDatum + IntoDatum>(
+    |                                       ^^^^^^^^^ required by this bound in `Spi::get_one_with_args`
+    = note: this error originates in the macro `roundtrip_test` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<&CStr>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/roundtrip-tests.rs:22:23
-   |
-22 |               fn $fname(i: $rtype) -> $rtype {
-   |                         ^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<&CStr>>`
+ --> tests/todo/roundtrip-tests.rs:22:23
+  |
+ 22 |               fn $fname(i: $rtype) -> $rtype {
+    |                         ^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<&CStr>>`
 ...
-73 | /     roundtrip!(
-74 | |         rt_array_cstr,
-75 | |         test_rt_array_cstr,
-76 | |         Vec<Option<&'static CStr>>,
-...  |
-85 | |     );
-   | |_____- in this macro invocation
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ 73 | /     roundtrip!(
+ 74 | |         rt_array_cstr,
+ 75 | |         test_rt_array_cstr,
+ 76 | |         Vec<Option<&'static CStr>>,
+...   |
+ 85 | |     );
+    | |_____- in this macro invocation
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<&CStr>>: FromDatum` is not satisfied
-  --> tests/todo/roundtrip-tests.rs:36:38
-   |
-36 |                   let result: $rtype = Spi::get_one_with_args(
-   |  ______________________________________^
-37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
-38 | |                     &[value.into()],
-39 | |                 )?
-   | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&CStr>>`
+ --> tests/todo/roundtrip-tests.rs:36:38
+  |
+ 36 |                   let result: $rtype = Spi::get_one_with_args(
+    |  ______________________________________^
+ 37 | |                     &format!("SELECT {}($1)", stringify!(tests.$fname)),
+ 38 | |                     &[value.into()],
+ 39 | |                 )?
+    | |_________________^ the trait `FromDatum` is not implemented for `Vec<Option<&CStr>>`
 ...
-73 | /     roundtrip!(
-74 | |         rt_array_cstr,
-75 | |         test_rt_array_cstr,
-76 | |         Vec<Option<&'static CStr>>,
-...  |
-85 | |     );
-   | |_____- in this macro invocation
-   |
-   = help: the following other types implement trait `FromDatum`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ 73 | /     roundtrip!(
+ 74 | |         rt_array_cstr,
+ 75 | |         test_rt_array_cstr,
+ 76 | |         Vec<Option<&'static CStr>>,
+...   |
+ 85 | |     );
+    | |_____- in this macro invocation
+    |
+    = help: the following other types implement trait `FromDatum`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::Spi::get_one_with_args`
-  --> $WORKSPACE/pgrx/src/spi.rs
-   |
-   |     pub fn get_one_with_args<'mcx, A: FromDatum + IntoDatum>(
-   |                                       ^^^^^^^^^ required by this bound in `Spi::get_one_with_args`
-   = note: this error originates in the macro `roundtrip_test` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/spi.rs
+    |
+    |     pub fn get_one_with_args<'mcx, A: FromDatum + IntoDatum>(
+    |                                       ^^^^^^^^^ required by this bound in `Spi::get_one_with_args`
+    = note: this error originates in the macro `roundtrip_test` which comes from the expansion of the macro `roundtrip` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx-tests/tests/todo/vec-option-composite_type-nesting-problems.stderr
+++ b/pgrx-tests/tests/todo/vec-option-composite_type-nesting-problems.stderr
@@ -1,105 +1,105 @@
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/vec-option-composite_type-nesting-problems.rs:55:5
-   |
-53 | #[pg_extern]
-   | ------------ in this procedural macro expansion
-54 | fn sum_scritches_for_names_strict_optional_items(
-55 |     dogs: Vec<Option<pgrx::composite_type!("Dog")>>,
-   |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ --> tests/todo/vec-option-composite_type-nesting-problems.rs:55:5
+  |
+ 53 | #[pg_extern]
+    | ------------ in this procedural macro expansion
+ 54 | fn sum_scritches_for_names_strict_optional_items(
+ 55 |     dogs: Vec<Option<pgrx::composite_type!("Dog")>>,
+    |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/vec-option-composite_type-nesting-problems.rs:72:5
-   |
-70 | #[pg_extern]
-   | ------------ in this procedural macro expansion
-71 | fn sum_scritches_for_names_default_optional_items(
-72 |     dogs: pgrx::default!(Vec<Option<pgrx::composite_type!("Dog")>>, "ARRAY[ROW('Nami', 0)]::Dog[]"),
-   |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
+ --> tests/todo/vec-option-composite_type-nesting-problems.rs:72:5
+  |
+ 70 | #[pg_extern]
+    | ------------ in this procedural macro expansion
+ 71 | fn sum_scritches_for_names_default_optional_items(
+ 72 |     dogs: pgrx::default!(Vec<Option<pgrx::composite_type!("Dog")>>, "ARRAY[ROW('Nami', 0)]::Dog[]"),
+    |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>: ArgAbi<'_>` is not satisfied
-  --> tests/todo/vec-option-composite_type-nesting-problems.rs:89:5
-   |
-87 | #[pg_extern]
-   | ------------ in this procedural macro expansion
-88 | fn sum_scritches_for_names_optional_items(
-89 |     dogs: Option<Vec<Option<pgrx::composite_type!("Dog")>>>,
-   |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
-   |
-   = help: the following other types implement trait `ArgAbi<'fcx>`:
-             Vec<Option<T>>
-             Vec<T>
-             Vec<u8>
-   = note: required for `Option<Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>>` to implement `ArgAbi<'_>`
+ --> tests/todo/vec-option-composite_type-nesting-problems.rs:89:5
+  |
+ 87 | #[pg_extern]
+    | ------------ in this procedural macro expansion
+ 88 | fn sum_scritches_for_names_optional_items(
+ 89 |     dogs: Option<Vec<Option<pgrx::composite_type!("Dog")>>>,
+    |     ^^^^ the trait `ArgAbi<'_>` is not implemented for `Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>`
+    |
+    = help: the following other types implement trait `ArgAbi<'fcx>`:
+              Vec<Option<T>>
+              Vec<T>
+              Vec<u8>
+    = note: required for `Option<Vec<Option<pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>>>>` to implement `ArgAbi<'_>`
 note: required by a bound in `pgrx::callconv::Args::<'a, 'fcx>::next_arg_unchecked`
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^ required by this bound in `Args::<'a, 'fcx>::next_arg_unchecked`
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
  --> tests/todo/vec-option-composite_type-nesting-problems.rs:8:1
   |
-8 | #[pg_extern]
-  | ^^^^^^^^^^^^ one type is more general than the other
-  |
-  = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
-             found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
+  8 | #[pg_extern]
+    | ^^^^^^^^^^^^ one type is more general than the other
+    |
+    = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
+               found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
 note: the lifetime requirement is introduced here
- --> $WORKSPACE/pgrx/src/callconv.rs
-  |
-  |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-  |                                         ^^^^^^^^^^^^
-  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/todo/vec-option-composite_type-nesting-problems.rs:23:1
-   |
-23 | #[pg_extern]
-   | ^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
-              found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
+ --> tests/todo/vec-option-composite_type-nesting-problems.rs:23:1
+  |
+ 23 | #[pg_extern]
+    | ^^^^^^^^^^^^ one type is more general than the other
+    |
+    = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
+               found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
 note: the lifetime requirement is introduced here
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/todo/vec-option-composite_type-nesting-problems.rs:39:1
-   |
-39 | #[pg_extern]
-   | ^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
-              found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
+ --> tests/todo/vec-option-composite_type-nesting-problems.rs:39:1
+  |
+ 39 | #[pg_extern]
+    | ^^^^^^^^^^^^ one type is more general than the other
+    |
+    = note: expected struct `pgrx::prelude::PgHeapTuple<'arr, pgrx::AllocatedByRust>`
+               found struct `pgrx::prelude::PgHeapTuple<'_, pgrx::AllocatedByRust>`
 note: the lifetime requirement is introduced here
-  --> $WORKSPACE/pgrx/src/callconv.rs
-   |
-   |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
-   |                                         ^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $WORKSPACE/pgrx/src/callconv.rs
+    |
+    |     pub unsafe fn next_arg_unchecked<T: ArgAbi<'fcx>>(&mut self) -> Option<T> {
+    |                                         ^^^^^^^^^^^^
+    = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
1. Why cfi directives are needed in `call_closure_with_sigsetjmp`?

CFI directives are necessary for generating unwind tables. Without unwind tables, debuggers and profilers will be unable to correctly produce backtraces.

2. What does this pull request do?

This pull request removes dependency on `cee_scape` and uses clang generated asm to build the naked asm function `call_closure_with_sigsetjmp`.

3. How is assembly code generated?

```c
// sigsetjmp.c
#include <setjmp.h>

int call_closure_with_sigsetjmp(int savemask, void *closure_env_ptr,
                                int (*closure_code)(sigjmp_buf jbuf,
                                                    void *env_ptr)) {
  sigjmp_buf jbuf;
  int val;
  if (0 == (val = sigsetjmp(jbuf, savemask))) {
    return closure_code(jbuf, closure_env_ptr);
  } else {
    return val;
  }
}
```

The following command is executed on my machine (Arch Linux, clang version 20.1.8):

```sh
clang sigsetjmp.c -O2 -S -masm=intel -fno-stack-protector -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fasynchronous-unwind-tables --target=x86_64-linux-gnu -o sigsetjmp-x86_64-linux.s
clang sigsetjmp.c -O2 -S -fno-stack-protector -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fasynchronous-unwind-tables --target=aarch64-linux-gnu --sysroot=/usr/aarch64-linux-gnu -o sigsetjmp-aarch64-linux.s
SDKROOT=/home/usamoi/.macos-sdks/MacOSX15.4.sdk/ clang sigsetjmp.c -O2 -S -masm=intel -fno-stack-protector -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fasynchronous-unwind-tables --target=x86_64-apple-macos -o sigsetjmp-x86_64-macos.s
SDKROOT=/home/usamoi/.macos-sdks/MacOSX15.4.sdk/ clang sigsetjmp.c -O2 -S -fno-stack-protector -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fasynchronous-unwind-tables --target=aarch64-apple-macos -o sigsetjmp-aarch64-macos.s
```

Now there are 4 files:

<details>
<summary>sigsetjmp-aarch64-linux.s</summary>

```asm
	.file	"sigsetjmp.c"
	.text
	.globl	call_closure_with_sigsetjmp     // -- Begin function call_closure_with_sigsetjmp
	.p2align	2
	.type	call_closure_with_sigsetjmp,@function
call_closure_with_sigsetjmp:            // @call_closure_with_sigsetjmp
	.cfi_startproc
// %bb.0:
	sub	sp, sp, #368
	.cfi_def_cfa_offset 368
	stp	x29, x30, [sp, #320]            // 16-byte Folded Spill
	str	x28, [sp, #336]                 // 8-byte Folded Spill
	stp	x20, x19, [sp, #352]            // 16-byte Folded Spill
	add	x29, sp, #320
	.cfi_def_cfa w29, 48
	.cfi_offset w19, -8
	.cfi_offset w20, -16
	.cfi_offset w28, -32
	.cfi_offset w30, -40
	.cfi_offset w29, -48
	mov	x20, x1
	mov	w1, w0
	add	x0, sp, #8
	mov	x19, x2
	bl	__sigsetjmp
	mov	w1, w0
	cbnz	w0, .LBB0_2
// %bb.1:
	add	x0, sp, #8
	mov	x1, x20
	blr	x19
	mov	w1, w0
.LBB0_2:
	mov	w0, w1
	.cfi_def_cfa wsp, 368
	ldp	x20, x19, [sp, #352]            // 16-byte Folded Reload
	ldr	x28, [sp, #336]                 // 8-byte Folded Reload
	ldp	x29, x30, [sp, #320]            // 16-byte Folded Reload
	add	sp, sp, #368
	.cfi_def_cfa_offset 0
	.cfi_restore w19
	.cfi_restore w20
	.cfi_restore w28
	.cfi_restore w30
	.cfi_restore w29
	ret
.Lfunc_end0:
	.size	call_closure_with_sigsetjmp, .Lfunc_end0-call_closure_with_sigsetjmp
	.cfi_endproc
                                        // -- End function
	.ident	"clang version 20.1.8"
	.section	".note.GNU-stack","",@progbits
	.addrsig
```

</details>

<details>
<summary>sigsetjmp-aarch64-macos.s</summary>

```asm
	.build_version macos, 11, 0	sdk_version 15, 4
	.section	__TEXT,__text,regular,pure_instructions
	.globl	_call_closure_with_sigsetjmp    ; -- Begin function call_closure_with_sigsetjmp
	.p2align	2
_call_closure_with_sigsetjmp:           ; @call_closure_with_sigsetjmp
	.cfi_startproc
; %bb.0:
	sub	sp, sp, #240
	.cfi_def_cfa_offset 240
	stp	x20, x19, [sp, #208]            ; 16-byte Folded Spill
	stp	x29, x30, [sp, #224]            ; 16-byte Folded Spill
	add	x29, sp, #224
	.cfi_def_cfa w29, 16
	.cfi_offset w30, -8
	.cfi_offset w29, -16
	.cfi_offset w19, -24
	.cfi_offset w20, -32
	mov	x19, x2
	mov	x20, x1
	mov	x1, x0
	add	x0, sp, #12
	bl	_sigsetjmp
	mov	x1, x0
	cbnz	w0, LBB0_2
; %bb.1:
	add	x0, sp, #12
	mov	x1, x20
	blr	x19
	mov	x1, x0
LBB0_2:
	mov	x0, x1
	.cfi_def_cfa wsp, 240
	ldp	x29, x30, [sp, #224]            ; 16-byte Folded Reload
	ldp	x20, x19, [sp, #208]            ; 16-byte Folded Reload
	add	sp, sp, #240
	.cfi_def_cfa_offset 0
	.cfi_restore w30
	.cfi_restore w29
	.cfi_restore w19
	.cfi_restore w20
	ret
	.cfi_endproc
                                        ; -- End function
.subsections_via_symbols
```

</details>

<details>
<summary>sigsetjmp-x86_64-linux.s</summary>

```asm
	.intel_syntax noprefix
	.file	"sigsetjmp.c"
	.text
	.globl	call_closure_with_sigsetjmp     # -- Begin function call_closure_with_sigsetjmp
	.p2align	4
	.type	call_closure_with_sigsetjmp,@function
call_closure_with_sigsetjmp:            # @call_closure_with_sigsetjmp
	.cfi_startproc
# %bb.0:
	push	rbp
	.cfi_def_cfa_offset 16
	.cfi_offset rbp, -16
	mov	rbp, rsp
	.cfi_def_cfa_register rbp
	push	r14
	push	rbx
	sub	rsp, 208
	.cfi_offset rbx, -32
	.cfi_offset r14, -24
	mov	rbx, rdx
	mov	r14, rsi
	mov	esi, edi
	lea	rdi, [rbp - 224]
	call	__sigsetjmp@PLT
	mov	ecx, eax
	test	eax, eax
	jne	.LBB0_2
# %bb.1:
	lea	rdi, [rbp - 224]
	mov	rsi, r14
	call	rbx
	mov	ecx, eax
.LBB0_2:
	mov	eax, ecx
	add	rsp, 208
	pop	rbx
	pop	r14
	pop	rbp
	.cfi_def_cfa rsp, 8
	ret
.Lfunc_end0:
	.size	call_closure_with_sigsetjmp, .Lfunc_end0-call_closure_with_sigsetjmp
	.cfi_endproc
                                        # -- End function
	.ident	"clang version 20.1.8"
	.section	".note.GNU-stack","",@progbits
	.addrsig
```

</details>

<details>
<summary>sigsetjmp-x86_64-macos.s</summary>

```asm
	.macosx_version_min 10, 4	sdk_version 15, 4
	.section	__TEXT,__text,regular,pure_instructions
	.intel_syntax noprefix
	.globl	_call_closure_with_sigsetjmp    ## -- Begin function call_closure_with_sigsetjmp
	.p2align	4
_call_closure_with_sigsetjmp:           ## @call_closure_with_sigsetjmp
	.cfi_startproc
## %bb.0:
	push	rbp
	.cfi_def_cfa_offset 16
	.cfi_offset rbp, -16
	mov	rbp, rsp
	.cfi_def_cfa_register rbp
	push	r14
	push	rbx
	sub	rsp, 160
	.cfi_offset rbx, -32
	.cfi_offset r14, -24
	mov	rbx, rdx
	mov	r14, rsi
	mov	esi, edi
	lea	rdi, [rbp - 176]
	call	_sigsetjmp
	mov	ecx, eax
	test	eax, eax
	jne	LBB0_2
## %bb.1:
	lea	rdi, [rbp - 176]
	mov	rsi, r14
	call	rbx
	mov	ecx, eax
LBB0_2:
	mov	eax, ecx
	add	rsp, 160
	pop	rbx
	pop	r14
	pop	rbp
	ret
	.cfi_endproc
                                        ## -- End function
.subsections_via_symbols
```

</details>

Replace `\t` with `    `, delete comments, use a numberic label `2` instead of named labels, replace the symbol name of `sigsetjmp` with `{}`, replace `^(.*)$` with `            "$1",`, and the final output is the same as the body in naked asm in the code.