### PR TITLE
Add `MemCx<'current, T>` arguments and `PBox<'current, T>` returns

### DIFF
--- a/pgrx-tests/src/tests/memcxt_tests.rs
+++ b/pgrx-tests/src/tests/memcxt_tests.rs
@@ -37,10 +37,7 @@ mod tests {
     ) -> PBox<'mcx, TimeWithTimeZone> {
         let palloc = memcx.alloc_bytes(size_of::<TimeWithTimeZone>());
         let timetz = TimeWithTimeZone::new(4, 20, 0.0).unwrap();
-        unsafe {
-            *(palloc as *mut _) = timetz;
-            PBox::from_raw_in(NonNull::new(palloc.cast()).unwrap(), memcx)
-        }
+        PBox::new_in(timetz, memcx)
     }
 
     #[pg_test]

--- a/pgrx-tests/src/tests/memcxt_tests.rs
+++ b/pgrx-tests/src/tests/memcxt_tests.rs
@@ -18,7 +18,6 @@ mod tests {
     use pgrx::palloc::PBox;
     use pgrx::pg_test;
     use pgrx::prelude::*;
-    use std::ptr::NonNull;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/pgrx-tests/src/tests/memcxt_tests.rs
+++ b/pgrx-tests/src/tests/memcxt_tests.rs
@@ -14,9 +14,10 @@ mod tests {
     use crate as pgrx_tests;
 
     use pgrx::PgMemoryContexts;
-    use pgrx::memcx::MemCx;
+    use pgrx::memcx::{MemCx, PBox};
     use pgrx::pg_test;
     use pgrx::prelude::*;
+    use std::ptr::NonNull;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -31,8 +32,15 @@ mod tests {
     }
 
     #[pg_extern]
-    pub fn accept_return_memcx<'mcx>(memcx: &'mcx MemCx<'mcx>) -> &'mcx MemCx<'mcx> {
-        memcx
+    pub fn accept_mcx_return_timetz<'mcx>(
+        memcx: &'mcx MemCx<'mcx>,
+    ) -> PBox<'mcx, TimeWithTimeZone> {
+        let palloc = memcx.alloc_bytes(size_of::<TimeWithTimeZone>());
+        let timetz = TimeWithTimeZone::new(4, 20, 0.0).unwrap();
+        unsafe {
+            *(palloc as *mut _) = timetz;
+            PBox::from_raw_in(NonNull::new(palloc.cast()).unwrap(), memcx)
+        }
     }
 
     #[pg_test]

--- a/pgrx-tests/src/tests/memcxt_tests.rs
+++ b/pgrx-tests/src/tests/memcxt_tests.rs
@@ -14,6 +14,7 @@ mod tests {
     use crate as pgrx_tests;
 
     use pgrx::PgMemoryContexts;
+    use pgrx::memcx::MemCx;
     use pgrx::pg_test;
     use pgrx::prelude::*;
     use std::sync::Arc;
@@ -27,6 +28,11 @@ mod tests {
         fn drop(&mut self) {
             self.did_drop.store(true, Ordering::SeqCst);
         }
+    }
+
+    #[pg_extern]
+    pub fn accept_return_memcx<'mcx>(memcx: &'mcx MemCx<'mcx>) -> &'mcx MemCx<'mcx> {
+        memcx
     }
 
     #[pg_test]

