### PR TITLE
give exported `__pgrx_internals_fn_*` functions unique names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Print sccache stats (before)
         run: sccache --show-stats
 
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -380,6 +380,9 @@ jobs:
       - name: Print sccache stats (before)
         run: sccache --show-stats
 
+      - name: Install clippy
+        run: rustup component add clippy
+
       - name: Install cargo-pgrx
         run: cargo install --path cargo-pgrx/ --debug --force
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install rustfmt
         run: rustup component add rustfmt
 
+      - name: Install clippy
+        run: rustup component add clippy
+
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,6 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "thiserror 2.0.12",
- "uuid",
 ]
 
 [[package]]
@@ -2068,6 +2067,7 @@ dependencies = [
  "syntect",
  "thiserror 2.0.12",
  "unescape",
+ "uuid",
 ]
 
 [[package]]
@@ -3578,11 +3578,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.2",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -7,7 +7,7 @@
 #LICENSE All rights reserved.
 #LICENSE
 #LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
- 
+
 [package]
 name = "pgrx-sql-entity-graph"
 version = "0.16.0"
@@ -35,6 +35,7 @@ thiserror.workspace = true
 convert_case = "0.8.0"
 petgraph = "0.8.1"
 unescape = "0.1.0" # for escaped-character-handling
+uuid = { version = "1.18.0", features = ["v4"] } # PgLwLock and shmem
 
 # colorized sql output
 owo-colors = { optional = true, workspace = true }

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -356,7 +356,11 @@ impl PgExtern {
             .collect::<Vec<_>>();
         let hrtb = if lifetimes.is_empty() { None } else { Some(quote! { for<#(#lifetimes),*> }) };
 
-        let sql_graph_entity_fn_name = format_ident!("__pgrx_internals_fn_{}", ident);
+        let uuid = uuid::Uuid::new_v4();
+        let sql_graph_entity_fn_name = Ident::new(
+            &format!("__pgrx_internals_fn_{}_{}", ident, uuid.as_simple()),
+            Span::call_site(),
+        );
         quote_spanned! { self.func.sig.span() =>
             #[unsafe(no_mangle)]
             #[doc(hidden)]

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -54,7 +54,6 @@ thiserror.workspace = true # error handling and logging
 
 # used to internally impl things
 once_cell = "1.21.3" # polyfill until std::lazy::OnceCell stabilizes
-uuid = { version = "1.16.0", features = ["v4"] } # PgLwLock and shmem
 enum-map = "2.7.3"
 
 # exposed in public API


### PR DESCRIPTION
It's entirely possible for a pgrx extension to have functions like this:

```rust
mod a {
   #[pg_extern]
   fn foo() { }
}

mod b {
   #[pg_extern]
   fn foo() { }
}
```

These are two distinct functions in Rust, and should be in the SQL schema, but the naming of the sql entity graph `__pgrx_internals_fn_*` function isn't unique enough and causes compilation problems.

We could maybe include the schema name here, but I don't think that's quite enough, so instead we just append a UUIDv4 value.