### PR TITLE
include `utils/guc_tables.h`

### DIFF
--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -182,6 +182,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"
+#include "utils/guc_tables.h"
 #include "utils/json.h"
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -183,6 +183,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"
+#include "utils/guc_tables.h"
 #include "utils/json.h"
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -184,6 +184,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"
+#include "utils/guc_tables.h"
 #include "utils/json.h"
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -186,6 +186,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"
+#include "utils/guc_tables.h"
 #include "utils/json.h"
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -186,6 +186,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"
+#include "utils/guc_tables.h"
 #include "utils/json.h"
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -185,6 +185,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/geo_decls.h"
 #include "utils/guc.h"
+#include "utils/guc_tables.h"
 #include "utils/json.h"
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"


### PR DESCRIPTION
It contains [`find_option`](https://github.com/postgres/postgres/blob/REL_16_STABLE/src/include/utils/guc_tables.h#L296), which returns the internal config struct of a GUC.