--- a/pgrx-tests/src/tests/memcxt_tests.rs
+++ b/pgrx-tests/src/tests/memcxt_tests.rs
@@ -14,7 +14,8 @@ mod tests {
     use crate as pgrx_tests;
 
     use pgrx::PgMemoryContexts;
-    use pgrx::memcx::{MemCx, PBox};
+    use pgrx::memcx::MemCx;
+    use pgrx::palloc::PBox;
     use pgrx::pg_test;
     use pgrx::prelude::*;
     use std::ptr::NonNull;

--- a/pgrx-tests/tests/compile-fail/no-static-memcx.rs
+++ b/pgrx-tests/tests/compile-fail/no-static-memcx.rs
@@ -1,0 +1,11 @@
+use pgrx::memcx::MemCx;
+use pgrx::palloc::PBox;
+use pgrx::prelude::*;
+
+#[pg_extern]
+pub fn accept_mcx_return_timetz(memcx: &MemCx<'static>) -> PBox<'static, TimeWithTimeZone> {
+    let timetz = TimeWithTimeZone::new(4, 20, 0.0).unwrap();
+    PBox::new_in(timetz, memcx)
+}
+
+fn main() {}

--- a/pgrx-tests/tests/compile-fail/no-static-memcx.stderr
+++ b/pgrx-tests/tests/compile-fail/no-static-memcx.stderr
@@ -1,0 +1,20 @@
+error[E0521]: borrowed data escapes outside of function
+ --> tests/compile-fail/no-static-memcx.rs:6:92
+  |
+5 |   #[pg_extern]
+  |   ------------
+  |   |
+  |   lifetime `'fcx` defined here
+  |   in this procedural macro expansion
+6 |   pub fn accept_mcx_return_timetz(memcx: &MemCx<'static>) -> PBox<'static, TimeWithTimeZone> {
+  |  ____________________________________________________________________________________________^
+7 | |     let timetz = TimeWithTimeZone::new(4, 20, 0.0).unwrap();
+8 | |     PBox::new_in(timetz, memcx)
+9 | | }
+  | | ^
+  | | |
+  | | `fcinfo` is a reference that is only valid in the function body
+  | |_`fcinfo` escapes the function body here
+  |   argument requires that `'fcx` must outlive `'static`
+  |
+  = note: this error originates in the attribute macro `pg_extern` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -91,7 +91,7 @@ pub unsafe trait ArgAbi<'fcx>: Sized {
         }
     }
 
-    /// "Is this a virtual arg?"
+    /// Virtual args do not affect Datum arg iteration
     fn is_virtual_arg() -> bool {
         false
     }

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -63,6 +63,7 @@ pub mod misc;
 pub mod namespace;
 pub mod nodes;
 pub mod nullable;
+pub mod palloc;
 pub mod pg_catalog;
 pub mod pgbox;
 pub mod rel;

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -10,8 +10,7 @@ use pgrx_sql_entity_graph::metadata::{
 // - mctx
 // Search engines will see "memc[tx]{2}" and assume you mean memcpy!
 // And it's nice-ish to have shorter lifetime names and have 'mcx consistently mean the lifetime.
-use crate::callconv::{Arg, ArgAbi, BoxRet, FcInfo};
-use crate::datum::{BorrowDatum, Datum};
+use crate::callconv::{Arg, ArgAbi};
 use crate::pg_sys;
 use core::{marker::PhantomData, ptr::NonNull};
 
@@ -150,40 +149,5 @@ unsafe impl<'mcx> SqlTranslatable for &MemCx<'mcx> {
 
     fn return_sql() -> Result<Returns, ReturnsError> {
         Ok(Returns::One(SqlMapping::Skip))
-    }
-}
-
-/// A type pallocated in a context
-pub struct PBox<'mcx, T: ?Sized> {
-    ptr: NonNull<T>,
-    _cx: PhantomData<MemCx<'mcx>>,
-}
-
-impl<'mcx, T: ?Sized> PBox<'mcx, T> {
-    pub unsafe fn from_raw_in(ptr: NonNull<T>, _cx: &MemCx<'mcx>) -> PBox<'mcx, T> {
-        PBox { ptr, _cx: PhantomData }
-    }
-}
-
-unsafe impl<'mcx, T> BoxRet for PBox<'mcx, T>
-where
-    T: ?Sized + BorrowDatum,
-{
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        // SAFETY: by proxy
-        unsafe { fcinfo.return_raw_datum(pg_sys::Datum::from(self.ptr.cast::<u8>().as_ptr())) }
-    }
-}
-
-unsafe impl<'mcx, T> SqlTranslatable for PBox<'mcx, T>
-where
-    T: SqlTranslatable + ?Sized,
-{
-    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
-        T::argument_sql()
-    }
-
-    fn return_sql() -> Result<Returns, ReturnsError> {
-        T::return_sql()
     }
 }

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -175,5 +175,18 @@ where
     }
 }
 
