### PR TITLE
Make `Scalar` provide `pg_sys::Oid` constant

### DIFF
--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -388,15 +388,30 @@ impl Toasty for RawArray {
 /// - No padding bits
 /// - All bitpatterns are valid
 /// - Postgres runtime handling which respects these properties
+/// - ...which also means it must have a statically-known OID
 ///
 /// This allows for it to be copied from a Rust slice to a Postgres array,
 /// and obtain a Rust slice from a Postgres array if it contains no nulls.
-pub unsafe trait Scalar: Sized + Copy {}
+pub unsafe trait Scalar: Sized + Copy {
+    const OID: pg_sys::Oid;
+}
 
-unsafe impl Scalar for f32 {}
+unsafe impl Scalar for f32 {
+    const OID: pg_sys::Oid = pg_sys::FLOAT4OID;
+}
 #[cfg(target_pointer_width = "64")]
-unsafe impl Scalar for f64 {}
-unsafe impl Scalar for i8 {}
-unsafe impl Scalar for i16 {}
-unsafe impl Scalar for i32 {}
-unsafe impl Scalar for i64 {}
+unsafe impl Scalar for f64 {
+    const OID: pg_sys::Oid = pg_sys::FLOAT8OID;
+}
+unsafe impl Scalar for i8 {
+    const OID: pg_sys::Oid = pg_sys::CHAROID;
+}
+unsafe impl Scalar for i16 {
+    const OID: pg_sys::Oid = pg_sys::INT2OID;
+}
+unsafe impl Scalar for i32 {
+    const OID: pg_sys::Oid = pg_sys::INT4OID;
+}
+unsafe impl Scalar for i64 {
+    const OID: pg_sys::Oid = pg_sys::INT8OID;
+}

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -380,3 +380,23 @@ impl Toasty for RawArray {
         unsafe { pg_sys::pfree(self.ptr.as_ptr().cast()) }
     }
 }
+
+/// Marker for "simple scalars" in arrays
+///
+/// A Scalar must have:
+/// - A fixed size
+/// - No padding bits
+/// - All bitpatterns are valid
+/// - Postgres runtime handling which respects these properties
+///
+/// This allows for it to be copied from a Rust slice to a Postgres array,
+/// and obtain a Rust slice from a Postgres array if it contains no nulls.
+pub unsafe trait Scalar: Sized + Copy {}
+
+unsafe impl Scalar for f32 {}
+#[cfg(target_pointer_width = "64")]
+unsafe impl Scalar for f64 {}
+unsafe impl Scalar for i8 {}
+unsafe impl Scalar for i16 {}
+unsafe impl Scalar for i32 {}
+unsafe impl Scalar for i64 {}

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -9,7 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![allow(clippy::question_mark)]
 use super::{UnboxDatum, unbox};
-use crate::array::RawArray;
+use crate::array::{RawArray, Scalar};
 use crate::nullable::{
     BitSliceNulls, IntoNullableIterator, MaybeStrictNulls, NullLayout, Nullable, NullableContainer,
 };
@@ -411,26 +411,6 @@ pub enum ArraySliceError {
     #[error("Cannot create a slice of an Array that contains nulls")]
     ContainsNulls,
 }
-
-/// Marker for "simple scalars" in arrays
-///
-/// A Scalar must have:
-/// - A fixed size
-/// - No padding bits
-/// - All bitpatterns are valid
-/// - Postgres runtime handling which respects these properties
-///
-/// This allows for it to be copied from a Rust slice to a Postgres array,
-/// and obtain a Rust slice from a Postgres array if it contains no nulls.
-pub unsafe trait Scalar: Sized + Copy {}
-
-unsafe impl Scalar for f32 {}
-#[cfg(target_pointer_width = "64")]
-unsafe impl Scalar for f64 {}
-unsafe impl Scalar for i8 {}
-unsafe impl Scalar for i16 {}
-unsafe impl Scalar for i32 {}
-unsafe impl Scalar for i64 {}
 
 impl<T> Array<'_, T>
 where


### PR DESCRIPTION
This makes it simpler to do a variety of things involving arrays of that type that are guaranteed to work at compile-time.

Also, I fuss around where it is: I think it should be visible at `pgrx::array::Scalar`.