### PR TITLE
Fixing CI

### DIFF
--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -86,6 +86,11 @@ jobs:
           cargo --version
           pg_config --version
 
+      - name: Install rustfmt & clippy
+        run: |
+          rustup component add rustfmt
+          rustup component add clippy
+
       - name: Install cargo pgrx
         run: cd cargo-pgrx && cargo install --path . --debug
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Print sccache stats (before)
         run: sccache --show-stats
 
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install rustfmt
         run: rustup component add rustfmt
 
+      - name: Install clippy
+        run: rustup component add clippy
+
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,11 +74,10 @@ jobs:
       - name: Print sccache stats (before)
         run: sccache --show-stats
 
-      - name: Install rustfmt
-        run: rustup component add rustfmt
-
-      - name: Install clippy
-        run: rustup component add clippy
+      - name: Install rustfmt & clippy
+        run: |
+          rustup component add rustfmt
+          rustup component add clippy
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check
@@ -224,6 +223,11 @@ jobs:
 
       - name: Print sccache stats (before run)
         run: sccache --show-stats
+
+      - name: Install rustfmt & clippy
+        run: |
+          rustup component add rustfmt
+          rustup component add clippy
 
       - name: Install cargo-pgrx
         run: cargo install --path cargo-pgrx/ --debug --force
@@ -380,6 +384,11 @@ jobs:
       - name: Print sccache stats (before)
         run: sccache --show-stats
 
+      - name: Install rustfmt & clippy
+        run: |
+          rustup component add rustfmt
+          rustup component add clippy
+
       - name: Install cargo-pgrx
         run: cargo install --path cargo-pgrx/ --debug --force
 
@@ -501,6 +510,11 @@ jobs:
       - name: Print sccache stats
         run: sccache --show-stats
 
+      - name: Install rustfmt & clippy
+        run: |
+          rustup component add rustfmt
+          rustup component add clippy
+
       - name: Install cargo-pgrx
         run: cargo install --path cargo-pgrx/ --debug --force
 
@@ -580,6 +594,11 @@ jobs:
 
       - name: Install cargo-pgrx
         run: cargo install --path cargo-pgrx/ --debug --force
+
+      - name: Install rustfmt & clippy
+        run: |
+          rustup component add rustfmt
+          rustup component add clippy
 
       - name: Print sccache stats
         run: sccache --show-stats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,6 +1934,7 @@ dependencies = [
  "bitvec",
  "enum-map",
  "libc",
+ "once_cell",
  "pgrx-macros",
  "pgrx-pg-sys",
  "pgrx-sql-entity-graph",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.89.0"


### PR DESCRIPTION
CI has bitrotted and it looks like the new rust 1.90.0 lights up some of our "ui" tests, and I'd prefer to not deal with that, so this also adds a rust-toolchain.toml to set us to 1.89.0