### PR TITLE
link to libs recorded by pg_config

### DIFF
--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -374,6 +374,17 @@ fn generate_bindings(
         "cargo:rustc-link-search={}",
         lib_dir.to_str().ok_or(eyre!("{lib_dir:?} is not valid UTF-8 string"))?
     );
+
+    let libs = pg_config.libs()?;
+    for lib in shlex::split(libs.to_str().ok_or(eyre!("{libs:?} is not valid UTF-8 string"))?)
+        .into_iter()
+        .flatten()
+        .filter_map(|p| p.strip_prefix("-l").map(String::from))
+        .filter(|lib| !["pgcommon", "pgport"].contains(&lib.as_str()))
+    {
+        println!("cargo:rustc-link-lib={}", lib);
+    }
+
     Ok(())
 }
 

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -444,6 +444,10 @@ impl PgConfig {
         Ok(self.run("--cppflags")?.into())
     }
 
+    pub fn libs(&self) -> eyre::Result<PathBuf> {
+        Ok(self.run("--libs")?.into())
+    }
+
     pub fn extension_dir(&self) -> eyre::Result<PathBuf> {
         let mut path = self.sharedir()?;
         path.push("extension");


### PR DESCRIPTION
I think this could avoid the issue of needing to manually link libraries in https://github.com/pgcentralfoundation/pgrx/pull/2117. However, due to https://github.com/EnterpriseDB/edb-installers/issues/372, this fix won't actually work. But I still leave this PR here for now, so I don't forget about it later.
