### PR TITLE
Restore so-called needless lifetimes

### DIFF
--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -72,6 +72,7 @@ clippy.missing_safety_doc = "allow"
 clippy.too_many_arguments = "allow"
 clippy.type_complexity = "allow"
 clippy.unnecessary_cast = "allow"
+clippy.needless_lifetime = "allow"
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "allow" # repo-wide issue

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -609,7 +609,7 @@ unsafe impl<T: Copy> BoxRet for PgVarlena<T> {
     }
 }
 
-unsafe impl<A> BoxRet for PgHeapTuple<'_, A>
+unsafe impl<'mcx, A> BoxRet for PgHeapTuple<'mcx, A>
 where
     A: WhoAllocated,
 {
@@ -861,7 +861,7 @@ impl<'fcx> FcInfo<'fcx> {
 // TODO: rebadge this as AnyElement
 pub struct Arg<'a, 'fcx>(&'a FcInfo<'fcx>, usize, &'a pg_sys::NullableDatum);
 
-impl<'fcx> Arg<'_, 'fcx> {
+impl<'a, 'fcx> Arg<'a, 'fcx> {
     /// # Performance note
     /// This uses an FFI call to obtain the Oid, so avoid calling it if not necessary.
     pub fn raw_oid(&self) -> pg_sys::Oid {

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -423,7 +423,7 @@ impl<'mcx> PgHeapTuple<'mcx, AllocatedByRust> {
     }
 }
 
-impl<AllocatedBy: WhoAllocated> IntoDatum for PgHeapTuple<'_, AllocatedBy> {
+impl<'mcx, AllocatedBy: WhoAllocated> IntoDatum for PgHeapTuple<'mcx, AllocatedBy> {
     // Delegate to `into_composite_datum()` as this will normally be used with composite types.
     // See `into_trigger_datum()` if using as a trigger.
     fn into_datum(self) -> Option<pg_sys::Datum> {
@@ -449,7 +449,7 @@ impl<AllocatedBy: WhoAllocated> IntoDatum for PgHeapTuple<'_, AllocatedBy> {
     }
 }
 
-impl<AllocatedBy: WhoAllocated> PgHeapTuple<'_, AllocatedBy> {
+impl<'mcx, AllocatedBy: WhoAllocated> PgHeapTuple<'mcx, AllocatedBy> {
     /// Consume this [`PgHeapTuple`] and return a composite Datum representation, containing the tuple
     /// data and the corresponding tuple descriptor information.
     pub fn into_composite_datum(self) -> Option<pg_sys::Datum> {

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -132,7 +132,7 @@ impl<T: Enlist> List<'_, T> {
     }
 }
 
-impl<T> List<'_, T> {
+impl<'cx, T> List<'cx, T> {
     #[inline]
     pub fn len(&self) -> usize {
         match self {

--- a/pgrx/src/list/flat_list.rs
+++ b/pgrx/src/list/flat_list.rs
@@ -361,7 +361,7 @@ pub struct Drain<'a, 'cx, T> {
     raw: *mut pg_sys::List,
 }
 
-impl<T> Drop for Drain<'_, '_, T> {
+impl<'a, 'cx, T> Drop for Drain<'a, 'cx, T> {
     fn drop(&mut self) {
         if self.raw.is_null() {
             return;

--- a/pgrx/src/spi/query.rs
+++ b/pgrx/src/spi/query.rs
@@ -64,9 +64,9 @@ pub trait PreparableQuery<'conn>: Query<'conn> {
     ) -> SpiResult<PreparedStatement<'conn>>;
 }
 
-fn execute<'conn>(
+fn execute<'conn, 'mcx>(
     cmd: &CStr,
-    args: &[DatumWithOid<'_>],
+    args: &[DatumWithOid<'mcx>],
     limit: Option<libc::c_long>,
 ) -> SpiResult<SpiTupleTable<'conn>> {
     // SAFETY: no concurrent access
@@ -100,7 +100,10 @@ fn execute<'conn>(
     SpiClient::prepare_tuple_table(status_code)
 }
 
-fn open_cursor<'conn>(cmd: &CStr, args: &[DatumWithOid<'_>]) -> SpiResult<SpiCursor<'conn>> {
+fn open_cursor<'conn, 'mcx>(
+    cmd: &CStr,
+    args: &[DatumWithOid<'mcx>],
+) -> SpiResult<SpiCursor<'conn>> {
     let nargs = args.len();
     let (mut argtypes, mut datums, nulls) = args_to_datums(args);
 
@@ -122,8 +125,8 @@ fn open_cursor<'conn>(cmd: &CStr, args: &[DatumWithOid<'_>]) -> SpiResult<SpiCur
     Ok(SpiCursor { ptr, __marker: PhantomData })
 }
 
-fn args_to_datums(
-    args: &[DatumWithOid<'_>],
+fn args_to_datums<'mcx>(
+    args: &[DatumWithOid<'mcx>],
 ) -> (Vec<pg_sys::Oid>, Vec<pg_sys::Datum>, Vec<c_char>) {
     let mut argtypes = Vec::with_capacity(args.len());
     let mut datums = Vec::with_capacity(args.len());
@@ -140,7 +143,7 @@ fn args_to_datums(
     (argtypes, datums, nulls)
 }
 
-fn prepare_datum(datum: &DatumWithOid<'_>) -> (pg_sys::Datum, std::os::raw::c_char) {
+fn prepare_datum<'mcx>(datum: &DatumWithOid<'mcx>) -> (pg_sys::Datum, std::os::raw::c_char) {
     match datum.datum() {
         Some(datum) => (datum.sans_lifetime(), ' ' as std::os::raw::c_char),
         None => (pg_sys::Datum::from(0usize), 'n' as std::os::raw::c_char),
@@ -296,7 +299,7 @@ impl<'conn> Query<'conn> for OwnedPreparedStatement {
     }
 }
 
-impl PreparedStatement<'_> {
+impl<'conn> PreparedStatement<'conn> {
     /// Converts prepared statement into an owned prepared statement
     ///
     /// These statements have static lifetime and are freed only when dropped
@@ -314,9 +317,9 @@ impl PreparedStatement<'_> {
         })
     }
 
-    fn args_to_datums(
+    fn args_to_datums<'mcx>(
         &self,
-        args: &[DatumWithOid<'_>],
+        args: &[DatumWithOid<'mcx>],
     ) -> SpiResult<(Vec<pg_sys::Datum>, Vec<std::os::raw::c_char>)> {
         let actual = args.len();
         let expected = unsafe { pg_sys::SPI_getargcount(self.plan.as_ptr()) } as usize;

--- a/pgrx/src/spi/tuple.rs
+++ b/pgrx/src/spi/tuple.rs
@@ -458,7 +458,7 @@ impl<'conn> SpiHeapTupleData<'conn> {
     }
 }
 
-impl SpiHeapTupleDataEntry<'_> {
+impl<'conn> SpiHeapTupleDataEntry<'conn> {
     pub fn value<T: IntoDatum + FromDatum>(&self) -> SpiResult<Option<T>> {
         match self.datum.as_ref() {
             Some(datum) => unsafe {


### PR DESCRIPTION
These were removed in pgcentralfoundation/pgrx#2097 but some instances wound up erasing deliberate, meaningful names for lifetimes. Eliding them as technically-meaningless at some use-sites is unhelpful.