### PR TITLE
Update version to 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bzip2",
  "cargo-edit",
@@ -1928,13 +1928,12 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bitflags 2.9.0",
  "bitvec",
  "enum-map",
  "libc",
- "once_cell",
  "pgrx-macros",
  "pgrx-pg-sys",
  "pgrx-sql-entity-graph",
@@ -1948,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1965,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1976,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "cargo_toml",
  "codepage",
@@ -1994,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "cee-scape",
  "libc",
@@ -2006,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2022,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "clap-cargo 0.14.1",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -70,72 +70,72 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.22"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+checksum = "9611ec0b6acea03372540509035db2f7f1e9f04da5d27728436fa994033c00a0"
 dependencies = [
- "flate2",
+ "compression-codecs",
+ "compression-core",
  "futures-core",
- "memchr",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -188,9 +188,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bincode"
@@ -208,7 +208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -258,9 +258,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -320,6 +320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,11 +340,11 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -359,7 +368,7 @@ dependencies = [
  "serde_derive",
  "tame-index",
  "termcolor",
- "toml 0.8.20",
+ "toml 0.8.23",
  "toml_edit",
  "url",
 ]
@@ -368,7 +377,7 @@ dependencies = [
 name = "cargo-pgrx"
 version = "0.16.1"
 dependencies = [
- "bzip2",
+ "bzip2 0.5.2",
  "cargo-edit",
  "cargo_metadata 0.18.1",
  "cargo_toml",
@@ -391,7 +400,7 @@ dependencies = [
  "serde-xml-rs",
  "tar",
  "tempfile",
- "toml 0.9.5",
+ "toml 0.9.7",
  "toml_edit",
  "tracing",
  "tracing-error",
@@ -436,25 +445,26 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "cargo_toml"
-version = "0.22.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.8.20",
+ "toml 0.9.7",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -487,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -520,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -551,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -564,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -576,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "codepage"
@@ -618,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -631,6 +641,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485abf41ac0c8047c07c87c72c8fb3eb5197f6e9d7ded615dfd1a00ae00a0f64"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
 name = "concolor-control"
@@ -676,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -701,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -716,9 +743,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -775,9 +802,9 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "pem-rfc7468",
  "zeroize",
@@ -785,18 +812,18 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -901,12 +928,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -943,15 +970,21 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fixedbitset"
@@ -961,11 +994,12 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -998,9 +1032,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1085,28 +1119,28 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1118,15 +1152,15 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1149,14 +1183,20 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -1239,19 +1279,21 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1259,11 +1301,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -1278,17 +1319,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1298,21 +1343,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1322,30 +1368,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1353,72 +1379,59 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1427,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1437,18 +1450,18 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -1461,10 +1474,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_ci"
@@ -1517,33 +1551,33 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
 [[package]]
 name = "jobslot"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14ffb4145759d1032337501fb73b427c754a5f37d89dfe281dd89f48048e6ef"
+checksum = "58715c67c327da7f1558708348d68c207fd54900c4ae0529e29305d04d795b8c"
 dependencies = [
  "cfg-if",
  "derive_destructure2",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1556,30 +1590,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.171"
+name = "libbz2-rs-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
+name = "libc"
+version = "0.2.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1590,66 +1639,55 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
 ]
 
 [[package]]
-name = "lockfree-object-pool"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
-
-[[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
-name = "lzma-rs"
-version = "0.3.0"
+name = "lru-slab"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
 dependencies = [
- "byteorder",
  "crc",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "sha2",
 ]
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1664,15 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "minimal-lexical"
@@ -1682,22 +1714,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1738,12 +1770,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1763,11 +1794,11 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1786,12 +1817,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1819,9 +1856,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1830,25 +1867,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "owo-colors"
-version = "4.2.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 dependencies = [
  "supports-color",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1856,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1910,18 +1941,18 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "serde",
 ]
@@ -1930,7 +1961,7 @@ dependencies = [
 name = "pgrx"
 version = "0.16.1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "bitvec",
  "enum-map",
  "libc",
@@ -1941,7 +1972,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "uuid",
 ]
 
@@ -1985,8 +2016,8 @@ dependencies = [
  "pathsearch",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
- "toml 0.9.5",
+ "thiserror 2.0.16",
+ "toml 0.9.7",
  "url",
  "winapi",
 ]
@@ -2015,7 +2046,7 @@ dependencies = [
  "quote",
  "syn",
  "syntect",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "unescape",
 ]
 
@@ -2033,14 +2064,14 @@ dependencies = [
  "pgrx-pg-config",
  "postgres",
  "proptest",
- "rand 0.9.0",
+ "rand",
  "regex",
  "serde",
  "serde_json",
  "shlex",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "trybuild",
  "winapi",
 ]
@@ -2053,25 +2084,26 @@ dependencies = [
  "clap",
  "owo-colors",
  "rustc-hash",
- "toml 0.9.5",
+ "toml 0.9.7",
  "toml_edit",
  "walkdir",
 ]
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2096,9 +2128,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
@@ -2109,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.10"
+version = "0.19.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363e6dfbdd780d3aa3597b6eb430db76bb315fa9bad7fae595bb8def808b8470"
+checksum = "8bc19a61586a93e0663e8663dcc37c361f11e44ab0309d23eba1aa5a1965116d"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2123,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
+checksum = "fbef655056b916eb868048276cfd5d6a7dea4f81560dfd047f97c8c6fe3fcfd4"
 dependencies = [
  "base64",
  "byteorder",
@@ -2134,16 +2166,16 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.0",
+ "rand",
  "sha2",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+checksum = "77a120daaabfcb0e324d5bf6e411e9222994cb3795c79943a0ef28ed27ea76e4"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2151,10 +2183,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
 
 [[package]]
 name = "ppv-lite86"
@@ -2167,28 +2214,28 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2202,18 +2249,18 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2223,7 +2270,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -2231,19 +2278,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
- "rand 0.9.0",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2251,16 +2299,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2274,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -2286,34 +2334,12 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
- "zerocopy",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2323,16 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
+ "rand_core",
 ]
 
 [[package]]
@@ -2341,23 +2358,23 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -2365,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2375,62 +2392,47 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "async-compression",
  "base64",
@@ -2445,17 +2447,13 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2465,13 +2463,13 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "windows-registry",
 ]
 
 [[package]]
@@ -2482,7 +2480,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2490,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -2502,22 +2500,22 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "log",
  "once_cell",
@@ -2537,7 +2535,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.5.0",
 ]
 
 [[package]]
@@ -2551,20 +2549,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "be59af91596cac372a6942530653ad0c3a246cdd491aaa9dcaee47f88d67d5a0"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2573,7 +2572,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.2.0",
+ "security-framework 3.5.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.59.0",
@@ -2587,9 +2586,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2598,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -2631,11 +2630,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2656,7 +2655,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2665,12 +2664,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.4",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2678,9 +2677,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2688,19 +2687,21 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2727,10 +2728,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2739,32 +2749,33 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2792,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2830,18 +2841,15 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
@@ -2855,12 +2863,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2903,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2923,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2945,7 +2953,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "plist",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2987,7 +2995,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smol_str",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "toml-span",
  "twox-hash",
@@ -3018,15 +3026,15 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3040,12 +3048,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3059,11 +3067,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -3079,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3090,19 +3098,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -3115,15 +3122,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3131,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3141,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3156,24 +3163,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
+checksum = "a156efe7fff213168257853e1dfde202eed5f487522cbbbf7d219941d753d853"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -3188,7 +3197,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.0",
+ "rand",
  "socket2",
  "tokio",
  "tokio-util",
@@ -3197,9 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
  "rustls",
  "tokio",
@@ -3207,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3220,26 +3229,26 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.8",
- "toml_datetime 0.6.8",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
 ]
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "serde_core",
+ "serde_spanned 1.0.2",
+ "toml_datetime 0.7.2",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -3256,49 +3265,56 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned 0.6.8",
- "toml_datetime 0.6.8",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.0.2"
+name = "toml_write"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tower"
@@ -3311,6 +3327,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3340,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3351,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3382,14 +3416,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3406,9 +3440,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.104"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+checksum = "0ded9fdb81f30a5708920310bfcd9ea7482ff9cba5f54601f7a19a877d5c2392"
 dependencies = [
  "glob",
  "serde",
@@ -3416,14 +3450,14 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.8.20",
+ "toml 0.9.7",
 ]
 
 [[package]]
 name = "twox-hash"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -3451,9 +3485,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-normalization"
@@ -3478,9 +3512,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"
@@ -3490,9 +3524,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.0.10"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0351ca625c7b41a8e4f9bb6c5d9755f67f62c2187ebedecacd9974674b271d"
+checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
 dependencies = [
  "base64",
  "der",
@@ -3512,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.3.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae239d0a3341aebc94259414d1dc67cfce87d41cbebc816772c91b77902fafa4"
+checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
 dependencies = [
  "base64",
  "http",
@@ -3524,13 +3558,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3538,12 +3573,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3559,11 +3588,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3614,17 +3645,26 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3635,21 +3675,22 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -3661,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3674,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3684,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3697,18 +3738,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3726,18 +3767,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3756,11 +3797,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
- "redox_syscall",
+ "libredox",
  "wasite",
  "web-sys",
 ]
@@ -3783,11 +3824,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3814,7 +3855,7 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -3842,20 +3883,15 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
+name = "windows-link"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result 0.3.2",
- "windows-strings",
- "windows-targets 0.53.0",
-]
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-result"
@@ -3864,24 +3900,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -3909,6 +3927,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -3944,10 +3980,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -4112,25 +4149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
@@ -4143,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
@@ -4153,18 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "yaml-rust"
@@ -4177,9 +4196,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4189,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4201,18 +4220,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4261,10 +4280,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4273,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4284,27 +4314,26 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
 dependencies = [
  "aes",
  "arbitrary",
- "bzip2",
+ "bzip2 0.6.0",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
  "deflate64",
  "flate2",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "hmac",
  "indexmap",
- "lzma-rs",
+ "lzma-rust2",
  "memchr",
  "pbkdf2",
+ "ppmd-rust",
  "sha1",
  "time",
- "xz2",
  "zeroize",
  "zopfli",
  "zstd",
@@ -4312,26 +4341,30 @@ dependencies = [
 
 [[package]]
 name = "zip-extract"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3938d2b7d7ffd0fb7d4a86baeade9189535487d05d175401daf92306c531c0"
+checksum = "db6d94e397dd6d0273e6747e46e7aa0289bfd9736ba8772f2fe948bc4adc3f73"
 dependencies = [
  "log",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "zip",
 ]
 
 [[package]]
-name = "zopfli"
-version = "0.8.1"
+name = "zlib-rs"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
 dependencies = [
  "bumpalo",
  "crc32fast",
- "lockfree-object-pool",
  "log",
- "once_cell",
  "simd-adler32",
 ]
 
@@ -4355,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,11 +66,11 @@ version = "0.16.0"
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-macros = { path = "./pgrx-macros", version = "=0.16.0" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.16.0" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.16.0" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.16.0" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.16.0" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.16.1" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.16.1" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.16.1" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.16.1" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.16.1" }
 
 cargo_metadata = "0.18.0"
 cargo-edit = "=0.13.2" # format-preserving edits to cargo.toml

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "cargo-pgrx"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 license.workspace = true
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -21,10 +21,10 @@ pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.16.0"
+pgrx = "=0.16.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.16.0"
+pgrx-tests = "=0.16.1"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/pgcentralfoundation/pgrx"

--- a/pgrx-examples/hooks/Cargo.toml
+++ b/pgrx-examples/hooks/Cargo.toml
@@ -21,10 +21,10 @@ pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.16.0"
+pgrx = "=0.16.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.16.0"
+pgrx-tests = "=0.16.1"
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-examples/hooks/Cargo.toml
+++ b/pgrx-examples/hooks/Cargo.toml
@@ -35,7 +35,7 @@ pg_test = []
 pgrx = { path = "../../pgrx", default-features = false }
 
 [dev-dependencies]
-pgrx = { path = "../../pgrx-tests" }
+pgrx-tests = { path = "../../pgrx-tests" }
 
 # uncomment these if compiling outside of 'pgrx'
 # [profile.dev]

--- a/pgrx-examples/hooks/Cargo.toml
+++ b/pgrx-examples/hooks/Cargo.toml
@@ -1,7 +1,18 @@
+#LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+#LICENSE
+#LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+#LICENSE
+#LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+#LICENSE
+#LICENSE All rights reserved.
+#LICENSE
+#LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 [package]
 name = "hooks"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -24,13 +35,16 @@ pg_test = []
 pgrx = { path = "../../pgrx", default-features = false }
 
 [dev-dependencies]
-pgrx = { path = "../../pgrx-tests", default-features = false }
+pgrx = { path = "../../pgrx-tests" }
 
-[profile.dev]
-panic = "unwind"
+# uncomment these if compiling outside of 'pgrx'
+# [profile.dev]
+# panic = "unwind"
 
-[profile.release]
-panic = "unwind"
-opt-level = 3
-lto = "fat"
-codegen-units = 1
+# [profile.release]
+# panic = "unwind"
+# opt-level = 3
+# lto = "fat"
+# codegen-units = 1
+                                                                                               50,1          Bot
+

--- a/pgrx-examples/hooks/Cargo.toml
+++ b/pgrx-examples/hooks/Cargo.toml
@@ -46,5 +46,3 @@ pgrx = { path = "../../pgrx-tests" }
 # opt-level = 3
 # lto = "fat"
 # codegen-units = 1
-                                                                                               50,1          Bot
-

--- a/pgrx-examples/hooks/Cargo.toml
+++ b/pgrx-examples/hooks/Cargo.toml
@@ -21,10 +21,10 @@ pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.16.1"
+pgrx = { path = "../../pgrx", default-features = false }
 
 [dev-dependencies]
-pgrx-tests = "=0.16.1"
+pgrx = { path = "../../pgrx-tests", default-features = false }
 
 [profile.dev]
 panic = "unwind"

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 license.workspace = true
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-config"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 license.workspace = true
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 license.workspace = true
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -183,18 +183,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 13.21";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 13.22";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"13.21";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"13.22";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"13";
 pub const PG_MAJORVERSION_NUM: u32 = 13;
-pub const PG_MINORVERSION_NUM: u32 = 21;
+pub const PG_MINORVERSION_NUM: u32 = 22;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"13.21";
-pub const PG_VERSION_NUM: u32 = 130021;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 13.21 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"13.22";
+pub const PG_VERSION_NUM: u32 = 130022;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 13.22 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -255,7 +255,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 13.21\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 13.22\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -2311,6 +2311,19 @@ pub const LOG_METAINFO_DATAFILE_TMP: &::core::ffi::CStr = c"current_logfiles.tmp
 pub const RBTXN_HAS_CATALOG_CHANGES: u32 = 1;
 pub const RBTXN_IS_SUBXACT: u32 = 2;
 pub const RBTXN_IS_SERIALIZED: u32 = 4;
+pub const RBTXN_DISTR_INVAL_OVERFLOWED: u32 = 8;
+pub const SYNC_REP_NO_WAIT: i32 = -1;
+pub const SYNC_REP_WAIT_WRITE: u32 = 0;
+pub const SYNC_REP_WAIT_FLUSH: u32 = 1;
+pub const SYNC_REP_WAIT_APPLY: u32 = 2;
+pub const NUM_SYNC_REP_WAIT_MODE: u32 = 3;
+pub const SYNC_REP_NOT_WAITING: u32 = 0;
+pub const SYNC_REP_WAITING: u32 = 1;
+pub const SYNC_REP_WAIT_COMPLETE: u32 = 2;
+pub const SYNC_REP_PRIORITY: u32 = 0;
+pub const SYNC_REP_QUORUM: u32 = 1;
+pub const SYNC_STANDBY_INIT: u32 = 1;
+pub const SYNC_STANDBY_DEFINED: u32 = 2;
 pub const STATS_MAX_DIMENSIONS: u32 = 8;
 pub const STATS_NDISTINCT_MAGIC: u32 = 2740109220;
 pub const STATS_NDISTINCT_TYPE_BASIC: u32 = 1;
@@ -27108,6 +27121,8 @@ pub struct ReorderBufferTXN {
     pub invalidations: *mut SharedInvalidationMessage,
     pub node: dlist_node,
     pub size: Size,
+    pub ninvalidations_distributed: uint32,
+    pub invalidations_distributed: *mut SharedInvalidationMessage,
 }
 impl Default for ReorderBufferTXN {
     fn default() -> Self {
@@ -27390,6 +27405,78 @@ pub struct LogicalDecodingContext {
     pub in_create: bool,
 }
 impl Default for LogicalDecodingContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SyncRepStandbyData {
+    pub pid: pid_t,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub walsnd_index: ::core::ffi::c_int,
+    pub is_me: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SyncRepConfigData {
+    pub config_size: ::core::ffi::c_int,
+    pub num_sync: ::core::ffi::c_int,
+    pub syncrep_method: uint8,
+    pub nmembers: ::core::ffi::c_int,
+    pub member_names: __IncompleteArrayField<::core::ffi::c_char>,
+}
+pub mod WalSndState {
+    pub type Type = ::core::ffi::c_uint;
+    pub const WALSNDSTATE_STARTUP: Type = 0;
+    pub const WALSNDSTATE_BACKUP: Type = 1;
+    pub const WALSNDSTATE_CATCHUP: Type = 2;
+    pub const WALSNDSTATE_STREAMING: Type = 3;
+    pub const WALSNDSTATE_STOPPING: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WalSnd {
+    pub pid: pid_t,
+    pub state: WalSndState::Type,
+    pub sentPtr: XLogRecPtr,
+    pub needreload: bool,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub writeLag: TimeOffset,
+    pub flushLag: TimeOffset,
+    pub applyLag: TimeOffset,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub mutex: slock_t,
+    pub latch: *mut Latch,
+    pub replyTime: TimestampTz,
+}
+impl Default for WalSnd {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct WalSndCtlData {
+    pub SyncRepQueue: [SHM_QUEUE; 3usize],
+    pub lsn: [XLogRecPtr; 3usize],
+    pub sync_standbys_status: bits8,
+    pub walsnds: __IncompleteArrayField<WalSnd>,
+}
+impl Default for WalSndCtlData {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -31422,6 +31509,7 @@ unsafe extern "C-unwind" {
     pub fn standard_ExecutorEnd(queryDesc: *mut QueryDesc);
     pub fn ExecutorRewind(queryDesc: *mut QueryDesc);
     pub fn ExecCheckRTPerms(rangeTable: *mut List, ereport_on_violation: bool) -> bool;
+    pub fn ExecCheckRTEPerms(rte: *mut RangeTblEntry) -> bool;
     pub fn CheckValidResultRel(resultRelInfo: *mut ResultRelInfo, operation: CmdType::Type);
     pub fn InitResultRelInfo(
         resultRelInfo: *mut ResultRelInfo,
@@ -38738,6 +38826,7 @@ unsafe extern "C-unwind" {
     );
     pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
     pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
+    pub fn has_transition_tables(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
     pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
     pub fn get_dependent_generated_columns(
         root: *mut PlannerInfo,
@@ -39969,6 +40058,13 @@ unsafe extern "C-unwind" {
         nmsgs: Size,
         msgs: *mut SharedInvalidationMessage,
     );
+    pub fn ReorderBufferAddDistributedInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        lsn: XLogRecPtr,
+        nmsgs: Size,
+        msgs: *mut SharedInvalidationMessage,
+    );
     pub fn ReorderBufferImmediateInvalidation(
         arg1: *mut ReorderBuffer,
         ninvalidations: uint32,
@@ -40064,6 +40160,43 @@ unsafe extern "C-unwind" {
     ) -> bool;
     pub fn ApplyWorkerMain(main_arg: Datum);
     pub fn IsLogicalWorker() -> bool;
+    pub static mut SyncRepConfig: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_result: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_error_msg: *mut ::core::ffi::c_char;
+    pub static mut SyncRepStandbyNames: *mut ::core::ffi::c_char;
+    pub fn SyncRepWaitForLSN(lsn: XLogRecPtr, commit: bool);
+    pub fn SyncRepCleanupAtProcExit();
+    pub fn SyncRepInitConfig();
+    pub fn SyncRepReleaseWaiters();
+    pub fn SyncRepGetCandidateStandbys(
+        standbys: *mut *mut SyncRepStandbyData,
+    ) -> ::core::ffi::c_int;
+    pub fn SyncRepUpdateSyncStandbysDefined();
+    pub fn check_synchronous_standby_names(
+        newval: *mut *mut ::core::ffi::c_char,
+        extra: *mut *mut ::core::ffi::c_void,
+        source: GucSource::Type,
+    ) -> bool;
+    pub fn assign_synchronous_standby_names(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    );
+    pub fn assign_synchronous_commit(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void);
+    pub fn syncrep_yyparse() -> ::core::ffi::c_int;
+    pub fn syncrep_yylex() -> ::core::ffi::c_int;
+    pub fn syncrep_yyerror(str_: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_init(query_string: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_finish();
+    pub static mut MyWalSnd: *mut WalSnd;
+    pub static mut WalSndCtl: *mut WalSndCtlData;
+    pub fn WalSndSetState(state: WalSndState::Type);
+    pub fn replication_yyparse() -> ::core::ffi::c_int;
+    pub fn replication_yylex() -> ::core::ffi::c_int;
+    pub fn replication_yyerror(str_: *const ::core::ffi::c_char) -> !;
+    pub fn replication_scanner_init(query_string: *const ::core::ffi::c_char);
+    pub fn replication_scanner_finish();
+    pub fn replication_scanner_is_replication_command() -> bool;
+    pub static mut replication_parse_result: *mut Node;
     pub fn QueryRewrite(parsetree: *mut Query) -> *mut List;
     pub fn AcquireRewriteLocks(parsetree: *mut Query, forExecute: bool, forUpdatePushedDown: bool);
     pub fn build_column_default(rel: Relation, attrno: ::core::ffi::c_int) -> *mut Node;
@@ -43956,6 +44089,11 @@ unsafe extern "C-unwind" {
         varRelid: ::core::ffi::c_int,
         vardata: *mut VariableStatData,
     );
+    pub fn all_rows_selectable(
+        root: *mut PlannerInfo,
+        varno: Index,
+        varattnos: *mut Bitmapset,
+    ) -> bool;
     pub fn statistic_proc_security_check(vardata: *mut VariableStatData, func_oid: Oid) -> bool;
     pub fn get_restriction_variable(
         root: *mut PlannerInfo,
@@ -48528,6 +48666,16 @@ pub const WalLevel_WAL_LEVEL_MINIMAL: u32 = 0;
 pub const WalLevel_WAL_LEVEL_REPLICA: u32 = 1;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalLevel::WAL_LEVEL_LOGICAL")]
 pub const WalLevel_WAL_LEVEL_LOGICAL: u32 = 2;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STARTUP")]
+pub const WalSndState_WALSNDSTATE_STARTUP: u32 = 0;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_BACKUP")]
+pub const WalSndState_WALSNDSTATE_BACKUP: u32 = 1;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_CATCHUP")]
+pub const WalSndState_WALSNDSTATE_CATCHUP: u32 = 2;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STREAMING")]
+pub const WalSndState_WALSNDSTATE_STREAMING: u32 = 3;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STOPPING")]
+pub const WalSndState_WALSNDSTATE_STOPPING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::XLTW_Oper::XLTW_None")]
 pub const XLTW_Oper_XLTW_None: u32 = 0;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::XLTW_Oper::XLTW_Update")]

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -183,18 +183,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 14.18";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 14.19";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"14.18";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"14.19";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"14";
 pub const PG_MAJORVERSION_NUM: u32 = 14;
-pub const PG_MINORVERSION_NUM: u32 = 18;
+pub const PG_MINORVERSION_NUM: u32 = 19;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"14.18";
-pub const PG_VERSION_NUM: u32 = 140018;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 14.18 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"14.19";
+pub const PG_VERSION_NUM: u32 = 140019;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 14.19 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -252,7 +252,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 14.18\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 14.19\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -2249,6 +2249,7 @@ pub const RBTXN_IS_STREAMED: u32 = 16;
 pub const RBTXN_HAS_PARTIAL_CHANGE: u32 = 32;
 pub const RBTXN_PREPARE: u32 = 64;
 pub const RBTXN_SKIPPED_PREPARE: u32 = 128;
+pub const RBTXN_DISTR_INVAL_OVERFLOWED: u32 = 256;
 pub const LOGICALREP_PROTO_MIN_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_STREAM_VERSION_NUM: u32 = 2;
@@ -2258,6 +2259,18 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const SYNC_REP_NO_WAIT: i32 = -1;
+pub const SYNC_REP_WAIT_WRITE: u32 = 0;
+pub const SYNC_REP_WAIT_FLUSH: u32 = 1;
+pub const SYNC_REP_WAIT_APPLY: u32 = 2;
+pub const NUM_SYNC_REP_WAIT_MODE: u32 = 3;
+pub const SYNC_REP_NOT_WAITING: u32 = 0;
+pub const SYNC_REP_WAITING: u32 = 1;
+pub const SYNC_REP_WAIT_COMPLETE: u32 = 2;
+pub const SYNC_REP_PRIORITY: u32 = 0;
+pub const SYNC_REP_QUORUM: u32 = 1;
+pub const SYNC_STANDBY_INIT: u32 = 1;
+pub const SYNC_STANDBY_DEFINED: u32 = 2;
 pub const STATS_MAX_DIMENSIONS: u32 = 8;
 pub const STATS_NDISTINCT_MAGIC: u32 = 2740109220;
 pub const STATS_NDISTINCT_TYPE_BASIC: u32 = 1;
@@ -28601,6 +28614,8 @@ pub struct ReorderBufferTXN {
     pub total_size: Size,
     pub concurrent_abort: bool,
     pub output_plugin_private: *mut ::core::ffi::c_void,
+    pub ninvalidations_distributed: uint32,
+    pub invalidations_distributed: *mut SharedInvalidationMessage,
 }
 impl Default for ReorderBufferTXN {
     fn default() -> Self {
@@ -29422,6 +29437,78 @@ pub struct LogicalDecodingContext {
     pub in_create: bool,
 }
 impl Default for LogicalDecodingContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SyncRepStandbyData {
+    pub pid: pid_t,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub walsnd_index: ::core::ffi::c_int,
+    pub is_me: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SyncRepConfigData {
+    pub config_size: ::core::ffi::c_int,
+    pub num_sync: ::core::ffi::c_int,
+    pub syncrep_method: uint8,
+    pub nmembers: ::core::ffi::c_int,
+    pub member_names: __IncompleteArrayField<::core::ffi::c_char>,
+}
+pub mod WalSndState {
+    pub type Type = ::core::ffi::c_uint;
+    pub const WALSNDSTATE_STARTUP: Type = 0;
+    pub const WALSNDSTATE_BACKUP: Type = 1;
+    pub const WALSNDSTATE_CATCHUP: Type = 2;
+    pub const WALSNDSTATE_STREAMING: Type = 3;
+    pub const WALSNDSTATE_STOPPING: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WalSnd {
+    pub pid: pid_t,
+    pub state: WalSndState::Type,
+    pub sentPtr: XLogRecPtr,
+    pub needreload: bool,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub writeLag: TimeOffset,
+    pub flushLag: TimeOffset,
+    pub applyLag: TimeOffset,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub mutex: slock_t,
+    pub latch: *mut Latch,
+    pub replyTime: TimestampTz,
+}
+impl Default for WalSnd {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct WalSndCtlData {
+    pub SyncRepQueue: [SHM_QUEUE; 3usize],
+    pub lsn: [XLogRecPtr; 3usize],
+    pub sync_standbys_status: bits8,
+    pub walsnds: __IncompleteArrayField<WalSnd>,
+}
+impl Default for WalSndCtlData {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -33551,6 +33638,7 @@ unsafe extern "C-unwind" {
     pub fn standard_ExecutorEnd(queryDesc: *mut QueryDesc);
     pub fn ExecutorRewind(queryDesc: *mut QueryDesc);
     pub fn ExecCheckRTPerms(rangeTable: *mut List, ereport_on_violation: bool) -> bool;
+    pub fn ExecCheckRTEPerms(rte: *mut RangeTblEntry) -> bool;
     pub fn CheckValidResultRel(resultRelInfo: *mut ResultRelInfo, operation: CmdType::Type);
     pub fn InitResultRelInfo(
         resultRelInfo: *mut ResultRelInfo,
@@ -40981,6 +41069,7 @@ unsafe extern "C-unwind" {
     );
     pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
     pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
+    pub fn has_transition_tables(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
     pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
     pub fn get_dependent_generated_columns(
         root: *mut PlannerInfo,
@@ -42235,6 +42324,13 @@ unsafe extern "C-unwind" {
         nmsgs: Size,
         msgs: *mut SharedInvalidationMessage,
     );
+    pub fn ReorderBufferAddDistributedInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        lsn: XLogRecPtr,
+        nmsgs: Size,
+        msgs: *mut SharedInvalidationMessage,
+    );
     pub fn ReorderBufferImmediateInvalidation(
         arg1: *mut ReorderBuffer,
         ninvalidations: uint32,
@@ -42513,6 +42609,43 @@ unsafe extern "C-unwind" {
     pub fn UpdateDecodingStats(ctx: *mut LogicalDecodingContext);
     pub fn ApplyWorkerMain(main_arg: Datum);
     pub fn IsLogicalWorker() -> bool;
+    pub static mut SyncRepConfig: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_result: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_error_msg: *mut ::core::ffi::c_char;
+    pub static mut SyncRepStandbyNames: *mut ::core::ffi::c_char;
+    pub fn SyncRepWaitForLSN(lsn: XLogRecPtr, commit: bool);
+    pub fn SyncRepCleanupAtProcExit();
+    pub fn SyncRepInitConfig();
+    pub fn SyncRepReleaseWaiters();
+    pub fn SyncRepGetCandidateStandbys(
+        standbys: *mut *mut SyncRepStandbyData,
+    ) -> ::core::ffi::c_int;
+    pub fn SyncRepUpdateSyncStandbysDefined();
+    pub fn check_synchronous_standby_names(
+        newval: *mut *mut ::core::ffi::c_char,
+        extra: *mut *mut ::core::ffi::c_void,
+        source: GucSource::Type,
+    ) -> bool;
+    pub fn assign_synchronous_standby_names(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    );
+    pub fn assign_synchronous_commit(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void);
+    pub fn syncrep_yyparse() -> ::core::ffi::c_int;
+    pub fn syncrep_yylex() -> ::core::ffi::c_int;
+    pub fn syncrep_yyerror(str_: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_init(query_string: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_finish();
+    pub static mut MyWalSnd: *mut WalSnd;
+    pub static mut WalSndCtl: *mut WalSndCtlData;
+    pub fn WalSndSetState(state: WalSndState::Type);
+    pub fn replication_yyparse() -> ::core::ffi::c_int;
+    pub fn replication_yylex() -> ::core::ffi::c_int;
+    pub fn replication_yyerror(str_: *const ::core::ffi::c_char) -> !;
+    pub fn replication_scanner_init(query_string: *const ::core::ffi::c_char);
+    pub fn replication_scanner_finish();
+    pub fn replication_scanner_is_replication_command() -> bool;
+    pub static mut replication_parse_result: *mut Node;
     pub fn QueryRewrite(parsetree: *mut Query) -> *mut List;
     pub fn AcquireRewriteLocks(parsetree: *mut Query, forExecute: bool, forUpdatePushedDown: bool);
     pub fn build_column_default(rel: Relation, attrno: ::core::ffi::c_int) -> *mut Node;
@@ -46740,6 +46873,11 @@ unsafe extern "C-unwind" {
         varRelid: ::core::ffi::c_int,
         vardata: *mut VariableStatData,
     );
+    pub fn all_rows_selectable(
+        root: *mut PlannerInfo,
+        varno: Index,
+        varattnos: *mut Bitmapset,
+    ) -> bool;
     pub fn statistic_proc_security_check(vardata: *mut VariableStatData, func_oid: Oid) -> bool;
     pub fn get_restriction_variable(
         root: *mut PlannerInfo,
@@ -51594,6 +51732,16 @@ pub const WalRcvState_WALRCV_WAITING: u32 = 3;
 pub const WalRcvState_WALRCV_RESTARTING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalRcvState::WALRCV_STOPPING")]
 pub const WalRcvState_WALRCV_STOPPING: u32 = 5;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STARTUP")]
+pub const WalSndState_WALSNDSTATE_STARTUP: u32 = 0;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_BACKUP")]
+pub const WalSndState_WALSNDSTATE_BACKUP: u32 = 1;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_CATCHUP")]
+pub const WalSndState_WALSNDSTATE_CATCHUP: u32 = 2;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STREAMING")]
+pub const WalSndState_WALSNDSTATE_STREAMING: u32 = 3;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STOPPING")]
+pub const WalSndState_WALSNDSTATE_STOPPING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::XLTW_Oper::XLTW_None")]
 pub const XLTW_Oper_XLTW_None: u32 = 0;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::XLTW_Oper::XLTW_Update")]

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -184,18 +184,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 15.13";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 15.14";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"15.13";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"15.14";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"15";
 pub const PG_MAJORVERSION_NUM: u32 = 15;
-pub const PG_MINORVERSION_NUM: u32 = 13;
+pub const PG_MINORVERSION_NUM: u32 = 14;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"15.13";
-pub const PG_VERSION_NUM: u32 = 150013;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 15.13 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"15.14";
+pub const PG_VERSION_NUM: u32 = 150014;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 15.14 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -254,7 +254,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 15.13\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 15.14\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -2295,6 +2295,7 @@ pub const RBTXN_IS_STREAMED: u32 = 16;
 pub const RBTXN_HAS_PARTIAL_CHANGE: u32 = 32;
 pub const RBTXN_PREPARE: u32 = 64;
 pub const RBTXN_SKIPPED_PREPARE: u32 = 128;
+pub const RBTXN_DISTR_INVAL_OVERFLOWED: u32 = 256;
 pub const LOGICALREP_PROTO_MIN_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_STREAM_VERSION_NUM: u32 = 2;
@@ -2305,6 +2306,18 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const SYNC_REP_NO_WAIT: i32 = -1;
+pub const SYNC_REP_WAIT_WRITE: u32 = 0;
+pub const SYNC_REP_WAIT_FLUSH: u32 = 1;
+pub const SYNC_REP_WAIT_APPLY: u32 = 2;
+pub const NUM_SYNC_REP_WAIT_MODE: u32 = 3;
+pub const SYNC_REP_NOT_WAITING: u32 = 0;
+pub const SYNC_REP_WAITING: u32 = 1;
+pub const SYNC_REP_WAIT_COMPLETE: u32 = 2;
+pub const SYNC_REP_PRIORITY: u32 = 0;
+pub const SYNC_REP_QUORUM: u32 = 1;
+pub const SYNC_STANDBY_INIT: u32 = 1;
+pub const SYNC_STANDBY_DEFINED: u32 = 2;
 pub const STATS_MAX_DIMENSIONS: u32 = 8;
 pub const STATS_NDISTINCT_MAGIC: u32 = 2740109220;
 pub const STATS_NDISTINCT_TYPE_BASIC: u32 = 1;
@@ -28647,6 +28660,8 @@ pub struct ReorderBufferTXN {
     pub total_size: Size,
     pub concurrent_abort: bool,
     pub output_plugin_private: *mut ::core::ffi::c_void,
+    pub ninvalidations_distributed: uint32,
+    pub invalidations_distributed: *mut SharedInvalidationMessage,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -29547,6 +29562,78 @@ pub struct LogicalDecodingContext {
     pub in_create: bool,
 }
 impl Default for LogicalDecodingContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SyncRepStandbyData {
+    pub pid: pid_t,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub walsnd_index: ::core::ffi::c_int,
+    pub is_me: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SyncRepConfigData {
+    pub config_size: ::core::ffi::c_int,
+    pub num_sync: ::core::ffi::c_int,
+    pub syncrep_method: uint8,
+    pub nmembers: ::core::ffi::c_int,
+    pub member_names: __IncompleteArrayField<::core::ffi::c_char>,
+}
+pub mod WalSndState {
+    pub type Type = ::core::ffi::c_uint;
+    pub const WALSNDSTATE_STARTUP: Type = 0;
+    pub const WALSNDSTATE_BACKUP: Type = 1;
+    pub const WALSNDSTATE_CATCHUP: Type = 2;
+    pub const WALSNDSTATE_STREAMING: Type = 3;
+    pub const WALSNDSTATE_STOPPING: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WalSnd {
+    pub pid: pid_t,
+    pub state: WalSndState::Type,
+    pub sentPtr: XLogRecPtr,
+    pub needreload: bool,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub writeLag: TimeOffset,
+    pub flushLag: TimeOffset,
+    pub applyLag: TimeOffset,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub mutex: slock_t,
+    pub latch: *mut Latch,
+    pub replyTime: TimestampTz,
+}
+impl Default for WalSnd {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct WalSndCtlData {
+    pub SyncRepQueue: [SHM_QUEUE; 3usize],
+    pub lsn: [XLogRecPtr; 3usize],
+    pub sync_standbys_status: bits8,
+    pub walsnds: __IncompleteArrayField<WalSnd>,
+}
+impl Default for WalSndCtlData {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -33696,6 +33783,7 @@ unsafe extern "C-unwind" {
     pub fn standard_ExecutorEnd(queryDesc: *mut QueryDesc);
     pub fn ExecutorRewind(queryDesc: *mut QueryDesc);
     pub fn ExecCheckRTPerms(rangeTable: *mut List, ereport_on_violation: bool) -> bool;
+    pub fn ExecCheckRTEPerms(rte: *mut RangeTblEntry) -> bool;
     pub fn CheckValidResultRel(resultRelInfo: *mut ResultRelInfo, operation: CmdType::Type);
     pub fn InitResultRelInfo(
         resultRelInfo: *mut ResultRelInfo,
@@ -41415,6 +41503,7 @@ unsafe extern "C-unwind" {
     );
     pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
     pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
+    pub fn has_transition_tables(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
     pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
     pub fn get_dependent_generated_columns(
         root: *mut PlannerInfo,
@@ -42684,6 +42773,13 @@ unsafe extern "C-unwind" {
         nmsgs: Size,
         msgs: *mut SharedInvalidationMessage,
     );
+    pub fn ReorderBufferAddDistributedInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        lsn: XLogRecPtr,
+        nmsgs: Size,
+        msgs: *mut SharedInvalidationMessage,
+    );
     pub fn ReorderBufferImmediateInvalidation(
         arg1: *mut ReorderBuffer,
         ninvalidations: uint32,
@@ -43014,6 +43110,43 @@ unsafe extern "C-unwind" {
     pub fn UpdateDecodingStats(ctx: *mut LogicalDecodingContext);
     pub fn ApplyWorkerMain(main_arg: Datum);
     pub fn IsLogicalWorker() -> bool;
+    pub static mut SyncRepConfig: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_result: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_error_msg: *mut ::core::ffi::c_char;
+    pub static mut SyncRepStandbyNames: *mut ::core::ffi::c_char;
+    pub fn SyncRepWaitForLSN(lsn: XLogRecPtr, commit: bool);
+    pub fn SyncRepCleanupAtProcExit();
+    pub fn SyncRepInitConfig();
+    pub fn SyncRepReleaseWaiters();
+    pub fn SyncRepGetCandidateStandbys(
+        standbys: *mut *mut SyncRepStandbyData,
+    ) -> ::core::ffi::c_int;
+    pub fn SyncRepUpdateSyncStandbysDefined();
+    pub fn check_synchronous_standby_names(
+        newval: *mut *mut ::core::ffi::c_char,
+        extra: *mut *mut ::core::ffi::c_void,
+        source: GucSource::Type,
+    ) -> bool;
+    pub fn assign_synchronous_standby_names(
+        newval: *const ::core::ffi::c_char,
+        extra: *mut ::core::ffi::c_void,
+    );
+    pub fn assign_synchronous_commit(newval: ::core::ffi::c_int, extra: *mut ::core::ffi::c_void);
+    pub fn syncrep_yyparse() -> ::core::ffi::c_int;
+    pub fn syncrep_yylex() -> ::core::ffi::c_int;
+    pub fn syncrep_yyerror(str_: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_init(query_string: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_finish();
+    pub static mut MyWalSnd: *mut WalSnd;
+    pub static mut WalSndCtl: *mut WalSndCtlData;
+    pub fn WalSndSetState(state: WalSndState::Type);
+    pub fn replication_yyparse() -> ::core::ffi::c_int;
+    pub fn replication_yylex() -> ::core::ffi::c_int;
+    pub fn replication_yyerror(str_: *const ::core::ffi::c_char) -> !;
+    pub fn replication_scanner_init(query_string: *const ::core::ffi::c_char);
+    pub fn replication_scanner_finish();
+    pub fn replication_scanner_is_replication_command() -> bool;
+    pub static mut replication_parse_result: *mut Node;
     pub fn QueryRewrite(parsetree: *mut Query) -> *mut List;
     pub fn AcquireRewriteLocks(parsetree: *mut Query, forExecute: bool, forUpdatePushedDown: bool);
     pub fn build_column_default(rel: Relation, attrno: ::core::ffi::c_int) -> *mut Node;
@@ -47294,6 +47427,11 @@ unsafe extern "C-unwind" {
         varRelid: ::core::ffi::c_int,
         vardata: *mut VariableStatData,
     );
+    pub fn all_rows_selectable(
+        root: *mut PlannerInfo,
+        varno: Index,
+        varattnos: *mut Bitmapset,
+    ) -> bool;
     pub fn statistic_proc_security_check(vardata: *mut VariableStatData, func_oid: Oid) -> bool;
     pub fn get_restriction_variable(
         root: *mut PlannerInfo,
@@ -52228,6 +52366,16 @@ pub const WalRcvState_WALRCV_WAITING: u32 = 3;
 pub const WalRcvState_WALRCV_RESTARTING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalRcvState::WALRCV_STOPPING")]
 pub const WalRcvState_WALRCV_STOPPING: u32 = 5;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STARTUP")]
+pub const WalSndState_WALSNDSTATE_STARTUP: u32 = 0;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_BACKUP")]
+pub const WalSndState_WALSNDSTATE_BACKUP: u32 = 1;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_CATCHUP")]
+pub const WalSndState_WALSNDSTATE_CATCHUP: u32 = 2;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STREAMING")]
+pub const WalSndState_WALSNDSTATE_STREAMING: u32 = 3;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STOPPING")]
+pub const WalSndState_WALSNDSTATE_STOPPING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WindowAggStatus::WINDOWAGG_DONE")]
 pub const WindowAggStatus_WINDOWAGG_DONE: u32 = 0;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WindowAggStatus::WINDOWAGG_RUN")]

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -184,18 +184,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 16.9";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 16.10";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"16.9";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"16.10";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"16";
 pub const PG_MAJORVERSION_NUM: u32 = 16;
-pub const PG_MINORVERSION_NUM: u32 = 9;
+pub const PG_MINORVERSION_NUM: u32 = 10;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"16.9";
-pub const PG_VERSION_NUM: u32 = 160009;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 16.9 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"16.10";
+pub const PG_VERSION_NUM: u32 = 160010;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 16.10 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -255,7 +255,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 16.9\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 16.10\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -2311,6 +2311,7 @@ pub const RBTXN_HAS_PARTIAL_CHANGE: u32 = 32;
 pub const RBTXN_PREPARE: u32 = 64;
 pub const RBTXN_SKIPPED_PREPARE: u32 = 128;
 pub const RBTXN_HAS_STREAMABLE_CHANGE: u32 = 256;
+pub const RBTXN_DISTR_INVAL_OVERFLOWED: u32 = 512;
 pub const LOGICALREP_PROTO_MIN_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_STREAM_VERSION_NUM: u32 = 2;
@@ -2322,6 +2323,18 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const SYNC_REP_NO_WAIT: i32 = -1;
+pub const SYNC_REP_WAIT_WRITE: u32 = 0;
+pub const SYNC_REP_WAIT_FLUSH: u32 = 1;
+pub const SYNC_REP_WAIT_APPLY: u32 = 2;
+pub const NUM_SYNC_REP_WAIT_MODE: u32 = 3;
+pub const SYNC_REP_NOT_WAITING: u32 = 0;
+pub const SYNC_REP_WAITING: u32 = 1;
+pub const SYNC_REP_WAIT_COMPLETE: u32 = 2;
+pub const SYNC_REP_PRIORITY: u32 = 0;
+pub const SYNC_REP_QUORUM: u32 = 1;
+pub const SYNC_STANDBY_INIT: u32 = 1;
+pub const SYNC_STANDBY_DEFINED: u32 = 2;
 pub const STATS_MAX_DIMENSIONS: u32 = 8;
 pub const STATS_NDISTINCT_MAGIC: u32 = 2740109220;
 pub const STATS_NDISTINCT_TYPE_BASIC: u32 = 1;
@@ -29465,6 +29478,8 @@ pub struct ReorderBufferTXN {
     pub total_size: Size,
     pub concurrent_abort: bool,
     pub output_plugin_private: *mut ::core::ffi::c_void,
+    pub ninvalidations_distributed: uint32,
+    pub invalidations_distributed: *mut SharedInvalidationMessage,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -30402,6 +30417,81 @@ pub struct LogicalDecodingContext {
     pub in_create: bool,
 }
 impl Default for LogicalDecodingContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SyncRepStandbyData {
+    pub pid: pid_t,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub walsnd_index: ::core::ffi::c_int,
+    pub is_me: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SyncRepConfigData {
+    pub config_size: ::core::ffi::c_int,
+    pub num_sync: ::core::ffi::c_int,
+    pub syncrep_method: uint8,
+    pub nmembers: ::core::ffi::c_int,
+    pub member_names: __IncompleteArrayField<::core::ffi::c_char>,
+}
+pub mod WalSndState {
+    pub type Type = ::core::ffi::c_uint;
+    pub const WALSNDSTATE_STARTUP: Type = 0;
+    pub const WALSNDSTATE_BACKUP: Type = 1;
+    pub const WALSNDSTATE_CATCHUP: Type = 2;
+    pub const WALSNDSTATE_STREAMING: Type = 3;
+    pub const WALSNDSTATE_STOPPING: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WalSnd {
+    pub pid: pid_t,
+    pub state: WalSndState::Type,
+    pub sentPtr: XLogRecPtr,
+    pub needreload: bool,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub writeLag: TimeOffset,
+    pub flushLag: TimeOffset,
+    pub applyLag: TimeOffset,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub mutex: slock_t,
+    pub latch: *mut Latch,
+    pub replyTime: TimestampTz,
+    pub kind: ReplicationKind::Type,
+}
+impl Default for WalSnd {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct WalSndCtlData {
+    pub SyncRepQueue: [dlist_head; 3usize],
+    pub lsn: [XLogRecPtr; 3usize],
+    pub sync_standbys_status: bits8,
+    pub wal_flush_cv: ConditionVariable,
+    pub wal_replay_cv: ConditionVariable,
+    pub walsnds: __IncompleteArrayField<WalSnd>,
+}
+impl Default for WalSndCtlData {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -34732,6 +34822,7 @@ unsafe extern "C-unwind" {
         rteperminfos: *mut List,
         ereport_on_violation: bool,
     ) -> bool;
+    pub fn ExecCheckOneRelPerms(perminfo: *mut RTEPermissionInfo) -> bool;
     pub fn CheckValidResultRel(resultRelInfo: *mut ResultRelInfo, operation: CmdType::Type);
     pub fn InitResultRelInfo(
         resultRelInfo: *mut ResultRelInfo,
@@ -42485,6 +42576,7 @@ unsafe extern "C-unwind" {
     );
     pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
     pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
+    pub fn has_transition_tables(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
     pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
     pub fn get_dependent_generated_columns(
         root: *mut PlannerInfo,
@@ -43763,6 +43855,13 @@ unsafe extern "C-unwind" {
         nmsgs: Size,
         msgs: *mut SharedInvalidationMessage,
     );
+    pub fn ReorderBufferAddDistributedInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        lsn: XLogRecPtr,
+        nmsgs: Size,
+        msgs: *mut SharedInvalidationMessage,
+    );
     pub fn ReorderBufferImmediateInvalidation(
         rb: *mut ReorderBuffer,
         ninvalidations: uint32,
@@ -44110,6 +44209,33 @@ unsafe extern "C-unwind" {
     pub fn HandleParallelApplyMessages();
     pub fn LogicalRepWorkersWakeupAtCommit(subid: Oid);
     pub fn AtEOXact_LogicalRepWorkers(isCommit: bool);
+    pub static mut SyncRepConfig: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_result: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_error_msg: *mut ::core::ffi::c_char;
+    pub static mut SyncRepStandbyNames: *mut ::core::ffi::c_char;
+    pub fn SyncRepWaitForLSN(lsn: XLogRecPtr, commit: bool);
+    pub fn SyncRepCleanupAtProcExit();
+    pub fn SyncRepInitConfig();
+    pub fn SyncRepReleaseWaiters();
+    pub fn SyncRepGetCandidateStandbys(
+        standbys: *mut *mut SyncRepStandbyData,
+    ) -> ::core::ffi::c_int;
+    pub fn SyncRepUpdateSyncStandbysDefined();
+    pub fn syncrep_yyparse() -> ::core::ffi::c_int;
+    pub fn syncrep_yylex() -> ::core::ffi::c_int;
+    pub fn syncrep_yyerror(str_: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_init(str_: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_finish();
+    pub static mut MyWalSnd: *mut WalSnd;
+    pub static mut WalSndCtl: *mut WalSndCtlData;
+    pub fn WalSndSetState(state: WalSndState::Type);
+    pub fn replication_yyparse() -> ::core::ffi::c_int;
+    pub fn replication_yylex() -> ::core::ffi::c_int;
+    pub fn replication_yyerror(message: *const ::core::ffi::c_char) -> !;
+    pub fn replication_scanner_init(str_: *const ::core::ffi::c_char);
+    pub fn replication_scanner_finish();
+    pub fn replication_scanner_is_replication_command() -> bool;
+    pub static mut replication_parse_result: *mut Node;
     pub fn QueryRewrite(parsetree: *mut Query) -> *mut List;
     pub fn AcquireRewriteLocks(parsetree: *mut Query, forExecute: bool, forUpdatePushedDown: bool);
     pub fn build_column_default(rel: Relation, attrno: ::core::ffi::c_int) -> *mut Node;
@@ -48543,6 +48669,11 @@ unsafe extern "C-unwind" {
         varRelid: ::core::ffi::c_int,
         vardata: *mut VariableStatData,
     );
+    pub fn all_rows_selectable(
+        root: *mut PlannerInfo,
+        varno: Index,
+        varattnos: *mut Bitmapset,
+    ) -> bool;
     pub fn statistic_proc_security_check(vardata: *mut VariableStatData, func_oid: Oid) -> bool;
     pub fn get_restriction_variable(
         root: *mut PlannerInfo,
@@ -53677,6 +53808,16 @@ pub const WalRcvState_WALRCV_WAITING: u32 = 3;
 pub const WalRcvState_WALRCV_RESTARTING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalRcvState::WALRCV_STOPPING")]
 pub const WalRcvState_WALRCV_STOPPING: u32 = 5;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STARTUP")]
+pub const WalSndState_WALSNDSTATE_STARTUP: u32 = 0;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_BACKUP")]
+pub const WalSndState_WALSNDSTATE_BACKUP: u32 = 1;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_CATCHUP")]
+pub const WalSndState_WALSNDSTATE_CATCHUP: u32 = 2;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STREAMING")]
+pub const WalSndState_WALSNDSTATE_STREAMING: u32 = 3;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STOPPING")]
+pub const WalSndState_WALSNDSTATE_STOPPING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WindowAggStatus::WINDOWAGG_DONE")]
 pub const WindowAggStatus_WINDOWAGG_DONE: u32 = 0;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WindowAggStatus::WINDOWAGG_RUN")]

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -183,18 +183,18 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 17.5";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 17.6";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"17.5";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"17.6";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"17";
 pub const PG_MAJORVERSION_NUM: u32 = 17;
-pub const PG_MINORVERSION_NUM: u32 = 5;
+pub const PG_MINORVERSION_NUM: u32 = 6;
 pub const PG_USE_STDBOOL: u32 = 1;
-pub const PG_VERSION: &::core::ffi::CStr = c"17.5";
-pub const PG_VERSION_NUM: u32 = 170005;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 17.5 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION: &::core::ffi::CStr = c"17.6";
+pub const PG_VERSION_NUM: u32 = 170006;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 17.6 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_BOOL: u32 = 1;
 pub const SIZEOF_LONG: u32 = 8;
@@ -255,7 +255,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 17.5\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 17.6\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -2398,6 +2398,7 @@ pub const RBTXN_HAS_PARTIAL_CHANGE: u32 = 32;
 pub const RBTXN_PREPARE: u32 = 64;
 pub const RBTXN_SKIPPED_PREPARE: u32 = 128;
 pub const RBTXN_HAS_STREAMABLE_CHANGE: u32 = 256;
+pub const RBTXN_DISTR_INVAL_OVERFLOWED: u32 = 512;
 pub const LOGICALREP_PROTO_MIN_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_VERSION_NUM: u32 = 1;
 pub const LOGICALREP_PROTO_STREAM_VERSION_NUM: u32 = 2;
@@ -2409,6 +2410,18 @@ pub const LOGICALREP_COLUMN_UNCHANGED: u8 = 117u8;
 pub const LOGICALREP_COLUMN_TEXT: u8 = 116u8;
 pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
+pub const SYNC_REP_NO_WAIT: i32 = -1;
+pub const SYNC_REP_WAIT_WRITE: u32 = 0;
+pub const SYNC_REP_WAIT_FLUSH: u32 = 1;
+pub const SYNC_REP_WAIT_APPLY: u32 = 2;
+pub const NUM_SYNC_REP_WAIT_MODE: u32 = 3;
+pub const SYNC_REP_NOT_WAITING: u32 = 0;
+pub const SYNC_REP_WAITING: u32 = 1;
+pub const SYNC_REP_WAIT_COMPLETE: u32 = 2;
+pub const SYNC_REP_PRIORITY: u32 = 0;
+pub const SYNC_REP_QUORUM: u32 = 1;
+pub const SYNC_STANDBY_INIT: u32 = 1;
+pub const SYNC_STANDBY_DEFINED: u32 = 2;
 pub const STATS_MAX_DIMENSIONS: u32 = 8;
 pub const STATS_NDISTINCT_MAGIC: u32 = 2740109220;
 pub const STATS_NDISTINCT_TYPE_BASIC: u32 = 1;
@@ -30340,6 +30353,8 @@ pub struct ReorderBufferTXN {
     pub total_size: Size,
     pub concurrent_abort: bool,
     pub output_plugin_private: *mut ::core::ffi::c_void,
+    pub ninvalidations_distributed: uint32,
+    pub invalidations_distributed: *mut SharedInvalidationMessage,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -31296,6 +31311,82 @@ pub struct LogicalDecodingContext {
     pub processing_required: bool,
 }
 impl Default for LogicalDecodingContext {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SyncRepStandbyData {
+    pub pid: pid_t,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub walsnd_index: ::core::ffi::c_int,
+    pub is_me: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SyncRepConfigData {
+    pub config_size: ::core::ffi::c_int,
+    pub num_sync: ::core::ffi::c_int,
+    pub syncrep_method: uint8,
+    pub nmembers: ::core::ffi::c_int,
+    pub member_names: __IncompleteArrayField<::core::ffi::c_char>,
+}
+pub mod WalSndState {
+    pub type Type = ::core::ffi::c_uint;
+    pub const WALSNDSTATE_STARTUP: Type = 0;
+    pub const WALSNDSTATE_BACKUP: Type = 1;
+    pub const WALSNDSTATE_CATCHUP: Type = 2;
+    pub const WALSNDSTATE_STREAMING: Type = 3;
+    pub const WALSNDSTATE_STOPPING: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WalSnd {
+    pub pid: pid_t,
+    pub state: WalSndState::Type,
+    pub sentPtr: XLogRecPtr,
+    pub needreload: bool,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub writeLag: TimeOffset,
+    pub flushLag: TimeOffset,
+    pub applyLag: TimeOffset,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub mutex: slock_t,
+    pub latch: *mut Latch,
+    pub replyTime: TimestampTz,
+    pub kind: ReplicationKind::Type,
+}
+impl Default for WalSnd {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct WalSndCtlData {
+    pub SyncRepQueue: [dlist_head; 3usize],
+    pub lsn: [XLogRecPtr; 3usize],
+    pub sync_standbys_status: bits8,
+    pub wal_flush_cv: ConditionVariable,
+    pub wal_replay_cv: ConditionVariable,
+    pub wal_confirm_rcv_cv: ConditionVariable,
+    pub walsnds: __IncompleteArrayField<WalSnd>,
+}
+impl Default for WalSndCtlData {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -35941,6 +36032,7 @@ unsafe extern "C-unwind" {
         rteperminfos: *mut List,
         ereport_on_violation: bool,
     ) -> bool;
+    pub fn ExecCheckOneRelPerms(perminfo: *mut RTEPermissionInfo) -> bool;
     pub fn CheckValidResultRel(
         resultRelInfo: *mut ResultRelInfo,
         operation: CmdType::Type,
@@ -40588,6 +40680,17 @@ unsafe extern "C-unwind" {
         relinfo: *mut ResultRelInfo,
         transition_capture: *mut TransitionCaptureState,
     );
+    pub fn ExecBRDeleteTriggersNew(
+        estate: *mut EState,
+        epqstate: *mut EPQState,
+        relinfo: *mut ResultRelInfo,
+        tupleid: ItemPointer,
+        fdw_trigtuple: HeapTuple,
+        epqslot: *mut *mut TupleTableSlot,
+        tmresult: *mut TM_Result::Type,
+        tmfd: *mut TM_FailureData,
+        is_merge_delete: bool,
+    ) -> bool;
     pub fn ExecBRDeleteTriggers(
         estate: *mut EState,
         epqstate: *mut EPQState,
@@ -40617,6 +40720,17 @@ unsafe extern "C-unwind" {
         relinfo: *mut ResultRelInfo,
         transition_capture: *mut TransitionCaptureState,
     );
+    pub fn ExecBRUpdateTriggersNew(
+        estate: *mut EState,
+        epqstate: *mut EPQState,
+        relinfo: *mut ResultRelInfo,
+        tupleid: ItemPointer,
+        fdw_trigtuple: HeapTuple,
+        newslot: *mut TupleTableSlot,
+        tmresult: *mut TM_Result::Type,
+        tmfd: *mut TM_FailureData,
+        is_merge_update: bool,
+    ) -> bool;
     pub fn ExecBRUpdateTriggers(
         estate: *mut EState,
         epqstate: *mut EPQState,
@@ -43774,6 +43888,7 @@ unsafe extern "C-unwind" {
     );
     pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
     pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
+    pub fn has_transition_tables(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
     pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
     pub fn get_dependent_generated_columns(
         root: *mut PlannerInfo,
@@ -45047,6 +45162,13 @@ unsafe extern "C-unwind" {
         nmsgs: Size,
         msgs: *mut SharedInvalidationMessage,
     );
+    pub fn ReorderBufferAddDistributedInvalidations(
+        rb: *mut ReorderBuffer,
+        xid: TransactionId,
+        lsn: XLogRecPtr,
+        nmsgs: Size,
+        msgs: *mut SharedInvalidationMessage,
+    );
     pub fn ReorderBufferImmediateInvalidation(
         rb: *mut ReorderBuffer,
         ninvalidations: uint32,
@@ -45414,6 +45536,33 @@ unsafe extern "C-unwind" {
     pub fn HandleParallelApplyMessages();
     pub fn LogicalRepWorkersWakeupAtCommit(subid: Oid);
     pub fn AtEOXact_LogicalRepWorkers(isCommit: bool);
+    pub static mut SyncRepConfig: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_result: *mut SyncRepConfigData;
+    pub static mut syncrep_parse_error_msg: *mut ::core::ffi::c_char;
+    pub static mut SyncRepStandbyNames: *mut ::core::ffi::c_char;
+    pub fn SyncRepWaitForLSN(lsn: XLogRecPtr, commit: bool);
+    pub fn SyncRepCleanupAtProcExit();
+    pub fn SyncRepInitConfig();
+    pub fn SyncRepReleaseWaiters();
+    pub fn SyncRepGetCandidateStandbys(
+        standbys: *mut *mut SyncRepStandbyData,
+    ) -> ::core::ffi::c_int;
+    pub fn SyncRepUpdateSyncStandbysDefined();
+    pub fn syncrep_yyparse() -> ::core::ffi::c_int;
+    pub fn syncrep_yylex() -> ::core::ffi::c_int;
+    pub fn syncrep_yyerror(str_: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_init(str_: *const ::core::ffi::c_char);
+    pub fn syncrep_scanner_finish();
+    pub static mut MyWalSnd: *mut WalSnd;
+    pub static mut WalSndCtl: *mut WalSndCtlData;
+    pub fn WalSndSetState(state: WalSndState::Type);
+    pub fn replication_yyparse() -> ::core::ffi::c_int;
+    pub fn replication_yylex() -> ::core::ffi::c_int;
+    pub fn replication_yyerror(message: *const ::core::ffi::c_char) -> !;
+    pub fn replication_scanner_init(str_: *const ::core::ffi::c_char);
+    pub fn replication_scanner_finish();
+    pub fn replication_scanner_is_replication_command() -> bool;
+    pub static mut replication_parse_result: *mut Node;
     pub fn QueryRewrite(parsetree: *mut Query) -> *mut List;
     pub fn AcquireRewriteLocks(parsetree: *mut Query, forExecute: bool, forUpdatePushedDown: bool);
     pub fn build_column_default(rel: Relation, attrno: ::core::ffi::c_int) -> *mut Node;
@@ -49829,6 +49978,11 @@ unsafe extern "C-unwind" {
         varRelid: ::core::ffi::c_int,
         vardata: *mut VariableStatData,
     );
+    pub fn all_rows_selectable(
+        root: *mut PlannerInfo,
+        varno: Index,
+        varattnos: *mut Bitmapset,
+    ) -> bool;
     pub fn statistic_proc_security_check(vardata: *mut VariableStatData, func_oid: Oid) -> bool;
     pub fn get_restriction_variable(
         root: *mut PlannerInfo,
@@ -55165,6 +55319,16 @@ pub const WalRcvState_WALRCV_WAITING: u32 = 3;
 pub const WalRcvState_WALRCV_RESTARTING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalRcvState::WALRCV_STOPPING")]
 pub const WalRcvState_WALRCV_STOPPING: u32 = 5;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STARTUP")]
+pub const WalSndState_WALSNDSTATE_STARTUP: u32 = 0;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_BACKUP")]
+pub const WalSndState_WALSNDSTATE_BACKUP: u32 = 1;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_CATCHUP")]
+pub const WalSndState_WALSNDSTATE_CATCHUP: u32 = 2;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STREAMING")]
+pub const WalSndState_WALSNDSTATE_STREAMING: u32 = 3;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STOPPING")]
+pub const WalSndState_WALSNDSTATE_STOPPING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalSyncMethod::WAL_SYNC_METHOD_FSYNC")]
 pub const WalSyncMethod_WAL_SYNC_METHOD_FSYNC: u32 = 0;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalSyncMethod::WAL_SYNC_METHOD_FDATASYNC")]

--- a/pgrx-pg-sys/src/include/pg18.rs
+++ b/pgrx-pg-sys/src/include/pg18.rs
@@ -165,17 +165,17 @@ pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
 pub const PACKAGE_NAME: &::core::ffi::CStr = c"PostgreSQL";
-pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 18beta2";
+pub const PACKAGE_STRING: &::core::ffi::CStr = c"PostgreSQL 18.0";
 pub const PACKAGE_TARNAME: &::core::ffi::CStr = c"postgresql";
 pub const PACKAGE_URL: &::core::ffi::CStr = c"https://www.postgresql.org/";
-pub const PACKAGE_VERSION: &::core::ffi::CStr = c"18beta2";
+pub const PACKAGE_VERSION: &::core::ffi::CStr = c"18.0";
 pub const PG_KRB_SRVNAM: &::core::ffi::CStr = c"postgres";
 pub const PG_MAJORVERSION: &::core::ffi::CStr = c"18";
 pub const PG_MAJORVERSION_NUM: u32 = 18;
 pub const PG_MINORVERSION_NUM: u32 = 0;
-pub const PG_VERSION: &::core::ffi::CStr = c"18beta2";
+pub const PG_VERSION: &::core::ffi::CStr = c"18.0";
 pub const PG_VERSION_NUM: u32 = 180000;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 18beta2 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit" ;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 18.0 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_LONG: u32 = 8;
 pub const SIZEOF_LONG_LONG: u32 = 8;
@@ -232,8 +232,6 @@ pub const PG_DIAG_SOURCE_LINE: u8 = 76u8;
 pub const PG_DIAG_SOURCE_FUNCTION: u8 = 82u8;
 pub const INT64_FORMAT: &::core::ffi::CStr = c"%ld";
 pub const UINT64_FORMAT: &::core::ffi::CStr = c"%lu";
-pub const INT64_HEX_FORMAT: &::core::ffi::CStr = c"%lx";
-pub const UINT64_HEX_FORMAT: &::core::ffi::CStr = c"%lx";
 pub const PG_INT8_MIN: i32 = -128;
 pub const PG_INT8_MAX: u32 = 127;
 pub const PG_UINT8_MAX: u32 = 255;
@@ -254,7 +252,7 @@ pub const PG_BINARY_A: &::core::ffi::CStr = c"a";
 pub const PG_BINARY_R: &::core::ffi::CStr = c"r";
 pub const PG_BINARY_W: &::core::ffi::CStr = c"w";
 pub const PGINVALID_SOCKET: i32 = -1;
-pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 18beta2\n";
+pub const PG_BACKEND_VERSIONSTR: &::core::ffi::CStr = c"postgres (PostgreSQL) 18.0\n";
 pub const EXE: &::core::ffi::CStr = c"";
 pub const DEVNULL: &::core::ffi::CStr = c"/dev/null";
 pub const USE_REPL_SNPRINTF: u32 = 1;
@@ -1106,7 +1104,7 @@ pub const AUTH_REQ_MAX: u32 = 12;
 pub const MAX_STARTUP_PACKET_LENGTH: u32 = 10000;
 pub const PG_ALPN_PROTOCOL: &::core::ffi::CStr = c"postgresql";
 pub const PGSTAT_KIND_MIN: u32 = 1;
-pub const PGSTAT_KIND_MAX: u32 = 256;
+pub const PGSTAT_KIND_MAX: u32 = 32;
 pub const PGSTAT_KIND_INVALID: u32 = 0;
 pub const PGSTAT_KIND_DATABASE: u32 = 1;
 pub const PGSTAT_KIND_RELATION: u32 = 2;
@@ -1123,10 +1121,10 @@ pub const PGSTAT_KIND_WAL: u32 = 12;
 pub const PGSTAT_KIND_BUILTIN_MIN: u32 = 1;
 pub const PGSTAT_KIND_BUILTIN_MAX: u32 = 12;
 pub const PGSTAT_KIND_BUILTIN_SIZE: u32 = 13;
-pub const PGSTAT_KIND_CUSTOM_MIN: u32 = 128;
-pub const PGSTAT_KIND_CUSTOM_MAX: u32 = 256;
-pub const PGSTAT_KIND_CUSTOM_SIZE: u32 = 129;
-pub const PGSTAT_KIND_EXPERIMENTAL: u32 = 128;
+pub const PGSTAT_KIND_CUSTOM_MIN: u32 = 24;
+pub const PGSTAT_KIND_CUSTOM_MAX: u32 = 32;
+pub const PGSTAT_KIND_CUSTOM_SIZE: u32 = 9;
+pub const PGSTAT_KIND_EXPERIMENTAL: u32 = 24;
 pub const PG_WAIT_LWLOCK: u32 = 16777216;
 pub const PG_WAIT_LOCK: u32 = 50331648;
 pub const PG_WAIT_BUFFERPIN: u32 = 67108864;
@@ -2535,6 +2533,18 @@ pub const LOGICALREP_COLUMN_BINARY: u8 = 98u8;
 pub const MAXCONNINFO: u32 = 1024;
 pub const PG_REPLSLOT_DIR: &::core::ffi::CStr = c"pg_replslot";
 pub const RS_INVAL_MAX_CAUSES: u32 = 4;
+pub const SYNC_REP_NO_WAIT: i32 = -1;
+pub const SYNC_REP_WAIT_WRITE: u32 = 0;
+pub const SYNC_REP_WAIT_FLUSH: u32 = 1;
+pub const SYNC_REP_WAIT_APPLY: u32 = 2;
+pub const NUM_SYNC_REP_WAIT_MODE: u32 = 3;
+pub const SYNC_REP_NOT_WAITING: u32 = 0;
+pub const SYNC_REP_WAITING: u32 = 1;
+pub const SYNC_REP_WAIT_COMPLETE: u32 = 2;
+pub const SYNC_REP_PRIORITY: u32 = 0;
+pub const SYNC_REP_QUORUM: u32 = 1;
+pub const SYNC_STANDBY_INIT: u32 = 1;
+pub const SYNC_STANDBY_DEFINED: u32 = 2;
 pub const BUF_REFCOUNT_BITS: u32 = 18;
 pub const BUF_USAGECOUNT_BITS: u32 = 4;
 pub const BUF_FLAG_BITS: u32 = 10;
@@ -6304,6 +6314,7 @@ impl Default for lconv {
         }
     }
 }
+pub type pg_int64 = i64;
 pub type pg_funcptr_t = ::core::option::Option<unsafe extern "C-unwind" fn()>;
 pub type Pointer = *mut ::core::ffi::c_char;
 pub type int8 = i8;
@@ -19639,11 +19650,10 @@ pub mod WaitEventIPC {
     pub const WAIT_EVENT_RESTORE_COMMAND: Type = 134217778;
     pub const WAIT_EVENT_SAFE_SNAPSHOT: Type = 134217779;
     pub const WAIT_EVENT_SYNC_REP: Type = 134217780;
-    pub const WAIT_EVENT_WAL_BUFFER_INIT: Type = 134217781;
-    pub const WAIT_EVENT_WAL_RECEIVER_EXIT: Type = 134217782;
-    pub const WAIT_EVENT_WAL_RECEIVER_WAIT_START: Type = 134217783;
-    pub const WAIT_EVENT_WAL_SUMMARY_READY: Type = 134217784;
-    pub const WAIT_EVENT_XACT_GROUP_UPDATE: Type = 134217785;
+    pub const WAIT_EVENT_WAL_RECEIVER_EXIT: Type = 134217781;
+    pub const WAIT_EVENT_WAL_RECEIVER_WAIT_START: Type = 134217782;
+    pub const WAIT_EVENT_WAL_SUMMARY_READY: Type = 134217783;
+    pub const WAIT_EVENT_XACT_GROUP_UPDATE: Type = 134217784;
 }
 pub mod WaitEventTimeout {
     pub type Type = ::core::ffi::c_uint;
@@ -32732,6 +32742,81 @@ impl Default for LogicalDecodingContext {
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SyncRepStandbyData {
+    pub pid: pid_t,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub walsnd_index: ::core::ffi::c_int,
+    pub is_me: bool,
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct SyncRepConfigData {
+    pub config_size: ::core::ffi::c_int,
+    pub num_sync: ::core::ffi::c_int,
+    pub syncrep_method: uint8,
+    pub nmembers: ::core::ffi::c_int,
+    pub member_names: __IncompleteArrayField<::core::ffi::c_char>,
+}
+pub mod WalSndState {
+    pub type Type = ::core::ffi::c_uint;
+    pub const WALSNDSTATE_STARTUP: Type = 0;
+    pub const WALSNDSTATE_BACKUP: Type = 1;
+    pub const WALSNDSTATE_CATCHUP: Type = 2;
+    pub const WALSNDSTATE_STREAMING: Type = 3;
+    pub const WALSNDSTATE_STOPPING: Type = 4;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WalSnd {
+    pub pid: pid_t,
+    pub state: WalSndState::Type,
+    pub sentPtr: XLogRecPtr,
+    pub needreload: bool,
+    pub write: XLogRecPtr,
+    pub flush: XLogRecPtr,
+    pub apply: XLogRecPtr,
+    pub writeLag: TimeOffset,
+    pub flushLag: TimeOffset,
+    pub applyLag: TimeOffset,
+    pub sync_standby_priority: ::core::ffi::c_int,
+    pub mutex: slock_t,
+    pub replyTime: TimestampTz,
+    pub kind: ReplicationKind::Type,
+}
+impl Default for WalSnd {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct WalSndCtlData {
+    pub SyncRepQueue: [dlist_head; 3usize],
+    pub lsn: [XLogRecPtr; 3usize],
+    pub sync_standbys_status: bits8,
+    pub wal_flush_cv: ConditionVariable,
+    pub wal_replay_cv: ConditionVariable,
+    pub wal_confirm_rcv_cv: ConditionVariable,
+    pub walsnds: __IncompleteArrayField<WalSnd>,
+}
+impl Default for WalSndCtlData {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct RowSecurityPolicy {
     pub policy_name: *mut ::core::ffi::c_char,
@@ -37383,9 +37468,11 @@ unsafe extern "C-unwind" {
         rteperminfos: *mut List,
         ereport_on_violation: bool,
     ) -> bool;
+    pub fn ExecCheckOneRelPerms(perminfo: *mut RTEPermissionInfo) -> bool;
     pub fn CheckValidResultRel(
         resultRelInfo: *mut ResultRelInfo,
         operation: CmdType::Type,
+        onConflictAction: OnConflictAction::Type,
         mergeActions: *mut List,
     );
     pub fn InitResultRelInfo(
@@ -42234,6 +42321,7 @@ unsafe extern "C-unwind" {
         epqslot: *mut *mut TupleTableSlot,
         tmresult: *mut TM_Result::Type,
         tmfd: *mut TM_FailureData,
+        is_merge_delete: bool,
     ) -> bool;
     pub fn ExecARDeleteTriggers(
         estate: *mut EState,
@@ -42263,6 +42351,7 @@ unsafe extern "C-unwind" {
         newslot: *mut TupleTableSlot,
         tmresult: *mut TM_Result::Type,
         tmfd: *mut TM_FailureData,
+        is_merge_update: bool,
     ) -> bool;
     pub fn ExecARUpdateTriggers(
         estate: *mut EState,
@@ -45502,6 +45591,7 @@ unsafe extern "C-unwind" {
     );
     pub fn get_function_rows(root: *mut PlannerInfo, funcid: Oid, node: *mut Node) -> f64;
     pub fn has_row_triggers(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
+    pub fn has_transition_tables(root: *mut PlannerInfo, rti: Index, event: CmdType::Type) -> bool;
     pub fn has_stored_generated_columns(root: *mut PlannerInfo, rti: Index) -> bool;
     pub fn get_dependent_generated_columns(
         root: *mut PlannerInfo,
@@ -46721,7 +46811,7 @@ unsafe extern "C-unwind" {
     pub fn postmaster_child_launch(
         child_type: BackendType::Type,
         child_slot: ::core::ffi::c_int,
-        startup_data: *const ::core::ffi::c_void,
+        startup_data: *mut ::core::ffi::c_void,
         startup_data_len: usize,
         client_sock: *mut ClientSocket,
     ) -> pid_t;
@@ -47254,6 +47344,51 @@ unsafe extern "C-unwind" {
     pub fn ProcessParallelApplyMessages();
     pub fn LogicalRepWorkersWakeupAtCommit(subid: Oid);
     pub fn AtEOXact_LogicalRepWorkers(isCommit: bool);
+    pub static mut SyncRepConfig: *mut SyncRepConfigData;
+    pub static mut SyncRepStandbyNames: *mut ::core::ffi::c_char;
+    pub fn SyncRepWaitForLSN(lsn: XLogRecPtr, commit: bool);
+    pub fn SyncRepCleanupAtProcExit();
+    pub fn SyncRepInitConfig();
+    pub fn SyncRepReleaseWaiters();
+    pub fn SyncRepGetCandidateStandbys(
+        standbys: *mut *mut SyncRepStandbyData,
+    ) -> ::core::ffi::c_int;
+    pub fn SyncRepUpdateSyncStandbysDefined();
+    pub fn syncrep_yyparse(
+        syncrep_parse_result_p: *mut *mut SyncRepConfigData,
+        syncrep_parse_error_msg_p: *mut *mut ::core::ffi::c_char,
+        yyscanner: yyscan_t,
+    ) -> ::core::ffi::c_int;
+    pub fn syncrep_yylex(
+        yylval_param: *mut YYSTYPE,
+        syncrep_parse_error_msg_p: *mut *mut ::core::ffi::c_char,
+        yyscanner: yyscan_t,
+    ) -> ::core::ffi::c_int;
+    pub fn syncrep_yyerror(
+        syncrep_parse_result_p: *mut *mut SyncRepConfigData,
+        syncrep_parse_error_msg_p: *mut *mut ::core::ffi::c_char,
+        yyscanner: yyscan_t,
+        str_: *const ::core::ffi::c_char,
+    );
+    pub fn syncrep_scanner_init(str_: *const ::core::ffi::c_char, yyscannerp: *mut yyscan_t);
+    pub fn syncrep_scanner_finish(yyscanner: yyscan_t);
+    pub static mut MyWalSnd: *mut WalSnd;
+    pub static mut WalSndCtl: *mut WalSndCtlData;
+    pub fn WalSndSetState(state: WalSndState::Type);
+    pub fn replication_yyparse(
+        replication_parse_result_p: *mut *mut Node,
+        yyscanner: yyscan_t,
+    ) -> ::core::ffi::c_int;
+    pub fn replication_yylex(yylval_param: *mut YYSTYPE, yyscanner: yyscan_t)
+        -> ::core::ffi::c_int;
+    pub fn replication_yyerror(
+        replication_parse_result_p: *mut *mut Node,
+        yyscanner: yyscan_t,
+        message: *const ::core::ffi::c_char,
+    );
+    pub fn replication_scanner_init(str_: *const ::core::ffi::c_char, yyscannerp: *mut yyscan_t);
+    pub fn replication_scanner_finish(yyscanner: yyscan_t);
+    pub fn replication_scanner_is_replication_command(yyscanner: yyscan_t) -> bool;
     pub fn QueryRewrite(parsetree: *mut Query) -> *mut List;
     pub fn AcquireRewriteLocks(parsetree: *mut Query, forExecute: bool, forUpdatePushedDown: bool);
     pub fn build_column_default(rel: Relation, attrno: ::core::ffi::c_int) -> *mut Node;
@@ -51752,6 +51887,11 @@ unsafe extern "C-unwind" {
         varRelid: ::core::ffi::c_int,
         vardata: *mut VariableStatData,
     );
+    pub fn all_rows_selectable(
+        root: *mut PlannerInfo,
+        varno: Index,
+        varattnos: *mut Bitmapset,
+    ) -> bool;
     pub fn statistic_proc_security_check(vardata: *mut VariableStatData, func_oid: Oid) -> bool;
     pub fn get_restriction_variable(
         root: *mut PlannerInfo,
@@ -57150,28 +57290,26 @@ pub const WaitEventIPC_WAIT_EVENT_RESTORE_COMMAND: u32 = 134217778;
 pub const WaitEventIPC_WAIT_EVENT_SAFE_SNAPSHOT: u32 = 134217779;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WaitEventIPC::WAIT_EVENT_SYNC_REP")]
 pub const WaitEventIPC_WAIT_EVENT_SYNC_REP: u32 = 134217780;
-#[deprecated(since = "0.12.0", note = "you want pg_sys::WaitEventIPC::WAIT_EVENT_WAL_BUFFER_INIT")]
-pub const WaitEventIPC_WAIT_EVENT_WAL_BUFFER_INIT: u32 = 134217781;
 #[deprecated(
     since = "0.12.0",
     note = "you want pg_sys::WaitEventIPC::WAIT_EVENT_WAL_RECEIVER_EXIT"
 )]
-pub const WaitEventIPC_WAIT_EVENT_WAL_RECEIVER_EXIT: u32 = 134217782;
+pub const WaitEventIPC_WAIT_EVENT_WAL_RECEIVER_EXIT: u32 = 134217781;
 #[deprecated(
     since = "0.12.0",
     note = "you want pg_sys::WaitEventIPC::WAIT_EVENT_WAL_RECEIVER_WAIT_START"
 )]
-pub const WaitEventIPC_WAIT_EVENT_WAL_RECEIVER_WAIT_START: u32 = 134217783;
+pub const WaitEventIPC_WAIT_EVENT_WAL_RECEIVER_WAIT_START: u32 = 134217782;
 #[deprecated(
     since = "0.12.0",
     note = "you want pg_sys::WaitEventIPC::WAIT_EVENT_WAL_SUMMARY_READY"
 )]
-pub const WaitEventIPC_WAIT_EVENT_WAL_SUMMARY_READY: u32 = 134217784;
+pub const WaitEventIPC_WAIT_EVENT_WAL_SUMMARY_READY: u32 = 134217783;
 #[deprecated(
     since = "0.12.0",
     note = "you want pg_sys::WaitEventIPC::WAIT_EVENT_XACT_GROUP_UPDATE"
 )]
-pub const WaitEventIPC_WAIT_EVENT_XACT_GROUP_UPDATE: u32 = 134217785;
+pub const WaitEventIPC_WAIT_EVENT_XACT_GROUP_UPDATE: u32 = 134217784;
 #[deprecated(
     since = "0.12.0",
     note = "you want pg_sys::WaitEventTimeout::WAIT_EVENT_BASE_BACKUP_THROTTLE"
@@ -57251,6 +57389,16 @@ pub const WalRcvState_WALRCV_WAITING: u32 = 3;
 pub const WalRcvState_WALRCV_RESTARTING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalRcvState::WALRCV_STOPPING")]
 pub const WalRcvState_WALRCV_STOPPING: u32 = 5;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STARTUP")]
+pub const WalSndState_WALSNDSTATE_STARTUP: u32 = 0;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_BACKUP")]
+pub const WalSndState_WALSNDSTATE_BACKUP: u32 = 1;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_CATCHUP")]
+pub const WalSndState_WALSNDSTATE_CATCHUP: u32 = 2;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STREAMING")]
+pub const WalSndState_WALSNDSTATE_STREAMING: u32 = 3;
+#[deprecated(since = "0.12.0", note = "you want pg_sys::WalSndState::WALSNDSTATE_STOPPING")]
+pub const WalSndState_WALSNDSTATE_STOPPING: u32 = 4;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalSyncMethod::WAL_SYNC_METHOD_FSYNC")]
 pub const WalSyncMethod_WAL_SYNC_METHOD_FSYNC: u32 = 0;
 #[deprecated(since = "0.12.0", note = "you want pg_sys::WalSyncMethod::WAL_SYNC_METHOD_FDATASYNC")]

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 license.workspace = true
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 license.workspace = true
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -77,7 +77,7 @@ rand = "0.9.0"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.16.0"
+version = "=0.16.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = [

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.16.0"
+version = "0.16.1"
 authors.workspace = true
 license.workspace = true
 description = "pgrx:  A Rust framework for creating Postgres extensions"


### PR DESCRIPTION
Welcome to pgrx v0.16.1.  This is a relatively minor release but does add support for Postgres v18, released on September 25, 2025.

As always, install/update `cargo-pgrx` with `cargo install cargo-pgrx --version 0.16.1 --locked`.  Then run `cargo pgrx update` in all your extension crates.

To pick up Postgres v18, you'll need to run (at least) `cargo pgrx init` and then add the `pg18` feature flag to your extension's `Cargo.toml`.


## What's Changed

* remove polyfill crates by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2128
* Example : register PostgreSQL hooks by @daamien in https://github.com/pgcentralfoundation/pgrx/pull/2125
* add more WAL/replication headers by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2130
* remove home, supports-color 0.2 and update toml, color-eyre by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2133
* cargo-pgrx: fix pg_regress path inconsistency by @charmitro in https://github.com/pgcentralfoundation/pgrx/pull/2137
* fix big endian by @usamoi in https://github.com/pgcentralfoundation/pgrx/pull/2132
* Fixing CI by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2143
* pg18 support by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2144


**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.16.0...v0.16.1