### PR TITLE
Deref instead of borrowing `Option<&String>`

### DIFF
--- a/cargo-pgrx/src/command/connect.rs
+++ b/cargo-pgrx/src/command/connect.rs
@@ -50,7 +50,7 @@ impl CommandExecute for Connect {
 
         let (package_manifest, package_manifest_path) = get_package_manifest(
             &Features::default(),
-            self.package.as_ref(),
+            self.package.as_deref(),
             self.manifest_path.as_deref(),
         )?;
         let (pg_config, _pg_version) = match pg_config_and_version(

--- a/cargo-pgrx/src/command/get.rs
+++ b/cargo-pgrx/src/command/get.rs
@@ -38,7 +38,7 @@ impl CommandExecute for Get {
                 .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(self.manifest_path.as_deref(), &metadata)?;
         let package_manifest_path =
-            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+            crate::manifest::manifest_path(&metadata, self.package.as_deref())
                 .wrap_err("Couldn't get manifest path")?;
 
         if let Some(value) = get_property(&package_manifest_path, &self.name)? {

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -75,7 +75,7 @@ impl CommandExecute for Install {
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(self.manifest_path.as_deref(), &metadata)?;
         let package_manifest_path =
-            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+            crate::manifest::manifest_path(&metadata, self.package.as_deref())
                 .wrap_err("Couldn't get manifest path")?;
         let package_manifest =
             Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
@@ -101,7 +101,7 @@ impl CommandExecute for Install {
         display_version_info(&pg_config, &PgVersionSource::PgConfig(pg_config.label()?));
         install_extension(
             self.manifest_path.as_deref(),
-            self.package.as_ref(),
+            self.package.as_deref(),
             &package_manifest_path,
             &pg_config,
             &profile,
@@ -123,7 +123,7 @@ impl CommandExecute for Install {
 ))]
 pub(crate) fn install_extension(
     user_manifest_path: Option<&Path>,
-    user_package: Option<&String>,
+    user_package: Option<&str>,
     package_manifest_path: &Path,
     pg_config: &PgConfig,
     profile: &CargoProfile,
@@ -282,7 +282,7 @@ fn copy_file(
 
 pub(crate) fn build_extension(
     user_manifest_path: Option<&Path>,
-    user_package: Option<&String>,
+    user_package: Option<&str>,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
     target: Option<&str>,
@@ -345,7 +345,7 @@ pub(crate) fn build_extension(
 
 fn copy_sql_files(
     user_manifest_path: Option<&Path>,
-    user_package: Option<&String>,
+    user_package: Option<&str>,
     package_manifest_path: &Path,
     profile: &CargoProfile,
     is_test: bool,

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -55,7 +55,7 @@ impl Package {
             .wrap_err("couldn't get cargo metadata")?;
         crate::metadata::validate(self.manifest_path.as_deref(), &metadata)?;
         let package_manifest_path =
-            crate::manifest::manifest_path(&metadata, self.package.as_ref())
+            crate::manifest::manifest_path(&metadata, self.package.as_deref())
                 .wrap_err("Couldn't get manifest path")?;
         let package_manifest =
             Manifest::from_path(&package_manifest_path).wrap_err("Couldn't parse manifest")?;
@@ -86,7 +86,7 @@ impl Package {
 
         let output_files = package_extension(
             self.manifest_path.as_deref(),
-            self.package.as_ref(),
+            self.package.as_deref(),
             &package_manifest_path,
             &pg_config,
             out_dir.clone(),
@@ -115,7 +115,7 @@ impl CommandExecute for Package {
 ))]
 pub(crate) fn package_extension(
     user_manifest_path: Option<&Path>,
-    user_package: Option<&String>,
+    user_package: Option<&str>,
     package_manifest_path: &Path,
     pg_config: &PgConfig,
     out_dir: PathBuf,

--- a/cargo-pgrx/src/command/regress.rs
+++ b/cargo-pgrx/src/command/regress.rs
@@ -347,7 +347,7 @@ impl CommandExecute for Regress {
         }
         let (_, manifest_path) = get_package_manifest(
             &self.features,
-            self.package.as_ref(),
+            self.package.as_deref(),
             self.manifest_path.as_deref(),
         )?;
         let extname = get_property(&manifest_path, "extname")?

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -86,7 +86,7 @@ impl Run {
         let pgrx = Pgrx::from_config()?;
         let (package_manifest, package_manifest_path) = get_package_manifest(
             &self.features,
-            self.package.as_ref(),
+            self.package.as_deref(),
             self.manifest_path.as_deref(),
         )?;
         let (pg_config, _pg_version) = pg_config_and_version(
@@ -110,7 +110,7 @@ impl Run {
         run(
             &pg_config,
             self.manifest_path.as_deref(),
-            self.package.as_ref(),
+            self.package.as_deref(),
             &package_manifest_path,
             &dbname,
             create_database,
@@ -144,7 +144,7 @@ impl CommandExecute for Run {
 pub(crate) fn run(
     pg_config: &PgConfig,
     user_manifest_path: Option<&Path>,
-    user_package: Option<&String>,
+    user_package: Option<&str>,
     package_manifest_path: &Path,
     dbname: &str,
     create_database: bool,

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -79,7 +79,7 @@ impl CommandExecute for Schema {
         let pgrx = Pgrx::from_config()?;
         let (package_manifest, package_manifest_path) = get_package_manifest(
             &self.features,
-            self.package.as_ref(),
+            self.package.as_deref(),
             self.manifest_path.as_deref(),
         )?;
         // This does meaningful mutation, unfortunately
@@ -98,7 +98,7 @@ impl CommandExecute for Schema {
 
         generate_schema(
             self.manifest_path.as_deref(),
-            self.package.as_ref(),
+            self.package.as_deref(),
             &package_manifest_path,
             &profile,
             self.test,
@@ -122,7 +122,7 @@ impl CommandExecute for Schema {
 ))]
 pub(crate) fn generate_schema(
     user_manifest_path: Option<&Path>,
-    user_package: Option<&String>,
+    user_package: Option<&str>,
     package_manifest_path: &Path,
     profile: &CargoProfile,
     is_test: bool,
@@ -142,7 +142,7 @@ pub(crate) fn generate_schema(
     let features_arg = features.features.join(" ");
 
     let package_name = if let Some(user_package) = user_package {
-        user_package.clone()
+        user_package.to_owned()
     } else {
         manifest.package_name()?
     };

--- a/cargo-pgrx/src/command/start.rs
+++ b/cargo-pgrx/src/command/start.rs
@@ -52,7 +52,7 @@ impl CommandExecute for Start {
         ) -> eyre::Result<()> {
             let (package_manifest, _) = get_package_manifest(
                 &clap_cargo::Features::default(),
-                me.package.as_ref(),
+                me.package.as_deref(),
                 me.manifest_path.as_deref(),
             )?;
 
@@ -63,7 +63,7 @@ impl CommandExecute for Start {
         }
         let (package_manifest, _) = get_package_manifest(
             &clap_cargo::Features::default(),
-            self.package.as_ref(),
+            self.package.as_deref(),
             self.manifest_path.as_deref(),
         )?;
 

--- a/cargo-pgrx/src/command/stop.rs
+++ b/cargo-pgrx/src/command/stop.rs
@@ -39,7 +39,7 @@ impl CommandExecute for Stop {
         fn perform(me: Stop, pgrx: &Pgrx) -> eyre::Result<()> {
             let (package_manifest, _) = get_package_manifest(
                 &clap_cargo::Features::default(),
-                me.package.as_ref(),
+                me.package.as_deref(),
                 me.manifest_path.as_deref(),
             )?;
             let (pg_config, _) =
@@ -51,7 +51,7 @@ impl CommandExecute for Stop {
         let pgrx = Pgrx::from_config()?;
         let (package_manifest, _) = get_package_manifest(
             &clap_cargo::Features::default(),
-            self.package.as_ref(),
+            self.package.as_deref(),
             self.manifest_path.as_deref(),
         )?;
         if self.pg_version == Some("all".into()) {

--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -60,7 +60,7 @@ impl CommandExecute for Test {
             let mut features = me.features.clone();
             let (package_manifest, _package_manifest_path) = get_package_manifest(
                 &me.features,
-                me.package.as_ref(),
+                me.package.as_deref(),
                 me.manifest_path.as_deref(),
             )?;
             let (pg_config, _pg_version) = pg_config_and_version(
@@ -79,7 +79,7 @@ impl CommandExecute for Test {
             test_extension(
                 &pg_config,
                 me.manifest_path.as_deref(),
-                me.package.as_ref(),
+                me.package.as_deref(),
                 &profile,
                 me.no_schema,
                 &features,
@@ -93,7 +93,7 @@ impl CommandExecute for Test {
 
         let (package_manifest, _) = get_package_manifest(
             &self.features,
-            self.package.as_ref(),
+            self.package.as_deref(),
             self.manifest_path.as_deref(),
         )?;
         let pgrx = Pgrx::from_config()?;
@@ -121,7 +121,7 @@ impl CommandExecute for Test {
 pub fn test_extension(
     pg_config: &PgConfig,
     user_manifest_path: Option<&Path>,
-    user_package: Option<&String>,
+    user_package: Option<&str>,
     profile: &CargoProfile,
     no_schema: bool,
     features: &clap_cargo::Features,

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -47,7 +47,7 @@ impl PgVersionSource {
 #[tracing::instrument(skip_all)]
 pub(crate) fn manifest_path(
     metadata: &Metadata,
-    package_name: Option<&String>,
+    package_name: Option<&str>,
 ) -> eyre::Result<PathBuf> {
     let manifest_path = if let Some(package_name) = package_name {
         let found = metadata
@@ -196,7 +196,7 @@ pub(crate) fn display_version_info(pg_config: &PgConfig, pg_version: &PgVersionS
 
 pub(crate) fn get_package_manifest(
     features: &Features,
-    package_name: Option<&String>,
+    package_name: Option<&str>,
     manifest_path: Option<&Path>,
 ) -> eyre::Result<(Manifest, PathBuf)> {
     let metadata = crate::metadata::metadata(features, manifest_path)


### PR DESCRIPTION
Instances of `Option<&String>` are weird. They should be either `Option<String>` or `Option<&str>`. I chose `Option<&str>` to avoid clones.