### PR TITLE
introduce `#[pg_guard(unsafe_entry_thread)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ exclude = [
     "pgrx-examples/wal_decoder",
     "pgrx-examples/errors",
     "pgrx-examples/hooks",
+    "pgrx-examples/pgthread",
     "pgrx-examples/nostd",
     "pgrx-examples/numeric",
     "pgrx-examples/pgtrybuilder",

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -7,13 +7,11 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use crate::{detect_pg_config, env_tracked, is_for_release};
 use bindgen::NonCopyUnionStyle;
 use bindgen::callbacks::{DeriveTrait, EnumVariantValue, ImplementsTrait, MacroParsingBehavior};
 use eyre::{WrapErr, eyre};
-use pgrx_pg_config::{
-    PgConfig, PgConfigSelector, PgMinorVersion, PgVersion, Pgrx, SUPPORTED_VERSIONS,
-    is_supported_major_version,
-};
+use pgrx_pg_config::{PgConfig, PgMinorVersion, PgVersion, Pgrx};
 use quote::{ToTokens, quote};
 use std::cell::RefCell;
 use std::cmp::Ordering;
@@ -161,81 +159,13 @@ pub fn main() -> eyre::Result<()> {
     }
 
     let compile_cshim = env_tracked("CARGO_FEATURE_CSHIM").as_deref() == Some("1");
-    let is_for_release =
-        env_tracked("PGRX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE").as_deref() == Some("1");
-
     let build_paths = BuildPaths::from_env();
 
     eprintln!("build_paths={build_paths:?}");
 
     emit_rerun_if_changed();
 
-    let pg_configs: Vec<(u16, PgConfig)> = if is_for_release {
-        // This does not cross-check config.toml and Cargo.toml versions, as it is release infra.
-        Pgrx::from_config()?.iter(PgConfigSelector::All)
-            .map(|r| r.expect("invalid pg_config"))
-            .map(|c| (c.major_version().expect("invalid major version"), c))
-            .filter_map(|t| {
-                if is_supported_major_version(t.0) {
-                    Some(t)
-                } else {
-                    println!(
-                        "cargo:warning={} contains a configuration for pg{}, which pgrx does not support.",
-                        Pgrx::config_toml()
-                            .expect("Could not get PGRX configuration TOML")
-                            .to_string_lossy(),
-                        t.0
-                    );
-                    None
-                }
-            })
-            .collect()
-    } else {
-        let mut found = Vec::new();
-        for pgver in SUPPORTED_VERSIONS() {
-            if env_tracked(&format!("CARGO_FEATURE_PG{}", pgver.major)).is_some() {
-                found.push(pgver);
-            }
-        }
-        let found_ver = match &found[..] {
-            [ver] => ver,
-            [] => {
-                return Err(eyre!(
-                    "Did not find `pg$VERSION` feature. `pgrx-pg-sys` requires one of {} to be set",
-                    SUPPORTED_VERSIONS()
-                        .iter()
-                        .map(|pgver| format!("`pg{}`", pgver.major))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ));
-            }
-            versions => {
-                return Err(eyre!(
-                    "Multiple `pg$VERSION` features found.\n`--no-default-features` may be required.\nFound: {}",
-                    versions
-                        .iter()
-                        .map(|version| format!("pg{}", version.major))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ));
-            }
-        };
-
-        let found_major = found_ver.major;
-        if let Ok(pg_config) = PgConfig::from_env() {
-            let major_version = pg_config.major_version()?;
-
-            if major_version != found_major {
-                panic!(
-                    "Feature flag `pg{found_major}` does not match version from the environment-described PgConfig (`{major_version}`)"
-                )
-            }
-            vec![(major_version, pg_config)]
-        } else {
-            let specific = Pgrx::from_config()?.get(&format!("pg{}", found_ver.major))?;
-            vec![(found_ver.major, specific)]
-        }
-    };
+    let pg_configs = detect_pg_config()?;
 
     // make sure we're not trying to build any of the yanked postgres versions
     for (_, pg_config) in &pg_configs {
@@ -262,7 +192,7 @@ pub fn main() -> eyre::Result<()> {
                         *pg_major_ver,
                         pg_config,
                         &build_paths,
-                        is_for_release,
+                        is_for_release(),
                         compile_cshim,
                     )
                 })
@@ -901,37 +831,6 @@ fn add_derives(bind: bindgen::Builder) -> bindgen::Builder {
         .derive_hash(false)
         .derive_ord(false)
         .derive_partialord(false)
-}
-
-fn env_tracked(s: &str) -> Option<String> {
-    // a **sorted** list of environment variable keys that cargo might set that we don't need to track
-    // these were picked out, by hand, from: https://doc.rust-lang.org/cargo/reference/environment-variables.html
-    const CARGO_KEYS: &[&str] = &[
-        "BROWSER",
-        "DEBUG",
-        "DOCS_RS",
-        "HOST",
-        "HTTP_PROXY",
-        "HTTP_TIMEOUT",
-        "NUM_JOBS",
-        "OPT_LEVEL",
-        "OUT_DIR",
-        "PATH",
-        "PROFILE",
-        "TARGET",
-        "TERM",
-    ];
-
-    let is_cargo_key =
-        s.starts_with("CARGO") || s.starts_with("RUST") || CARGO_KEYS.binary_search(&s).is_ok();
-
-    if !is_cargo_key {
-        // if it's an envar that cargo gives us, we don't want to ask it to rerun build.rs if it changes
-        // we'll let cargo figure that out for itself, and doing so, depending on the key, seems to
-        // cause cargo to rerun build.rs every time, which is terrible
-        println!("cargo:rerun-if-env-changed={s}");
-    }
-    std::env::var(s).ok()
 }
 
 fn target_env_tracked(s: &str) -> Option<String> {

--- a/pgrx-bindgen/src/lib.rs
+++ b/pgrx-bindgen/src/lib.rs
@@ -1,1 +1,122 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use eyre::eyre;
+use pgrx_pg_config::{
+    PgConfig, PgConfigSelector, Pgrx, SUPPORTED_VERSIONS, is_supported_major_version,
+};
+
 pub mod build;
+
+fn is_for_release() -> bool {
+    env_tracked("PGRX_PG_SYS_GENERATE_BINDINGS_FOR_RELEASE").as_deref() == Some("1")
+}
+
+/// Determines which `pg_config` is to be used, based on a combination of pgrx' internal knowledge
+/// of supported Postgres versions and `cargo` options/feature flags.
+pub fn detect_pg_config() -> eyre::Result<Vec<(u16, PgConfig)>> {
+    let pg_configs: Vec<(u16, PgConfig)> = if is_for_release() {
+        // This does not cross-check config.toml and Cargo.toml versions, as it is release infra.
+        Pgrx::from_config()?.iter(PgConfigSelector::All)
+            .map(|r| r.expect("invalid pg_config"))
+            .map(|c| (c.major_version().expect("invalid major version"), c))
+            .filter_map(|t| {
+                if is_supported_major_version(t.0) {
+                    Some(t)
+                } else {
+                    println!(
+                        "cargo:warning={} contains a configuration for pg{}, which pgrx does not support.",
+                        Pgrx::config_toml()
+                            .expect("Could not get PGRX configuration TOML")
+                            .to_string_lossy(),
+                        t.0
+                    );
+                    None
+                }
+            })
+            .collect()
+    } else {
+        let mut found = Vec::new();
+        for pgver in SUPPORTED_VERSIONS() {
+            if env_tracked(&format!("CARGO_FEATURE_PG{}", pgver.major)).is_some() {
+                found.push(pgver);
+            }
+        }
+        let found_ver = match &found[..] {
+            [ver] => ver,
+            [] => {
+                return Err(eyre!(
+                    "Did not find `pg$VERSION` feature. `pgrx-pg-sys` requires one of {} to be set",
+                    SUPPORTED_VERSIONS()
+                        .iter()
+                        .map(|pgver| format!("`pg{}`", pgver.major))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            versions => {
+                return Err(eyre!(
+                    "Multiple `pg$VERSION` features found.\n`--no-default-features` may be required.\nFound: {}",
+                    versions
+                        .iter()
+                        .map(|version| format!("pg{}", version.major))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                ));
+            }
+        };
+
+        let found_major = found_ver.major;
+        if let Ok(pg_config) = PgConfig::from_env() {
+            let major_version = pg_config.major_version()?;
+
+            if major_version != found_major {
+                panic!(
+                    "Feature flag `pg{found_major}` does not match version from the environment-described PgConfig (`{major_version}`)"
+                )
+            }
+            vec![(major_version, pg_config)]
+        } else {
+            let specific = Pgrx::from_config()?.get(&format!("pg{}", found_ver.major))?;
+            vec![(found_ver.major, specific)]
+        }
+    };
+    Ok(pg_configs)
+}
+
+fn env_tracked(s: &str) -> Option<String> {
+    // a **sorted** list of environment variable keys that cargo might set that we don't need to track
+    // these were picked out, by hand, from: https://doc.rust-lang.org/cargo/reference/environment-variables.html
+    const CARGO_KEYS: &[&str] = &[
+        "BROWSER",
+        "DEBUG",
+        "DOCS_RS",
+        "HOST",
+        "HTTP_PROXY",
+        "HTTP_TIMEOUT",
+        "NUM_JOBS",
+        "OPT_LEVEL",
+        "OUT_DIR",
+        "PATH",
+        "PROFILE",
+        "TARGET",
+        "TERM",
+    ];
+
+    let is_cargo_key =
+        s.starts_with("CARGO") || s.starts_with("RUST") || CARGO_KEYS.binary_search(&s).is_ok();
+
+    if !is_cargo_key {
+        // if it's an envar that cargo gives us, we don't want to ask it to rerun build.rs if it changes
+        // we'll let cargo figure that out for itself, and doing so, depending on the key, seems to
+        // cause cargo to rerun build.rs every time, which is terrible
+        println!("cargo:rerun-if-env-changed={s}");
+    }
+    std::env::var(s).ok()
+}

--- a/pgrx-examples/pgthread/.gitignore
+++ b/pgrx-examples/pgthread/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock
+sql/*
+c_ext/*.o
+c_ext/*.dylib
+c_ext/*.so

--- a/pgrx-examples/pgthread/Cargo.toml
+++ b/pgrx-examples/pgthread/Cargo.toml
@@ -1,0 +1,51 @@
+#LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+#LICENSE
+#LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+#LICENSE
+#LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+#LICENSE
+#LICENSE All rights reserved.
+#LICENSE
+#LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+[package]
+name = "pgthread"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[[bin]]
+name = "pgrx_embed_pgthread"
+path = "./src/bin/pgrx_embed.rs"
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
+pg_test = []
+
+[dependencies]
+pgrx = { path = "../../pgrx", default-features = false }
+
+[dev-dependencies]
+pgrx-tests = { path = "../../pgrx-tests" }
+
+[build-dependencies]
+pgrx-bindgen = { path = "../../pgrx-bindgen" }
+
+# uncomment these if compiling outside of 'pgrx'
+# [profile.dev]
+# panic = "unwind"
+
+# [profile.release]
+# panic = "unwind"
+# opt-level = 3
+# lto = "fat"
+# codegen-units = 1

--- a/pgrx-examples/pgthread/build.rs
+++ b/pgrx-examples/pgthread/build.rs
@@ -1,0 +1,28 @@
+use std::process::{Command, ExitCode};
+
+fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=c_ext/c_ext.c");
+    println!("cargo:rerun-if-changed=c_ext/Makefile");
+
+    let (_, pg_config) =
+        pgrx_bindgen::detect_pg_config()?.pop().unwrap_or_else(|| panic!("no pg_config detected"));
+
+    let child = Command::new("make")
+        .current_dir("c_ext")
+        .env("USE_PGXS", "1")
+        .env("PROFILE", "")
+        .env("PG_CONFIG", pg_config.path().expect("pg_config must have a path"))
+        .spawn()?;
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        eprintln!("{}", std::str::from_utf8(&output.stderr)?);
+        return Ok(ExitCode::from(output.status.code().unwrap() as u8));
+    }
+
+    let output = std::env::current_dir()?.join("c_ext");
+    println!("cargo:rustc-link-arg-cdylib={}/c_ext.o", output.display());
+    println!("cargo:rustc-link-arg-cdylib=-Wl,-u,_start_thread");
+    println!("cargo:rustc-link-arg-cdylib=-Wl,-exported_symbol,_start_thread"); // export
+    println!("cargo:rustc-link-arg-cdylib=-Wl,-exported_symbol,_pg_finfo_start_thread");
+    Ok(ExitCode::SUCCESS)
+}

--- a/pgrx-examples/pgthread/build.rs
+++ b/pgrx-examples/pgthread/build.rs
@@ -1,5 +1,8 @@
 use std::process::{Command, ExitCode};
 
+use std::fs;
+use std::path::PathBuf;
+
 fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=c_ext/c_ext.c");
     println!("cargo:rerun-if-changed=c_ext/Makefile");
@@ -21,8 +24,34 @@ fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
 
     let output = std::env::current_dir()?.join("c_ext");
     println!("cargo:rustc-link-arg-cdylib={}/c_ext.o", output.display());
-    println!("cargo:rustc-link-arg-cdylib=-Wl,-u,_start_thread");
-    println!("cargo:rustc-link-arg-cdylib=-Wl,-exported_symbol,_start_thread"); // export
-    println!("cargo:rustc-link-arg-cdylib=-Wl,-exported_symbol,_pg_finfo_start_thread");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+
+    // Force-export these symbols from the final .so
+    let vers = out_dir.join("exports.map");
+    fs::write(
+        &vers,
+        r#"
+{
+  global:
+    start_thread;
+    pg_finfo_start_thread;
+  local:
+    *;
+};
+"#,
+    )?;
+
+    let target = std::env::var("TARGET")?;
+    if target.contains("apple-darwin") {
+        println!("cargo:rustc-link-arg-cdylib=-Wl,-u,_start_thread");
+        println!("cargo:rustc-link-arg-cdylib=-Wl,-exported_symbol,_start_thread");
+        println!("cargo:rustc-link-arg-cdylib=-Wl,-exported_symbol,_pg_finfo_start_thread");
+    } else if target.contains("unknown-linux-gnu") {
+        println!("cargo:rustc-link-arg-cdylib=-Wl,--undefined=start_thread");
+        println!("cargo:rustc-link-arg-cdylib=-Wl,--undefined=pg_finfo_start_thread");
+        println!("cargo:rustc-link-arg-cdylib=-Wl,--version-script={}", vers.display());
+    }
+
     Ok(ExitCode::SUCCESS)
 }

--- a/pgrx-examples/pgthread/c_ext/Makefile
+++ b/pgrx-examples/pgthread/c_ext/Makefile
@@ -1,0 +1,17 @@
+MODULE_big = c_ext
+OBJS = \
+	$(WIN32RES) \
+	c_ext.o
+
+EXTENSION = c_ext
+PGFILEDESC = "c_ext - pgrx example"
+
+#FOO = $(shell set)
+#$(error $(FOO))
+ifdef USE_PGXS
+PG_CONFIG ?= pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+$(error requires USE_PGXS=1 to compile)
+endif

--- a/pgrx-examples/pgthread/c_ext/c_ext.c
+++ b/pgrx-examples/pgthread/c_ext/c_ext.c
@@ -87,7 +87,7 @@ static void *spi_thread_main(void *arg)
     return NULL;
 }
 
-Datum
+PGDLLEXPORT Datum
 start_thread(PG_FUNCTION_ARGS)
 {
     pthread_t tid;

--- a/pgrx-examples/pgthread/c_ext/c_ext.c
+++ b/pgrx-examples/pgthread/c_ext/c_ext.c
@@ -1,0 +1,109 @@
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "executor/spi.h"
+#include "miscadmin.h"
+#include "utils/memutils.h"
+
+#include <pthread.h>
+
+PG_FUNCTION_INFO_V1(start_thread);
+
+typedef struct ThreadResult
+{
+    int  spi_rc;
+    int  exec_rc;
+    bool ok;
+} ThreadResult;
+
+static void *spi_thread_main(void *arg)
+{
+    ThreadResult *res = (ThreadResult *) arg;
+
+    /*
+     * IMPORTANT: This is not how Postgres is meant to be used.
+     * We do *some* “make SPI less immediately explode” setup anyway.
+     */
+
+    /* Create a private memory context for the thread's work */
+    MemoryContext thread_mcxt =
+        AllocSetContextCreate(TopMemoryContext,
+                              "pthread SPI context",
+                              ALLOCSET_DEFAULT_SIZES);
+
+    /* Create a private resource owner */
+    ResourceOwner thread_owner = ResourceOwnerCreate(NULL, "pthread SPI owner");
+
+    /* Switch global pointers (this is where things get truly unsafe) */
+    MemoryContext old_mcxt = CurrentMemoryContext;
+    ResourceOwner old_owner = CurrentResourceOwner;
+
+    CurrentMemoryContext = thread_mcxt;
+    CurrentResourceOwner = thread_owner;
+
+    res->ok = false;
+    res->spi_rc = -1;
+    res->exec_rc = -1;
+
+    PG_TRY();
+    {
+        res->spi_rc = SPI_connect();
+        if (res->spi_rc != SPI_OK_CONNECT)
+            ereport(ERROR, (errmsg("SPI_connect failed: %d", res->spi_rc)));
+
+        res->exec_rc = SPI_execute("SELECT 1;", true, 0);
+        if (res->exec_rc < 0)
+            ereport(ERROR, (errmsg("SPI_execute failed: %d", res->exec_rc)));
+
+        (void) SPI_finish();
+        res->ok = true;
+    }
+    PG_CATCH();
+    {
+        /*
+         * Don't rethrow; swallow so the main thread can return normally.
+         * (Error state is global; this is still not “clean”.)
+         */
+        FlushErrorState();
+        res->ok = false;
+
+        /* Best effort to unwind SPI if we got that far */
+        (void) SPI_finish();
+    }
+    PG_END_TRY();
+
+    /* Restore globals */
+    CurrentResourceOwner = old_owner;
+    CurrentMemoryContext = old_mcxt;
+
+    /* Cleanup thread-local allocations */
+    ResourceOwnerRelease(thread_owner, RESOURCE_RELEASE_BEFORE_LOCKS, false, false);
+    ResourceOwnerRelease(thread_owner, RESOURCE_RELEASE_LOCKS, false, true);
+    ResourceOwnerRelease(thread_owner, RESOURCE_RELEASE_AFTER_LOCKS, false, false);
+    ResourceOwnerDelete(thread_owner);
+
+    MemoryContextDelete(thread_mcxt);
+
+    return NULL;
+}
+
+Datum
+start_thread(PG_FUNCTION_ARGS)
+{
+    pthread_t tid;
+    ThreadResult res;
+
+    int err = pthread_create(&tid, NULL, spi_thread_main, &res);
+    if (err != 0)
+        ereport(ERROR, (errmsg("pthread_create failed: %d", err)));
+
+    err = pthread_join(tid, NULL);
+    if (err != 0)
+        ereport(ERROR, (errmsg("pthread_join failed: %d", err)));
+
+    if (!res.ok)
+        ereport(ERROR, (errmsg("pthread SPI work failed (spi_rc=%d exec_rc=%d)",
+                               res.spi_rc, res.exec_rc)));
+
+    PG_RETURN_VOID();
+}

--- a/pgrx-examples/pgthread/c_ext/c_ext.control
+++ b/pgrx-examples/pgthread/c_ext/c_ext.control
@@ -1,0 +1,6 @@
+comment = 'c_ext: helper "extension"'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'c_ext'
+relocatable = false
+superuser = true
+trusted = false

--- a/pgrx-examples/pgthread/pgthread.control
+++ b/pgrx-examples/pgthread/pgthread.control
@@ -1,0 +1,6 @@
+comment = 'pgthread:  Created by pgrx'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'pgthread'
+relocatable = false
+superuser = true
+trusted = false

--- a/pgrx-examples/pgthread/src/bin/pgrx_embed.rs
+++ b/pgrx-examples/pgthread/src/bin/pgrx_embed.rs
@@ -1,0 +1,1 @@
+::pgrx::pgrx_embed!();

--- a/pgrx-examples/pgthread/src/lib.rs
+++ b/pgrx-examples/pgthread/src/lib.rs
@@ -1,0 +1,86 @@
+use pgrx::pg_sys::ffi::pg_guard_ffi_boundary;
+use pgrx::prelude::*;
+use std::ffi::CStr;
+
+::pgrx::pg_module_magic!(name, version);
+
+static mut PREV_POST_PARSE_ANALYZE_HOOK: pg_sys::post_parse_analyze_hook_type = None;
+
+// this function is in the "c_ext.c" extension which is built/linked via our "build.rs"
+extension_sql!(
+    r#"
+        create function start_thread() returns void language c as 'pgthread', 'start_thread';
+    "#,
+    name = "start_thread"
+);
+
+#[pg_guard]
+pub unsafe extern "C-unwind" fn _PG_init() {
+    PREV_POST_PARSE_ANALYZE_HOOK = pg_sys::post_parse_analyze_hook;
+    pg_sys::post_parse_analyze_hook = Some(parse_analyze_hook);
+}
+
+#[cfg(feature = "pg13")]
+#[pg_guard(unsafe_entry_thread)]
+unsafe extern "C-unwind" fn parse_analyze_hook(
+    pstate: *mut pg_sys::ParseState,
+    query: *mut pg_sys::Query,
+) {
+    do_the_hook(pstate);
+    if let Some(prev_hook) = PREV_POST_PARSE_ANALYZE_HOOK {
+        pg_guard_ffi_boundary(|| prev_hook(pstate, query));
+    }
+}
+#[cfg(not(feature = "pg13"))]
+#[pg_guard(unsafe_entry_thread)]
+unsafe extern "C-unwind" fn parse_analyze_hook(
+    pstate: *mut pg_sys::ParseState,
+    query: *mut pg_sys::Query,
+    jstate: *mut pg_sys::JumbleState,
+) {
+    do_the_hook(pstate);
+    if let Some(prev_hook) = PREV_POST_PARSE_ANALYZE_HOOK {
+        pg_guard_ffi_boundary(|| prev_hook(pstate, query, jstate));
+    }
+}
+
+unsafe fn do_the_hook(pstate: *mut pg_sys::ParseState) {
+    pg_sys::palloc(1);
+
+    let query_source = CStr::from_ptr((*pstate).p_sourcetext);
+
+    if query_source.eq(c"SELECT 1;") {
+        panic!("oh no");
+    }
+}
+
+#[pg_extern]
+fn hello_pgthread() -> &'static str {
+    "Hello, pgthread"
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_hello_pgthread() {
+        assert_eq!("Hello, pgthread", crate::hello_pgthread());
+    }
+}
+
+/// This module is required by `cargo pgrx test` invocations.
+/// It must be visible at the root of your extension crate.
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    #[must_use]
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}

--- a/pgrx-examples/pgthread/tests/pg_regress/expected/setup.out
+++ b/pgrx-examples/pgthread/tests/pg_regress/expected/setup.out
@@ -1,0 +1,3 @@
+-- this setup file is run immediately after the regression database is (re)created
+-- the file is optional but you likely want to create the extension
+CREATE EXTENSION pgthread;

--- a/pgrx-examples/pgthread/tests/pg_regress/sql/setup.sql
+++ b/pgrx-examples/pgthread/tests/pg_regress/sql/setup.sql
@@ -1,0 +1,3 @@
+-- this setup file is run immediately after the regression database is (re)created
+-- the file is optional but you likely want to create the extension
+CREATE EXTENSION pgthread;

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -31,7 +31,7 @@ mod rewriter;
 /// Declare a function as `#[pg_guard]` to indicate that it is called from a Postgres `extern "C-unwind"`
 /// function so that Rust `panic!()`s (and Postgres `elog(ERROR)`s) will be properly handled by `pgrx`
 #[proc_macro_attribute]