+unsafe impl<'mcx, T> SqlTranslatable for PBox<'mcx, T>
+where
+    T: SqlTranslatable + ?Sized,
+{
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        T::argument_sql()
+    }
+
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        T::return_sql()
+    }
+}
+
 /// An "owning" palloc.
 pub struct Palloc<'mcx, T>(T, &'mcx MemCx<'mcx>);

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -171,7 +171,7 @@ where
 {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
         // SAFETY: by proxy
-        unsafe { fcinfo.return_raw_datum(mem::transmute(self.ptr)) }
+        unsafe { fcinfo.return_raw_datum(pg_sys::Datum::from(self.ptr.cast::<u8>().as_ptr())) }
     }
 }
 

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -152,3 +152,28 @@ unsafe impl<'mcx> SqlTranslatable for &MemCx<'mcx> {
         Ok(Returns::One(SqlMapping::Skip))
     }
 }
+
+/// A type pallocated in a context
+pub struct PBox<'mcx, T: ?Sized> {
+    ptr: NonNull<T>,
+    _cx: PhantomData<MemCx<'mcx>>,
+}
+
+impl<'mcx, T: ?Sized> PBox<'mcx, T> {
+    pub unsafe fn from_raw_in(ptr: NonNull<T>, _cx: &MemCx<'mcx>) -> PBox<'mcx, T> {
+        PBox { ptr, _cx: PhantomData }
+    }
+}
+
+unsafe impl<'mcx, T> BoxRet for PBox<'mcx, T>
+where
+    T: ?Sized + BorrowDatum,
+{
+    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
+        // SAFETY: by proxy
+        unsafe { fcinfo.return_raw_datum(mem::transmute(self.ptr)) }
+    }
+}
+
+/// An "owning" palloc.
+pub struct Palloc<'mcx, T>(T, &'mcx MemCx<'mcx>);

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -187,6 +187,3 @@ where
         T::return_sql()
     }
 }
-
-/// An "owning" palloc.
-pub struct Palloc<'mcx, T>(T, &'mcx MemCx<'mcx>);

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -1,4 +1,8 @@
 //! Memory Contexts in PostgreSQL, now with lifetimes.
+use pgrx_sql_entity_graph::metadata::{
+    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+};
+
 // "Why isn't this pgrx::mem or pgrx::memcxt?"
 // Postgres actually uses all of:
 // - mcxt
@@ -136,5 +140,15 @@ unsafe impl<'fcx> ArgAbi<'fcx> for &MemCx<'fcx> {
 
     fn is_virtual_arg() -> bool {
         true
+    }
+}
+
+unsafe impl<'mcx> SqlTranslatable for &MemCx<'mcx> {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::Skip)
+    }
+
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::Skip))
     }
 }

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -136,9 +136,13 @@ unsafe impl<'fcx> ArgAbi<'fcx> for &MemCx<'fcx> {
         unsafe { &*((&raw mut pg_sys::CurrentMemoryContext).cast()) }
     }
 
