### PR TITLE
Add `repr(C)` to `struct Port` on `pg13..=16`

### DIFF
--- a/pgrx-pg-sys/src/libpq.rs
+++ b/pgrx-pg-sys/src/libpq.rs
@@ -23,6 +23,7 @@ pub mod be {
 
     /// Port for Postgres 13..=16
     #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
+    #[repr(C)]
     pub struct Port {
         pub sock: crate::pgsocket,
         pub noblock: bool,


### PR DESCRIPTION
Caught during self-review right after I clicked the green button for pgcentralfoundation/pgrx#2200.