### PR TITLE
Refactor schema.rs using a cargo command builder

### DIFF
--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -99,7 +99,7 @@ impl Cargo {
             profile,
             package,
             subcmd: _,
-            more_args,
+            more_args: _,
         } = self;
 
         // set most-interesting flags first, like profile, target, and manifest-path
@@ -143,10 +143,10 @@ impl Cargo {
         }
 
         // And now the miscellaneous build flags!
-        // let flags = env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
-        // for arg in flags.split_ascii_whitespace() {
-        //     cmd.arg(arg);
-        // }
+        let flags = env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
+        for arg in flags.split_ascii_whitespace() {
+            cmd.arg(arg);
+        }
 
         // set envs
         if let Some(log_level) = log_level {

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::{env, process};
 
 /// Configuration for building a cargo execution
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct Cargo {
     subcmd: String,
     features: clap_cargo::Features,
@@ -79,7 +79,17 @@ impl Cargo {
         self
     }
 
+    #[track_caller]
     pub fn into_command(self) -> process::Command {
+        let mut cmd = cargo();
+
+        // subcommand *must* go first
+        if self.subcmd != "" {
+            cmd.arg(&self.subcmd);
+        } else {
+            panic!("`Cargo::into_command` requires a subcommand to be set, was: {self:?}")
+        }
+
         let Cargo {
             features,
             stdio,
@@ -88,13 +98,9 @@ impl Cargo {
             target,
             profile,
             package,
-            subcmd,
+            subcmd: _,
             more_args,
         } = self;
-
-        let mut cmd = cargo();
-        // subcommand *must* go first
-        cmd.arg(subcmd);
 
         // set most-interesting flags first, like profile, target, and manifest-path
         // so that when we read dumped command lines we can see that info first
@@ -155,7 +161,7 @@ impl Cargo {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Stdio {
     Inherit,
     #[allow(unused)]

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -98,7 +98,7 @@ impl Cargo {
 
         // set most-interesting flags first, like profile, target, and manifest-path
         // so that when we read dumped command lines we can see that info first
-        // cmd.args(profile.cargo_args());
+        cmd.args(profile.cargo_args());
 
         if let Some(target) = target {
             cmd.arg("--target").arg(target);

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -69,6 +69,11 @@ impl Cargo {
         self
     }
 
+    pub fn flag_args(mut self, flag: impl Into<String>, args: Vec<String>) -> Self {
+        self.more_args.insert(flag.into(), args);
+        self
+    }
+
     pub fn features(mut self, features: clap_cargo::Features) -> Self {
         self.features = features;
         self

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -7,6 +7,171 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use crate::profile::CargoProfile;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::{env, process};
+
+/// Configuration for building a cargo execution
+#[derive(Default, Clone)]
+pub struct Cargo {
+    subcmd: String,
+    features: clap_cargo::Features,
+    stdio: [Stdio; 3],
+    manifest: Option<PathBuf>,
+    package: String,
+    log_level: Option<String>,
+    target: Option<String>,
+    profile: CargoProfile,
+    // use a BTreeMap for deterministic order of iteration
+    more_args: BTreeMap<String, Vec<String>>,
+}
+
+impl Cargo {
+    pub fn subcommand(mut self, s: &str) -> Self {
+        self.subcmd.clear();
+        self.subcmd.push_str(s);
+        self
+    }
+
+    pub fn std_streams(mut self, streams: [Stdio; 3]) -> Self {
+        self.stdio = streams;
+        self
+    }
+
+    pub fn manifest(mut self, path: Option<PathBuf>) -> Self {
+        self.manifest = path;
+        self
+    }
+
+    pub fn package(mut self, package: String) -> Self {
+        self.package = package;
+        self
+    }
+
+    pub fn target(mut self, target: Option<String>) -> Self {
+        self.target = target;
+        self
+    }
+
+    pub fn profile(mut self, profile: CargoProfile) -> Self {
+        self.profile = profile;
+        self
+    }
+
+    pub fn log_level(mut self, level: Option<String>) -> Self {
+        self.log_level = level;
+        self
+    }
+
+    pub fn flag(mut self, flag: impl Into<String>) -> Self {
+        self.more_args.insert(flag.into(), Vec::new());
+        self
+    }
+
+    pub fn flag_args(mut self, flag: impl Into<String>, args: Vec<String>) -> Self {
+        self.more_args.insert(flag.into(), args);
+        self
+    }
+
+    pub fn features(mut self, features: clap_cargo::Features) -> Self {
+        self.features = features;
+        self
+    }
+
+    pub fn into_command(self) -> process::Command {
+        let Cargo {
+            features,
+            stdio,
+            manifest,
+            log_level,
+            target,
+            profile,
+            package,
+            subcmd,
+            more_args,
+        } = self;
+
+        let mut cmd = cargo();
+        // subcommand *must* go first
+        cmd.arg(subcmd);
+
+        // set most-interesting flags first, like profile, target, and manifest-path
+        // so that when we read dumped command lines we can see that info first
+        cmd.args(profile.cargo_args());
+        if let Some(target) = target {
+            cmd.arg("--target").arg(target);
+        }
+        if let Some(manifest) = manifest {
+            cmd.arg("--manifest-path").arg(manifest);
+        }
+        if !package.is_empty() {
+            cmd.arg("--package").arg(package);
+        }
+
+        // set std streams
+        let [stdin, stdout, stderr] = stdio;
+        if let Some(stdio) = stdin.into_stdio() {
+            cmd.stdin(stdio);
+        }
+        if let Some(stdio) = stdout.into_stdio() {
+            cmd.stdout(stdio);
+        }
+        if let Some(stdio) = stderr.into_stdio() {
+            cmd.stderr(stdio);
+        }
+
+        // set features
+        if features.no_default_features {
+            cmd.arg("--no-default-features");
+        }
+
+        if features.all_features {
+            cmd.arg("--all-features");
+        } else if !features.features.is_empty() {
+            cmd.arg("--features").args(features.features);
+        }
+
+        // And now the miscellaneous build flags!
+        let flags = env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
+        for arg in flags.split_ascii_whitespace() {
+            cmd.arg(arg);
+        }
+
+        // set envs
+        if let Some(log_level) = log_level {
+            cmd.env("RUST_LOG", log_level);
+        }
+
+        for (flag, args) in more_args {
+            cmd.arg(flag).args(args);
+        }
+
+        cmd
+    }
+}
+
+#[derive(Clone, Copy, Default, PartialEq)]
+pub enum Stdio {
+    Inherit,
+    #[allow(unused)]
+    Piped,
+    Null,
+    #[default]
+    Default,
+}
+
+impl Stdio {
+    fn into_stdio(self) -> Option<process::Stdio> {
+        match self {
+            Stdio::Inherit => Some(process::Stdio::inherit()),
+            Stdio::Piped => Some(process::Stdio::piped()),
+            Stdio::Null => Some(process::Stdio::null()),
+            _ => None,
+        }
+    }
+}
+
 pub(crate) fn cargo() -> std::process::Command {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     std::process::Command::new(cargo)

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -173,7 +173,6 @@ impl Stdio {
     fn into_stdio(self) -> Option<process::Stdio> {
         match self {
             Stdio::Inherit => Some(process::Stdio::inherit()),
-            Stdio::Piped => Some(process::Stdio::piped()),
             Stdio::Null => Some(process::Stdio::null()),
             Stdio::Default => None,
         }

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -164,8 +164,6 @@ impl Cargo {
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Stdio {
     Inherit,
-    #[allow(unused)]
-    Piped,
     Null,
     #[default]
     Default,

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -98,7 +98,7 @@ impl Cargo {
 
         // set most-interesting flags first, like profile, target, and manifest-path
         // so that when we read dumped command lines we can see that info first
-        cmd.args(profile.cargo_args());
+        // cmd.args(profile.cargo_args());
 
         if let Some(target) = target {
             cmd.arg("--target").arg(target);
@@ -137,19 +137,19 @@ impl Cargo {
         }
 
         // And now the miscellaneous build flags!
-        let flags = env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
-        for arg in flags.split_ascii_whitespace() {
-            cmd.arg(arg);
-        }
+        // let flags = env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
+        // for arg in flags.split_ascii_whitespace() {
+        //     cmd.arg(arg);
+        // }
 
         // set envs
         if let Some(log_level) = log_level {
             cmd.env("RUST_LOG", log_level);
         }
 
-        for (flag, args) in more_args {
-            cmd.arg(flag).args(args);
-        }
+        // for (flag, args) in more_args {
+        //     cmd.arg(flag).args(args);
+        // }
 
         cmd
     }
@@ -171,7 +171,7 @@ impl Stdio {
             Stdio::Inherit => Some(process::Stdio::inherit()),
             Stdio::Piped => Some(process::Stdio::piped()),
             Stdio::Null => Some(process::Stdio::null()),
-            _ => None,
+            Stdio::Default => None,
         }
     }
 }

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -39,7 +39,7 @@ impl Cargo {
         self
     }
 
-    pub fn manifest(mut self, path: Option<PathBuf>) -> Self {
+    pub fn manifest_path(mut self, path: Option<PathBuf>) -> Self {
         self.manifest = path;
         self
     }

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -69,11 +69,6 @@ impl Cargo {
         self
     }
 
-    pub fn flag_args(mut self, flag: impl Into<String>, args: Vec<String>) -> Self {
-        self.more_args.insert(flag.into(), args);
-        self
-    }
-
     pub fn features(mut self, features: clap_cargo::Features) -> Self {
         self.features = features;
         self
@@ -99,7 +94,7 @@ impl Cargo {
             profile,
             package,
             subcmd: _,
-            more_args: _,
+            more_args,
         } = self;
 
         // set most-interesting flags first, like profile, target, and manifest-path
@@ -153,9 +148,9 @@ impl Cargo {
             cmd.env("RUST_LOG", log_level);
         }
 
-        // for (flag, args) in more_args {
-        //     cmd.arg(flag).args(args);
-        // }
+        for (flag, args) in more_args {
+            cmd.arg(flag).args(args);
+        }
 
         cmd
     }

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -99,6 +99,7 @@ impl Cargo {
         // set most-interesting flags first, like profile, target, and manifest-path
         // so that when we read dumped command lines we can see that info first
         cmd.args(profile.cargo_args());
+
         if let Some(target) = target {
             cmd.arg("--target").arg(target);
         }
@@ -128,8 +129,11 @@ impl Cargo {
 
         if features.all_features {
             cmd.arg("--all-features");
-        } else if !features.features.is_empty() {
-            cmd.arg("--features").args(features.features);
+        }
+
+        if !features.features.is_empty() {
+            cmd.arg("--features");
+            cmd.arg(features.features.join(" "));
         }
 
         // And now the miscellaneous build flags!

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -137,8 +137,6 @@ pub(crate) fn generate_schema_for_cli(
     output_tracking: &mut Vec<PathBuf>,
 ) -> eyre::Result<()> {
     let manifest = Manifest::from_path(&package_manifest_path)?;
-    let (control_file, _extname) = find_control_file(&package_manifest_path)?;
-
     let features_arg = features.features.join(" ");
 
     let package_name = if let Some(user_package) = user_package {
@@ -146,8 +144,6 @@ pub(crate) fn generate_schema_for_cli(
     } else {
         manifest.package_name()?
     };
-    let lib_name = manifest.lib_name()?;
-    let lib_filename = manifest.lib_filename()?;
 
     let cargo = Cargo::default()
         .package(package_name)
@@ -170,9 +166,6 @@ pub(crate) fn generate_schema_for_cli(
         dot,
         output_tracking,
         manifest,
-        control_file,
-        lib_name,
-        lib_filename,
     )
 }
 pub(crate) use generate_schema_for_cli as generate_schema;
@@ -187,10 +180,11 @@ pub(crate) fn generate_schema_implicit(
     dot: Option<&Path>,
     output_tracking: &mut Vec<PathBuf>,
     manifest: cargo_toml::Manifest,
-    control_file: PathBuf,
-    lib_name: String,
-    lib_filename: String,
 ) -> eyre::Result<()> {
+    let (control_file, _extname) = find_control_file(&package_manifest_path)?;
+    let lib_name = manifest.lib_name()?;
+    let lib_filename = manifest.lib_filename()?;
+
     let symbols = find_and_compute_symbols(profile, &lib_filename, target)?;
 
     let codegen =

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -8,7 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::CommandExecute;
-use crate::cargo::{self, Cargo};
 use crate::command::get::{find_control_file, get_property};
 use crate::manifest::{get_package_manifest, pg_config_and_version};
 use crate::profile::CargoProfile;
@@ -139,6 +138,8 @@ pub(crate) fn generate_schema_for_cli(
     let manifest = Manifest::from_path(&package_manifest_path)?;
     let (control_file, _extname) = find_control_file(&package_manifest_path)?;
 
+    let flags = std::env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
+
     let features_arg = features.features.join(" ");
 
     let package_name = if let Some(user_package) = user_package {
@@ -149,49 +150,58 @@ pub(crate) fn generate_schema_for_cli(
     let lib_name = manifest.lib_name()?;
     let lib_filename = manifest.lib_filename()?;
 
-    let cargo = Cargo::default()
-        .target(target.map(|s| s.to_owned()))
-        .manifest(user_manifest_path.map(|p| p.to_owned()))
-        .package(package_name)
-        .std_streams([cargo::Stdio::Null, cargo::Stdio::Null, cargo::Stdio::Inherit])
-        .profile(profile.clone())
-        .log_level(log_level)
-        .features(features.clone());
-
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
-        first_build(cargo.clone(), is_test, &features_arg)?;
+        first_build(
+            user_manifest_path,
+            profile,
+            features,
+            log_level.clone(),
+            is_test,
+            &features_arg,
+            &flags,
+            target,
+            &package_name,
+        )?;
     };
     generate_schema_implicit(
-        cargo,
+        user_manifest_path,
+        package_name,
         package_manifest_path,
         profile,
+        features,
         features_arg,
         target,
         path,
         dot,
+        log_level,
         output_tracking,
         manifest,
         control_file,
         lib_name,
         lib_filename,
+        flags,
     )
 }
 pub(crate) use generate_schema_for_cli as generate_schema;
 
 pub(crate) fn generate_schema_implicit(
-    cargo: Cargo,
+    user_manifest_path: Option<&Path>,
+    package_name: String,
     package_manifest_path: &Path,
     profile: &CargoProfile,
+    features: &clap_cargo::Features,
     features_arg: String,
     target: Option<&str>,
     path: Option<&Path>,
     dot: Option<&Path>,
+    log_level: Option<String>,
     output_tracking: &mut Vec<PathBuf>,
     manifest: cargo_toml::Manifest,
     control_file: PathBuf,
     lib_name: String,
     lib_filename: String,
+    flags: String,
 ) -> eyre::Result<()> {
     let symbols = find_and_compute_symbols(profile, &lib_filename, target)?;
 
@@ -216,7 +226,16 @@ pub(crate) fn generate_schema_implicit(
         tracing::info!(dot = %dot_path.display(), "Writing Graphviz DOT");
     }
 
-    second_build(cargo, &features_arg, embed.path(), &manifest)?;
+    second_build(
+        user_manifest_path,
+        features,
+        log_level.clone(),
+        &features_arg,
+        &flags,
+        embed.path(),
+        &package_name,
+        &manifest,
+    )?;
 
     compute_sql(&manifest)?;
 
@@ -323,14 +342,65 @@ fn compute_symbols(obj_file: &object::File<'_>, symbol_prefix: &str) -> eyre::Re
     Ok(fns_to_call.into_iter().collect())
 }
 
-fn first_build(cargo: Cargo, is_test: bool, features_arg: &str) -> eyre::Result<()> {
-    let cargo = if is_test {
-        cargo.subcommand("test").flag("--no-run")
-    } else {
-        cargo.subcommand("build").flag("--lib")
-    };
+fn first_build(
+    user_manifest_path: Option<&Path>,
+    profile: &CargoProfile,
+    features: &clap_cargo::Features,
+    log_level: Option<String>,
+    is_test: bool,
+    features_arg: &str,
+    flags: &str,
+    target: Option<&str>,
+    package_name: &str,
+) -> eyre::Result<()> {
+    let mut command = crate::cargo::cargo();
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::inherit());
 
-    let mut command = cargo.into_command();
+    if is_test {
+        command.arg("test");
+        command.arg("--no-run");
+    } else {
+        command.arg("build");
+        command.arg("--lib");
+    }
+
+    command.arg("--package");
+    command.arg(package_name);
+
+    if let Some(user_manifest_path) = user_manifest_path.as_ref() {
+        command.arg("--manifest-path");
+        command.arg(user_manifest_path);
+    }
+
+    command.args(profile.cargo_args());
+
+    if let Some(log_level) = &log_level {
+        command.env("RUST_LOG", log_level);
+    }
+
+    if !features_arg.trim().is_empty() {
+        command.arg("--features");
+        command.arg(features_arg);
+    }
+
+    if features.no_default_features {
+        command.arg("--no-default-features");
+    }
+
+    if features.all_features {
+        command.arg("--all-features");
+    }
+
+    for arg in flags.split_ascii_whitespace() {
+        command.arg(arg);
+    }
+
+    if let Some(target) = target {
+        command.arg("--target");
+        command.arg(target);
+    }
 
     let command_str = format!("{command:?}");
     eprintln!(
@@ -449,16 +519,54 @@ fn compute_codegen(
 }
 
 fn second_build(
-    cargo: Cargo,
+    user_manifest_path: Option<&Path>,
+    features: &clap_cargo::Features,
+    log_level: Option<String>,
     features_arg: &str,
+    flags: &str,
     embed_path: &Path,
+    package_name: &str,
     manifest: &Manifest,
 ) -> eyre::Result<()> {
+    let mut command = crate::cargo::cargo();
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::inherit());
+
     // We do pass cfg to the binary and do not pass cfg to dependencies to avoid recompilation
     // The only cargo command respecting our need is `cargo rustc`
-    let cargo = cargo.subcommand("rustc").flag_args("--bin", vec![pgrx_embed_name(manifest)?]);
+    command.arg("rustc");
+    command.arg("--bin");
+    command.arg(pgrx_embed_name(manifest)?);
 
-    let mut command = cargo.into_command();
+    command.arg("--package");
+    command.arg(package_name);
+
+    if let Some(user_manifest_path) = user_manifest_path.as_ref() {
+        command.arg("--manifest-path");
+        command.arg(user_manifest_path);
+    }
+
+    if let Some(log_level) = &log_level {
+        command.env("RUST_LOG", log_level);
+    }
+
+    if !features_arg.trim().is_empty() {
+        command.arg("--features");
+        command.arg(features_arg);
+    }
+
+    if features.no_default_features {
+        command.arg("--no-default-features");
+    }
+
+    if features.all_features {
+        command.arg("--all-features");
+    }
+
+    for arg in flags.split_ascii_whitespace() {
+        command.arg(arg);
+    }
 
     command.arg("--");
 

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -8,6 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::CommandExecute;
+use crate::cargo::{self, Cargo};
 use crate::command::get::{find_control_file, get_property};
 use crate::manifest::{get_package_manifest, pg_config_and_version};
 use crate::profile::CargoProfile;
@@ -138,8 +139,6 @@ pub(crate) fn generate_schema_for_cli(
     let manifest = Manifest::from_path(&package_manifest_path)?;
     let (control_file, _extname) = find_control_file(&package_manifest_path)?;
 
-    let flags = std::env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
-
     let features_arg = features.features.join(" ");
 
     let package_name = if let Some(user_package) = user_package {
@@ -150,58 +149,49 @@ pub(crate) fn generate_schema_for_cli(
     let lib_name = manifest.lib_name()?;
     let lib_filename = manifest.lib_filename()?;
 
+    let cargo = Cargo::default()
+        .target(target.map(|s| s.to_owned()))
+        .manifest(user_manifest_path.map(|p| p.to_owned()))
+        .package(package_name)
+        .std_streams([cargo::Stdio::Null, cargo::Stdio::Null, cargo::Stdio::Inherit])
+        .profile(profile.clone())
+        .log_level(log_level)
+        .features(features.clone());
+
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
-        first_build(
-            user_manifest_path,
-            profile,
-            features,
-            log_level.clone(),
-            is_test,
-            &features_arg,
-            &flags,
-            target,
-            &package_name,
-        )?;
+        first_build(cargo.clone(), is_test, &features_arg)?;
     };
     generate_schema_implicit(
-        user_manifest_path,
-        package_name,
+        cargo,
         package_manifest_path,
         profile,
-        features,
         features_arg,
         target,
         path,
         dot,
-        log_level,
         output_tracking,
         manifest,
         control_file,
         lib_name,
         lib_filename,
-        flags,
     )
 }
 pub(crate) use generate_schema_for_cli as generate_schema;
 
 pub(crate) fn generate_schema_implicit(
-    user_manifest_path: Option<&Path>,
-    package_name: String,
+    cargo: Cargo,
     package_manifest_path: &Path,
     profile: &CargoProfile,
-    features: &clap_cargo::Features,
     features_arg: String,
     target: Option<&str>,
     path: Option<&Path>,
     dot: Option<&Path>,
-    log_level: Option<String>,
     output_tracking: &mut Vec<PathBuf>,
     manifest: cargo_toml::Manifest,
     control_file: PathBuf,
     lib_name: String,
     lib_filename: String,
-    flags: String,
 ) -> eyre::Result<()> {
     let symbols = find_and_compute_symbols(profile, &lib_filename, target)?;
 
@@ -226,16 +216,7 @@ pub(crate) fn generate_schema_implicit(
         tracing::info!(dot = %dot_path.display(), "Writing Graphviz DOT");
     }
 
-    second_build(
-        user_manifest_path,
-        features,
-        log_level.clone(),
-        &features_arg,
-        &flags,
-        embed.path(),
-        &package_name,
-        &manifest,
-    )?;
+    second_build(cargo, &features_arg, embed.path(), &manifest)?;
 
     compute_sql(&manifest)?;
 
@@ -342,65 +323,14 @@ fn compute_symbols(obj_file: &object::File<'_>, symbol_prefix: &str) -> eyre::Re
     Ok(fns_to_call.into_iter().collect())
 }
 
-fn first_build(
-    user_manifest_path: Option<&Path>,
-    profile: &CargoProfile,
-    features: &clap_cargo::Features,
-    log_level: Option<String>,
-    is_test: bool,
-    features_arg: &str,
-    flags: &str,
-    target: Option<&str>,
-    package_name: &str,
-) -> eyre::Result<()> {
-    let mut command = crate::cargo::cargo();
-    command.stdin(Stdio::null());
-    command.stdout(Stdio::null());
-    command.stderr(Stdio::inherit());
-
-    if is_test {
-        command.arg("test");
-        command.arg("--no-run");
+fn first_build(cargo: Cargo, is_test: bool, features_arg: &str) -> eyre::Result<()> {
+    let cargo = if is_test {
+        cargo.subcommand("test").flag("--no-run")
     } else {
-        command.arg("build");
-        command.arg("--lib");
-    }
+        cargo.subcommand("build").flag("--lib")
+    };
 
-    command.arg("--package");
-    command.arg(package_name);
-
-    if let Some(user_manifest_path) = user_manifest_path.as_ref() {
-        command.arg("--manifest-path");
-        command.arg(user_manifest_path);
-    }
-
-    command.args(profile.cargo_args());
-
-    if let Some(log_level) = &log_level {
-        command.env("RUST_LOG", log_level);
-    }
-
-    if !features_arg.trim().is_empty() {
-        command.arg("--features");
-        command.arg(features_arg);
-    }
-
-    if features.no_default_features {
-        command.arg("--no-default-features");
-    }
-
-    if features.all_features {
-        command.arg("--all-features");
-    }
-
-    for arg in flags.split_ascii_whitespace() {
-        command.arg(arg);
-    }
-
-    if let Some(target) = target {
-        command.arg("--target");
-        command.arg(target);
-    }
+    let mut command = cargo.into_command();
 
     let command_str = format!("{command:?}");
     eprintln!(
@@ -519,54 +449,16 @@ fn compute_codegen(
 }
 
 fn second_build(
-    user_manifest_path: Option<&Path>,
-    features: &clap_cargo::Features,
-    log_level: Option<String>,
+    cargo: Cargo,
     features_arg: &str,
-    flags: &str,
     embed_path: &Path,
-    package_name: &str,
     manifest: &Manifest,
 ) -> eyre::Result<()> {
-    let mut command = crate::cargo::cargo();
-    command.stdin(Stdio::null());
-    command.stdout(Stdio::null());
-    command.stderr(Stdio::inherit());
-
     // We do pass cfg to the binary and do not pass cfg to dependencies to avoid recompilation
     // The only cargo command respecting our need is `cargo rustc`
-    command.arg("rustc");
-    command.arg("--bin");
-    command.arg(pgrx_embed_name(manifest)?);
+    let cargo = cargo.subcommand("rustc").flag_args("--bin", vec![pgrx_embed_name(manifest)?]);
 
-    command.arg("--package");
-    command.arg(package_name);
-
-    if let Some(user_manifest_path) = user_manifest_path.as_ref() {
-        command.arg("--manifest-path");
-        command.arg(user_manifest_path);
-    }
-
-    if let Some(log_level) = &log_level {
-        command.env("RUST_LOG", log_level);
-    }
-
-    if !features_arg.trim().is_empty() {
-        command.arg("--features");
-        command.arg(features_arg);
-    }
-
-    if features.no_default_features {
-        command.arg("--no-default-features");
-    }
-
-    if features.all_features {
-        command.arg("--all-features");
-    }
-
-    for arg in flags.split_ascii_whitespace() {
-        command.arg(arg);
-    }
+    let mut command = cargo.into_command();
 
     command.arg("--");
 

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -151,7 +151,7 @@ pub(crate) fn generate_schema_for_cli(
     let lib_name = manifest.lib_name()?;
     let lib_filename = manifest.lib_filename()?;
 
-    let cargo = Cargo::default();
+    let cargo = Cargo::default().package(package_name);
 
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
@@ -165,13 +165,11 @@ pub(crate) fn generate_schema_for_cli(
             &features_arg,
             &flags,
             target,
-            &package_name,
         )?;
     };
     generate_schema_implicit(
         cargo,
         user_manifest_path,
-        package_name,
         package_manifest_path,
         profile,
         features,
@@ -193,7 +191,6 @@ pub(crate) use generate_schema_for_cli as generate_schema;
 pub(crate) fn generate_schema_implicit(
     cargo: Cargo,
     user_manifest_path: Option<&Path>,
-    package_name: String,
     package_manifest_path: &Path,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
@@ -240,7 +237,6 @@ pub(crate) fn generate_schema_implicit(
         &features_arg,
         &flags,
         embed.path(),
-        &package_name,
         &manifest,
     )?;
 
@@ -359,7 +355,6 @@ fn first_build(
     features_arg: &str,
     flags: &str,
     target: Option<&str>,
-    package_name: &str,
 ) -> eyre::Result<()> {
     let mut command = if is_test {
         let mut command = cargo.subcommand("test").into_command();
@@ -374,9 +369,6 @@ fn first_build(
     command.stdin(Stdio::null());
     command.stdout(Stdio::null());
     command.stderr(Stdio::inherit());
-
-    command.arg("--package");
-    command.arg(package_name);
 
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");
@@ -535,7 +527,6 @@ fn second_build(
     features_arg: &str,
     flags: &str,
     embed_path: &Path,
-    package_name: &str,
     manifest: &Manifest,
 ) -> eyre::Result<()> {
     // We do pass cfg to the binary and do not pass cfg to dependencies to avoid recompilation
@@ -547,9 +538,6 @@ fn second_build(
     command.stdin(Stdio::null());
     command.stdout(Stdio::null());
     command.stderr(Stdio::inherit());
-
-    command.arg("--package");
-    command.arg(package_name);
 
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -154,7 +154,7 @@ pub(crate) fn generate_schema_for_cli(
     let cargo = Cargo::default()
         .package(package_name)
         .std_streams([cargo::Stdio::Null, cargo::Stdio::Null, cargo::Stdio::Inherit])
-        .manifest(user_manifest_path.map(|p| p.to_owned()))
+        .manifest_path(user_manifest_path.map(|p| p.to_owned()))
         .log_level(log_level);
 
     if !skip_build {

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -121,7 +121,7 @@ impl CommandExecute for Schema {
     dot,
     features = ?features.features,
 ))]
-pub(crate) fn generate_schema(
+pub(crate) fn generate_schema_for_cli(
     user_manifest_path: Option<&Path>,
     user_package: Option<&str>,
     package_manifest_path: &Path,
@@ -164,7 +164,45 @@ pub(crate) fn generate_schema(
             &package_name,
         )?;
     };
+    generate_schema_implicit(
+        user_manifest_path,
+        package_name,
+        package_manifest_path,
+        profile,
+        features,
+        features_arg,
+        target,
+        path,
+        dot,
+        log_level,
+        output_tracking,
+        manifest,
+        control_file,
+        lib_name,
+        lib_filename,
+        flags,
+    )
+}
+pub(crate) use generate_schema_for_cli as generate_schema;
 
+pub(crate) fn generate_schema_implicit(
+    user_manifest_path: Option<&Path>,
+    package_name: String,
+    package_manifest_path: &Path,
+    profile: &CargoProfile,
+    features: &clap_cargo::Features,
+    features_arg: String,
+    target: Option<&str>,
+    path: Option<&Path>,
+    dot: Option<&Path>,
+    log_level: Option<String>,
+    output_tracking: &mut Vec<PathBuf>,
+    manifest: cargo_toml::Manifest,
+    control_file: PathBuf,
+    lib_name: String,
+    lib_filename: String,
+    flags: String,
+) -> eyre::Result<()> {
     let symbols = find_and_compute_symbols(profile, &lib_filename, target)?;
 
     let codegen =
@@ -177,7 +215,7 @@ pub(crate) fn generate_schema(
         embed
     };
 
-    if let Some(out_path) = path.as_ref() {
+    if let Some(out_path) = path {
         if let Some(parent) = out_path.parent() {
             std::fs::create_dir_all(parent).wrap_err("Could not create parent directory")?;
         }

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -20,6 +20,7 @@ use pgrx_pg_config::{Pgrx, get_target_dir};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::str;
 
 /// Generate extension schema files
 #[derive(clap::Args, Debug)]
@@ -164,7 +165,7 @@ pub(crate) fn generate_schema(
         )?;
     };
 
-    let symbols = compute_symbols(profile, &lib_filename, target)?;
+    let symbols = find_and_compute_symbols(profile, &lib_filename, target)?;
 
     let mut out_path = None;
     if let Some(path) = path {
@@ -221,14 +222,11 @@ pub(crate) fn generate_schema(
     Ok(())
 }
 
-fn compute_symbols(
+fn find_and_compute_symbols(
     profile: &CargoProfile,
     lib_filename: &str,
     target: Option<&str>,
 ) -> eyre::Result<Vec<String>> {
-    use object::Object;
-    use std::collections::HashSet;
-
     // Inspect the symbol table for a list of `__pgrx_internals` we should have the generator call
     let mut lib_so = get_target_dir()?;
     if let Some(target) = target {
@@ -240,26 +238,28 @@ fn compute_symbols(
     let lib_so_data = std::fs::read(&lib_so).wrap_err("couldn't read extension shared object")?;
     let lib_so_obj_file =
         parse_object(&lib_so_data).wrap_err("couldn't parse extension shared object")?;
-    let lib_so_exports =
-        lib_so_obj_file.exports().wrap_err("couldn't get exports from extension shared object")?;
 
+    // FIXME: properly parse the target tuple per https://github.com/pgcentralfoundation/pgrx/issues/2183
+    let symbol_prefix = if cfg!(target_os = "macos") { "_" } else { "" };
+    compute_symbols(&lib_so_obj_file, symbol_prefix)
+}
+
+fn compute_symbols(obj_file: &object::File<'_>, symbol_prefix: &str) -> eyre::Result<Vec<String>> {
+    use std::collections::HashSet;
+    let lib_so_exports = object::Object::exports(obj_file)
+        .wrap_err("couldn't get exports from extension shared object")?;
     // Some users reported experiencing duplicate entries if we don't ensure `fns_to_call`
     // has unique entries.
     let mut fns_to_call = HashSet::new();
     for export in lib_so_exports {
-        let name = std::str::from_utf8(export.name())?.to_string();
-        #[cfg(target_os = "macos")]
-        let name = {
-            // Mac will prefix symbols with `_` automatically, so we remove it to avoid getting
-            // two.
-            let mut name = name;
-            let rename = name.split_off(1);
-            assert_eq!(name, "_");
-            rename
-        };
+        let name = str::from_utf8(export.name()).expect("Rust symbol names are UTF8");
+        // macOS will prefix symbols with `_` automatically, so we remove one
+        let name = name
+            .strip_prefix(symbol_prefix)
+            .ok_or(eyre!("platform symbol prefix not found on {name}"))?;
 
         if name.starts_with("__pgrx_internals") {
-            fns_to_call.insert(name);
+            fns_to_call.insert(name.to_owned());
         }
     }
     let mut seen_schemas = Vec::new();

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -403,8 +403,7 @@ fn compute_codegen(
     };
 
     let inputs = {
-        let control_file_path =
-            control_file_path.to_str().expect(".control file filename should be valid UTF8");
+        let control_file_path = str_from_path(".control file", control_file_path)?;
         let mut out = quote::quote! {
             // call the marker.  Primarily this ensures that rustc will actually link to the library
             // during the "pgrx_embed" build initiated by `cargo-pgrx schema` generation

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -333,25 +333,18 @@ fn first_build(
     flags: &str,
     target: Option<&str>,
 ) -> eyre::Result<()> {
-    let mut command = if is_test {
-        let mut command = cargo.subcommand("test").into_command();
-        command.arg("--no-run");
-        command
+    let cargo = if is_test {
+        cargo.subcommand("test").flag("--no-run")
     } else {
-        let mut command = cargo.subcommand("build").into_command();
-        command.arg("--lib");
-        command
+        cargo.subcommand("build").flag("--lib")
     };
 
-    command.args(profile.cargo_args());
+    let cargo = cargo.profile(profile.clone()).target(target.map(|t| t.to_owned()));
+
+    let mut command = cargo.into_command();
 
     for arg in flags.split_ascii_whitespace() {
         command.arg(arg);
-    }
-
-    if let Some(target) = target {
-        command.arg("--target");
-        command.arg(target);
     }
 
     let command_str = format!("{command:?}");

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -151,17 +151,15 @@ pub(crate) fn generate_schema_for_cli(
     let lib_name = manifest.lib_name()?;
     let lib_filename = manifest.lib_filename()?;
 
-    let cargo = Cargo::default().package(package_name).std_streams([
-        cargo::Stdio::Null,
-        cargo::Stdio::Null,
-        cargo::Stdio::Inherit,
-    ]);
+    let cargo = Cargo::default()
+        .package(package_name)
+        .std_streams([cargo::Stdio::Null, cargo::Stdio::Null, cargo::Stdio::Inherit])
+        .manifest(user_manifest_path.map(|p| p.to_owned()));
 
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
         first_build(
             cargo.clone(),
-            user_manifest_path,
             profile,
             features,
             log_level.clone(),
@@ -173,7 +171,6 @@ pub(crate) fn generate_schema_for_cli(
     };
     generate_schema_implicit(
         cargo,
-        user_manifest_path,
         package_manifest_path,
         profile,
         features,
@@ -194,7 +191,6 @@ pub(crate) use generate_schema_for_cli as generate_schema;
 
 pub(crate) fn generate_schema_implicit(
     cargo: Cargo,
-    user_manifest_path: Option<&Path>,
     package_manifest_path: &Path,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
@@ -235,7 +231,6 @@ pub(crate) fn generate_schema_implicit(
 
     second_build(
         cargo,
-        user_manifest_path,
         features,
         log_level.clone(),
         &features_arg,
@@ -351,7 +346,6 @@ fn compute_symbols(obj_file: &object::File<'_>, symbol_prefix: &str) -> eyre::Re
 
 fn first_build(
     cargo: Cargo,
-    user_manifest_path: Option<&Path>,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
     log_level: Option<String>,
@@ -369,11 +363,6 @@ fn first_build(
         command.arg("--lib");
         command
     };
-
-    if let Some(user_manifest_path) = user_manifest_path.as_ref() {
-        command.arg("--manifest-path");
-        command.arg(user_manifest_path);
-    }
 
     command.args(profile.cargo_args());
 
@@ -521,7 +510,6 @@ fn compute_codegen(
 
 fn second_build(
     cargo: Cargo,
-    user_manifest_path: Option<&Path>,
     features: &clap_cargo::Features,
     log_level: Option<String>,
     features_arg: &str,
@@ -534,11 +522,6 @@ fn second_build(
     let mut command = cargo.subcommand("rustc").into_command();
     command.arg("--bin");
     command.arg(pgrx_embed_name(manifest)?);
-
-    if let Some(user_manifest_path) = user_manifest_path.as_ref() {
-        command.arg("--manifest-path");
-        command.arg(user_manifest_path);
-    }
 
     if let Some(log_level) = &log_level {
         command.env("RUST_LOG", log_level);

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -462,9 +462,10 @@ fn second_build(
 ) -> eyre::Result<()> {
     // We do pass cfg to the binary and do not pass cfg to dependencies to avoid recompilation
     // The only cargo command respecting our need is `cargo rustc`
-    let mut command = cargo.subcommand("rustc").into_command();
-    command.arg("--bin");
-    command.arg(pgrx_embed_name(manifest)?);
+    let mut command = cargo
+        .subcommand("rustc")
+        .flag_args("--bin", vec![pgrx_embed_name(manifest)?])
+        .into_command();
 
     command.arg("--");
 

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -167,26 +167,8 @@ pub(crate) fn generate_schema(
 
     let symbols = find_and_compute_symbols(profile, &lib_filename, target)?;
 
-    let mut out_path = None;
-    if let Some(path) = path {
-        let x = path.to_str().expect("`path` is not a valid UTF8 string.");
-        out_path = Some(x.to_string());
-    }
-
-    let mut out_dot = None;
-    if let Some(dot) = dot {
-        let x = dot.to_str().expect("`dot` is not a valid UTF8 string.");
-        out_dot = Some(x.to_string());
-    };
-
-    let codegen = compute_codegen(
-        &control_file,
-        package_manifest_path,
-        &symbols,
-        &lib_name,
-        out_path,
-        out_dot,
-    )?;
+    let codegen =
+        compute_codegen(&control_file, package_manifest_path, &symbols, &lib_name, path, dot)?;
 
     let embed = {
         let mut embed = tempfile::NamedTempFile::new()?;
@@ -407,11 +389,18 @@ fn compute_codegen(
     package_manifest_path: &Path,
     symbols: &[String],
     lib_name: &str,
-    path: Option<String>,
-    dot: Option<String>,
+    path: Option<&Path>,
+    dot: Option<&Path>,
 ) -> eyre::Result<String> {
     use proc_macro2::{Ident, Span, TokenStream};
     let lib_name_ident = Ident::new(lib_name, Span::call_site());
+
+    let str_from_path = |name: &str, path: &Path| {
+        path.to_str().map(|s| s.to_owned()).ok_or_else(|| {
+            let err_str = path.to_string_lossy();
+            eyre!("{name} path is not UTF8: {err_str}")
+        })
+    };
 
     let inputs = {
         let control_file_path =
@@ -454,6 +443,7 @@ fn compute_codegen(
     let outputs = {
         let mut out = TokenStream::new();
         if let Some(path) = path {
+            let path = str_from_path("out", path)?;
             let writing = "     Writing".bold().green().to_string();
             out.extend(quote::quote! {
                 eprintln!("{} SQL entities to {}", #writing, #path);
@@ -471,6 +461,7 @@ fn compute_codegen(
             });
         }
         if let Some(dot) = dot {
+            let dot = str_from_path("dot", dot)?;
             out.extend(quote::quote! {
                 pgrx_sql
                     .to_dot(#dot)

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -151,7 +151,11 @@ pub(crate) fn generate_schema_for_cli(
     let lib_name = manifest.lib_name()?;
     let lib_filename = manifest.lib_filename()?;
 
-    let cargo = Cargo::default().package(package_name);
+    let cargo = Cargo::default().package(package_name).std_streams([
+        cargo::Stdio::Null,
+        cargo::Stdio::Null,
+        cargo::Stdio::Inherit,
+    ]);
 
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
@@ -366,10 +370,6 @@ fn first_build(
         command
     };
 
-    command.stdin(Stdio::null());
-    command.stdout(Stdio::null());
-    command.stderr(Stdio::inherit());
-
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");
         command.arg(user_manifest_path);
@@ -534,10 +534,6 @@ fn second_build(
     let mut command = cargo.subcommand("rustc").into_command();
     command.arg("--bin");
     command.arg(pgrx_embed_name(manifest)?);
-
-    command.stdin(Stdio::null());
-    command.stdout(Stdio::null());
-    command.stderr(Stdio::inherit());
 
     if let Some(user_manifest_path) = user_manifest_path.as_ref() {
         command.arg("--manifest-path");

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -8,6 +8,7 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::CommandExecute;
+use crate::cargo::{self, Cargo};
 use crate::command::get::{find_control_file, get_property};
 use crate::manifest::{get_package_manifest, pg_config_and_version};
 use crate::profile::CargoProfile;
@@ -150,9 +151,12 @@ pub(crate) fn generate_schema_for_cli(
     let lib_name = manifest.lib_name()?;
     let lib_filename = manifest.lib_filename()?;
 
+    let cargo = Cargo::default();
+
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
         first_build(
+            cargo.clone(),
             user_manifest_path,
             profile,
             features,
@@ -165,6 +169,7 @@ pub(crate) fn generate_schema_for_cli(
         )?;
     };
     generate_schema_implicit(
+        cargo,
         user_manifest_path,
         package_name,
         package_manifest_path,
@@ -186,6 +191,7 @@ pub(crate) fn generate_schema_for_cli(
 pub(crate) use generate_schema_for_cli as generate_schema;
 
 pub(crate) fn generate_schema_implicit(
+    cargo: Cargo,
     user_manifest_path: Option<&Path>,
     package_name: String,
     package_manifest_path: &Path,
@@ -227,6 +233,7 @@ pub(crate) fn generate_schema_implicit(
     }
 
     second_build(
+        cargo,
         user_manifest_path,
         features,
         log_level.clone(),
@@ -343,6 +350,7 @@ fn compute_symbols(obj_file: &object::File<'_>, symbol_prefix: &str) -> eyre::Re
 }
 
 fn first_build(
+    cargo: Cargo,
     user_manifest_path: Option<&Path>,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
@@ -353,18 +361,19 @@ fn first_build(
     target: Option<&str>,
     package_name: &str,
 ) -> eyre::Result<()> {
-    let mut command = crate::cargo::cargo();
+    let mut command = if is_test {
+        let mut command = cargo.subcommand("test").into_command();
+        command.arg("--no-run");
+        command
+    } else {
+        let mut command = cargo.subcommand("build").into_command();
+        command.arg("--lib");
+        command
+    };
+
     command.stdin(Stdio::null());
     command.stdout(Stdio::null());
     command.stderr(Stdio::inherit());
-
-    if is_test {
-        command.arg("test");
-        command.arg("--no-run");
-    } else {
-        command.arg("build");
-        command.arg("--lib");
-    }
 
     command.arg("--package");
     command.arg(package_name);
@@ -519,6 +528,7 @@ fn compute_codegen(
 }
 
 fn second_build(
+    cargo: Cargo,
     user_manifest_path: Option<&Path>,
     features: &clap_cargo::Features,
     log_level: Option<String>,
@@ -528,16 +538,15 @@ fn second_build(
     package_name: &str,
     manifest: &Manifest,
 ) -> eyre::Result<()> {
-    let mut command = crate::cargo::cargo();
+    // We do pass cfg to the binary and do not pass cfg to dependencies to avoid recompilation
+    // The only cargo command respecting our need is `cargo rustc`
+    let mut command = cargo.subcommand("rustc").into_command();
+    command.arg("--bin");
+    command.arg(pgrx_embed_name(manifest)?);
+
     command.stdin(Stdio::null());
     command.stdout(Stdio::null());
     command.stderr(Stdio::inherit());
-
-    // We do pass cfg to the binary and do not pass cfg to dependencies to avoid recompilation
-    // The only cargo command respecting our need is `cargo rustc`
-    command.arg("rustc");
-    command.arg("--bin");
-    command.arg(pgrx_embed_name(manifest)?);
 
     command.arg("--package");
     command.arg(package_name);

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -139,8 +139,6 @@ pub(crate) fn generate_schema_for_cli(
     let manifest = Manifest::from_path(&package_manifest_path)?;
     let (control_file, _extname) = find_control_file(&package_manifest_path)?;
 
-    let flags = std::env::var("PGRX_BUILD_FLAGS").unwrap_or_default();
-
     let features_arg = features.features.join(" ");
 
     let package_name = if let Some(user_package) = user_package {
@@ -160,7 +158,7 @@ pub(crate) fn generate_schema_for_cli(
 
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
-        first_build(cargo.clone(), profile, is_test, &features_arg, &flags, target)?;
+        first_build(cargo.clone(), profile, is_test, &features_arg, target)?;
     };
     generate_schema_implicit(
         cargo,
@@ -175,7 +173,6 @@ pub(crate) fn generate_schema_for_cli(
         control_file,
         lib_name,
         lib_filename,
-        flags,
     )
 }
 pub(crate) use generate_schema_for_cli as generate_schema;
@@ -193,7 +190,6 @@ pub(crate) fn generate_schema_implicit(
     control_file: PathBuf,
     lib_name: String,
     lib_filename: String,
-    flags: String,
 ) -> eyre::Result<()> {
     let symbols = find_and_compute_symbols(profile, &lib_filename, target)?;
 
@@ -218,7 +214,7 @@ pub(crate) fn generate_schema_implicit(
         tracing::info!(dot = %dot_path.display(), "Writing Graphviz DOT");
     }
 
-    second_build(cargo, &features_arg, &flags, embed.path(), &manifest)?;
+    second_build(cargo, &features_arg, embed.path(), &manifest)?;
 
     compute_sql(&manifest)?;
 
@@ -330,7 +326,6 @@ fn first_build(
     profile: &CargoProfile,
     is_test: bool,
     features_arg: &str,
-    flags: &str,
     target: Option<&str>,
 ) -> eyre::Result<()> {
     let cargo = if is_test {
@@ -342,10 +337,6 @@ fn first_build(
     let cargo = cargo.profile(profile.clone()).target(target.map(|t| t.to_owned()));
 
     let mut command = cargo.into_command();
-
-    for arg in flags.split_ascii_whitespace() {
-        command.arg(arg);
-    }
 
     let command_str = format!("{command:?}");
     eprintln!(
@@ -466,7 +457,6 @@ fn compute_codegen(
 fn second_build(
     cargo: Cargo,
     features_arg: &str,
-    flags: &str,
     embed_path: &Path,
     manifest: &Manifest,
 ) -> eyre::Result<()> {
@@ -475,10 +465,6 @@ fn second_build(
     let mut command = cargo.subcommand("rustc").into_command();
     command.arg("--bin");
     command.arg(pgrx_embed_name(manifest)?);
-
-    for arg in flags.split_ascii_whitespace() {
-        command.arg(arg);
-    }
 
     command.arg("--");
 

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -155,17 +155,17 @@ pub(crate) fn generate_schema_for_cli(
         .package(package_name)
         .std_streams([cargo::Stdio::Null, cargo::Stdio::Null, cargo::Stdio::Inherit])
         .manifest_path(user_manifest_path.map(|p| p.to_owned()))
-        .log_level(log_level);
+        .log_level(log_level)
+        .features(features.clone());
 
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
-        first_build(cargo.clone(), profile, features, is_test, &features_arg, &flags, target)?;
+        first_build(cargo.clone(), profile, is_test, &features_arg, &flags, target)?;
     };
     generate_schema_implicit(
         cargo,
         package_manifest_path,
         profile,
-        features,
         features_arg,
         target,
         path,
@@ -184,7 +184,6 @@ pub(crate) fn generate_schema_implicit(
     cargo: Cargo,
     package_manifest_path: &Path,
     profile: &CargoProfile,
-    features: &clap_cargo::Features,
     features_arg: String,
     target: Option<&str>,
     path: Option<&Path>,
@@ -219,7 +218,7 @@ pub(crate) fn generate_schema_implicit(
         tracing::info!(dot = %dot_path.display(), "Writing Graphviz DOT");
     }
 
-    second_build(cargo, features, &features_arg, &flags, embed.path(), &manifest)?;
+    second_build(cargo, &features_arg, &flags, embed.path(), &manifest)?;
 
     compute_sql(&manifest)?;
 
@@ -329,7 +328,6 @@ fn compute_symbols(obj_file: &object::File<'_>, symbol_prefix: &str) -> eyre::Re
 fn first_build(
     cargo: Cargo,
     profile: &CargoProfile,
-    features: &clap_cargo::Features,
     is_test: bool,
     features_arg: &str,
     flags: &str,
@@ -346,19 +344,6 @@ fn first_build(
     };
 
     command.args(profile.cargo_args());
-
-    if !features_arg.trim().is_empty() {
-        command.arg("--features");
-        command.arg(features_arg);
-    }
-
-    if features.no_default_features {
-        command.arg("--no-default-features");
-    }
-
-    if features.all_features {
-        command.arg("--all-features");
-    }
 
     for arg in flags.split_ascii_whitespace() {
         command.arg(arg);
@@ -487,7 +472,6 @@ fn compute_codegen(
 
 fn second_build(
     cargo: Cargo,
-    features: &clap_cargo::Features,
     features_arg: &str,
     flags: &str,
     embed_path: &Path,
@@ -498,19 +482,6 @@ fn second_build(
     let mut command = cargo.subcommand("rustc").into_command();
     command.arg("--bin");
     command.arg(pgrx_embed_name(manifest)?);
-
-    if !features_arg.trim().is_empty() {
-        command.arg("--features");
-        command.arg(features_arg);
-    }
-
-    if features.no_default_features {
-        command.arg("--no-default-features");
-    }
-
-    if features.all_features {
-        command.arg("--all-features");
-    }
 
     for arg in flags.split_ascii_whitespace() {
         command.arg(arg);

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -154,20 +154,12 @@ pub(crate) fn generate_schema_for_cli(
     let cargo = Cargo::default()
         .package(package_name)
         .std_streams([cargo::Stdio::Null, cargo::Stdio::Null, cargo::Stdio::Inherit])
-        .manifest(user_manifest_path.map(|p| p.to_owned()));
+        .manifest(user_manifest_path.map(|p| p.to_owned()))
+        .log_level(log_level);
 
     if !skip_build {
         // NB:  The only path where this happens is via the command line using `cargo pgrx schema`
-        first_build(
-            cargo.clone(),
-            profile,
-            features,
-            log_level.clone(),
-            is_test,
-            &features_arg,
-            &flags,
-            target,
-        )?;
+        first_build(cargo.clone(), profile, features, is_test, &features_arg, &flags, target)?;
     };
     generate_schema_implicit(
         cargo,
@@ -178,7 +170,6 @@ pub(crate) fn generate_schema_for_cli(
         target,
         path,
         dot,
-        log_level,
         output_tracking,
         manifest,
         control_file,
@@ -198,7 +189,6 @@ pub(crate) fn generate_schema_implicit(
     target: Option<&str>,
     path: Option<&Path>,
     dot: Option<&Path>,
-    log_level: Option<String>,
     output_tracking: &mut Vec<PathBuf>,
     manifest: cargo_toml::Manifest,
     control_file: PathBuf,
@@ -229,15 +219,7 @@ pub(crate) fn generate_schema_implicit(
         tracing::info!(dot = %dot_path.display(), "Writing Graphviz DOT");
     }
 
-    second_build(
-        cargo,
-        features,
-        log_level.clone(),
-        &features_arg,
-        &flags,
-        embed.path(),
-        &manifest,
-    )?;
+    second_build(cargo, features, &features_arg, &flags, embed.path(), &manifest)?;
 
     compute_sql(&manifest)?;
 
@@ -348,7 +330,6 @@ fn first_build(
     cargo: Cargo,
     profile: &CargoProfile,
     features: &clap_cargo::Features,
-    log_level: Option<String>,
     is_test: bool,
     features_arg: &str,
     flags: &str,
@@ -365,10 +346,6 @@ fn first_build(
     };
 
     command.args(profile.cargo_args());
-
-    if let Some(log_level) = &log_level {
-        command.env("RUST_LOG", log_level);
-    }
 
     if !features_arg.trim().is_empty() {
         command.arg("--features");
@@ -511,7 +488,6 @@ fn compute_codegen(
 fn second_build(
     cargo: Cargo,
     features: &clap_cargo::Features,
-    log_level: Option<String>,
     features_arg: &str,
     flags: &str,
     embed_path: &Path,
@@ -522,10 +498,6 @@ fn second_build(
     let mut command = cargo.subcommand("rustc").into_command();
     command.arg("--bin");
     command.arg(pgrx_embed_name(manifest)?);
-
-    if let Some(log_level) = &log_level {
-        command.env("RUST_LOG", log_level);
-    }
 
     if !features_arg.trim().is_empty() {
         command.arg("--features");

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -622,6 +622,7 @@ fn parse_object(data: &[u8]) -> object::Result<object::File<'_>> {
 
     match kind {
         object::FileKind::MachOFat32 => {
+            // FIXME: properly parse the target tuple per https://github.com/pgcentralfoundation/pgrx/issues/2183
             let arch = std::env::consts::ARCH;
 
             match slice_arch32(data, arch) {

--- a/cargo-pgrx/src/profile.rs
+++ b/cargo-pgrx/src/profile.rs
@@ -10,9 +10,10 @@
 /// Represents a selected cargo profile
 ///
 /// Generally chosen from flags like `--release`, `--profile <profile name>`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum CargoProfile {
     /// The default non-release profile, `[profile.dev]`
+    #[default]
     Dev,
     /// The default release profile, `[profile.release]`
     Release,


### PR DESCRIPTION
I find the code in schema.rs to be poorly factored in general.
A great deal of code is repeated in `first_build` and `second_build`.
In other places, arguments are created long before they are needed.
All of this makes it hard to follow basic data flow or
understand what is distinct about each invocation.

First, split some functions more finely to make it easier to follow where arguments are used.
- `compute_symbols` grows `find_and_compute_symbols` as its "front end"
- `generate_schema` forks into `_for_cli` and `_implicit`

Secondly, absorb repeated code in `first_build` and `second_build`
into `cargo_pgrx::cargo::Cargo`, a builder for `process::Command`s.

This doesn't _entirely_ "pay off" yet due to the weight of boilerplate, some of the distinctions being still weak, and not all sites in cargo-pgrx using improved abstractions. This will improve over time.