-    unsafe fn unbox_nullable_arg(_arg: Arg<'_, 'fcx>) -> crate::nullable::Nullable<Self> {
-        crate::nullable::Nullable::Null
-    }
+    unsafe fn unbox_nullable_arg(_arg: Arg<'_, 'fcx>) -> Nullable<Self> {
+        // SAFETY: Should never happen in actuality, but as long as we're here...
+        if unsafe { pg_sys::CurrentMemoryContext.is_null() } {
+            Nullable::Null
+        } else {
+            Nullable::Valid(Self::unbox_arg_unchecked(_arg))
+        }
 
     fn is_virtual_arg() -> bool {
         true

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -136,12 +136,12 @@ unsafe impl<'fcx> ArgAbi<'fcx> for &MemCx<'fcx> {
         unsafe { &*((&raw mut pg_sys::CurrentMemoryContext).cast()) }
     }
 
-    unsafe fn unbox_nullable_arg(_arg: Arg<'_, 'fcx>) -> Nullable<Self> {
+    unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
         // SAFETY: Should never happen in actuality, but as long as we're here...
         if unsafe { pg_sys::CurrentMemoryContext.is_null() } {
             Nullable::Null
         } else {
-            Nullable::Valid(Self::unbox_arg_unchecked(_arg))
+            Nullable::Valid(Self::unbox_arg_unchecked(arg))
         }
     }
 

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -11,6 +11,7 @@ use pgrx_sql_entity_graph::metadata::{
 // Search engines will see "memc[tx]{2}" and assume you mean memcpy!
 // And it's nice-ish to have shorter lifetime names and have 'mcx consistently mean the lifetime.
 use crate::callconv::{Arg, ArgAbi};
+use crate::nullable::Nullable;
 use crate::pg_sys;
 use core::{marker::PhantomData, ptr::NonNull};
 
@@ -130,6 +131,8 @@ unsafe impl<'fcx> ArgAbi<'fcx> for &MemCx<'fcx> {
         // SAFETY: We are called to unbox an argument, which means the backend was initialized.
         // We use this horrific expression to allow the lifetime to be extended arbitrarily
         // and achieve an "in-place" transformation of CurrentMemoryContext's pointer.
+        // The soundness of this is riding on the lifetimes used for `unbox_arg_unchecked` in our macros,
+        // as the expanded code is designed so that `fcinfo` and each `arg` are truly "borrowed" in rustc's eyes.
         unsafe { &*((&raw mut pg_sys::CurrentMemoryContext).cast()) }
     }
 
@@ -142,6 +145,7 @@ unsafe impl<'fcx> ArgAbi<'fcx> for &MemCx<'fcx> {
     }
 }
 
+/// SAFETY: virtual argument
 unsafe impl<'mcx> SqlTranslatable for &MemCx<'mcx> {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::Skip)

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -6,10 +6,13 @@
 // - mctx
 // Search engines will see "memc[tx]{2}" and assume you mean memcpy!
 // And it's nice-ish to have shorter lifetime names and have 'mcx consistently mean the lifetime.
+use crate::callconv::{Arg, ArgAbi, BoxRet, FcInfo};
+use crate::datum::{BorrowDatum, Datum};
 use crate::pg_sys;
 use core::{marker::PhantomData, ptr::NonNull};
 
 /// A borrowed memory context.
+#[repr(transparent)]
 pub struct MemCx<'mcx> {
     ptr: NonNull<pg_sys::MemoryContextData>,
     _marker: PhantomData<&'mcx pg_sys::MemoryContextData>,
@@ -116,5 +119,22 @@ mod nightly {
                 Ok(NonNull::new_unchecked(slice))
             }
         }
+    }
+}
+
+unsafe impl<'fcx> ArgAbi<'fcx> for &MemCx<'fcx> {
+    unsafe fn unbox_arg_unchecked(_arg: Arg<'_, 'fcx>) -> Self {
+        // SAFETY: We are called to unbox an argument, which means the backend was initialized.
+        // We use this horrific expression to allow the lifetime to be extended arbitrarily
+        // and achieve an "in-place" transformation of CurrentMemoryContext's pointer.
+        unsafe { &*((&raw mut pg_sys::CurrentMemoryContext).cast()) }
+    }
+
+    unsafe fn unbox_nullable_arg(_arg: Arg<'_, 'fcx>) -> crate::nullable::Nullable<Self> {
+        crate::nullable::Nullable::Null
+    }
+
+    fn is_virtual_arg() -> bool {
+        true
     }
 }

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -143,6 +143,7 @@ unsafe impl<'fcx> ArgAbi<'fcx> for &MemCx<'fcx> {
         } else {
             Nullable::Valid(Self::unbox_arg_unchecked(_arg))
         }
+    }
 
     fn is_virtual_arg() -> bool {
         true

--- a/pgrx/src/palloc.rs
+++ b/pgrx/src/palloc.rs
@@ -1,0 +1,3 @@
+mod pbox;
+
+pub use pbox::PBox;

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -25,6 +25,17 @@ impl<'mcx, T: ?Sized> PBox<'mcx, T> {
     }
 }
 
