### PR TITLE
Replace `impl AsRef<T>` with `&T`

### DIFF
--- a/cargo-pgrx/src/command/connect.rs
+++ b/cargo-pgrx/src/command/connect.rs
@@ -75,7 +75,7 @@ impl CommandExecute for Connect {
             Some(dbname) => dbname,
             None => {
                 // We should infer from package
-                get_property(package_manifest_path, "extname")
+                get_property(&package_manifest_path, "extname")
                     .wrap_err("could not determine extension name")?
                     .ok_or(eyre!("extname not found in control file"))?
             }

--- a/cargo-pgrx/src/command/connect.rs
+++ b/cargo-pgrx/src/command/connect.rs
@@ -51,7 +51,7 @@ impl CommandExecute for Connect {
         let (package_manifest, package_manifest_path) = get_package_manifest(
             &Features::default(),
             self.package.as_ref(),
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
         )?;
         let (pg_config, _pg_version) = match pg_config_and_version(
             &pgrx,

--- a/cargo-pgrx/src/command/get.rs
+++ b/cargo-pgrx/src/command/get.rs
@@ -40,7 +40,7 @@ impl CommandExecute for Get {
             crate::manifest::manifest_path(&metadata, self.package.as_ref())
                 .wrap_err("Couldn't get manifest path")?;
 
-        if let Some(value) = get_property(package_manifest_path, &self.name)? {
+        if let Some(value) = get_property(&package_manifest_path, &self.name)? {
             println!("{value}");
         }
         Ok(())
@@ -49,9 +49,9 @@ impl CommandExecute for Get {
 
 #[tracing::instrument(level = "error", skip_all, fields(
     %name,
-    manifest_path = %manifest_path.as_ref().display(),
+    manifest_path = %manifest_path.display(),
 ))]
-pub fn get_property(manifest_path: impl AsRef<Path>, name: &str) -> eyre::Result<Option<String>> {
+pub fn get_property(manifest_path: &Path, name: &str) -> eyre::Result<Option<String>> {
     let (control_file, extname) = find_control_file(manifest_path)?;
 
     if name == "extname" {
@@ -84,13 +84,10 @@ pub fn get_property(manifest_path: impl AsRef<Path>, name: &str) -> eyre::Result
     Ok(None)
 }
 
-pub(crate) fn find_control_file(
-    manifest_path: impl AsRef<Path>,
-) -> eyre::Result<(PathBuf, String)> {
+pub(crate) fn find_control_file(manifest_path: &Path) -> eyre::Result<(PathBuf, String)> {
     let parent = manifest_path
-        .as_ref()
         .parent()
-        .ok_or_else(|| eyre!("could not get parent of `{}`", manifest_path.as_ref().display()))?;
+        .ok_or_else(|| eyre!("could not get parent of `{}`", manifest_path.display()))?;
 
     for f in (std::fs::read_dir(parent).wrap_err_with(|| {
         eyre!("cannot open current directory `{}` for reading", parent.display())
@@ -112,7 +109,7 @@ pub(crate) fn find_control_file(
         }
     }
 
-    Err(eyre!("control file not found in `{}`", manifest_path.as_ref().display()))
+    Err(eyre!("control file not found in `{}`", manifest_path.display()))
 }
 
 fn determine_git_hash() -> eyre::Result<Option<String>> {

--- a/cargo-pgrx/src/command/get.rs
+++ b/cargo-pgrx/src/command/get.rs
@@ -33,9 +33,10 @@ pub(crate) struct Get {
 impl CommandExecute for Get {
     #[tracing::instrument(level = "error", skip(self))]
     fn execute(self) -> eyre::Result<()> {
-        let metadata = crate::metadata::metadata(&Default::default(), self.manifest_path.as_ref())
-            .wrap_err("couldn't get cargo metadata")?;
-        crate::metadata::validate(self.manifest_path.as_ref(), &metadata)?;
+        let metadata =
+            crate::metadata::metadata(&Default::default(), self.manifest_path.as_deref())
+                .wrap_err("couldn't get cargo metadata")?;
+        crate::metadata::validate(self.manifest_path.as_deref(), &metadata)?;
         let package_manifest_path =
             crate::manifest::manifest_path(&metadata, self.package.as_ref())
                 .wrap_err("Couldn't get manifest path")?;

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -71,9 +71,9 @@ impl CommandExecute for Install {
             return sudo_install.execute();
         }
 
-        let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
+        let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_deref())
             .wrap_err("couldn't get cargo metadata")?;
-        crate::metadata::validate(self.manifest_path.as_ref(), &metadata)?;
+        crate::metadata::validate(self.manifest_path.as_deref(), &metadata)?;
         let package_manifest_path =
             crate::manifest::manifest_path(&metadata, self.package.as_ref())
                 .wrap_err("Couldn't get manifest path")?;

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -100,7 +100,7 @@ impl CommandExecute for Install {
 
         display_version_info(&pg_config, &PgVersionSource::PgConfig(pg_config.label()?));
         install_extension(
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
             self.package.as_ref(),
             &package_manifest_path,
             &pg_config,
@@ -122,7 +122,7 @@ impl CommandExecute for Install {
     features = ?features.features,
 ))]
 pub(crate) fn install_extension(
-    user_manifest_path: Option<impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
     package_manifest_path: &Path,
     pg_config: &PgConfig,
@@ -344,7 +344,7 @@ pub(crate) fn build_extension(
 }
 
 fn copy_sql_files(
-    user_manifest_path: Option<impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
     package_manifest_path: impl AsRef<Path>,
     profile: &CargoProfile,
@@ -364,13 +364,13 @@ fn copy_sql_files(
         crate::command::schema::generate_schema(
             user_manifest_path,
             user_package,
-            &package_manifest_path,
+            package_manifest_path.as_ref(),
             profile,
             is_test,
             features,
             target,
             Some(&dest),
-            Option::<String>::None,
+            None,
             None,
             skip_build,
             output_tracking,

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -140,7 +140,7 @@ pub(crate) fn install_extension(
     let versioned_so = get_property(package_manifest_path, "module_pathname")?.is_none();
 
     let build_command_output =
-        build_extension(user_manifest_path.as_ref(), user_package, profile, features, target)?;
+        build_extension(user_manifest_path, user_package, profile, features, target)?;
     let build_command_bytes = build_command_output.stdout;
     let build_command_reader = BufReader::new(build_command_bytes.as_slice());
     let build_command_stream = CargoMessage::parse_stream(build_command_reader);
@@ -241,7 +241,7 @@ fn copy_file(
     dest: PathBuf,
     msg: &str,
     do_filter: bool,
-    package_manifest_path: impl AsRef<Path>,
+    package_manifest_path: &Path,
     output_tracking: &mut Vec<PathBuf>,
 ) -> eyre::Result<()> {
     let Some(dest_dir) = dest.parent() else {
@@ -281,7 +281,7 @@ fn copy_file(
 }
 
 pub(crate) fn build_extension(
-    user_manifest_path: Option<impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
@@ -295,7 +295,7 @@ pub(crate) fn build_extension(
 
     if let Some(user_manifest_path) = user_manifest_path {
         command.arg("--manifest-path");
-        command.arg(user_manifest_path.as_ref());
+        command.arg(user_manifest_path);
     }
 
     if let Some(user_package) = user_package {
@@ -346,7 +346,7 @@ pub(crate) fn build_extension(
 fn copy_sql_files(
     user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
-    package_manifest_path: impl AsRef<Path>,
+    package_manifest_path: &Path,
     profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
@@ -378,7 +378,7 @@ fn copy_sql_files(
     }
 
     // now copy all the version upgrade files too
-    if let Ok(dir) = fs::read_dir(package_manifest_path.as_ref().parent().unwrap().join("sql/")) {
+    if let Ok(dir) = fs::read_dir(package_manifest_path.parent().unwrap().join("sql/")) {
         for sql in dir.flatten() {
             let filename = sql.file_name().into_string().unwrap();
 
@@ -444,8 +444,8 @@ pub(crate) fn find_library_file(
 
 static CARGO_VERSION: OnceLock<MemoizeKeyValue> = OnceLock::new();
 
-pub(crate) fn get_version(manifest_path: impl AsRef<Path>) -> eyre::Result<String> {
-    let path_string = manifest_path.as_ref().to_owned();
+pub(crate) fn get_version(manifest_path: &Path) -> eyre::Result<String> {
+    let path_string = manifest_path.to_owned();
 
     if let Some(version) =
         CARGO_VERSION.get_or_init(Default::default).lock().unwrap().get(&path_string)
@@ -486,8 +486,8 @@ pub(crate) fn get_version(manifest_path: impl AsRef<Path>) -> eyre::Result<Strin
 
 static GIT_HASH: OnceLock<MemoizeKeyValue> = OnceLock::new();
 
-fn get_git_hash(manifest_path: impl AsRef<Path>) -> eyre::Result<String> {
-    let path_string = manifest_path.as_ref().to_owned();
+fn get_git_hash(manifest_path: &Path) -> eyre::Result<String> {
+    let path_string = manifest_path.to_owned();
 
     let mut mutex = GIT_HASH.get_or_init(Default::default).lock().unwrap();
     if let Some(hash) = mutex.get(&path_string) {
@@ -540,8 +540,7 @@ fn make_relative_extdir(_: PathBuf) -> PathBuf {
     "share/extension".into()
 }
 
-pub(crate) fn format_display_path(path: impl AsRef<Path>) -> eyre::Result<String> {
-    let path = path.as_ref();
+pub(crate) fn format_display_path(path: &Path) -> eyre::Result<String> {
     let out = path
         .strip_prefix(get_target_dir()?.parent().unwrap())
         .unwrap_or(path)
@@ -550,7 +549,7 @@ pub(crate) fn format_display_path(path: impl AsRef<Path>) -> eyre::Result<String
     Ok(out)
 }
 
-fn filter_contents(manifest_path: impl AsRef<Path>, mut input: String) -> eyre::Result<String> {
+fn filter_contents(manifest_path: &Path, mut input: String) -> eyre::Result<String> {
     if input.contains("@GIT_HASH@") {
         // avoid doing this if we don't actually have the token
         // the project might not be a git repo so running `git`

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -85,7 +85,7 @@ impl Package {
         };
 
         let output_files = package_extension(
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
             self.package.as_ref(),
             &package_manifest_path,
             &pg_config,
@@ -114,7 +114,7 @@ impl CommandExecute for Package {
     test = is_test,
 ))]
 pub(crate) fn package_extension(
-    user_manifest_path: Option<impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
     package_manifest_path: &Path,
     pg_config: &PgConfig,

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -51,9 +51,9 @@ pub(crate) struct Package {
 
 impl Package {
     pub(crate) fn perform(mut self) -> eyre::Result<(PathBuf, Vec<PathBuf>)> {
-        let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_ref())
+        let metadata = crate::metadata::metadata(&self.features, self.manifest_path.as_deref())
             .wrap_err("couldn't get cargo metadata")?;
-        crate::metadata::validate(self.manifest_path.as_ref(), &metadata)?;
+        crate::metadata::validate(self.manifest_path.as_deref(), &metadata)?;
         let package_manifest_path =
             crate::manifest::manifest_path(&metadata, self.package.as_ref())
                 .wrap_err("Couldn't get manifest path")?;

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -147,7 +147,7 @@ pub(crate) fn package_extension(
 
 pub(crate) fn build_base_path(
     pg_config: &PgConfig,
-    manifest_path: impl AsRef<Path>,
+    manifest_path: &Path,
     profile: &CargoProfile,
     target: Option<&str>,
 ) -> eyre::Result<PathBuf> {

--- a/cargo-pgrx/src/command/regress.rs
+++ b/cargo-pgrx/src/command/regress.rs
@@ -348,7 +348,7 @@ impl CommandExecute for Regress {
         let (_, manifest_path) = get_package_manifest(
             &self.features,
             self.package.as_ref(),
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
         )?;
         let extname = get_property(&manifest_path, "extname")?
             .expect("extension name property `extname` should always be known");

--- a/cargo-pgrx/src/command/regress.rs
+++ b/cargo-pgrx/src/command/regress.rs
@@ -75,7 +75,7 @@ pub(crate) struct Regress {
 
 impl Regress {
     #[rustfmt::skip]
-    fn is_setup_sql_newer(&self, manifest_path: impl AsRef<Path>) -> bool {
+    fn is_setup_sql_newer(&self, manifest_path: &Path) -> bool {
 
         // if we have reset the db, then re-run the setup
         if self.resetdb {
@@ -101,7 +101,7 @@ impl Regress {
 
     fn list_sql_tests(
         &self,
-        manifest_path: impl AsRef<Path>,
+        manifest_path: &Path,
         include_setup: bool,
     ) -> eyre::Result<Vec<DirEntry>> {
         let sql = manifest_path_to_sql_tests_path(manifest_path);
@@ -116,7 +116,7 @@ impl Regress {
 
     fn list_expected_outputs(
         &self,
-        manifest_path: impl AsRef<Path>,
+        manifest_path: &Path,
         include_setup: bool,
     ) -> eyre::Result<Vec<DirEntry>> {
         let expected = manifest_path_to_expected_tests_output_path(manifest_path);
@@ -132,7 +132,7 @@ impl Regress {
 
     fn list_results_outputs(
         &self,
-        manifest_path: impl AsRef<Path>,
+        manifest_path: &Path,
         include_setup: bool,
     ) -> eyre::Result<Vec<DirEntry>> {
         let results = manifest_path_to_results_output_path(manifest_path);
@@ -188,15 +188,14 @@ impl Regress {
 
     fn accept_new_test(
         &self,
-        manifest_path: impl AsRef<Path>,
-        test_result_output: impl AsRef<Path>,
+        manifest_path: &Path,
+        test_result_output: &Path,
         auto: bool,
     ) -> eyre::Result<()> {
         if !std::io::stdin().is_terminal() {
             panic!("not a terminal: cannot perform user interaction to accept tests")
         }
         let test_name = test_result_output
-            .as_ref()
             .file_stem()
             .expect("test result output should have a stem")
             .to_str()
@@ -255,15 +254,15 @@ impl Regress {
             std::fs::copy(test_result_output, &expected_path)?;
 
             // make sure to add the file to git
-            add_to_git(expected_path)
+            add_to_git(&expected_path)
         }
     }
 
     fn run_all_tests(
         &self,
         pg_config: &PgConfig,
-        manifest_path: impl AsRef<Path>,
-        pgregress_path: impl AsRef<Path>,
+        manifest_path: &Path,
+        pgregress_path: &Path,
         dbname: &str,
         test_files: &[&DirEntry],
         output_files: &[&DirEntry],
@@ -295,7 +294,7 @@ impl Regress {
                     dbname,
                     new_test,
                 )? {
-                    self.accept_new_test(&manifest_path, test_result_output, auto)?;
+                    self.accept_new_test(&manifest_path, &test_result_output, auto)?;
                 }
             }
         }
@@ -416,7 +415,7 @@ impl CommandExecute for Regress {
 
 fn run_tests(
     pg_config: &PgConfig,
-    pg_regress_bin: impl AsRef<Path>,
+    pg_regress_bin: &Path,
     dbname: &str,
     test_files: &[&DirEntry],
 ) -> eyre::Result<bool> {
@@ -436,8 +435,8 @@ fn run_tests(
 
 fn create_regress_output(
     pg_config: &PgConfig,
-    manifest_path: impl AsRef<Path>,
-    pg_regress_bin: impl AsRef<Path>,
+    manifest_path: &Path,
+    pg_regress_bin: &Path,
     dbname: &str,
     test_file: &DirEntry,
 ) -> eyre::Result<Option<PathBuf>> {
@@ -469,9 +468,9 @@ fn create_regress_output(
 
 fn pg_regress(
     pg_config: &PgConfig,
-    bin: impl AsRef<Path>,
+    bin: &Path,
     dbname: &str,
-    input_dir: impl AsRef<Path>,
+    input_dir: &Path,
     tests: &[&DirEntry],
 ) -> eyre::Result<ExitStatus> {
     if tests.is_empty() {
@@ -480,7 +479,7 @@ fn pg_regress(
     let test_dir = tests[0].path().parent().unwrap().parent().unwrap().to_path_buf();
     let tests = tests.iter().map(|entry| make_test_name(entry));
 
-    let mut command = Command::new(bin.as_ref());
+    let mut command = Command::new(bin);
     command
         .current_dir(test_dir)
         .env_remove("PGDATABASE")
@@ -495,8 +494,8 @@ fn pg_regress(
         .arg(pg_config.port()?.to_string())
         .arg("--use-existing")
         .arg(format!("--dbname={dbname}"))
-        .arg(format!("--inputdir={}", input_dir.as_ref().display()))
-        .arg(format!("--outputdir={}", input_dir.as_ref().display()))
+        .arg(format!("--inputdir={}", input_dir.display()))
+        .arg(format!("--outputdir={}", input_dir.display()))
         .args(tests);
 
     #[cfg(not(target_os = "windows"))]
@@ -642,8 +641,8 @@ fn make_test_name(entry: &DirEntry) -> String {
     filename.to_string()
 }
 
-fn manifest_path_to_sql_tests_path(manifest_path: impl AsRef<Path>) -> PathBuf {
-    let mut path = PathBuf::from(manifest_path.as_ref());
+fn manifest_path_to_sql_tests_path(manifest_path: &Path) -> PathBuf {
+    let mut path = PathBuf::from(manifest_path);
     path.pop(); // pop `Cargo.toml`
     path.push("tests");
     path.push("pg_regress");
@@ -651,16 +650,16 @@ fn manifest_path_to_sql_tests_path(manifest_path: impl AsRef<Path>) -> PathBuf {
     path
 }
 
-fn manifest_path_to_expected_tests_output_path(manifest_path: impl AsRef<Path>) -> PathBuf {
-    let mut path = PathBuf::from(manifest_path.as_ref());
+fn manifest_path_to_expected_tests_output_path(manifest_path: &Path) -> PathBuf {
+    let mut path = PathBuf::from(manifest_path);
     path.pop(); // pop `Cargo.toml`
     path.push("tests");
     path.push("pg_regress");
     path.push("expected");
     path
 }
-fn manifest_path_to_results_output_path(manifest_path: impl AsRef<Path>) -> PathBuf {
-    let mut path = PathBuf::from(manifest_path.as_ref());
+fn manifest_path_to_results_output_path(manifest_path: &Path) -> PathBuf {
+    let mut path = PathBuf::from(manifest_path);
     path.pop(); // pop `Cargo.toml`
     path.push("tests");
     path.push("pg_regress");
@@ -668,18 +667,17 @@ fn manifest_path_to_results_output_path(manifest_path: impl AsRef<Path>) -> Path
     path
 }
 
-fn add_to_git(path: impl AsRef<Path>) -> eyre::Result<()> {
+fn add_to_git(path: &Path) -> eyre::Result<()> {
     if let Ok(git) = which::which("git") {
-        if is_git_repo(&git) && !Command::new(git).arg("add").arg(path.as_ref()).status()?.success()
-        {
-            panic!("unable to add {} to git", path.as_ref().display());
+        if is_git_repo(&git) && !Command::new(git).arg("add").arg(path).status()?.success() {
+            panic!("unable to add {} to git", path.display());
         }
     }
     Ok(())
 }
 
-fn is_git_repo(git: impl AsRef<Path>) -> bool {
-    Command::new(git.as_ref())
+fn is_git_repo(git: &Path) -> bool {
+    Command::new(git)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .arg("rev-parse")

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -87,7 +87,7 @@ impl Run {
         let (package_manifest, package_manifest_path) = get_package_manifest(
             &self.features,
             self.package.as_ref(),
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
         )?;
         let (pg_config, _pg_version) = pg_config_and_version(
             &pgrx,

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -109,7 +109,7 @@ impl Run {
 
         run(
             &pg_config,
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
             self.package.as_ref(),
             &package_manifest_path,
             &dbname,
@@ -143,7 +143,7 @@ impl CommandExecute for Run {
 ))]
 pub(crate) fn run(
     pg_config: &PgConfig,
-    user_manifest_path: Option<impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
     package_manifest_path: &Path,
     dbname: &str,

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -80,7 +80,7 @@ impl CommandExecute for Schema {
         let (package_manifest, package_manifest_path) = get_package_manifest(
             &self.features,
             self.package.as_ref(),
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
         )?;
         // This does meaningful mutation, unfortunately
         let (_pg_config, _pg_version) = pg_config_and_version(

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -97,15 +97,15 @@ impl CommandExecute for Schema {
         )?;
 
         generate_schema(
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
             self.package.as_ref(),
-            package_manifest_path,
+            &package_manifest_path,
             &profile,
             self.test,
             &self.features,
             self.target.as_deref(),
-            self.out.as_ref(),
-            self.dot,
+            self.out.as_deref(),
+            self.dot.as_deref(),
             log_level,
             self.skip_build,
             &mut vec![],
@@ -116,20 +116,20 @@ impl CommandExecute for Schema {
 #[tracing::instrument(level = "error", skip_all, fields(
     profile = ?profile,
     test = is_test,
-    path = path.as_ref().map(|path| tracing::field::display(path.as_ref().display())),
+    path = path.map(|path| tracing::field::display(path.display())),
     dot,
     features = ?features.features,
 ))]
 pub(crate) fn generate_schema(
-    user_manifest_path: Option<impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
-    package_manifest_path: impl AsRef<Path>,
+    package_manifest_path: &Path,
     profile: &CargoProfile,
     is_test: bool,
     features: &clap_cargo::Features,
     target: Option<&str>,
-    path: Option<impl AsRef<std::path::Path>>,
-    dot: Option<impl AsRef<std::path::Path>>,
+    path: Option<&Path>,
+    dot: Option<&Path>,
     log_level: Option<String>,
     skip_build: bool,
     output_tracking: &mut Vec<PathBuf>,
@@ -152,7 +152,7 @@ pub(crate) fn generate_schema(
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
         first_build(
-            user_manifest_path.as_ref(),
+            user_manifest_path,
             profile,
             features,
             log_level.clone(),
@@ -167,19 +167,19 @@ pub(crate) fn generate_schema(
     let symbols = compute_symbols(profile, &lib_filename, target)?;
 
     let mut out_path = None;
-    if let Some(path) = path.as_ref() {
-        let x = path.as_ref().to_str().expect("`path` is not a valid UTF8 string.");
+    if let Some(path) = path {
+        let x = path.to_str().expect("`path` is not a valid UTF8 string.");
         out_path = Some(x.to_string());
     }
 
     let mut out_dot = None;
-    if let Some(dot) = dot.as_ref() {
-        let x = dot.as_ref().to_str().expect("`dot` is not a valid UTF8 string.");
+    if let Some(dot) = dot {
+        let x = dot.to_str().expect("`dot` is not a valid UTF8 string.");
         out_dot = Some(x.to_string());
     };
 
     let codegen = compute_codegen(
-        control_file,
+        &control_file,
         package_manifest_path,
         &symbols,
         &lib_name,
@@ -195,18 +195,18 @@ pub(crate) fn generate_schema(
     };
 
     if let Some(out_path) = path.as_ref() {
-        if let Some(parent) = out_path.as_ref().parent() {
+        if let Some(parent) = out_path.parent() {
             std::fs::create_dir_all(parent).wrap_err("Could not create parent directory")?;
         }
-        output_tracking.push(out_path.as_ref().to_path_buf());
+        output_tracking.push(out_path.to_path_buf());
     }
 
     if let Some(dot_path) = dot.as_ref() {
-        tracing::info!(dot = %dot_path.as_ref().display(), "Writing Graphviz DOT");
+        tracing::info!(dot = %dot_path.display(), "Writing Graphviz DOT");
     }
 
     second_build(
-        user_manifest_path.as_ref(),
+        user_manifest_path,
         features,
         log_level.clone(),
         &features_arg,
@@ -323,7 +323,7 @@ fn compute_symbols(
 }
 
 fn first_build(
-    user_manifest_path: Option<&impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
     log_level: Option<String>,
@@ -351,7 +351,7 @@ fn first_build(
 
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");
-        command.arg(user_manifest_path.as_ref());
+        command.arg(user_manifest_path);
     }
 
     command.args(profile.cargo_args());
@@ -403,8 +403,8 @@ fn first_build(
 }
 
 fn compute_codegen(
-    control_file_path: impl AsRef<Path>,
-    package_manifest_path: impl AsRef<Path>,
+    control_file_path: &Path,
+    package_manifest_path: &Path,
     symbols: &[String],
     lib_name: &str,
     path: Option<String>,
@@ -414,10 +414,8 @@ fn compute_codegen(
     let lib_name_ident = Ident::new(lib_name, Span::call_site());
 
     let inputs = {
-        let control_file_path = control_file_path
-            .as_ref()
-            .to_str()
-            .expect(".control file filename should be valid UTF8");
+        let control_file_path =
+            control_file_path.to_str().expect(".control file filename should be valid UTF8");
         let mut out = quote::quote! {
             // call the marker.  Primarily this ensures that rustc will actually link to the library
             // during the "pgrx_embed" build initiated by `cargo-pgrx schema` generation
@@ -493,12 +491,12 @@ fn compute_codegen(
 }
 
 fn second_build(
-    user_manifest_path: Option<&impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     features: &clap_cargo::Features,
     log_level: Option<String>,
     features_arg: &str,
     flags: &str,
-    embed_path: impl AsRef<Path>,
+    embed_path: &Path,
     package_name: &str,
     manifest: &Manifest,
 ) -> eyre::Result<()> {
@@ -518,7 +516,7 @@ fn second_build(
 
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");
-        command.arg(user_manifest_path.as_ref());
+        command.arg(user_manifest_path);
     }
 
     if let Some(log_level) = &log_level {
@@ -546,7 +544,7 @@ fn second_build(
 
     command.args(["--cfg", "pgrx_embed"]);
 
-    command.env("PGRX_EMBED", embed_path.as_ref());
+    command.env("PGRX_EMBED", embed_path);
 
     let command_str = format!("{command:?}");
     eprintln!(

--- a/cargo-pgrx/src/command/start.rs
+++ b/cargo-pgrx/src/command/start.rs
@@ -53,7 +53,7 @@ impl CommandExecute for Start {
             let (package_manifest, _) = get_package_manifest(
                 &clap_cargo::Features::default(),
                 me.package.as_ref(),
-                me.manifest_path,
+                me.manifest_path.as_deref(),
             )?;
 
             let (pg_config, _) =
@@ -64,7 +64,7 @@ impl CommandExecute for Start {
         let (package_manifest, _) = get_package_manifest(
             &clap_cargo::Features::default(),
             self.package.as_ref(),
-            self.manifest_path.clone(),
+            self.manifest_path.as_deref(),
         )?;
 
         let postgresql_conf = collect_postgresql_conf_settings(&self.postgresql_conf)?;

--- a/cargo-pgrx/src/command/stop.rs
+++ b/cargo-pgrx/src/command/stop.rs
@@ -40,7 +40,7 @@ impl CommandExecute for Stop {
             let (package_manifest, _) = get_package_manifest(
                 &clap_cargo::Features::default(),
                 me.package.as_ref(),
-                me.manifest_path.clone(),
+                me.manifest_path.as_deref(),
             )?;
             let (pg_config, _) =
                 pg_config_and_version(pgrx, &package_manifest, me.pg_version, None, false)?;
@@ -52,7 +52,7 @@ impl CommandExecute for Stop {
         let (package_manifest, _) = get_package_manifest(
             &clap_cargo::Features::default(),
             self.package.as_ref(),
-            self.manifest_path.clone(),
+            self.manifest_path.as_deref(),
         )?;
         if self.pg_version == Some("all".into()) {
             for v in crate::manifest::all_pg_in_both_tomls(&package_manifest, &pgrx) {

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -58,8 +58,11 @@ impl CommandExecute for Test {
         #[tracing::instrument(level = "error", skip(me))]
         fn perform(me: Test, pgrx: &Pgrx) -> eyre::Result<()> {
             let mut features = me.features.clone();
-            let (package_manifest, _package_manifest_path) =
-                get_package_manifest(&me.features, me.package.as_ref(), me.manifest_path.as_ref())?;
+            let (package_manifest, _package_manifest_path) = get_package_manifest(
+                &me.features,
+                me.package.as_ref(),
+                me.manifest_path.as_deref(),
+            )?;
             let (pg_config, _pg_version) = pg_config_and_version(
                 pgrx,
                 &package_manifest,
@@ -91,7 +94,7 @@ impl CommandExecute for Test {
         let (package_manifest, _) = get_package_manifest(
             &self.features,
             self.package.as_ref(),
-            self.manifest_path.as_ref(),
+            self.manifest_path.as_deref(),
         )?;
         let pgrx = Pgrx::from_config()?;
         if self.pg_version == Some("all".to_string()) {

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -75,12 +75,12 @@ impl CommandExecute for Test {
 
             test_extension(
                 &pg_config,
-                me.manifest_path.as_ref(),
+                me.manifest_path.as_deref(),
                 me.package.as_ref(),
                 &profile,
                 me.no_schema,
                 &features,
-                me.testname,
+                me.testname.as_deref(),
                 me.runas,
                 me.pgdata,
             )?;
@@ -117,12 +117,12 @@ impl CommandExecute for Test {
 ))]
 pub fn test_extension(
     pg_config: &PgConfig,
-    user_manifest_path: Option<impl AsRef<Path>>,
+    user_manifest_path: Option<&Path>,
     user_package: Option<&String>,
     profile: &CargoProfile,
     no_schema: bool,
     features: &clap_cargo::Features,
-    testname: Option<impl AsRef<str>>,
+    testname: Option<&str>,
     runas: Option<String>,
     pgdata: Option<PathBuf>,
 ) -> eyre::Result<()> {
@@ -132,7 +132,7 @@ pub fn test_extension(
     }
 
     if let Some(ref testname) = testname {
-        tracing::Span::current().record("testname", tracing::field::display(&testname.as_ref()));
+        tracing::Span::current().record("testname", tracing::field::display(&testname));
     }
     let target_dir = get_target_dir()?;
 
@@ -184,7 +184,7 @@ pub fn test_extension(
 
     if let Some(user_manifest_path) = user_manifest_path {
         command.arg("--manifest-path");
-        command.arg(user_manifest_path.as_ref());
+        command.arg(user_manifest_path);
     }
 
     if let Some(user_package) = user_package {
@@ -193,7 +193,7 @@ pub fn test_extension(
     }
 
     if let Some(testname) = testname {
-        command.arg(testname.as_ref());
+        command.arg(testname);
     }
 
     eprintln!("{command:?}");

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -12,7 +12,7 @@ use cargo_toml::Manifest;
 use clap_cargo::Features;
 use eyre::{Context, eyre};
 use pgrx_pg_config::{PgConfig, PgConfigSelector, Pgrx};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub(crate) enum PgVersionSource {
@@ -197,7 +197,7 @@ pub(crate) fn display_version_info(pg_config: &PgConfig, pg_version: &PgVersionS
 pub(crate) fn get_package_manifest(
     features: &Features,
     package_name: Option<&String>,
-    manifest_path: Option<impl AsRef<std::path::Path>>,
+    manifest_path: Option<&Path>,
 ) -> eyre::Result<(Manifest, PathBuf)> {
     let metadata = crate::metadata::metadata(features, manifest_path.as_ref())
         .wrap_err("couldn't get cargo metadata")?;

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -199,9 +199,9 @@ pub(crate) fn get_package_manifest(
     package_name: Option<&String>,
     manifest_path: Option<&Path>,
 ) -> eyre::Result<(Manifest, PathBuf)> {
-    let metadata = crate::metadata::metadata(features, manifest_path.as_ref())
+    let metadata = crate::metadata::metadata(features, manifest_path)
         .wrap_err("couldn't get cargo metadata")?;
-    crate::metadata::validate(manifest_path.as_ref(), &metadata)?;
+    crate::metadata::validate(manifest_path, &metadata)?;
     let package_manifest_path = crate::manifest::manifest_path(&metadata, package_name)
         .wrap_err("Couldn't get manifest path")?;
 

--- a/cargo-pgrx/src/metadata.rs
+++ b/cargo-pgrx/src/metadata.rs
@@ -16,11 +16,11 @@ use std::path::Path;
 
 pub fn metadata(
     features: &clap_cargo::Features,
-    manifest_path: Option<impl AsRef<Path>>,
+    manifest_path: Option<&Path>,
 ) -> eyre::Result<Metadata> {
     let mut metadata_command = MetadataCommand::new();
     if let Some(manifest_path) = manifest_path {
-        metadata_command.manifest_path(manifest_path.as_ref().to_owned());
+        metadata_command.manifest_path(manifest_path.to_owned());
     }
     features.forward_metadata(&mut metadata_command);
     let metadata = metadata_command.exec()?;
@@ -28,10 +28,7 @@ pub fn metadata(
 }
 
 #[tracing::instrument(level = "error", skip_all)]
-pub fn validate(
-    path: Option<impl AsRef<std::path::Path>>,
-    metadata: &Metadata,
-) -> eyre::Result<()> {
+pub fn validate(path: Option<&Path>, metadata: &Metadata) -> eyre::Result<()> {
     let cargo_pgrx_version = env!("CARGO_PKG_VERSION");
     let cargo_pgrx_version_req = VersionReq::parse(&format!("~{cargo_pgrx_version}"))?;
 
@@ -86,7 +83,7 @@ pub fn validate(
 cargo-pgrx and pgrx library versions must be identical.
 {help}"#,
             if many == 1 { "dependency" } else { "dependencies" },
-            path.map(|p| p.as_ref().display().to_string())
+            path.map(|p| p.display().to_string())
                 .unwrap_or_else(|| "./Cargo.toml".to_string())
                 .yellow(),
         ));

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -935,7 +935,7 @@ fn remap_self_to_target(ty: &mut syn::Type, target: &syn::Ident) {
     }
 }
 
-fn get_pgrx_attr_macro(attr_name: impl AsRef<str>, ty: &syn::Type) -> Option<TokenStream2> {
+fn get_pgrx_attr_macro(attr_name: &str, ty: &syn::Type) -> Option<TokenStream2> {
     match &ty {
         syn::Type::Macro(ty_macro) => {
             let mut found_pgrx = false;
@@ -944,7 +944,7 @@ fn get_pgrx_attr_macro(attr_name: impl AsRef<str>, ty: &syn::Type) -> Option<Tok
             for (idx, segment) in ty_macro.mac.path.segments.iter().enumerate() {
                 match segment.ident.to_string().as_str() {
                     "pgrx" if idx == 0 => found_pgrx = true,
-                    attr if attr == attr_name.as_ref() => found_attr = true,
+                    attr if attr == attr_name => found_attr = true,
                     _ => (),
                 }
             }

--- a/pgrx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/entity.rs
@@ -168,7 +168,7 @@ impl SqlDeclaredEntity {
                 format!("pgrx::pgbox::PgBox<{}, pgrx::pgbox::AllocatedByPostgres>", name),
             ],
         };
-        let retval = match variant.as_ref() {
+        let retval = match variant {
             "Type" => Self::Type(data),
             "Enum" => Self::Enum(data),
             "Function" => Self::Function(data),

--- a/pgrx-sql-entity-graph/src/extension_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/extension_sql/entity.rs
@@ -146,8 +146,7 @@ impl Display for SqlDeclaredEntity {
 }
 
 impl SqlDeclaredEntity {
-    pub fn build(variant: impl AsRef<str>, name: impl AsRef<str>) -> eyre::Result<Self> {
-        let name = name.as_ref();
+    pub fn build(variant: &str, name: &str) -> eyre::Result<Self> {
         let data = SqlDeclaredEntityData {
             sql: name
                 .split("::")

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -251,6 +251,7 @@ impl PgrxSql {
         Ok(this)
     }
 
+    // NOTE: this signature is demanded by the codegen we embed via cargo-pgrx
     pub fn to_file(&self, file: impl AsRef<Path> + Debug) -> eyre::Result<()> {
         use std::fs::{File, create_dir_all};
         use std::io::Write;
@@ -321,6 +322,7 @@ impl PgrxSql {
         Ok(())
     }
 
+    // NOTE: this signature is demanded by the codegen we embed via cargo-pgrx
     pub fn to_dot(&self, file: impl AsRef<Path> + Debug) -> eyre::Result<()> {
         use std::fs::{File, create_dir_all};
         use std::io::Write;

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -251,11 +251,11 @@ impl PgrxSql {
         Ok(this)
     }
 
-    pub fn to_file(&self, file: impl AsRef<Path> + Debug) -> eyre::Result<()> {
+    pub fn to_file(&self, file: &Path) -> eyre::Result<()> {
         use std::fs::{File, create_dir_all};
         use std::io::Write;
         let generated = self.to_sql()?;
-        let path = Path::new(file.as_ref());
+        let path = Path::new(file);
 
         let parent = path.parent();
         if let Some(parent) = parent {
@@ -321,7 +321,7 @@ impl PgrxSql {
         Ok(())
     }
 
-    pub fn to_dot(&self, file: impl AsRef<Path> + Debug) -> eyre::Result<()> {
+    pub fn to_dot(&self, path: &Path) -> eyre::Result<()> {
         use std::fs::{File, create_dir_all};
         use std::io::Write;
         let generated = Dot::with_attr_getters(
@@ -375,7 +375,6 @@ impl PgrxSql {
                 }
             },
         );
-        let path = Path::new(file.as_ref());
 
         let parent = path.parent();
         if let Some(parent) = parent {

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -251,11 +251,11 @@ impl PgrxSql {
         Ok(this)
     }
 
-    pub fn to_file(&self, file: &Path) -> eyre::Result<()> {
+    pub fn to_file(&self, file: impl AsRef<Path> + Debug) -> eyre::Result<()> {
         use std::fs::{File, create_dir_all};
         use std::io::Write;
         let generated = self.to_sql()?;
-        let path = Path::new(file);
+        let path = Path::new(file.as_ref());
 
         let parent = path.parent();
         if let Some(parent) = parent {
@@ -321,7 +321,7 @@ impl PgrxSql {
         Ok(())
     }
 
-    pub fn to_dot(&self, path: &Path) -> eyre::Result<()> {
+    pub fn to_dot(&self, file: impl AsRef<Path> + Debug) -> eyre::Result<()> {
         use std::fs::{File, create_dir_all};
         use std::io::Write;
         let generated = Dot::with_attr_getters(
@@ -375,6 +375,7 @@ impl PgrxSql {
                 }
             },
         );
+        let path = Path::new(file.as_ref());
 
         let parent = path.parent();
         if let Some(parent) = parent {


### PR DESCRIPTION
A pattern that was popular some years ago, when `impl Trait` arguments were first introduced, was to make everything an `impl Trait` arg. This can be undesirable because it weakens type inference and spreads whatever indirection is used throughout the codebase, demanding repeat invocations of `.as_ref()` or whatever. Unfortunately, pgrx was first made in the period of that being en vogue.

The alternative, of requiring things like `Option<&T>`, does demand using `Option::as_deref` a bit, but fortunately that convenience exists nowadays. It also means that the indirection is handled once at the top level and not addressed after that, which is more appropriate for internals. ~~None~~ **Almost** none of the relevant functions in pgrx are considered public API, after all, as they are found throughout cargo-pgrx and pgrx-sql-entity-graph.

Remove almost all instances of `impl AsRef`, usually with `Path` or `str`, and replace them with `&Path` or `&str` as appropriate. This deletes a few lines from the codebase outright, and in those that remain, it usually simplifies the existing code. In a couple cases, the benefit involves actually removing `clone`s of data!

The remaining instances linger with a note about their shame.