### PR TITLE
Add rust-analyzer.toml

### DIFF
--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,0 +1,11 @@
+cargo.allFeatures = false
+cargo.buildScripts.overrideCommand = [
+  "cargo",
+  "check",
+  "--quiet",
+  "--workspace",
+  "--message-format=json",
+  "--features",
+  "pg18", # ideally we'd use cargo.features but r-a whines that cargo-pgrx does not have "pg18"
+  "--keep-going",
+]


### PR DESCRIPTION
This allows the repo to work for anyone using an r-a-based editor, regardless of whether it's VS Code or Helix or whatever.