### PR TITLE
Add `array::Element` and `callconv::DatumPass`

### DIFF
--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -16,7 +16,10 @@ use bitvec::slice::BitSlice;
 use core::ptr::{self, NonNull};
 use core::slice;
 
+mod element;
 mod port;
+
+pub use element::Element;
 
 /**
 An aligned, dereferenceable `NonNull<ArrayType>` with low-level accessors.

--- a/pgrx/src/array/element.rs
+++ b/pgrx/src/array/element.rs
@@ -1,0 +1,46 @@
+use crate::callconv::DatumPass;
+use crate::datum::BorrowDatum;
+use crate::layout::PassBy;
+use core::ptr;
+
+/// `BorrowDatum` for array elements
+///
+/// # Safety
+/// As BorrowDatum, due to the blanket implementation.
+pub unsafe trait Element {
+    unsafe fn point_from(ptr: ptr::NonNull<u8>) -> ptr::NonNull<Self>;
+
+    /// Cast a pointer to aligned varlena headers to this type
+    ///
+    /// This version allows you to assume the pointer is aligned to, and readable for, 4 bytes.
+    /// This optimization is not required. When in doubt, avoid implementing it, and rely on your
+    /// `point_from` implementation alone.
+    ///
+    /// # Safety
+    /// - This must be correctly invoked for the pointee type, as it may deref.
+    /// - This must be 4-byte aligned!
+    unsafe fn point_from_align4(ptr: ptr::NonNull<u32>) -> ptr::NonNull<Self> {
+        debug_assert!(ptr.is_aligned());
+        unsafe { Element::point_from(ptr.cast()) }
+    }
+
+    /// Optimization for borrowing the referent
+    unsafe fn borrow_unchecked<'dat>(ptr: ptr::NonNull<u8>) -> &'dat Self {
+        unsafe { Element::point_from(ptr).as_ref() }
+    }
+}
+
+unsafe impl<T> BorrowDatum for T
+where
+    T: ?Sized + Element + DatumPass,
+{
+    const PASS: PassBy = <T as DatumPass>::PASS;
+
+    unsafe fn point_from(ptr: ptr::NonNull<u8>) -> std::ptr::NonNull<Self> {
+        unsafe { Element::point_from(ptr) }
+    }
+
+    unsafe fn point_from_align4(ptr: ptr::NonNull<u32>) -> ptr::NonNull<Self> {
+        unsafe { Element::point_from_align4(ptr.cast()) }
+    }
+}

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -1031,3 +1031,8 @@ impl<'fcx> ReturnSetInfoWrapper<'fcx> {
         unsafe { (*self.0).setDesc }
     }
 }
+
+/// Denotes a type that may be passed as a Datum
+pub unsafe trait DatumPass {
+    const PASS: PassBy;
+}

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -1,5 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 use super::*;
+use crate::array::Element;
+use crate::callconv::DatumPass;
 use crate::layout::PassBy;
 use core::{ffi, mem, ptr};
 
@@ -87,13 +89,14 @@ where
 macro_rules! impl_borrow_fixed_len {
     ($($value_ty:ty),*) => {
         $(
-            unsafe impl BorrowDatum for $value_ty {
+            unsafe impl DatumPass for $value_ty {
                 const PASS: PassBy = if mem::size_of::<Self>() <= mem::size_of::<Datum>() {
                     PassBy::Value
                 } else {
                     PassBy::Ref
                 };
-
+            }
+            unsafe impl Element for $value_ty {
                 unsafe fn point_from(ptr: ptr::NonNull<u8>) -> ptr::NonNull<Self> {
                     #[cfg(target_endian = "big")]
                     unsafe {
@@ -120,9 +123,10 @@ impl_borrow_fixed_len! {
 }
 
 /// It is rare to pass CStr via Datums, but not unheard of
-unsafe impl BorrowDatum for ffi::CStr {
+unsafe impl DatumPass for ffi::CStr {
     const PASS: PassBy = PassBy::Ref;
-
+}
+unsafe impl Element for ffi::CStr {
     unsafe fn point_from(ptr: ptr::NonNull<u8>) -> ptr::NonNull<Self> {
         let char_ptr: *mut ffi::c_char = ptr.as_ptr().cast();
         unsafe {


### PR DESCRIPTION
This enables adding `FlatArray` with a correct model of nested arrays for Postgres (i.e. there is no such thing).