-pub fn pg_guard(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn pg_guard(attr: TokenStream, item: TokenStream) -> TokenStream {
     // get a usable token stream
     let ast = parse_macro_input!(item as syn::Item);
 
@@ -41,7 +41,7 @@ pub fn pg_guard(_attr: TokenStream, item: TokenStream) -> TokenStream {
         Item::ForeignMod(block) => Ok(rewriter::extern_block(block)),
 
         // process top-level functions
-        Item::Fn(func) => rewriter::item_fn_without_rewrite(func),
+        Item::Fn(func) => rewriter::item_fn_without_rewrite(func, attr),
         unknown => Err(syn::Error::new(
             unknown.span(),
             "#[pg_guard] can only be applied to extern \"C-unwind\" blocks and top-level functions",

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -9,6 +9,7 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 extern crate proc_macro;
 
+use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use std::mem;
 use std::ops::Deref;
@@ -41,7 +42,10 @@ pub fn extern_block(block: ItemForeignMod) -> proc_macro2::TokenStream {
     stream
 }
 
-pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+pub fn item_fn_without_rewrite(
+    mut func: ItemFn,
+    attr: TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
     // remember the original visibility and signature classifications as we want
     // to use those for the outer function
     let input_func_name = func.sig.ident.to_string();
@@ -49,6 +53,10 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
     let vis = func.vis.clone();
     let attrs = mem::take(&mut func.attrs);
     let generics = func.sig.generics.clone();
+
+    // looking for this pattern: #[pg_guard(unsafe_entry_thread)]
+    let unsafe_entry_thread =
+        attr.into_iter().find(|tt| tt.to_string() == "unsafe_entry_thread").is_some();
 
     if sig.abi.clone().and_then(|abi| abi.name).is_none_or(|name| name.value() != "C-unwind") {
         panic!("#[pg_guard] must be combined with extern \"C-unwind\"");
@@ -88,7 +96,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
         quote! {}
     };
 
-    let body = if generics.params.is_empty() {
+    let mut body = if generics.params.is_empty() {
         quote! { #func_name(#arg_list) }
     } else {
         let ty = generics
@@ -103,6 +111,18 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
         quote! { #func_name::<#ty>(#arg_list) }
     };
 
+    if unsafe_entry_thread {
+        body = quote! {
+            pgrx::pg_sys::submodules::thread_check::active_thread::clear();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { #body }));
+            pgrx::pg_sys::submodules::thread_check::active_thread::clear();
+            match result {
+                Ok(result) => result,
+                Err(e) => std::panic::resume_unwind(e),
+            }
+        }
+    }
+
     let synthetic = proc_macro2::Span::mixed_site().located_at(func.span());
 
     Ok(quote_spanned! {synthetic=>
@@ -115,7 +135,7 @@ pub fn item_fn_without_rewrite(mut func: ItemFn) -> syn::Result<proc_macro2::Tok
             #[allow(unused_unsafe)]
             unsafe {
                 // NB: this is purposely not spelled `::pgrx` as pgrx itself uses #[pg_guard]
-                pgrx::pg_sys::submodules::panic::pgrx_extern_c_guard(move || #body )
+                pgrx::pg_sys::submodules::panic::pgrx_extern_c_guard(move || { #body } )
             }
         }
     })

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -575,6 +575,9 @@ fn do_ereport(ereport: ErrorReportWithLevel) {
                 pfree(context.cast());
             }
 
+            if level >= PgLogLevel::ERROR {
+                crate::submodules::thread_check::active_thread::clear();
+            }
             errfinish(file, lineno as _, funcname);
 
             if level >= PgLogLevel::ERROR {

--- a/pgrx-pg-sys/src/submodules/thread_check.rs
+++ b/pgrx-pg-sys/src/submodules/thread_check.rs
@@ -22,7 +22,7 @@
 //! future...
 
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 static ACTIVE_THREAD: AtomicUsize = AtomicUsize::new(0);
 #[track_caller]
@@ -37,6 +37,23 @@ pub fn check_active_thread() {
                 thread_id_check_failed();
             }
         }
+    }
+}
+
+pub mod active_thread {
+
+    /// Clear the concept of the "active thread", allowing whatever the current thread is to claim
+    /// that it is the "active thread".
+    ///
+    /// This function exists to help facilitate the `#[pg_guard(unsafe_entry_thread)]` annotation
+    /// on Rust functions that Postgres can call.
+    ///
+    /// Apparently there's at least one Postgres extension, written in C++, that uses threads and
+    /// claims its thread usage is correct and that a thread it creates/manages can safely call
+    /// into Postgres via FFI.  That extension, pg_duckdb, will remain unnamed.
+    #[doc(hidden)]
+    pub fn clear() {
+        super::ACTIVE_THREAD.store(0, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -83,25 +100,21 @@ pub(super) fn is_os_main_thread() -> Option<bool> {
 
 #[track_caller]
 fn init_active_thread(tid: NonZeroUsize) {
-    // Check if we're the actual honest-to-god main thread (if we know). Or at
-    // least make sure we detect cases where we're definitely *not* the OS main
-    // thread.
-    //
-    // This avoids a case where Rust and Postgres disagree about the main
-    // thread. Such cases are almost certainly going to fail the thread check
-    // *eventually*.
-    if is_os_main_thread() == Some(false) {
-        panic!("Attempt to initialize `pgrx` active thread from a thread other than the main");
-    }
+    // Check if we're the thread that was previously set to be the ACTIVE_THREAD.
     match ACTIVE_THREAD.compare_exchange(0, tid.get(), Ordering::Relaxed, Ordering::Relaxed) {
         #[cfg(all(target_family = "unix", not(target_os = "emscripten")))]
         Ok(_) => unsafe {
+            static ATFORK_REGISTERED: AtomicBool = AtomicBool::new(false);
+
             // We won the race. Register an atfork handler to clear the atomic
             // in any child processes we spawn.
-            extern "C" fn clear_in_child() {
-                ACTIVE_THREAD.store(0, Ordering::Relaxed);
+            if !ATFORK_REGISTERED.swap(true, Ordering::Relaxed) {
+                extern "C" fn clear_in_child() {
+                    ACTIVE_THREAD.store(0, Ordering::Relaxed);
+                    ATFORK_REGISTERED.store(false, Ordering::Relaxed);
+                }
+                libc::pthread_atfork(None, None, Some(clear_in_child));
             }
-            libc::pthread_atfork(None, None, Some(clear_in_child));
         },
         #[allow(unreachable_patterns)]
         Ok(_) => (),

--- a/pgrx-pg-sys/src/submodules/thread_check.rs
+++ b/pgrx-pg-sys/src/submodules/thread_check.rs
@@ -40,6 +40,7 @@ pub fn check_active_thread() {
     }
 }
 
+#[doc(hidden)]
 pub mod active_thread {
 
     /// Clear the concept of the "active thread", allowing whatever the current thread is to claim


### PR DESCRIPTION
initial commit of rejiggering how pgrx tracks the "ACTIVE_THREAD".   This is to address issue #2228.

Functions annotated with `#[pg_guard(unsafe_entry_thread)]` do some trickery to reset pgrx' understanding of the "ACTIVE_THREAD" so that whatever thread happens to be calling that function then becomes our understanding of the "ACTIVE_THREAD", thereby allowing pgrx to do Postgres FFI on a thread that isn't the main thread.

The situation behind #2228 is that pg_duckdb, an extension written in C++, uses threads (presumably "safely") within Postgres and if one of those threads does something like SPI, which then causes planner/executor hooks to be called, and one of those hooks is implemented with pgrx, this new `unsafe_entry_thread` tag will let that callback run.  It's basically making an assumption that the caller is properly managing the thread it's on.

There's very little code changes here -- the bulk of the PR is a new example crate/extension with its own little c-shim so that I could manually test Postgres itself kicking off a thread that does SPI that ends up calling into a planner hook setup by the rust/pgrx extension.

I have a need to push this through for $DayJob, so I'm probably going to do that later this week.
