### PR TITLE
chore: minor lints

### DIFF
--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -83,11 +83,10 @@ impl Cargo {
         let mut cmd = cargo();
 
         // subcommand *must* go first
-        if self.subcmd != "" {
-            cmd.arg(&self.subcmd);
-        } else {
+        if self.subcmd.is_empty() {
             panic!("`Cargo::into_command` requires a subcommand to be set, was: {self:?}")
         }
+        cmd.arg(&self.subcmd);
 
         let Cargo {
             features,

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -435,7 +435,7 @@ pub(crate) fn find_library_file(
                 .map(|filename| filename.to_string())
         })
         .ok_or_else(|| {
-            eyre!("Could not get shared object file `{lib_filename}` from Cargo output.",)
+            eyre!("Could not get shared object file `{lib_filename}` from Cargo output.")
         })?;
     let library_file_path = PathBuf::from(library_file);
 

--- a/cargo-pgrx/src/command/regress.rs
+++ b/cargo-pgrx/src/command/regress.rs
@@ -298,7 +298,7 @@ impl Regress {
                     pgregress_path,
                     dbname,
                     new_test,
-                    &verbosity,
+                    verbosity,
                 )? {
                     self.accept_new_test(manifest_path, &test_result_output, auto)?;
                 }
@@ -513,8 +513,7 @@ fn pg_regress(
         fn make_launcher_script(verbosity: &str) -> eyre::Result<PathBuf> {
             use std::os::unix::fs::PermissionsExt;
 
-            let launcher_script =
-                format!("#! /bin/bash\n$* -v VERBOSITY={}", verbosity.to_string(),).into_bytes();
+            let launcher_script = format!("#! /bin/bash\n$* -v VERBOSITY={verbosity}").into_bytes();
 
             let path = temp_dir().join(format!("pgrx-pg_regress-runner-{}.sh", std::process::id()));
             let mut tmpfile = File::create(&path)?;

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -420,7 +420,7 @@ fn compute_codegen(
         } else {
             let writing = "     Writing".bold().green().to_string();
             out.extend(quote::quote! {
-                eprintln!("{} SQL entities to {}", #writing, "/dev/stdout",);
+                eprintln!("{} SQL entities to {}", #writing, "/dev/stdout");
                 pgrx_sql
                     .write(&mut std::io::stdout())
                     .expect("Could not write SQL to stdout");

--- a/cargo-pgrx/src/command/version.rs
+++ b/cargo-pgrx/src/command/version.rs
@@ -59,10 +59,7 @@ mod rss {
             let mut buf = Vec::new();
             let _count = response.body_mut().as_reader().read_to_end(&mut buf)?;
             let body = String::from_utf8(buf)?;
-            let rss: Rss = match serde_xml_rs::from_str(&body) {
-                Ok(rss) => rss,
-                Err(e) => return Err(e.into()),
-            };
+            let rss: Rss = serde_xml_rs::from_str(&body)?;
 
             let mut versions: BTreeMap<u16, PgVersion> = BTreeMap::from_iter(
                 supported_versions.iter().map(|pgver| (pgver.major, pgver.clone())),

--- a/pgrx-macros/src/rewriter.rs
+++ b/pgrx-macros/src/rewriter.rs
@@ -55,8 +55,7 @@ pub fn item_fn_without_rewrite(
     let generics = func.sig.generics.clone();
 
     // looking for this pattern: #[pg_guard(unsafe_entry_thread)]
-    let unsafe_entry_thread =
-        attr.into_iter().find(|tt| tt.to_string() == "unsafe_entry_thread").is_some();
+    let unsafe_entry_thread = attr.into_iter().any(|tt| tt.to_string() == "unsafe_entry_thread");
 
     if sig.abi.clone().and_then(|abi| abi.name).is_none_or(|name| name.value() != "C-unwind") {
         panic!("#[pg_guard] must be combined with extern \"C-unwind\"");

--- a/pgrx-pg-config/src/cargo.rs
+++ b/pgrx-pg-config/src/cargo.rs
@@ -71,7 +71,7 @@ impl PgrxManifestExt for Manifest {
     fn lib_filename(&self) -> eyre::Result<String> {
         use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
         let lib_name = &self.lib_name()?;
-        Ok(format!("{DLL_PREFIX}{}{DLL_SUFFIX}", lib_name))
+        Ok(format!("{DLL_PREFIX}{lib_name}{DLL_SUFFIX}"))
     }
 }
 

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -82,17 +82,17 @@ where
                     .as_str(),
                 );
 
-                if let Ok(var) = std::env::var("RUST_BACKTRACE") {
-                    if var.eq("1") {
-                        let detail = dberror.detail().unwrap_or("None");
-                        let hint = dberror.hint().unwrap_or("None");
-                        let schema = dberror.hint().unwrap_or("None");
-                        let table = dberror.table().unwrap_or("None");
-                        let more_info = format!(
-                            "\ndetail: {detail}\nhint: {hint}\nschema: {schema}\ntable: {table}"
-                        );
-                        message.push_str(more_info.as_str());
-                    }
+                if let Ok(var) = std::env::var("RUST_BACKTRACE")
+                    && var.eq("1")
+                {
+                    let detail = dberror.detail().unwrap_or("None");
+                    let hint = dberror.hint().unwrap_or("None");
+                    let schema = dberror.hint().unwrap_or("None");
+                    let table = dberror.table().unwrap_or("None");
+                    let more_info = format!(
+                        "\ndetail: {detail}\nhint: {hint}\nschema: {schema}\ntable: {table}"
+                    );
+                    message.push_str(more_info.as_str());
                 }
 
                 Err(eyre!(message))
@@ -176,7 +176,7 @@ pub fn run_test(
         );
     } else if let Some(message) = expected_error {
         // we expected an ERROR, but didn't get one
-        return Err(eyre!("Expected error: {message}"));
+        Err(eyre!("Expected error: {message}"))
     } else {
         Ok(())
     }
@@ -559,10 +559,10 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
         command.arg("--time-stamp=yes");
         command.arg("--error-markers=VALGRINDERROR-BEGIN,VALGRINDERROR-END");
         command.arg("--trace-children=yes");
-        if let Ok(path) = valgrind_suppressions_path(&pg_config) {
-            if let Ok(true) = std::fs::exists(&path) {
-                command.arg(format!("--suppressions={}", path.display()));
-            }
+        if let Ok(path) = valgrind_suppressions_path(&pg_config)
+            && let Ok(true) = std::fs::exists(&path)
+        {
+            command.arg(format!("--suppressions={}", path.display()));
         }
         command.arg(pg_config.postmaster_path()?.display().to_string());
         file.write_all(format!("{command:?}").as_bytes())?;
@@ -658,10 +658,10 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
             use std::io::Read;
             let mut buffer = vec![0u8; 4096];
             let mut result = Vec::new();
-            if let Ok(n) = pipe.read(&mut buffer) {
-                if n > 0 {
-                    result.extend(&buffer[..n]);
-                }
+            if let Ok(n) = pipe.read(&mut buffer)
+                && n > 0
+            {
+                result.extend(&buffer[..n]);
             }
             result
         };

--- a/pgrx-tests/src/tests/array_borrowed.rs
+++ b/pgrx-tests/src/tests/array_borrowed.rs
@@ -398,7 +398,7 @@ mod tests {
     #[pg_test]
     fn borrow_test_cstring_array() -> Result<(), pgrx::spi::Error> {
         let strings = Spi::get_one::<bool>("SELECT borrow_validate_cstring_array(ARRAY['one', 'two', NULL, 'four', 'five', NULL, 'seven', NULL, NULL]::cstring[])")?.expect("datum was NULL");
-        assert_eq!(strings, true);
+        assert!(strings);
         Ok(())
     }
 

--- a/pgrx-tests/src/tests/trigger_tests.rs
+++ b/pgrx-tests/src/tests/trigger_tests.rs
@@ -194,12 +194,12 @@ mod tests {
         let new = trigger.new().ok_or(TriggerError::NullTriggerTuple)?;
 
         for index in 1..(new.len() + 1) {
-            if let Some(val) = new.get_by_index::<&str>(index.try_into()?)? {
-                if val == "Bear" {
-                    // We intercepted a bear! Avoid this update, return `old` instead.
-                    let old = trigger.old().ok_or(TriggerError::NullTriggerTuple)?;
-                    return Ok(Some(old));
-                }
+            if let Some(val) = new.get_by_index::<&str>(index.try_into()?)?
+                && val == "Bear"
+            {
+                // We intercepted a bear! Avoid this update, return `old` instead.
+                let old = trigger.old().ok_or(TriggerError::NullTriggerTuple)?;
+                return Ok(Some(old));
             }
         }
 

--- a/pgrx/src/datetime/date.rs
+++ b/pgrx/src/datetime/date.rs
@@ -148,8 +148,8 @@ impl Date {
     /// This function will panic, aborting the current transaction, if any part is out-of-bounds.
     pub fn new_unchecked(year: isize, month: u8, day: u8) -> Self {
         let year: i32 = year.try_into().expect("invalid year");
-        let month: i32 = month.try_into().expect("invalid month");
-        let day: i32 = day.try_into().expect("invalid day");
+        let month: i32 = month.into();
+        let day: i32 = day.into();
 
         unsafe {
             direct_function_call(
@@ -241,8 +241,7 @@ impl Date {
     /// Return the date as a stack-allocated [`libc::time_t`] instance
     #[inline]
     pub fn to_posix_time(&self) -> libc::time_t {
-        let secs_per_day: libc::time_t =
-            pg_sys::SECS_PER_DAY.try_into().expect("couldn't fit time into time_t");
+        let secs_per_day: libc::time_t = pg_sys::SECS_PER_DAY.into();
         libc::time_t::from(self.to_unix_epoch_days()) * secs_per_day
     }
 

--- a/pgrx/src/datetime/time.rs
+++ b/pgrx/src/datetime/time.rs
@@ -144,8 +144,8 @@ impl Time {
     ///
     /// This function panics if any part is out-of-bounds
     pub fn new_unchecked(hour: u8, minute: u8, second: f64) -> Time {
-        let hour: i32 = hour.try_into().expect("invalid hour");
-        let minute: i32 = minute.try_into().expect("invalid minute");
+        let hour: i32 = hour.into();
+        let minute: i32 = minute.into();
 
         unsafe {
             direct_function_call(

--- a/pgrx/src/datum/numeric.rs
+++ b/pgrx/src/datum/numeric.rs
@@ -165,8 +165,8 @@ impl AnyNumeric {
         unsafe {
             let s = pg_sys::numeric_normalize(self.as_ptr() as *mut _);
             let cstr = CStr::from_ptr(s);
-            let normalized = cstr.to_str().unwrap();
-            normalized
+
+            (cstr.to_str().unwrap()) as _
         }
     }
 

--- a/pgrx/src/memcx.rs
+++ b/pgrx/src/memcx.rs
@@ -72,6 +72,12 @@ impl<'mcx> MemCx<'mcx> {
 pub struct OutOfMemory {
     _reserve: (),
 }
+impl Default for OutOfMemory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl OutOfMemory {
     pub fn new() -> OutOfMemory {
         OutOfMemory { _reserve: () }

--- a/tools/version-updater/src/main.rs
+++ b/tools/version-updater/src/main.rs
@@ -158,9 +158,7 @@ fn update_files(args: &UpdateFilesArgs) {
             let package_path = workspace_manifest_parent.join(format!("{s}/Cargo.toml"));
             Ok(Manifest::from_path(package_path)?
                 .package
-                .ok_or_else(|| {
-                    cargo_toml::Error::Other("expected package field in workspace member")
-                })?
+                .ok_or({ cargo_toml::Error::Other("expected package field in workspace member") })?
                 .name)
         })
         .collect::<Result<FxHashSet<String>, cargo_toml::Error>>()


### PR DESCRIPTION
I ran this just to see if clippy would flag anything:

```
cargo clippy --all-targets --workspace --fix --allow-dirty --features pg18 -- -W clippy::uninlined_format_args
```

I have a suspicion that a few of these are incorrect - i.e. type casting is not always guaranteed - but if so, there should be an `#[allow(...)]` to highlight that.  I'll wait for the CI to pass first.