### PR TITLE
Remove testing for deprecated Intel Macs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -424,7 +424,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ "macos-13", "macos-14" ] # macos-14 is M1
+        os: [ "macos-14" ] # macos-14 is M1
         # Since Postgres 16 on macOS the dynamic library extension is "dylib" (instead of "so" on older versions),
         # so it's important to test against both versions (with "old" and "new" extensions).
         #

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 
 ## System Requirements
 
-PGRX has been tested to work on x86_64⹋ and aarch64⹋ Linux and aarch64 macOS and x86_64⹋ Windows targets.
+PGRX has been tested to work on x86_64 Linux, aarch64 Linux, aarch64 macOS, and x86_64 Windows targets⹋.
 It is currently expected to work on other "Unix" OS with possible small changes, but those remain untested.
 
 - A Rust toolchain: `rustc`, `cargo`, and `rustfmt`. The recommended way to get these is from https://rustup.rs †


### PR DESCRIPTION
Includes clarifying the list of targets down to a "simple" enumeration.