### PR TITLE
Drop stray Postgres 12 support in cargo-pgrx

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -174,7 +174,6 @@ pub(crate) fn install_extension(
             true,
             package_manifest_path,
             &mut output_tracking,
-            pg_config,
         )?;
     }
 
@@ -217,7 +216,6 @@ pub(crate) fn install_extension(
             false,
             package_manifest_path,
             &mut output_tracking,
-            pg_config,
         )?;
     }
 
@@ -246,7 +244,6 @@ fn copy_file(
     do_filter: bool,
     package_manifest_path: impl AsRef<Path>,
     output_tracking: &mut Vec<PathBuf>,
-    pg_config: &PgConfig,
 ) -> eyre::Result<()> {
     let Some(dest_dir) = dest.parent() else {
         // what fresh hell could ever cause such an error?
@@ -268,11 +265,7 @@ fn copy_file(
         // we want to filter the contents of the file we're to copy
         let input = fs::read_to_string(src)
             .wrap_err_with(|| format!("failed to read `{}`", src.display()))?;
-        let mut input = filter_contents(package_manifest_path, input)?;
-
-        if src.display().to_string().ends_with(".control") {
-            input = filter_out_fields_in_control(pg_config, input)?;
-        }
+        let input = filter_contents(package_manifest_path, input)?;
 
         fs::write(&dest, input).wrap_err_with(|| {
             format!("failed writing `{}` to `{}`", src.display(), dest.display())
@@ -404,7 +397,6 @@ fn copy_sql_files(
                     true,
                     &package_manifest_path,
                     output_tracking,
-                    pg_config,
                 )?;
             }
         }
@@ -570,20 +562,6 @@ fn filter_contents(manifest_path: impl AsRef<Path>, mut input: String) -> eyre::
     }
 
     input = input.replace("@CARGO_VERSION@", &get_version(&manifest_path)?);
-
-    Ok(input)
-}
-
-// remove fields in control for versions not supported
-// `trusted`` in only supported in version 13 and above
-fn filter_out_fields_in_control(pg_config: &PgConfig, mut input: String) -> eyre::Result<String> {
-    if pg_config.major_version().unwrap() < 13 {
-        input = input
-            .lines()
-            .filter(|line| !line.starts_with("trusted"))
-            .collect::<Vec<_>>()
-            .join("\n");
-    }
 
     Ok(input)
 }


### PR DESCRIPTION
Stop filtering `.control` fields Postgres 12 would not recognize. It is unnecessary in the Postgres 13 to Postgres 18 support window, and complicates the logic by requiring more parameters in `copy_file` and thus its callers.

This simplification is also an incremental step towards addressing https://github.com/pgcentralfoundation/pgrx/issues/2152#issuecomment-3457928047