### PR TITLE
include `access/tsmapi.h`

### DIFF
--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -32,6 +32,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tsmapi.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -32,6 +32,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tsmapi.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -32,6 +32,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tsmapi.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -33,6 +33,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tsmapi.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -33,6 +33,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tsmapi.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -33,6 +33,7 @@
 #include "access/skey.h"
 #include "access/sysattr.h"
 #include "access/table.h"
+#include "access/tsmapi.h"
 #include "access/visibilitymap.h"
 #include "access/xact.h"
 #include "access/xlog_internal.h"


### PR DESCRIPTION
`access/tsmapi.h` is the header for [Writing a Table Sampling Method](https://www.postgresql.org/docs/current/tablesample-method.html).