### PR TITLE
Set BGWORKER_SHMEM_ACCESS when building background workers

### DIFF
--- a/pgrx/src/bgworkers.rs
+++ b/pgrx/src/bgworkers.rs
@@ -510,7 +510,7 @@ impl BackgroundWorkerBuilder {
         BackgroundWorkerBuilder {
             bgw_name: name.to_string(),
             bgw_type: name.to_string(),
-            bgw_flags: BGWflags::empty(),
+            bgw_flags: BGWflags::BGWORKER_SHMEM_ACCESS, // required since Postgres 15
             bgw_start_time: BgWorkerStartTime::PostmasterStart,
             bgw_restart_time: None,
             bgw_library_name: name.to_string(),


### PR DESCRIPTION
Background workers must attach to shared memory since Postgres 15.

Fixes: pgcentralfoundation/pgrx#2160
Discussion:  https://postgr.es/m/20210802065116.j763tz3vz4egqy3w@alap3.anarazel.de
See: https://github.com/postgres/postgres/commit/80a8f95b3bca6a80672d1766c928cda34e979112