### PR TITLE
Add `commands/publicationcmds.h` to generated `pg_sys` bindings

### DIFF
--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -82,6 +82,7 @@
 #include "commands/prepare.h"
 #include "commands/proclang.h"
 #include "commands/progress.h"
+#include "commands/publicationcmds.h"
 #include "commands/seclabel.h"
 #include "commands/tablespace.h"
 #include "commands/tablecmds.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -82,6 +82,7 @@
 #include "commands/prepare.h"
 #include "commands/proclang.h"
 #include "commands/progress.h"
+#include "commands/publicationcmds.h"
 #include "commands/seclabel.h"
 #include "commands/tablespace.h"
 #include "commands/tablecmds.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -83,6 +83,7 @@
 #include "commands/prepare.h"
 #include "commands/proclang.h"
 #include "commands/progress.h"
+#include "commands/publicationcmds.h"
 #include "commands/seclabel.h"
 #include "commands/tablespace.h"
 #include "commands/tablecmds.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -84,6 +84,7 @@
 #include "commands/prepare.h"
 #include "commands/proclang.h"
 #include "commands/progress.h"
+#include "commands/publicationcmds.h"
 #include "commands/seclabel.h"
 #include "commands/tablespace.h"
 #include "commands/tablecmds.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -84,6 +84,7 @@
 #include "commands/prepare.h"
 #include "commands/proclang.h"
 #include "commands/progress.h"
+#include "commands/publicationcmds.h"
 #include "commands/seclabel.h"
 #include "commands/tablespace.h"
 #include "commands/tablecmds.h"

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -84,6 +84,7 @@
 #include "commands/prepare.h"
 #include "commands/proclang.h"
 #include "commands/progress.h"
+#include "commands/publicationcmds.h"
 #include "commands/seclabel.h"
 #include "commands/tablespace.h"
 #include "commands/tablecmds.h"


### PR DESCRIPTION
I was looking to use `pg_sys::AlterPublicationOwner` in a utility extension at PlanetScale and noticed it wasn't included in the generated bindings.

The functions in `publicationcmds.h` seem similarly useful to other command headers like `event_trigger.h`, so I figure including them won't be too controversial.