+impl<'mcx, T: Sized> PBox<'mcx, T> {
+    pub fn new_in(val: T, memcx: &MemCx<'mcx>) -> Self {
+        const { assert!(align_of::<T>() <= 8) };
+        let ptr = memcx.alloc_bytes(size_of::<T>()).cast();
+        // We were guaranteed an appropriately sized allocation to write to,
+        // and we have asserted our alignment maximum was upheld
+        unsafe { ptr.write(val) };
+        PBox { ptr, _cx: PhantomData }
+    }
+}
+
 unsafe impl<'mcx, T> BoxRet for PBox<'mcx, T>
 where
     T: ?Sized + BorrowDatum,

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -59,7 +59,7 @@ where
             }
             PassBy::Ref => pg_sys::Datum::from(self.ptr.cast::<u8>().as_ptr()),
         };
-        // SAFETY: by proxy, BorroWDatum is an `unsafe` trait so the above impl must be correct
+        // SAFETY: by proxy, BorrowDatum is an `unsafe traitw so the above impl must be correct
         unsafe { fcinfo.return_raw_datum(datum) }
     }
 }

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -21,6 +21,10 @@ pub struct PBox<'mcx, T: ?Sized> {
 }
 
 impl<'mcx, T: ?Sized> PBox<'mcx, T> {
+    // # Safety
+    // The same constraints as [`Box::from_raw`], AND 
+    // - you assert the pointer was allocated in the `MemCx`
+    // - you assert the pointer may be freed by `pfree`
     pub unsafe fn from_raw_in(ptr: NonNull<T>, _cx: &MemCx<'mcx>) -> PBox<'mcx, T> {
         PBox { ptr, _cx: PhantomData }
     }
@@ -30,7 +34,7 @@ impl<'mcx, T: Sized> PBox<'mcx, T> {
     pub fn new_in(val: T, memcx: &MemCx<'mcx>) -> Self {
         const { assert!(align_of::<T>() <= 8) };
         let ptr = memcx.alloc_bytes(size_of::<T>()).cast();
-        // We were guaranteed an appropriately sized allocation to write to,
+        // SAFETY: We were guaranteed an appropriately sized allocation to write to,
         // and we have asserted our alignment maximum was upheld
         unsafe { ptr.write(val) };
         PBox { ptr, _cx: PhantomData }
@@ -46,8 +50,8 @@ where
             PassBy::Value => {
                 // start with a zeroed Datum, just to minimize funny business
                 let mut datum = pg_sys::Datum::null();
-                // SAFETY: we know this type is Sized and has a size less than the Datum, and
-                // a PBox must have an initialized pointee, so a copy is sound-by-construction
+                // SAFETY: Due to BorrowDatum, this type has a definite size less than a Datum,
+                // and PBox must have an initialized pointee, so a copy is sound-by-construction.
                 unsafe {
                     let size = size_of_val(&*self.ptr.as_ptr());
                     debug_assert!(size <= size_of::<pg_sys::Datum>());
@@ -59,11 +63,13 @@ where
             }
             PassBy::Ref => pg_sys::Datum::from(self.ptr.cast::<u8>().as_ptr()),
         };
-        // SAFETY: by proxy, BorrowDatum is an `unsafe traitw so the above impl must be correct
+        // SAFETY: by proxy, BorrowDatum is an `unsafe trait` so the above impl must be correct
         unsafe { fcinfo.return_raw_datum(datum) }
     }
 }
 
+/// SAFETY: SQL has no "pointers" so by-val and by-ref calling conventions are identical,
+/// and all `PBox` truly does is enable pass-by-ref returns of unsized values.
 unsafe impl<'mcx, T> SqlTranslatable for PBox<'mcx, T>
 where
     T: SqlTranslatable + ?Sized,

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -1,5 +1,6 @@
 use crate::callconv::{BoxRet, FcInfo};
 use crate::datum::{BorrowDatum, Datum};
+use crate::layout::PassBy;
 use crate::memcx::MemCx;
 use crate::pg_sys;
 use core::marker::PhantomData;
@@ -41,8 +42,25 @@ where
     T: ?Sized + BorrowDatum,
 {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        // SAFETY: by proxy
-        unsafe { fcinfo.return_raw_datum(pg_sys::Datum::from(self.ptr.cast::<u8>().as_ptr())) }
+        let datum = match T::PASS {
+            PassBy::Value => {
+                // start with a zeroed Datum, just to minimize funny business
+                let mut datum = pg_sys::Datum::null();
+                // SAFETY: we know this type is Sized and has a size less than the Datum, and
+                // a PBox must have an initialized pointee, so a copy is sound-by-construction
+                unsafe {
+                    let size = size_of_val(&*self.ptr.as_ptr());
+                    debug_assert!(size <= size_of::<pg_sys::Datum>());
+                    // using `BorrowDatum::point_from` handles endianness
+                    let datum_ptr = T::point_from(NonNull::from_mut(&mut datum).cast::<u8>());
+                    datum_ptr.cast::<u8>().copy_from_nonoverlapping(self.ptr.cast(), size);
+                }
+                datum
+            }
+            PassBy::Ref => pg_sys::Datum::from(self.ptr.cast::<u8>().as_ptr()),
+        };
+        // SAFETY: by proxy, BorroWDatum is an `unsafe` trait so the above impl must be correct
+        unsafe { fcinfo.return_raw_datum(datum) }
     }
 }
 

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -19,7 +19,7 @@ pub struct PBox<'mcx, T: ?Sized> {
     _cx: PhantomData<MemCx<'mcx>>,
 }
 
