### PR TITLE
Show line number of failed asserts

### DIFF
--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -150,8 +150,11 @@ pub fn run_test(
                     return Ok(());
                 }
 
-                let pg_location = dberror.file().unwrap_or("<unknown>").to_string();
+                let mut pg_location = dberror.file().unwrap_or("<unknown>").to_string();
                 let rust_location = dberror.where_().unwrap_or("<unknown>").to_string();
+                if let Some(lineno) = dberror.line() {
+                    pg_location += &format!(":{lineno}");
+                }
 
                 (pg_location, rust_location, received_error_message.to_string())
             } else {


### PR DESCRIPTION
A little quality-of-life improvement: when a unit test fails, the test runner now shows the line number.  For tests with several assertions, this is quite handy.

Before:
<img width="287" height="127" alt="Screenshot 2025-10-28 at 3 59 27 PM" src="https://github.com/user-attachments/assets/d9058a8d-f667-49f8-84be-cd9ce554801c" />

After:
<img width="286" height="127" alt="Screenshot 2025-10-28 at 3 57 15 PM" src="https://github.com/user-attachments/assets/da6d0a14-7e34-414f-90a6-87f8124e53e0" />

