### PR TITLE
Add back `peer_dn` field to `Port` on `pg17..`

### DIFF
--- a/pgrx-pg-sys/src/libpq.rs
+++ b/pgrx-pg-sys/src/libpq.rs
@@ -112,6 +112,7 @@ pub mod be {
 
         ssl_in_use: bool,
         peer_cn: *mut core::ffi::c_char,
+        peer_dn: *mut core::ffi::c_char,
         peer_cert_valid: bool,
 
         alpn_used: bool,
@@ -186,6 +187,7 @@ pub mod be {
 
         ssl_in_use: bool,
         peer_cn: *mut core::ffi::c_char,
+        peer_dn: *mut core::ffi::c_char,
         peer_cert_valid: bool,
 
         alpn_used: bool,


### PR DESCRIPTION
Catch the field I accidentally dropped while splitting `Port` into different written-out versions, thanks to @cbandy!