### PR TITLE
Include `scanner.h` in Rust bindings

### DIFF
--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -133,6 +133,7 @@
 #include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
+#include "parser/scanner.h"
 #include "parser/scansup.h"
 #include "partitioning/partbounds.h"
 #include "partitioning/partdefs.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -134,6 +134,7 @@
 #include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
+#include "parser/scanner.h"
 #include "parser/scansup.h"
 #include "partitioning/partbounds.h"
 #include "partitioning/partdefs.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -135,6 +135,7 @@
 #include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
+#include "parser/scanner.h"
 #include "parser/scansup.h"
 #include "partitioning/partbounds.h"
 #include "partitioning/partdefs.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -137,6 +137,7 @@
 #include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
+#include "parser/scanner.h"
 #include "parser/scansup.h"
 #include "partitioning/partbounds.h"
 #include "partitioning/partdefs.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -137,6 +137,7 @@
 #include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
+#include "parser/scanner.h"
 #include "parser/scansup.h"
 #include "partitioning/partbounds.h"
 #include "partitioning/partdefs.h"

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -137,6 +137,7 @@
 #include "parser/parse_coerce.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
+#include "parser/scanner.h"
 #include "parser/scansup.h"
 #include "partitioning/partbounds.h"
 #include "partitioning/partdefs.h"


### PR DESCRIPTION
It provides symbols for the scanner, aka the lexer, such as:
 - `pg_sys::scanner_init`
 - `pg_sys::core_yylex`
 - `pg_sys::scanner_finish`
 - `pg_sys::ScanKeywords`
 - `pg_sys::ScanKeywordTokens`

We found this useful for normalizing SQL statements for PlanetScale Query Insights[^0] without the higher overhead of fully parsing them.

[^0]: https://planetscale.com/docs/postgres/monitoring/query-insights#schema-name-normalization