-impl<'mcx, T> PBox<'mcx, T> {
+impl<'mcx, T: ?Sized> PBox<'mcx, T> {
     pub unsafe fn from_raw_in(ptr: NonNull<T>, _cx: &MemCx<'mcx>) -> PBox<'mcx, T> {
         PBox { ptr, _cx: PhantomData }
     }

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -1,0 +1,49 @@
+use crate::callconv::{BoxRet, FcInfo};
+use crate::datum::{BorrowDatum, Datum};
+use crate::memcx::MemCx;
+use crate::pg_sys;
+use core::marker::PhantomData;
+use core::ptr::NonNull;
+
+use pgrx_sql_entity_graph::metadata::{
+    ArgumentError, Returns, ReturnsError, SqlMapping, SqlTranslatable,
+};
+
+/** As [`Box<T, A>`][stdbox] where `A` is a [`MemCx`]
+
+
+[stdbox]: alloc::boxed::Box
+*/
+pub struct PBox<'mcx, T: ?Sized> {
+    ptr: NonNull<T>,
+    _cx: PhantomData<MemCx<'mcx>>,
+}
+
+impl<'mcx, T> PBox<'mcx, T> {
+    pub unsafe fn from_raw_in(ptr: NonNull<T>, _cx: &MemCx<'mcx>) -> PBox<'mcx, T> {
+        PBox { ptr, _cx: PhantomData }
+    }
+}
+
+unsafe impl<'mcx, T> BoxRet for PBox<'mcx, T>
+where
+    T: ?Sized + BorrowDatum,
+{
+    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
+        // SAFETY: by proxy
+        unsafe { fcinfo.return_raw_datum(pg_sys::Datum::from(self.ptr.cast::<u8>().as_ptr())) }
+    }
+}
+
+unsafe impl<'mcx, T> SqlTranslatable for PBox<'mcx, T>
+where
+    T: SqlTranslatable + ?Sized,
+{
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        T::argument_sql()
+    }
+
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        T::return_sql()
+    }
+}

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -16,6 +16,7 @@ use pgrx_sql_entity_graph::metadata::{
 
 [stdbox]: alloc::boxed::Box
 */
+#[repr(transparent)]
 pub struct PBox<'mcx, T: ?Sized> {
     ptr: NonNull<T>,
     _cx: PhantomData<MemCx<'mcx>>,
@@ -33,7 +34,7 @@ impl<'mcx, T: ?Sized> PBox<'mcx, T> {
 
 impl<'mcx, T: Sized> PBox<'mcx, T> {
     pub fn new_in(val: T, memcx: &MemCx<'mcx>) -> Self {
-        const { assert!(align_of::<T>() <= 8) };
+        const { assert!(align_of::<T>() <= size_of::<pg_sys::Datum>()) };
         let ptr = memcx.alloc_bytes(size_of::<T>()).cast();
         // SAFETY: We were guaranteed an appropriately sized allocation to write to,
         // and we have asserted our alignment maximum was upheld

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -4,6 +4,7 @@ use crate::layout::PassBy;
 use crate::memcx::MemCx;
 use crate::pg_sys;
 use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
 use pgrx_sql_entity_graph::metadata::{
@@ -80,5 +81,27 @@ where
 
     fn return_sql() -> Result<Returns, ReturnsError> {
         T::return_sql()
+    }
+}
+
+impl<'mcx, T> Deref for PBox<'mcx, T>
+where
+    T: BorrowDatum + ?Sized,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: by construction
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<'mcx, T> DerefMut for PBox<'mcx, T>
+where
+    T: BorrowDatum + ?Sized,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: by construction
+        unsafe { self.ptr.as_mut() }
     }
 }

--- a/pgrx/src/palloc/pbox.rs
+++ b/pgrx/src/palloc/pbox.rs
@@ -23,7 +23,7 @@ pub struct PBox<'mcx, T: ?Sized> {
 
 impl<'mcx, T: ?Sized> PBox<'mcx, T> {
     // # Safety
-    // The same constraints as [`Box::from_raw`], AND 
+    // The same constraints as [`Box::from_raw`], AND
     // - you assert the pointer was allocated in the `MemCx`
     // - you assert the pointer may be freed by `pfree`
     pub unsafe fn from_raw_in(ptr: NonNull<T>, _cx: &MemCx<'mcx>) -> PBox<'mcx, T> {


### PR DESCRIPTION
tl;dr: `caller_picks_lifetime + macro_expansion == unsoundness`,
so prevent that by adding API for new, lifetime-bound allocations.

For functions exposed to PostgreSQL via `pg_extern`, signatures often resemble these:

```rust
#[pg_extern]
fn do_something(
    floats: Array<'a, f32>,
    hms: Time,
    day: TimestampTz
) -> Vec<TimestampTz> {
```

```sql
-- pgrx will generate something like this
CREATE FUNCTION do_something(
    floats real[],
    hms time,
    day timestamptz
) RETURNS timestamptz[]
```


In SQL, we accept an array and return an array of a different type, but in Rust, we return a `Vec`. This is because we lack API to allocate and return a fresh `Array<'a, T>`s. Behind the scenes, we *do* allocate an `ArrayType` at the translation boundary, unseen to a Rust programmer. That, plus the Vec, means two allocations just to mutate an array, even for a fixed-size type!

Unfortunately, pgrx-offered type translations like `Array<'a, T>`, cannot have a lifetime *and* expose a new *safe* function to make it from lifetime-free values! Such API must have the `unsafe` requirement of access-exclusivity for its lifetime, described in functions like `slice::from_raw_parts_mut`[^1], because the lifetime becomes caller-selected. This makes it easy to use a `'static` lifetime with `pg_extern` and expand `unsafe` code that trusts that lifetime.

A `'static` lifetime is always wrong for `palloc`ated types, even with `TopMemoryContext`, since it dies whenever Postgres resets the context and Postgres does have conditions under which it performs such a global reset. The result is various extremely subtle soundness problems are possible, yet the root cause lies in code that most never read. We can solve this by denying the possibility of a caller-selected lifetime. This will require removing some types, ultimately, but first we need an API to migrate to.

This new API is `MemCx<'mcx, T>` and `PBox<'mcx, T>`. Importantly, there is no *safe* route to creating `MemCx<'mcx, T>` with a caller-selected lifetime. One can only reach `MemCx<'mcx, T>` safely as an argument: either pass a closure to `memcx::current_context` or call a new `pg_extern` function via SQL. Either way gives you `&MemCx<'current>`. These let you create a lifetime-bound allocation that can live long enough to return it.

We can already return fixed-size pass-by-reference types, so right now `PBox` is only an optimization. It allows not putting a type on the stack and then immediately moving it directly into a heap allocation. More importantly, it enables writing tests, so it is important ground work for returning de facto unsized values, as they can hide behind `PBox` which is always `Sized`.

[^1]: https://doc.rust-lang.org/std/slice/fn.from_raw_parts_mut.html