### PR TITLE
style: fix `unused-qualifications` lint

### DIFF
--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -83,4 +83,7 @@ rustls = [
 
 [lints.clippy]
 or-fun-call = "allow" # kinda sus lint imo
-too_many_arguments = "allow"
+too-many-arguments = "allow"
+
+[lints.rust]
+unused-qualifications = "warn"

--- a/cargo-pgrx/src/cargo.rs
+++ b/cargo-pgrx/src/cargo.rs
@@ -178,18 +178,18 @@ impl Stdio {
     }
 }
 
-pub(crate) fn cargo() -> std::process::Command {
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    std::process::Command::new(cargo)
+pub(crate) fn cargo() -> process::Command {
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    process::Command::new(cargo)
 }
 
 /// Set some environment variables for use downstream (in `pgrx-test` for
 /// example). Does nothing if already set.
 pub(crate) fn initialize() {
-    match (std::env::var_os("CARGO_PGRX"), std::env::current_exe()) {
+    match (env::var_os("CARGO_PGRX"), env::current_exe()) {
         (None, Ok(path)) => {
             unsafe {
-                std::env::set_var("CARGO_PGRX", path);
+                env::set_var("CARGO_PGRX", path);
             }
             // TODO: Should we set `CARGO_PGRX_{CARGO,RUSTC}` to `RUSTC`/`CARGO`
             // if unset, then prefer those? The issue with `RUSTC`/`CARGO` vars

--- a/cargo-pgrx/src/command/cross/pgrx_target.rs
+++ b/cargo-pgrx/src/command/cross/pgrx_target.rs
@@ -58,7 +58,7 @@ pub(crate) struct PgrxTarget {
 }
 
 impl CommandExecute for PgrxTarget {
-    fn execute(self) -> eyre::Result<()> {
+    fn execute(self) -> Result<()> {
         let mut temp: Option<tempfile::TempDir> = None;
         let temp_path = if let Some(scratch) = &self.scratch_dir {
             &**scratch

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -453,9 +453,9 @@ fn configure_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::
         command.arg(flag);
     }
     command
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .stdin(std::process::Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
         .env("PATH", prefix_path(pgdir))
         .current_dir(pgdir);
     for var in PROCESS_ENV_DENYLIST {
@@ -498,9 +498,9 @@ fn make_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::Resul
 
     command
         .arg("world-bin")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .stdin(std::process::Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
         .current_dir(pgdir);
 
     for var in PROCESS_ENV_DENYLIST {
@@ -542,9 +542,9 @@ fn make_install_postgres(version: &PgConfig, pgdir: &Path, init: &Init) -> eyre:
 
     command
         .arg("install-world-bin")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .stdin(std::process::Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
         .current_dir(pgdir);
     for var in PROCESS_ENV_DENYLIST {
         command.env_remove(var);

--- a/cargo-pgrx/src/command/schema.rs
+++ b/cargo-pgrx/src/command/schema.rs
@@ -178,7 +178,7 @@ pub(crate) fn generate_schema_implicit(
     path: Option<&Path>,
     dot: Option<&Path>,
     output_tracking: &mut Vec<PathBuf>,
-    manifest: cargo_toml::Manifest,
+    manifest: Manifest,
 ) -> eyre::Result<()> {
     let (control_file, _extname) = find_control_file(package_manifest_path)?;
     let lib_name = manifest.lib_name()?;
@@ -292,13 +292,7 @@ fn compute_symbols(obj_file: &object::File<'_>, symbol_prefix: &str) -> eyre::Re
         "  Discovered".bold().green(),
         fns_to_call.len().to_string().bold().cyan(),
         seen_schemas.len().to_string().bold().cyan(),
-        seen_schemas
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len()
-            .to_string()
-            .bold()
-            .cyan(),
+        seen_schemas.iter().collect::<HashSet<_>>().len().to_string().bold().cyan(),
         num_funcs.to_string().bold().cyan(),
         num_types.to_string().bold().cyan(),
         num_enums.to_string().bold().cyan(),

--- a/cargo-pgrx/src/command/upgrade.rs
+++ b/cargo-pgrx/src/command/upgrade.rs
@@ -10,7 +10,6 @@
 use cargo_edit::{CertsSource, Dependency, IndexCache, LocalManifest, registry_url};
 use eyre::eyre;
 use std::path::{Path, PathBuf};
-use toml_edit::KeyMut;
 use tracing::{debug, error, info, warn};
 
 use crate::CommandExecute;
@@ -107,7 +106,7 @@ impl Upgrade {
     fn update_dep(
         &self,
         path: &PathBuf,
-        mut key: KeyMut,
+        mut key: toml_edit::KeyMut,
         dep: &mut toml_edit::Item,
     ) -> eyre::Result<()> {
         let mut index = IndexCache::new(CertsSource::Native);
@@ -260,8 +259,8 @@ impl CommandExecute for Upgrade {
             self.manifest_path.clone().unwrap_or(PathBuf::from("./Cargo.toml")),
         )?;
 
-        let mut manifest = cargo_edit::LocalManifest::find(Some(&path))
-            .map_err(|e| eyre!("Error opening manifest: {e}"))?;
+        let mut manifest =
+            LocalManifest::find(Some(&path)).map_err(|e| eyre!("Error opening manifest: {e}"))?;
 
         // Attempt to determine if this is a workspace and, if so, should we
         // navigate to a crate contained within.

--- a/cargo-pgrx/src/main.rs
+++ b/cargo-pgrx/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> color_eyre::Result<()> {
     // Initialize tracing with tracing-error, and eyre
     let fmt_layer = tracing_subscriber::fmt::Layer::new()
         .with_ansi(stderr_is_tty)
-        .with_writer(std::io::stderr)
+        .with_writer(io::stderr)
         .pretty();
 
     let filter_layer = match EnvFilter::try_from_default_env() {

--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -467,13 +467,10 @@ impl PgConfig {
     }
 
     fn run(&self, arg: &str) -> eyre::Result<String> {
-        if self.known_props.is_some() {
+        if let Some(known_props) = &self.known_props {
             // we have some known properties, so use them.  We'll return an `ErrorKind::InvalidData`
             // if the caller asks for a property we don't have
-            Ok(self
-                .known_props
-                .as_ref()
-                .unwrap()
+            Ok(known_props
                 .get(arg)
                 .ok_or_else(|| {
                     std::io::Error::new(

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -59,11 +59,11 @@ pgrx-bindgen.workspace = true
 # we allow improper_ctypes just to eliminate these warnings:
 #      = note: `#[warn(improper_ctypes)]` on by default
 #      = note: 128-bit integers don't currently have a known stable ABI
-non_camel_case_types = "allow"
-non_snake_case = "allow"
-dead_code = "allow"
-non_upper_case_globals = "allow"
-improper_ctypes = "allow"
-
+dead-code = "allow"
+improper-ctypes = "allow"
+non-camel-case-types = "allow"
+non-snake-case = "allow"
+non-upper-case-globals = "allow"
 unsafe-op-in-unsafe-fn = "allow" # repo-wide issue
 unused-braces = "allow"
+unused-qualifications = "warn"

--- a/pgrx-pg-sys/src/include.rs
+++ b/pgrx-pg-sys/src/include.rs
@@ -5,7 +5,7 @@
 #[cfg(all(feature = "pg13", not(docsrs)))]
 pub(crate) mod pg13 {
     #![allow(clippy::all)]
-    #![allow(unknown_lints, unnecessary_transmutes)]
+    #![allow(unknown_lints, unnecessary_transmutes, unused_qualifications)]
     include!(concat!(env!("OUT_DIR"), "/pg13.rs"));
 }
 #[cfg(all(feature = "pg13", docsrs))]
@@ -14,7 +14,7 @@ pub(crate) mod pg13;
 #[cfg(all(feature = "pg14", not(docsrs)))]
 pub(crate) mod pg14 {
     #![allow(clippy::all)]
-    #![allow(unknown_lints, unnecessary_transmutes)]
+    #![allow(unknown_lints, unnecessary_transmutes, unused_qualifications)]
     include!(concat!(env!("OUT_DIR"), "/pg14.rs"));
 }
 #[cfg(all(feature = "pg14", docsrs))]
@@ -23,7 +23,7 @@ pub(crate) mod pg14;
 #[cfg(all(feature = "pg15", not(docsrs)))]
 pub(crate) mod pg15 {
     #![allow(clippy::all)]
-    #![allow(unknown_lints, unnecessary_transmutes)]
+    #![allow(unknown_lints, unnecessary_transmutes, unused_qualifications)]
     include!(concat!(env!("OUT_DIR"), "/pg15.rs"));
 }
 #[cfg(all(feature = "pg15", docsrs))]
@@ -32,7 +32,7 @@ pub(crate) mod pg15;
 #[cfg(all(feature = "pg16", not(docsrs)))]
 pub(crate) mod pg16 {
     #![allow(clippy::all)]
-    #![allow(unknown_lints, unnecessary_transmutes)]
+    #![allow(unknown_lints, unnecessary_transmutes, unused_qualifications)]
     include!(concat!(env!("OUT_DIR"), "/pg16.rs"));
 }
 #[cfg(all(feature = "pg16", docsrs))]
@@ -41,7 +41,7 @@ pub(crate) mod pg16;
 #[cfg(all(feature = "pg17", not(docsrs)))]
 pub(crate) mod pg17 {
     #![allow(clippy::all)]
-    #![allow(unknown_lints, unnecessary_transmutes)]
+    #![allow(unknown_lints, unnecessary_transmutes, unused_qualifications)]
     include!(concat!(env!("OUT_DIR"), "/pg17.rs"));
 }
 #[cfg(all(feature = "pg17", docsrs))]
@@ -50,7 +50,7 @@ pub(crate) mod pg17;
 #[cfg(all(feature = "pg18", not(docsrs)))]
 pub(crate) mod pg18 {
     #![allow(clippy::all)]
-    #![allow(unknown_lints, unnecessary_transmutes)]
+    #![allow(unknown_lints, unnecessary_transmutes, unused_qualifications)]
     include!(concat!(env!("OUT_DIR"), "/pg18.rs"));
 }
 #[cfg(all(feature = "pg18", docsrs))]

--- a/pgrx-pg-sys/src/libpq.rs
+++ b/pgrx-pg-sys/src/libpq.rs
@@ -1,4 +1,4 @@
-/** Manually-constructed bindings to libpq
+/*! Manually-constructed bindings to libpq
 
 Because pgrx is for extensions which run in the Postgres server, it rarely needs access to libpq.
 However, some server-side extensions need to interact with the reality that clients exist.
@@ -7,7 +7,6 @@ areas of concern that are far beyond what pgrx wants to involve itself with or b
 
 We define some types and signatures here to allow a minimal amount of usage of items from libpq,
 while largely rejecting the notion that we should involve ourselves in security-laden concerns.
-
 */
 
 pub mod be {

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -8,9 +8,9 @@ pub const InvalidOid: crate::Oid = crate::Oid::INVALID;
 pub const InvalidOffsetNumber: super::OffsetNumber = 0;
 pub const FirstOffsetNumber: super::OffsetNumber = 1;
 pub const MaxOffsetNumber: super::OffsetNumber =
-    (super::BLCKSZ as usize / std::mem::size_of::<super::ItemIdData>()) as super::OffsetNumber;
+    (BLCKSZ as usize / size_of::<super::ItemIdData>()) as super::OffsetNumber;
 pub const InvalidBlockNumber: u32 = 0xFFFF_FFFF as crate::BlockNumber;
-pub const VARHDRSZ: usize = std::mem::size_of::<super::int32>();
+pub const VARHDRSZ: usize = size_of::<super::int32>();
 pub const InvalidCommandId: super::CommandId = (!(0 as super::CommandId)) as super::CommandId;
 pub const FirstCommandId: super::CommandId = 0 as super::CommandId;
 pub const InvalidTransactionId: crate::TransactionId = crate::TransactionId::INVALID;
@@ -96,7 +96,7 @@ pub unsafe fn GetMemoryChunkContext(pointer: *mut std::os::raw::c_void) -> pg_sy
             // means it'll have this header before it
             *(pointer
                 .cast::<::std::os::raw::c_char>()
-                .sub(std::mem::size_of::<*mut ::std::os::raw::c_void>())
+                .sub(size_of::<*mut ::std::os::raw::c_void>())
                 .cast())
         };
 
@@ -154,7 +154,7 @@ pub fn get_pg_major_version_string() -> &'static str {
 
 #[inline]
 pub fn get_pg_major_version_num() -> u16 {
-    u16::from_str(super::get_pg_major_version_string()).unwrap()
+    u16::from_str(get_pg_major_version_string()).unwrap()
 }
 
 #[cfg(any(not(target_env = "msvc"), feature = "pg17", feature = "pg18"))]
@@ -297,8 +297,7 @@ pub unsafe fn BufferGetBlock(buffer: crate::Buffer) -> crate::Block {
     if BufferIsLocal(buffer) {
         *crate::LocalBufferBlockPointers.offset(((-buffer) - 1) as isize)
     } else {
-        crate::BufferBlocks.add(((buffer as crate::Size) - 1) * crate::BLCKSZ as usize)
-            as crate::Block
+        crate::BufferBlocks.add(((buffer as crate::Size) - 1) * BLCKSZ as usize) as crate::Block
     }
 }
 
@@ -691,7 +690,7 @@ pub unsafe fn PageGetMaxOffsetNumber(page: pg_sys::Page) -> pg_sys::OffsetNumber
         0
     } else {
         ((*page_header).pd_lower - SizeOfPageHeaderData as u16)
-            / std::mem::size_of::<pg_sys::ItemIdData>() as u16
+            / size_of::<pg_sys::ItemIdData>() as u16
     }
 }
 

--- a/pgrx-pg-sys/src/submodules/ffi.rs
+++ b/pgrx-pg-sys/src/submodules/ffi.rs
@@ -170,7 +170,7 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
         let caller_memxct = pg_sys::CurrentMemoryContext;
         let prev_exception_stack = pg_sys::PG_exception_stack;
         let prev_error_context_stack = pg_sys::error_context_stack;
-        let mut result: std::mem::MaybeUninit<T> = MaybeUninit::uninit();
+        let mut result: MaybeUninit<T> = MaybeUninit::uninit();
         let jump_value = call_with_sigsetjmp(false, |jump_buffer| {
             // Make Postgres' error-handling system aware of our new
             // setjmp/longjmp restore point.

--- a/pgrx-pg-sys/src/submodules/htup.rs
+++ b/pgrx-pg-sys/src/submodules/htup.rs
@@ -278,13 +278,13 @@ unsafe fn fetch_att(T: *mut std::os::raw::c_char, attbyval: bool, attlen: i16) -
 
             // NB:  Compiler should solve this branch for us, and we write it like this to avoid
             // code duplication for the case where a Datum isn't 8 bytes wide
-            if SIZEOF_DATUM == 8 && attlen == std::mem::size_of::<Datum>() {
+            if SIZEOF_DATUM == 8 && attlen == size_of::<Datum>() {
                 return *T.cast::<Datum>();
             }
 
-            if attlen == std::mem::size_of::<i32>() {
+            if attlen == size_of::<i32>() {
                 Datum::from(*T.cast::<i32>())
-            } else if attlen == std::mem::size_of::<i16>() {
+            } else if attlen == size_of::<i16>() {
                 Datum::from(*T.cast::<i16>())
             } else {
                 assert_eq!(attlen, 1);

--- a/pgrx-pg-sys/src/submodules/oids.rs
+++ b/pgrx-pg-sys/src/submodules/oids.rs
@@ -120,7 +120,7 @@ impl From<Oid> for u32 {
     }
 }
 
-impl From<Oid> for crate::Datum {
+impl From<Oid> for Datum {
     fn from(oid: Oid) -> Self {
         Datum::from(oid.0)
     }
@@ -168,16 +168,16 @@ impl TryFrom<Oid> for BuiltinOid {
     }
 }
 
-impl TryFrom<crate::Datum> for BuiltinOid {
+impl TryFrom<Datum> for BuiltinOid {
     type Error = NotBuiltinOid;
-    fn try_from(datum: crate::Datum) -> Result<BuiltinOid, NotBuiltinOid> {
+    fn try_from(datum: Datum) -> Result<BuiltinOid, NotBuiltinOid> {
         let uint = u32::try_from(datum.value()).map_err(|_| NotBuiltinOid::TooBig)?;
         BuiltinOid::from_u32(uint)
     }
 }
 
 impl BuiltinOid {
-    pub const fn value(self) -> pg_sys::Oid {
+    pub const fn value(self) -> Oid {
         Oid(self as u32)
     }
 
@@ -218,7 +218,7 @@ impl From<Oid> for PgOid {
 
 impl PgOid {
     #[inline]
-    pub const fn value(self) -> pg_sys::Oid {
+    pub const fn value(self) -> Oid {
         match self {
             PgOid::Invalid => pg_sys::InvalidOid,
             PgOid::Custom(custom) => custom,

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -67,13 +67,7 @@ pub struct ErrorReportLocation {
 
 impl Default for ErrorReportLocation {
     fn default() -> Self {
-        Self {
-            file: std::string::String::from("<unknown>"),
-            funcname: None,
-            line: 0,
-            col: 0,
-            backtrace: None,
-        }
+        Self { file: String::from("<unknown>"), funcname: None, line: 0, col: 0, backtrace: None }
     }
 }
 

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -43,3 +43,6 @@ syntect = { version = "5.2.0", default-features = false, features = ["default-fa
 [lints.clippy]
 assigning-clones = "allow" # wrong diagnosis and wrong suggestions
 too-many-arguments = "allow" # I argue with myself all the time
+
+[lints.rust]
+unused-qualifications = "warn"

--- a/pgrx-sql-entity-graph/src/aggregate/aggregate_type.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/aggregate_type.rs
@@ -27,11 +27,11 @@ use syn::{Expr, Type, parse_quote};
 #[derive(Debug, Clone)]
 pub struct AggregateTypeList {
     pub found: Vec<AggregateType>,
-    pub original: syn::Type,
+    pub original: Type,
 }
 
 impl AggregateTypeList {
-    pub fn new(maybe_type_list: syn::Type) -> Result<Self, syn::Error> {
+    pub fn new(maybe_type_list: Type) -> Result<Self, syn::Error> {
         match &maybe_type_list {
             Type::Tuple(tuple) => {
                 let mut coll = Vec::new();
@@ -75,7 +75,7 @@ pub struct AggregateType {
 }
 
 impl AggregateType {
-    pub fn new(ty: syn::Type) -> Result<Self, syn::Error> {
+    pub fn new(ty: Type) -> Result<Self, syn::Error> {
         let (name_macro, name) = if let Some(name_macro) = get_pgrx_attr_macro("name", &ty) {
             let name_macro = syn::parse2::<NameMacro>(name_macro)?;
             let name = Some(name_macro.ident.clone());

--- a/pgrx-sql-entity-graph/src/aggregate/mod.rs
+++ b/pgrx-sql-entity-graph/src/aggregate/mod.rs
@@ -92,9 +92,9 @@ pub struct PgAggregate {
     type_moving_state: Option<UsedType>,
     type_stype: AggregateType,
     const_ordered_set: bool,
-    const_parallel: Option<syn::Expr>,
-    const_finalize_modify: Option<syn::Expr>,
-    const_moving_finalize_modify: Option<syn::Expr>,
+    const_parallel: Option<Expr>,
+    const_finalize_modify: Option<Expr>,
+    const_moving_finalize_modify: Option<Expr>,
     const_initial_condition: Option<String>,
     const_sort_operator: Option<String>,
     const_moving_intial_condition: Option<String>,
@@ -157,7 +157,7 @@ fn extract_generic_from_trait(item_impl: &ItemImpl) -> Result<&Type, syn::Error>
     }
 }
 
-fn get_generic_type_name(ty: &syn::Type) -> Result<String, syn::Error> {
+fn get_generic_type_name(ty: &Type) -> Result<String, syn::Error> {
     if let Type::Path(type_path) = ty
         && let Some(ident) = type_path.path.segments.last().map(|s| &s.ident)
     {
@@ -312,7 +312,7 @@ impl PgAggregate {
 
         // `Finalize` is an optional value, we default to nothing.
         let impl_type_finalize = get_impl_type_by_name(&item_impl_snapshot, "Finalize");
-        let type_finalize: syn::Type = if let Some(type_finalize) = impl_type_finalize {
+        let type_finalize: Type = if let Some(type_finalize) = impl_type_finalize {
             type_finalize.ty.clone()
         } else {
             item_impl.items.push(parse_quote! {
@@ -629,7 +629,7 @@ impl PgAggregate {
                 get_impl_const_by_name(&item_impl_snapshot, "HYPOTHETICAL")
             {
                 match &value.expr {
-                    syn::Expr::Lit(expr_lit) => match &expr_lit.lit {
+                    Expr::Lit(expr_lit) => match &expr_lit.lit {
                         syn::Lit::Bool(lit) => lit.value,
                         _ => {
                             return Err(syn::Error::new(
@@ -656,7 +656,7 @@ impl PgAggregate {
 impl ToEntityGraphTokens for PgAggregate {
     fn to_entity_graph_tokens(&self) -> TokenStream2 {
         let target_ident = &self.target_ident;
-        let sql_graph_entity_fn_name = syn::Ident::new(
+        let sql_graph_entity_fn_name = Ident::new(
             &format!("__pgrx_internals_aggregate_{}", self.snake_case_target_ident),
             target_ident.span(),
         );
@@ -757,7 +757,7 @@ fn get_target_ident(path: &Path) -> Result<Ident, syn::Error> {
 
 fn get_target_path(item_impl: &ItemImpl) -> Result<Path, syn::Error> {
     let target_ident = match &*item_impl.self_ty {
-        syn::Type::Path(type_path) => {
+        Type::Path(type_path) => {
             let last_segment = type_path.path.segments.last().ok_or_else(|| {
                 syn::Error::new(
                     type_path.span(),
@@ -766,7 +766,7 @@ fn get_target_path(item_impl: &ItemImpl) -> Result<Path, syn::Error> {
             })?;
             if last_segment.ident == "PgVarlena" {
                 match &last_segment.arguments {
-                    syn::PathArguments::AngleBracketed(angled) => {
+                    PathArguments::AngleBracketed(angled) => {
                         let first = angled.args.first().ok_or_else(|| syn::Error::new(
                             type_path.span(),
                             "`#[pg_aggregate]` only works with `PgVarlena` declarations if they have a type contained.",
@@ -876,7 +876,7 @@ fn get_impl_const_by_name<'a>(item_impl: &'a ItemImpl, name: &str) -> Option<&'a
 
 fn get_const_litbool(item: &ImplItemConst) -> Option<bool> {
     match &item.expr {
-        syn::Expr::Lit(expr_lit) => match &expr_lit.lit {
+        Expr::Lit(expr_lit) => match &expr_lit.lit {
             syn::Lit::Bool(lit) => Some(lit.value()),
             _ => None,
         },
@@ -886,18 +886,18 @@ fn get_const_litbool(item: &ImplItemConst) -> Option<bool> {
 
 fn get_const_litstr(item: &ImplItemConst) -> syn::Result<Option<String>> {
     match &item.expr {
-        syn::Expr::Lit(expr_lit) => match &expr_lit.lit {
+        Expr::Lit(expr_lit) => match &expr_lit.lit {
             syn::Lit::Str(lit) => Ok(Some(lit.value())),
             _ => Ok(None),
         },
-        syn::Expr::Call(expr_call) => match &*expr_call.func {
-            syn::Expr::Path(expr_path) => {
+        Expr::Call(expr_call) => match &*expr_call.func {
+            Expr::Path(expr_path) => {
                 let Some(last) = expr_path.path.segments.last() else {
                     return Ok(None);
                 };
                 if last.ident == "Some" {
                     match expr_call.args.first() {
-                        Some(syn::Expr::Lit(expr_lit)) => match &expr_lit.lit {
+                        Some(Expr::Lit(expr_lit)) => match &expr_lit.lit {
                             syn::Lit::Str(lit) => Ok(Some(lit.value())),
                             _ => Ok(None),
                         },
@@ -913,7 +913,7 @@ fn get_const_litstr(item: &ImplItemConst) -> syn::Result<Option<String>> {
     }
 }
 
-fn remap_self_to_target(ty: &mut syn::Type, target: &syn::Ident) {
+fn remap_self_to_target(ty: &mut Type, target: &Ident) {
     if let Type::Path(ty_path) = ty {
         for segment in ty_path.path.segments.iter_mut() {
             if segment.ident == "Self" {
@@ -935,9 +935,9 @@ fn remap_self_to_target(ty: &mut syn::Type, target: &syn::Ident) {
     }
 }
 
-fn get_pgrx_attr_macro(attr_name: &str, ty: &syn::Type) -> Option<TokenStream2> {
+fn get_pgrx_attr_macro(attr_name: &str, ty: &Type) -> Option<TokenStream2> {
     match &ty {
-        syn::Type::Macro(ty_macro) => {
+        Type::Macro(ty_macro) => {
             let mut found_pgrx = false;
             let mut found_attr = false;
             // We don't actually have type resolution here, this is a "Best guess".

--- a/pgrx-sql-entity-graph/src/finfo.rs
+++ b/pgrx-sql-entity-graph/src/finfo.rs
@@ -6,7 +6,7 @@ use syn::{self, ItemFn, spanned::Spanned};
 ///
 /// Equivalent to PG_FUNCTION_INFO_V1, Postgres will sprintf the fn ident, then `dlsym(so, expected_name)`,
 /// so it is important to pass exactly the ident that you want to have the record associated with!
-pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
+pub fn finfo_v1_tokens(ident: Ident) -> syn::Result<ItemFn> {
     let finfo_name = format_ident!("pg_finfo_{ident}");
     let tokens = quote! {
         #[unsafe(no_mangle)]
@@ -20,7 +20,7 @@ pub fn finfo_v1_tokens(ident: proc_macro2::Ident) -> syn::Result<ItemFn> {
 }
 
 pub fn finfo_v1_extern_c(
-    original: &syn::ItemFn,
+    original: &ItemFn,
     fcinfo: Ident,
     contents: TokenStream,
 ) -> syn::Result<ItemFn> {

--- a/pgrx-sql-entity-graph/src/mapping.rs
+++ b/pgrx-sql-entity-graph/src/mapping.rs
@@ -44,7 +44,7 @@ impl RustSqlMapping {
         Self {
             rust: core::any::type_name::<T>().to_string(),
             sql: sql.to_string(),
-            id: core::any::TypeId::of::<T>(),
+            id: TypeId::of::<T>(),
         }
     }
 }

--- a/pgrx-sql-entity-graph/src/pg_extern/argument.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/argument.rs
@@ -25,7 +25,7 @@ use syn::{FnArg, Pat, spanned::Spanned};
 /// It is created during [`PgExtern`](crate::PgExtern) parsing.
 #[derive(Debug, Clone)]
 pub struct PgExternArgument {
-    pub fn_arg: syn::FnArg,
+    pub fn_arg: FnArg,
     pub pat: syn::Ident,
     pub used_ty: UsedType,
 }
@@ -33,18 +33,15 @@ pub struct PgExternArgument {
 impl PgExternArgument {
     pub fn build(fn_arg: FnArg) -> Result<Self, syn::Error> {
         match &fn_arg {
-            syn::FnArg::Typed(pat) => Self::build_from_pat_type(fn_arg.clone(), pat.clone()),
-            syn::FnArg::Receiver(_) => {
+            FnArg::Typed(pat) => Self::build_from_pat_type(fn_arg.clone(), pat.clone()),
+            FnArg::Receiver(_) => {
                 // FIXME: Add a UI test for this
                 Err(syn::Error::new(fn_arg.span(), "Unable to parse FnArg that is Self"))
             }
         }
     }
 
-    pub fn build_from_pat_type(
-        fn_arg: syn::FnArg,
-        value: syn::PatType,
-    ) -> Result<Self, syn::Error> {
+    pub fn build_from_pat_type(fn_arg: FnArg, value: syn::PatType) -> Result<Self, syn::Error> {
         let identifier = match *value.pat {
             Pat::Ident(ref p) => p.ident.clone(),
             Pat::Reference(ref p_ref) => match *p_ref.pat {

--- a/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/entity/mod.rs
@@ -268,7 +268,7 @@ impl ToSql for PgExternEntity {
                     Err(err) => return Err(err).wrap_err("Error mapping return SQL"),
                 };
 
-                for (idx, returning::PgExternReturnEntityIteratedItem { ty, name: col_name }) in
+                for (idx, PgExternReturnEntityIteratedItem { ty, name: col_name }) in
                     table_items.iter().enumerate()
                 {
                     let graph_index =

--- a/pgrx-sql-entity-graph/src/pg_extern/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/mod.rs
@@ -392,12 +392,9 @@ impl PgExtern {
         let func_name = &signature.ident;
         // we do this odd dance so we can pass the same ident to macros that don't know each other
         let synthetic_ident_span = Span::mixed_site().located_at(signature.ident.span());
-        let fcinfo_ident = syn::Ident::new("fcinfo", synthetic_ident_span);
-        let mut lifetimes = signature
-            .generics
-            .lifetimes()
-            .cloned()
-            .collect::<syn::punctuated::Punctuated<_, Comma>>();
+        let fcinfo_ident = Ident::new("fcinfo", synthetic_ident_span);
+        let mut lifetimes =
+            signature.generics.lifetimes().cloned().collect::<Punctuated<_, Comma>>();
         // we pick an arbitrary lifetime from the provided signature of the fn, if available,
         // so lifetime-bound fn are easier to write with pgrx
         let fc_lt = lifetimes
@@ -414,7 +411,7 @@ impl PgExtern {
         let args = &self.inputs;
         // for unclear reasons the linker vomits if we don't do this
         let arg_pats = args.iter().map(|v| format_ident!("{}_", &v.pat)).collect::<Vec<_>>();
-        let args_ident = proc_macro2::Ident::new("_args", Span::call_site());
+        let args_ident = Ident::new("_args", Span::call_site());
         let arg_fetches = arg_pats.iter().map(|pat| {
                 quote_spanned!{ pat.span() =>
                     let #pat = #args_ident.next_arg_unchecked().unwrap_or_else(|| panic!("unboxing {} argument failed", stringify!(#pat)));

--- a/pgrx-sql-entity-graph/src/pg_extern/returning.rs
+++ b/pgrx-sql-entity-graph/src/pg_extern/returning.rs
@@ -42,14 +42,14 @@ pub enum Returning {
 }
 
 impl Returning {
-    fn parse_type_macro(type_macro: &mut syn::TypeMacro) -> Result<Returning, syn::Error> {
+    fn parse_type_macro(type_macro: &mut syn::TypeMacro) -> Result<Returning, Error> {
         let mac = &type_macro.mac;
         let opt_archetype = mac.path.segments.last().map(|archetype| archetype.ident.to_string());
         match opt_archetype.as_deref() {
             Some("composite_type") => {
-                Ok(Returning::Type(UsedType::new(syn::Type::Macro(type_macro.clone()))?))
+                Ok(Returning::Type(UsedType::new(Type::Macro(type_macro.clone()))?))
             }
-            _ => Err(syn::Error::new(
+            _ => Err(Error::new(
                 type_macro.span(),
                 "type macros other than `composite_type!` are not yet implemented",
             )),
@@ -60,7 +60,7 @@ impl Returning {
         let mut ty = Box::new(ty.clone());
 
         match &mut *ty {
-            syn::Type::Path(typepath) => {
+            Type::Path(typepath) => {
                 let is_option = typepath.last_ident_is("Option");
                 let is_result = typepath.last_ident_is("Result");
                 let mut is_setof_iter = typepath.last_ident_is("SetOfIterator");
@@ -70,19 +70,19 @@ impl Returning {
                 if is_option || is_result || is_setof_iter || is_table_iter {
                     let option_inner_path = if is_option || is_result {
                         match path.segments.last_mut().map(|s| &mut s.arguments) {
-                            Some(syn::PathArguments::AngleBracketed(args)) => {
+                            Some(PathArguments::AngleBracketed(args)) => {
                                 let args_span = args.span();
                                 match args.args.first_mut() {
-                                    Some(syn::GenericArgument::Type(syn::Type::Path(
-                                        syn::TypePath { qself: _, path },
-                                    ))) => path.clone(),
-                                    Some(syn::GenericArgument::Type(_)) => {
-                                        let used_ty =
-                                            UsedType::new(syn::Type::Path(typepath.clone()))?;
+                                    Some(GenericArgument::Type(Type::Path(syn::TypePath {
+                                        qself: _,
+                                        path,
+                                    }))) => path.clone(),
+                                    Some(GenericArgument::Type(_)) => {
+                                        let used_ty = UsedType::new(Type::Path(typepath.clone()))?;
                                         return Ok(Returning::Type(used_ty));
                                     }
                                     other => {
-                                        return Err(syn::Error::new(
+                                        return Err(Error::new(
                                             other.as_ref().map(|s| s.span()).unwrap_or(args_span),
                                             format!(
                                                 "Got unexpected generic argument for Option inner: {other:?}"
@@ -92,7 +92,7 @@ impl Returning {
                                 }
                             }
                             other => {
-                                return Err(syn::Error::new(
+                                return Err(Error::new(
                                     other.span(),
                                     format!(
                                         "Got unexpected path argument for Option inner: {other:?}"
@@ -114,7 +114,7 @@ impl Returning {
                             let Some(GenericArgument::Type(Type::Path(this_path))) =
                                 generics.args.last()
                             else {
-                                return Err(syn::Error::new_spanned(
+                                return Err(Error::new_spanned(
                                     generics,
                                     "where's the generic args?",
                                 ));
@@ -133,21 +133,21 @@ impl Returning {
                     if is_setof_iter {
                         let last_path_segment = option_inner_path.segments.last();
                         let used_ty = match &last_path_segment.map(|ps| &ps.arguments) {
-                            Some(syn::PathArguments::AngleBracketed(args)) => {
+                            Some(PathArguments::AngleBracketed(args)) => {
                                 match args.args.last().expect("should have one arg?") {
-                                    syn::GenericArgument::Type(ty) => match ty {
+                                    GenericArgument::Type(ty) => match ty {
                                         Type::Path(_) | Type::Macro(_) | Type::Reference(_) => {
                                             UsedType::new(ty.clone())?
                                         }
                                         ty => {
-                                            return Err(syn::Error::new(
+                                            return Err(Error::new(
                                                 ty.span(),
                                                 "SetOf Iterator must have an item",
                                             ));
                                         }
                                     },
                                     other => {
-                                        return Err(syn::Error::new(
+                                        return Err(Error::new(
                                             other.span(),
                                             format!(
                                                 "Got unexpected generic argument for SetOfIterator: {other:?}"
@@ -157,7 +157,7 @@ impl Returning {
                                 }
                             }
                             other => {
-                                return Err(syn::Error::new(
+                                return Err(Error::new(
                                     other
                                         .map(|s| s.span())
                                         .unwrap_or_else(proc_macro2::Span::call_site),
@@ -173,21 +173,21 @@ impl Returning {
                         let mut iterated_items = vec![];
 
                         match &mut last_path_segment.arguments {
-                            syn::PathArguments::AngleBracketed(args) => {
+                            PathArguments::AngleBracketed(args) => {
                                 match args.args.last_mut().unwrap() {
-                                    syn::GenericArgument::Type(syn::Type::Tuple(type_tuple)) => {
+                                    GenericArgument::Type(Type::Tuple(type_tuple)) => {
                                         for elem in &type_tuple.elems {
                                             match &elem {
-                                                syn::Type::Path(path) => {
+                                                Type::Path(path) => {
                                                     let iterated_item = ReturningIteratedItem {
                                                         name: None,
-                                                        used_ty: UsedType::new(syn::Type::Path(
+                                                        used_ty: UsedType::new(Type::Path(
                                                             path.clone(),
                                                         ))?,
                                                     };
                                                     iterated_items.push(iterated_item);
                                                 }
-                                                syn::Type::Macro(type_macro) => {
+                                                Type::Macro(type_macro) => {
                                                     let mac = &type_macro.mac;
                                                     let archetype =
                                                         mac.path.segments.last().unwrap();
@@ -207,7 +207,7 @@ impl Returning {
                                                                 ReturningIteratedItem {
                                                                     name: None,
                                                                     used_ty: UsedType::new(
-                                                                        syn::Type::Macro(
+                                                                        Type::Macro(
                                                                             type_macro.clone(),
                                                                         ),
                                                                     )?,
@@ -216,7 +216,7 @@ impl Returning {
                                                         }
                                                     }
                                                 }
-                                                reference @ syn::Type::Reference(_) => {
+                                                reference @ Type::Reference(_) => {
                                                     let iterated_item = ReturningIteratedItem {
                                                         name: None,
                                                         used_ty: UsedType::new(
@@ -226,7 +226,7 @@ impl Returning {
                                                     iterated_items.push(iterated_item);
                                                 }
                                                 ty => {
-                                                    return Err(syn::Error::new(
+                                                    return Err(Error::new(
                                                         ty.span(),
                                                         "Table Iterator must have an item",
                                                     ));
@@ -234,9 +234,9 @@ impl Returning {
                                             };
                                         }
                                     }
-                                    syn::GenericArgument::Lifetime(_) => (),
+                                    GenericArgument::Lifetime(_) => (),
                                     other => {
-                                        return Err(syn::Error::new(
+                                        return Err(Error::new(
                                             other.span(),
                                             format!("Got unexpected generic argument: {other:?}"),
                                         ));
@@ -244,7 +244,7 @@ impl Returning {
                                 };
                             }
                             other => {
-                                return Err(syn::Error::new(
+                                return Err(Error::new(
                                     other.span(),
                                     format!("Got unexpected path argument: {other:?}"),
                                 ));
@@ -252,37 +252,36 @@ impl Returning {
                         };
                         Ok(Returning::Iterated { tys: iterated_items })
                     } else {
-                        let used_ty = UsedType::new(syn::Type::Path(typepath.clone()))?;
+                        let used_ty = UsedType::new(Type::Path(typepath.clone()))?;
                         Ok(Returning::Type(used_ty))
                     }
                 } else {
-                    let used_ty = UsedType::new(syn::Type::Path(typepath.clone()))?;
+                    let used_ty = UsedType::new(Type::Path(typepath.clone()))?;
                     Ok(Returning::Type(used_ty))
                 }
             }
-            syn::Type::Reference(ty_ref) => {
-                let used_ty = UsedType::new(syn::Type::Reference(ty_ref.clone()))?;
+            Type::Reference(ty_ref) => {
+                let used_ty = UsedType::new(Type::Reference(ty_ref.clone()))?;
                 Ok(Returning::Type(used_ty))
             }
-            syn::Type::Macro(type_macro) => Self::parse_type_macro(type_macro),
-            syn::Type::Paren(type_paren) => match &mut *type_paren.elem {
-                syn::Type::Macro(type_macro) => Self::parse_type_macro(type_macro),
-                other => Err(syn::Error::new(
+            Type::Macro(type_macro) => Self::parse_type_macro(type_macro),
+            Type::Paren(type_paren) => match &mut *type_paren.elem {
+                Type::Macro(type_macro) => Self::parse_type_macro(type_macro),
+                other => Err(Error::new(
                     other.span(),
                     format!("Got unknown return type (type_paren): {type_paren:?}"),
                 )),
             },
-            syn::Type::Group(tg) => Self::match_type(&tg.elem),
-            other => Err(syn::Error::new(
-                other.span(),
-                format!("Got unknown return type (other): {other:?}"),
-            )),
+            Type::Group(tg) => Self::match_type(&tg.elem),
+            other => {
+                Err(Error::new(other.span(), format!("Got unknown return type (other): {other:?}")))
+            }
         }
     }
 }
 
 impl TryFrom<&syn::ReturnType> for Returning {
-    type Error = syn::Error;
+    type Error = Error;
 
     fn try_from(value: &syn::ReturnType) -> Result<Self, Self::Error> {
         match &value {
@@ -348,19 +347,19 @@ pub struct NameMacro {
 }
 
 impl Parse for NameMacro {
-    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+    fn parse(input: ParseStream) -> Result<Self, Error> {
         let ident = input
             .parse::<syn::Ident>()
             .map(|v| v.to_string())
             // Avoid making folks unable to use rust keywords.
-            .or_else(|_| input.parse::<syn::Token![type]>().map(|_| String::from("type")))
-            .or_else(|_| input.parse::<syn::Token![mod]>().map(|_| String::from("mod")))
-            .or_else(|_| input.parse::<syn::Token![extern]>().map(|_| String::from("extern")))
-            .or_else(|_| input.parse::<syn::Token![async]>().map(|_| String::from("async")))
-            .or_else(|_| input.parse::<syn::Token![crate]>().map(|_| String::from("crate")))
-            .or_else(|_| input.parse::<syn::Token![use]>().map(|_| String::from("use")))?;
+            .or_else(|_| input.parse::<Token![type]>().map(|_| String::from("type")))
+            .or_else(|_| input.parse::<Token![mod]>().map(|_| String::from("mod")))
+            .or_else(|_| input.parse::<Token![extern]>().map(|_| String::from("extern")))
+            .or_else(|_| input.parse::<Token![async]>().map(|_| String::from("async")))
+            .or_else(|_| input.parse::<Token![crate]>().map(|_| String::from("crate")))
+            .or_else(|_| input.parse::<Token![use]>().map(|_| String::from("use")))?;
         let _comma: Token![,] = input.parse()?;
-        let ty: syn::Type = input.parse()?;
+        let ty: Type = input.parse()?;
 
         let used_ty = UsedType::new(ty)?;
 

--- a/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
+++ b/pgrx-sql-entity-graph/src/pg_trigger/mod.rs
@@ -28,7 +28,7 @@ use syn::{ItemFn, Token, spanned::Spanned};
 
 #[derive(Debug, Clone)]
 pub struct PgTrigger {
-    func: syn::ItemFn,
+    func: ItemFn,
     to_sql_config: ToSqlConfig,
 }
 

--- a/pgrx-sql-entity-graph/src/to_sql/entity.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/entity.rs
@@ -113,22 +113,22 @@ impl ToSqlConfigEntity {
     }
 }
 
-impl std::cmp::PartialOrd for ToSqlConfigEntity {
+impl PartialOrd for ToSqlConfigEntity {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
-impl std::cmp::Ord for ToSqlConfigEntity {
+impl Ord for ToSqlConfigEntity {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.fields().cmp(&other.fields())
     }
 }
-impl std::cmp::PartialEq for ToSqlConfigEntity {
+impl PartialEq for ToSqlConfigEntity {
     fn eq(&self, other: &Self) -> bool {
         self.fields() == other.fields()
     }
 }
-impl std::cmp::Eq for ToSqlConfigEntity {}
+impl Eq for ToSqlConfigEntity {}
 impl std::hash::Hash for ToSqlConfigEntity {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.fields().hash(state);

--- a/pgrx-sql-entity-graph/src/to_sql/mod.rs
+++ b/pgrx-sql-entity-graph/src/to_sql/mod.rs
@@ -45,11 +45,10 @@ pub trait ToSql {
 ///
 /// Implementations can invoke `ToSql::to_sql(entity, context)` on the unwrapped SqlGraphEntity
 /// type should they wish to delegate to the default behavior for any reason.
-pub type ToSqlFn =
-    fn(
-        &SqlGraphEntity,
-        &PgrxSql,
-    ) -> std::result::Result<String, Box<dyn std::error::Error + Send + Sync + 'static>>;
+pub type ToSqlFn = fn(
+    &SqlGraphEntity,
+    &PgrxSql,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync + 'static>>;
 
 /// A parsed `sql` option from a `pgrx` related procedural macro.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -139,7 +139,7 @@ impl UsedType {
                 match ident_string.as_str() {
                     "Result" => {
                         if let syn::PathArguments::AngleBracketed(angles) = &last_segment.arguments
-                            && let syn::GenericArgument::Type(inner_ty) =
+                            && let GenericArgument::Type(inner_ty) =
                                 angles.args.first().ok_or(syn::Error::new(
                                     angles.span(),
                                     "No inner arg for Result<T, E> found",
@@ -187,11 +187,9 @@ impl UsedType {
                     "Option" => {
                         // Option<VariadicArray<T>>
                         if let syn::PathArguments::AngleBracketed(angles) = &last_segment.arguments
-                            && let syn::GenericArgument::Type(inner_ty) =
-                                angles.args.first().ok_or(syn::Error::new(
-                                    angles.span(),
-                                    "No inner arg for Option<T> found",
-                                ))?
+                            && let GenericArgument::Type(inner_ty) = angles.args.first().ok_or(
+                                syn::Error::new(angles.span(), "No inner arg for Option<T> found"),
+                            )?
                         {
                             match inner_ty {
                                 // Option<VariadicArray<T>>
@@ -250,7 +248,7 @@ impl UsedType {
             && let syn::Type::Path(tp) = &resolved_ty
             && let Some(first_segment) = tp.path.segments.first()
             && let syn::PathArguments::AngleBracketed(ab) = &first_segment.arguments
-            && let Some(syn::GenericArgument::Type(ty)) = ab.args.first()
+            && let Some(GenericArgument::Type(ty)) = ab.args.first()
         {
             resolved_ty_inner = Some(ty.clone());
         }
@@ -342,7 +340,7 @@ fn resolve_vec_inner(
         .ok_or(syn::Error::new(original.span(), "Could not read last segment of path"))?;
 
     if let syn::PathArguments::AngleBracketed(path_arg) = &last.arguments
-        && let Some(syn::GenericArgument::Type(ty)) = path_arg.args.last()
+        && let Some(GenericArgument::Type(ty)) = path_arg.args.last()
     {
         match ty.clone() {
             syn::Type::Macro(macro_pat) => {
@@ -400,7 +398,7 @@ fn resolve_variadic_array_inner(
 
     if let syn::PathArguments::AngleBracketed(ref mut path_arg) = last.arguments
         // TODO: Lifetime????
-        && let Some(syn::GenericArgument::Type(ty)) = path_arg.args.last()
+        && let Some(GenericArgument::Type(ty)) = path_arg.args.last()
     {
         match ty.clone() {
             syn::Type::Macro(macro_pat) => {
@@ -457,7 +455,7 @@ fn resolve_array_inner(
         .ok_or(syn::Error::new(original_span, "Could not read last segment of path"))?;
 
     if let syn::PathArguments::AngleBracketed(ref mut path_arg) = last.arguments
-        && let Some(syn::GenericArgument::Type(ty)) = path_arg.args.last()
+        && let Some(GenericArgument::Type(ty)) = path_arg.args.last()
     {
         match ty.clone() {
             syn::Type::Macro(macro_pat) => {
@@ -514,7 +512,7 @@ fn resolve_option_inner(
         .ok_or(syn::Error::new(original.span(), "Could not read last segment of path"))?;
 
     if let syn::PathArguments::AngleBracketed(path_arg) = &last.arguments
-        && let Some(syn::GenericArgument::Type(ty)) = path_arg.args.first()
+        && let Some(GenericArgument::Type(ty)) = path_arg.args.first()
     {
         match ty.clone() {
             syn::Type::Macro(macro_pat) => {
@@ -648,7 +646,7 @@ fn resolve_result_inner(
         }
     }
 
-    if let syn::GenericArgument::Type(ty) = ok_ty {
+    if let GenericArgument::Type(ty) = ok_ty {
         match ty.clone() {
             syn::Type::Macro(macro_pat) => {
                 let mac = &macro_pat.mac;

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -94,8 +94,9 @@ eyre.workspace = true # testing functions that return `eyre::Result`
 trybuild = "1"
 
 [lints.rust]
-unused-lifetimes = "deny"
 unsafe-op-in-unsafe-fn = "allow"
+unused-lifetimes = "deny"
+unused-qualifications = "warn"
 
 [lints.clippy]
 used-underscore-binding = "deny"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -65,14 +65,15 @@ serde.workspace = true # impls on pub types
 serde_cbor = "0.11.2" # derive(PostgresType)
 serde_json.workspace = true # everything JSON
 
-[lints]
-clippy.cast_ptr_alignment = "allow"
-clippy.len_without_is_empty = "allow"
-clippy.missing_safety_doc = "allow"
-clippy.too_many_arguments = "allow"
-clippy.type_complexity = "allow"
-clippy.unnecessary_cast = "allow"
-clippy.needless_lifetimes = "allow"
+[lints.clippy]
+cast-ptr-alignment = "allow"
+len-without-is-empty = "allow"
+missing-safety-doc = "allow"
+needless-lifetimes = "allow"
+too-many-arguments = "allow"
+type-complexity = "allow"
+unnecessary-cast = "allow"
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "allow" # repo-wide issue
+unused-qualifications = "warn"

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -126,8 +126,8 @@ impl RawArray {
         let array = self.ptr.as_ptr();
 
         // outvals for deconstruct_array
-        let mut elements = core::ptr::null_mut();
-        let mut nulls = core::ptr::null_mut();
+        let mut elements = ptr::null_mut();
+        let mut nulls = ptr::null_mut();
         let mut nelems = 0;
 
         unsafe {

--- a/pgrx/src/array/element.rs
+++ b/pgrx/src/array/element.rs
@@ -36,7 +36,7 @@ where
 {
     const PASS: PassBy = <T as DatumPass>::PASS;
 
-    unsafe fn point_from(ptr: ptr::NonNull<u8>) -> std::ptr::NonNull<Self> {
+    unsafe fn point_from(ptr: ptr::NonNull<u8>) -> ptr::NonNull<Self> {
         unsafe { Element::point_from(ptr) }
     }
 

--- a/pgrx/src/array/flat_array.rs
+++ b/pgrx/src/array/flat_array.rs
@@ -170,7 +170,7 @@ where
     pub fn new_empty<'cx>(
         memcx: &MemCx<'cx>,
     ) -> Result<PBox<'cx, FlatArray<'cx, T>>, ArrayAllocError> {
-        let nbytes = mem::size_of::<pg_sys::ArrayType>();
+        let nbytes = size_of::<pg_sys::ArrayType>();
         let ptr = alloc_zeroed_head(memcx, 0, 0, 0, <T as Scalar>::OID)?;
         // SAFETY: it's valid, if 0-dimensional
         Ok(unsafe { PBox::from_raw_in(FlatArray::cast_tailed(ptr), memcx) })
@@ -317,8 +317,7 @@ unsafe impl<T: ?Sized> BorrowDatum for FlatArray<'_, T> {
     const PASS: layout::PassBy = layout::PassBy::Ref;
     unsafe fn point_from(ptr: ptr::NonNull<u8>) -> ptr::NonNull<Self> {
         unsafe {
-            let len =
-                varlena::varsize_any(ptr.as_ptr().cast()) - mem::size_of::<pg_sys::ArrayType>();
+            let len = varlena::varsize_any(ptr.as_ptr().cast()) - size_of::<pg_sys::ArrayType>();
             ptr::NonNull::new_unchecked(
                 ptr::slice_from_raw_parts_mut(ptr.as_ptr(), len) as *mut Self
             )
@@ -394,7 +393,7 @@ where
         } else {
             let borrow = unsafe { T::borrow_unchecked(self.data.add(self.offset)) };
             // As we always have a borrow, we just ask Rust what the array element's size is
-            self.offset += self.align.pad(mem::size_of_val(borrow));
+            self.offset += self.align.pad(size_of_val(borrow));
             Some(Nullable::Valid(borrow))
         }
     }

--- a/pgrx/src/array/port.rs
+++ b/pgrx/src/array/port.rs
@@ -52,7 +52,7 @@ pub(super) const unsafe fn ARR_DIMS(a: *mut pg_sys::ArrayType) -> *mut i32 {
     // ((int *) (((char *) (a)) + sizeof(ArrayType)))
 
     // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
-    unsafe { a.cast::<u8>().add(mem::size_of::<pg_sys::ArrayType>()).cast::<i32>() }
+    unsafe { a.cast::<u8>().add(size_of::<pg_sys::ArrayType>()).cast::<i32>() }
 }
 
 /// Returns the "null bitmap" of the specified array.  If there isn't one (the array contains no nulls)
@@ -75,8 +75,7 @@ pub(super) unsafe fn ARR_NULLBITMAP(a: *mut pg_sys::ArrayType) -> *mut pg_sys::b
     // SAFETY:  caller has asserted that `a` is a properly allocated ArrayType pointer
     unsafe {
         if ARR_HASNULL(a) {
-            a.cast::<u8>()
-                .add(mem::size_of::<pg_sys::ArrayType>() + 2 * mem::size_of::<i32>() * ARR_NDIM(a))
+            a.cast::<u8>().add(size_of::<pg_sys::ArrayType>() + 2 * size_of::<i32>() * ARR_NDIM(a))
         } else {
             ptr::null_mut()
         }
@@ -90,7 +89,7 @@ pub(super) const fn ARR_OVERHEAD_NONULLS(ndims: usize) -> usize {
     // #define ARR_OVERHEAD_NONULLS(ndims) \
     // MAXALIGN(sizeof(ArrayType) + 2 * sizeof(int) * (ndims))
 
-    MAXALIGN(mem::size_of::<pg_sys::ArrayType>() + 2 * mem::size_of::<i32>() * ndims)
+    MAXALIGN(size_of::<pg_sys::ArrayType>() + 2 * size_of::<i32>() * ndims)
 }
 
 /// # Safety

--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -285,13 +285,13 @@ where
             PassBy::Value => ptr::addr_of!(arg.0.raw_args()[arg.1].value).cast_mut().cast(),
         };
         unsafe {
-            let ptr = ptr::NonNull::new_unchecked(ptr);
+            let ptr = NonNull::new_unchecked(ptr);
             T::borrow_unchecked(ptr)
         }
     }
 
     unsafe fn unbox_nullable_arg(arg: Arg<'_, 'fcx>) -> Nullable<Self> {
-        let ptr: Option<ptr::NonNull<u8>> = NonNull::new(match T::PASS {
+        let ptr: Option<NonNull<u8>> = NonNull::new(match T::PASS {
             PassBy::Ref => arg.2.value.cast_mut_ptr(),
             PassBy::Value => ptr::addr_of!(arg.0.raw_args()[arg.1].value).cast_mut().cast(),
         });

--- a/pgrx/src/datetime/date.rs
+++ b/pgrx/src/datetime/date.rs
@@ -262,7 +262,7 @@ impl serde::Serialize for Date {
     fn serialize<S>(
         &self,
         serializer: S,
-    ) -> std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
     where
         S: serde::Serializer,
     {

--- a/pgrx/src/datetime/interval.rs
+++ b/pgrx/src/datetime/interval.rs
@@ -232,8 +232,7 @@ impl FromDatum for Interval {
 impl IntoDatum for Interval {
     fn into_datum(self) -> Option<pg_sys::Datum> {
         unsafe {
-            let ptr =
-                pg_sys::palloc(std::mem::size_of::<pg_sys::Interval>()).cast::<pg_sys::Interval>();
+            let ptr = pg_sys::palloc(size_of::<pg_sys::Interval>()).cast::<pg_sys::Interval>();
             ptr.write(self.0);
             Some(pg_sys::Datum::from(ptr))
         }
@@ -291,7 +290,7 @@ impl serde::Serialize for Interval {
     fn serialize<S>(
         &self,
         serializer: S,
-    ) -> std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
     where
         S: serde::Serializer,
     {

--- a/pgrx/src/datetime/support/mod.rs
+++ b/pgrx/src/datetime/support/mod.rs
@@ -678,7 +678,7 @@ impl<T> DateTimeTypeVisitor<T> {
 impl<'a, T: FromStr + seal::DateTimeType> serde::de::Visitor<'a> for DateTimeTypeVisitor<T> {
     type Value = T;
 
-    fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
+    fn expecting(&self, formatter: &mut Formatter) -> alloc::fmt::Result {
         formatter.write_str("a borrowed string")
     }
 

--- a/pgrx/src/datetime/time.rs
+++ b/pgrx/src/datetime/time.rs
@@ -198,7 +198,7 @@ impl serde::Serialize for Time {
     fn serialize<S>(
         &self,
         serializer: S,
-    ) -> std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
     where
         S: serde::Serializer,
     {

--- a/pgrx/src/datetime/time_stamp.rs
+++ b/pgrx/src/datetime/time_stamp.rs
@@ -309,7 +309,7 @@ impl serde::Serialize for Timestamp {
     fn serialize<S>(
         &self,
         serializer: S,
-    ) -> std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
     where
         S: serde::Serializer,
     {
@@ -328,7 +328,7 @@ impl<'de> serde::Deserialize<'de> for Timestamp {
     }
 }
 
-unsafe impl SqlTranslatable for crate::datum::Timestamp {
+unsafe impl SqlTranslatable for Timestamp {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("timestamp"))
     }

--- a/pgrx/src/datetime/time_stamp_with_timezone.rs
+++ b/pgrx/src/datetime/time_stamp_with_timezone.rs
@@ -416,7 +416,7 @@ impl serde::Serialize for TimestampWithTimeZone {
     fn serialize<S>(
         &self,
         serializer: S,
-    ) -> std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
     where
         S: serde::Serializer,
     {

--- a/pgrx/src/datetime/time_with_timezone.rs
+++ b/pgrx/src/datetime/time_with_timezone.rs
@@ -79,7 +79,7 @@ impl IntoDatum for TimeWithTimeZone {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         let timetzadt = unsafe {
             PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self.0 as *mut _, core::mem::size_of::<pg_sys::TimeTzADT>())
+                .copy_ptr_into(&mut self.0 as *mut _, size_of::<pg_sys::TimeTzADT>())
         };
 
         Some(pg_sys::Datum::from(timetzadt))
@@ -306,7 +306,7 @@ impl serde::Serialize for TimeWithTimeZone {
     fn serialize<S>(
         &self,
         serializer: S,
-    ) -> std::result::Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
     where
         S: serde::Serializer,
     {

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -8,14 +8,14 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 #![allow(clippy::question_mark)]
-use super::{UnboxDatum, unbox};
+use super::UnboxDatum;
 use crate::array::{RawArray, Scalar};
+use crate::layout::*;
 use crate::nullable::{
     BitSliceNulls, IntoNullableIterator, MaybeStrictNulls, NullLayout, Nullable, NullableContainer,
 };
 use crate::toast::Toast;
 use crate::{FromDatum, IntoDatum, PgMemoryContexts, pg_sys};
-use crate::{layout::*, nullable};
 use core::fmt::{Debug, Formatter};
 use core::ops::DerefMut;
 use core::ptr::NonNull;
@@ -78,7 +78,7 @@ where
 
 type ChaChaSlideImpl<T> = Box<dyn casper::ChaChaSlide<T>>;
 
-impl<'mcx, T: UnboxDatum> serde::Serialize for Array<'mcx, T>
+impl<'mcx, T: UnboxDatum> Serialize for Array<'mcx, T>
 where
     for<'arr> <T as UnboxDatum>::As<'arr>: Serialize,
 {
@@ -99,9 +99,8 @@ impl<'mcx, T: UnboxDatum> Array<'mcx, T> {
     pub(crate) unsafe fn deconstruct_from(mut raw: Toast<RawArray>) -> Array<'mcx, T> {
         let oid = raw.oid();
         let elem_layout = Layout::lookup_oid(oid);
-        let null_inner = raw
-            .nulls_bitslice()
-            .map(|nonnull| unsafe { nullable::BitSliceNulls(&*nonnull.as_ptr()) });
+        let null_inner =
+            raw.nulls_bitslice().map(|nonnull| unsafe { BitSliceNulls(&*nonnull.as_ptr()) });
         let null_slice = MaybeStrictNulls::new(null_inner);
         // do a little two-step before jumping into the Cha-Cha Slide and figure out
         // which implementation is correct for the type of element in this Array.
@@ -363,7 +362,7 @@ impl<'mcx, T> Iterator for NullableArrayIterator<'mcx, T>
 where
     T: UnboxDatum,
 {
-    type Item = Nullable<<T as unbox::UnboxDatum>::As<'mcx>>;
+    type Item = Nullable<<T as UnboxDatum>::As<'mcx>>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -371,7 +370,7 @@ where
     }
 }
 
-impl<'mcx, T> IntoNullableIterator<<T as unbox::UnboxDatum>::As<'mcx>> for &'mcx Array<'mcx, T>
+impl<'mcx, T> IntoNullableIterator<<T as UnboxDatum>::As<'mcx>> for &'mcx Array<'mcx, T>
 where
     T: UnboxDatum,
 {
@@ -382,7 +381,7 @@ where
     }
 }
 
-impl<'mcx, T: UnboxDatum> NullableContainer<'mcx, usize, <T as unbox::UnboxDatum>::As<'mcx>>
+impl<'mcx, T: UnboxDatum> NullableContainer<'mcx, usize, <T as UnboxDatum>::As<'mcx>>
     for Array<'mcx, T>
 {
     type Layout = MaybeStrictNulls<BitSliceNulls<'mcx>>;
@@ -393,7 +392,7 @@ impl<'mcx, T: UnboxDatum> NullableContainer<'mcx, usize, <T as unbox::UnboxDatum
     }
 
     #[inline]
-    unsafe fn get_raw(&'mcx self, idx: usize) -> <T as unbox::UnboxDatum>::As<'mcx> {
+    unsafe fn get_raw(&'mcx self, idx: usize) -> <T as UnboxDatum>::As<'mcx> {
         self.get_strict_inner(idx).expect(
             "get_raw() called with an invalid index, bounds-checking\
             *should* occur before calling this method.",
@@ -468,7 +467,7 @@ mod casper {
 
     #[inline(always)]
     fn is_aligned<T>(p: *const T) -> bool {
-        (p as usize) & (core::mem::align_of::<T>() - 1) == 0
+        (p as usize) & (align_of::<T>() - 1) == 0
     }
 
     /// Safety: Equivalent to a (potentially) aligned read of `ptr`, which
@@ -477,7 +476,7 @@ mod casper {
     #[inline(always)]
     pub(super) unsafe fn byval_read<T: Copy>(ptr: *const u8) -> T {
         let ptr = ptr.cast::<T>();
-        debug_assert!(is_aligned(ptr), "not aligned to {}: {ptr:p}", std::mem::align_of::<T>());
+        debug_assert!(is_aligned(ptr), "not aligned to {}: {ptr:p}", align_of::<T>());
         ptr.read()
     }
 
@@ -680,11 +679,11 @@ impl<'arr, T: UnboxDatum> Iterator for ArrayTypedIterator<'arr, T> {
 }
 
 impl<'a, T: UnboxDatum> ExactSizeIterator for ArrayTypedIterator<'a, T> {}
-impl<'a, T: UnboxDatum> core::iter::FusedIterator for ArrayTypedIterator<'a, T> {}
+impl<'a, T: UnboxDatum> FusedIterator for ArrayTypedIterator<'a, T> {}
 
-impl<'arr, T: UnboxDatum + serde::Serialize> serde::Serialize for ArrayTypedIterator<'arr, T>
+impl<'arr, T: UnboxDatum + Serialize> Serialize for ArrayTypedIterator<'arr, T>
 where
-    <T as UnboxDatum>::As<'arr>: serde::Serialize,
+    <T as UnboxDatum>::As<'arr>: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where

--- a/pgrx/src/datum/geo.rs
+++ b/pgrx/src/datum/geo.rs
@@ -31,7 +31,7 @@ impl IntoDatum for pg_sys::BOX {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         unsafe {
             let ptr = PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::BOX>());
+                .copy_ptr_into(&mut self, size_of::<pg_sys::BOX>());
             Some(ptr.into())
         }
     }
@@ -63,7 +63,7 @@ impl IntoDatum for pg_sys::Point {
     fn into_datum(mut self) -> Option<pg_sys::Datum> {
         unsafe {
             let copy = PgMemoryContexts::CurrentMemoryContext
-                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::Point>());
+                .copy_ptr_into(&mut self, size_of::<pg_sys::Point>());
             Some(copy.into())
         }
     }

--- a/pgrx/src/datum/internal.rs
+++ b/pgrx/src/datum/internal.rs
@@ -181,7 +181,7 @@ impl IntoDatum for Internal {
     }
 }
 
-unsafe impl SqlTranslatable for crate::datum::Internal {
+unsafe impl SqlTranslatable for Internal {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("internal"))
     }

--- a/pgrx/src/datum/json.rs
+++ b/pgrx/src/datum/json.rs
@@ -196,7 +196,7 @@ unsafe impl SqlTranslatable for Json {
     }
 }
 
-unsafe impl SqlTranslatable for crate::datum::JsonB {
+unsafe impl SqlTranslatable for JsonB {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("jsonb"))
     }

--- a/pgrx/src/datum/mod.rs
+++ b/pgrx/src/datum/mod.rs
@@ -142,7 +142,7 @@ impl<'src> Datum<'src> {
     /// If the type is `PassBy::Ref`, this may be `None`.
     pub unsafe fn borrow_as<T: BorrowDatum>(&self) -> Option<&T> {
         let ptr = ptr::NonNull::new_unchecked(ptr::from_ref(self).cast_mut());
-        borrow::datum_ptr_to_bytes::<T>(ptr).map(|ptr| BorrowDatum::borrow_unchecked(ptr))
+        datum_ptr_to_bytes::<T>(ptr).map(|ptr| BorrowDatum::borrow_unchecked(ptr))
     }
 }
 

--- a/pgrx/src/datum/range.rs
+++ b/pgrx/src/datum/range.rs
@@ -428,7 +428,7 @@ where
     }
 }
 
-impl<T> From<std::ops::RangeFrom<T>> for Range<T>
+impl<T> From<RangeFrom<T>> for Range<T>
 where
     T: RangeSubType,
 {
@@ -448,7 +448,7 @@ where
     }
 }
 
-impl<T> From<std::ops::RangeInclusive<T>> for Range<T>
+impl<T> From<RangeInclusive<T>> for Range<T>
 where
     T: RangeSubType,
 {
@@ -461,7 +461,7 @@ where
     }
 }
 
-impl<T> From<std::ops::RangeTo<T>> for Range<T>
+impl<T> From<RangeTo<T>> for Range<T>
 where
     T: RangeSubType,
 {
@@ -471,7 +471,7 @@ where
     }
 }
 
-impl<T> From<std::ops::RangeToInclusive<T>> for Range<T>
+impl<T> From<RangeToInclusive<T>> for Range<T>
 where
     T: RangeSubType,
 {

--- a/pgrx/src/datum/unbox.rs
+++ b/pgrx/src/datum/unbox.rs
@@ -295,7 +295,7 @@ unbox_with_fromdatum! {
     TimeWithTimeZone, AnyNumeric, char, pg_sys::Point, Interval, pg_sys::BOX, pg_sys::ItemPointerData,
 }
 
-unsafe impl UnboxDatum for PgHeapTuple<'_, crate::AllocatedByRust> {
+unsafe impl UnboxDatum for PgHeapTuple<'_, AllocatedByRust> {
     #[rustfmt::skip]
     type As<'src> = PgHeapTuple<'src, AllocatedByRust> where Self: 'src;
     #[inline]

--- a/pgrx/src/datum/uuid.rs
+++ b/pgrx/src/datum/uuid.rs
@@ -130,7 +130,7 @@ impl std::fmt::UpperHex for Uuid {
     }
 }
 
-unsafe impl SqlTranslatable for crate::datum::Uuid {
+unsafe impl SqlTranslatable for Uuid {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("uuid"))
     }

--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -128,7 +128,7 @@ where
     /// v.c = 42;
     /// ```
     pub fn new() -> Self {
-        let size_of = std::mem::size_of::<T>();
+        let size_of = size_of::<T>();
 
         let ptr = unsafe { pg_sys::palloc0(pg_sys::VARHDRSZ + size_of) as *mut pg_sys::varlena };
 
@@ -244,7 +244,7 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.as_ref().cmp(other.as_ref()))
+        Some(self.cmp(other))
     }
 }
 

--- a/pgrx/src/datum/with_typeid.rs
+++ b/pgrx/src/datum/with_typeid.rs
@@ -7,19 +7,19 @@ use std::sync::LazyLock as Lazy;
 /// Obtain a TypeId for T without `T: 'static`
 #[inline]
 #[doc(hidden)]
-pub fn nonstatic_typeid<T: ?Sized>() -> core::any::TypeId {
+pub fn nonstatic_typeid<T: ?Sized>() -> TypeId {
     trait NonStaticAny {
-        fn type_id(&self) -> core::any::TypeId
+        fn type_id(&self) -> TypeId
         where
             Self: 'static;
     }
     impl<T: ?Sized> NonStaticAny for core::marker::PhantomData<T> {
         #[inline]
-        fn type_id(&self) -> core::any::TypeId
+        fn type_id(&self) -> TypeId
         where
             Self: 'static,
         {
-            core::any::TypeId::of::<T>()
+            TypeId::of::<T>()
         }
     }
     let it = core::marker::PhantomData::<T>;
@@ -184,7 +184,7 @@ impl<T> WithSizedTypeIds<T> {
         let set_sql = format!("{single_sql}[]");
 
         if let Some(id) = *WithSizedTypeIds::<T>::PG_BOX_ID {
-            let rust = core::any::type_name::<crate::PgBox<T>>().to_string();
+            let rust = core::any::type_name::<PgBox<T>>().to_string();
             assert!(
                 map.insert(RustSqlMapping { sql: single_sql.clone(), rust: rust.to_string(), id }),
                 "Cannot map `{rust}` twice.",
@@ -192,7 +192,7 @@ impl<T> WithSizedTypeIds<T> {
         }
 
         if let Some(id) = *WithSizedTypeIds::<T>::PG_BOX_OPTION_ID {
-            let rust = core::any::type_name::<crate::PgBox<Option<T>>>().to_string();
+            let rust = core::any::type_name::<PgBox<Option<T>>>().to_string();
             assert!(
                 map.insert(RustSqlMapping { sql: single_sql.clone(), rust: rust.to_string(), id }),
                 "Cannot map `{rust}` twice.",
@@ -200,7 +200,7 @@ impl<T> WithSizedTypeIds<T> {
         }
 
         if let Some(id) = *WithSizedTypeIds::<T>::PG_BOX_VEC_ID {
-            let rust = core::any::type_name::<crate::PgBox<Vec<T>>>().to_string();
+            let rust = core::any::type_name::<PgBox<Vec<T>>>().to_string();
             assert!(
                 map.insert(RustSqlMapping { sql: set_sql.clone(), rust: rust.to_string(), id }),
                 "Cannot map `{rust}` twice.",

--- a/pgrx/src/fcinfo.rs
+++ b/pgrx/src/fcinfo.rs
@@ -97,7 +97,7 @@ pub unsafe fn pg_getarg<T: FromDatum>(fcinfo: pg_sys::FunctionCallInfo, num: usi
     let datum = pg_get_nullable_datum(fcinfo, num);
     unsafe {
         if T::GET_TYPOID {
-            T::from_polymorphic_datum(datum.value, datum.isnull, super::pg_getarg_type(fcinfo, num))
+            T::from_polymorphic_datum(datum.value, datum.isnull, pg_getarg_type(fcinfo, num))
         } else {
             T::from_datum(datum.value, datum.isnull)
         }
@@ -327,14 +327,14 @@ unsafe fn direct_function_call_as_datum_internal(
 ) -> Option<pg_sys::Datum> {
     let nargs: i16 = args.len().try_into().expect("too many args passed to function");
     let fcinfo = pg_sys::palloc0(
-        std::mem::size_of::<pg_sys::FunctionCallInfoBaseData>()
-            + std::mem::size_of::<pg_sys::NullableDatum>() * args.len(),
+        size_of::<pg_sys::FunctionCallInfoBaseData>()
+            + size_of::<pg_sys::NullableDatum>() * args.len(),
     )
     .cast::<pg_sys::FunctionCallInfoBaseData>();
 
-    (*fcinfo).flinfo = std::ptr::null_mut();
-    (*fcinfo).context = std::ptr::null_mut();
-    (*fcinfo).resultinfo = std::ptr::null_mut();
+    (*fcinfo).flinfo = ptr::null_mut();
+    (*fcinfo).context = ptr::null_mut();
+    (*fcinfo).resultinfo = ptr::null_mut();
     (*fcinfo).fncollation = pg_sys::InvalidOid;
     (*fcinfo).isnull = false;
     (*fcinfo).nargs = nargs;

--- a/pgrx/src/fn_call.rs
+++ b/pgrx/src/fn_call.rs
@@ -281,8 +281,8 @@ pub fn fn_call_with_collation<R: FromDatum + IntoDatum>(
         // we have, and we've asserted that we have the correct number of arguments
         assert_eq!(nargs, pg_proc.pronargs());
         let fcinfo = pg_sys::palloc0(
-            std::mem::size_of::<pg_sys::FunctionCallInfoBaseData>()
-                + std::mem::size_of::<pg_sys::NullableDatum>() * nargs,
+            size_of::<pg_sys::FunctionCallInfoBaseData>()
+                + size_of::<pg_sys::NullableDatum>() * nargs,
         ) as *mut pg_sys::FunctionCallInfoBaseData;
 
         // initialize it

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -222,8 +222,8 @@ impl<'mcx> PgHeapTuple<'mcx, AllocatedByRust> {
             let natts = tuple_desc.len();
 
             unsafe {
-                let datums = pg_sys::palloc0(natts * std::mem::size_of::<pg_sys::Datum>())
-                    as *mut pg_sys::Datum;
+                let datums =
+                    pg_sys::palloc0(natts * size_of::<pg_sys::Datum>()) as *mut pg_sys::Datum;
                 let mut is_null = vec![true; natts];
 
                 let heap_tuple =
@@ -431,7 +431,7 @@ impl<'mcx, AllocatedBy: WhoAllocated> IntoDatum for PgHeapTuple<'mcx, AllocatedB
     }
 
     fn type_oid() -> pg_sys::Oid {
-        crate::pg_sys::RECORDOID
+        pg_sys::RECORDOID
     }
 
     fn composite_type_oid(&self) -> Option<pg_sys::Oid> {
@@ -483,7 +483,7 @@ impl<'mcx, AllocatedBy: WhoAllocated> PgHeapTuple<'mcx, AllocatedBy> {
     /// The return value is `(attribute_number: NonZeroUsize, attribute_info: &pg_sys::FormData_pg_attribute)`.
     pub fn attributes(
         &self,
-    ) -> impl std::iter::Iterator<Item = (NonZeroUsize, &pg_sys::FormData_pg_attribute)> {
+    ) -> impl Iterator<Item = (NonZeroUsize, &pg_sys::FormData_pg_attribute)> {
         self.tupdesc.iter().enumerate().map(|(i, att)| (NonZeroUsize::new(i + 1).unwrap(), att))
     }
 
@@ -710,7 +710,7 @@ macro_rules! composite_type {
     };
 }
 
-unsafe impl SqlTranslatable for crate::heap_tuple::PgHeapTuple<'static, AllocatedByPostgres> {
+unsafe impl SqlTranslatable for PgHeapTuple<'static, AllocatedByPostgres> {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::Composite { array_brackets: false })
     }
@@ -719,7 +719,7 @@ unsafe impl SqlTranslatable for crate::heap_tuple::PgHeapTuple<'static, Allocate
     }
 }
 
-unsafe impl SqlTranslatable for crate::heap_tuple::PgHeapTuple<'static, AllocatedByRust> {
+unsafe impl SqlTranslatable for PgHeapTuple<'static, AllocatedByRust> {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::Composite { array_brackets: false })
     }

--- a/pgrx/src/htup.rs
+++ b/pgrx/src/htup.rs
@@ -40,7 +40,7 @@ pub fn heap_tuple_header_get_datum_length(htup_header: pg_sys::HeapTupleHeader) 
         panic!("Attempt to dereference a null HeapTupleHeader");
     }
 
-    unsafe { crate::varlena::varsize(htup_header as *const pg_sys::varlena) }
+    unsafe { varsize(htup_header as *const pg_sys::varlena) }
 }
 
 /// convert a HeapTupleHeader to a Datum.

--- a/pgrx/src/layout.rs
+++ b/pgrx/src/layout.rs
@@ -22,7 +22,6 @@ then we may want to offer more help.
 */
 #![allow(dead_code)]
 use crate::pg_sys::{self, TYPALIGN_CHAR, TYPALIGN_DOUBLE, TYPALIGN_INT, TYPALIGN_SHORT};
-use core::mem;
 
 /// Postgres type information, corresponds to part of a row in pg_type
 /// This layout describes T, not &T, even if passbyval: false, which would mean the datum array is effectively `&[&T]`
@@ -86,10 +85,10 @@ impl TryFrom<libc::c_char> for Align {
 impl Align {
     pub(crate) fn as_usize(self) -> usize {
         match self {
-            Align::Byte => mem::align_of::<libc::c_char>(),
-            Align::Short => mem::align_of::<libc::c_short>(),
-            Align::Int => mem::align_of::<libc::c_int>(),
-            Align::Double => mem::align_of::<libc::c_double>(),
+            Align::Byte => align_of::<libc::c_char>(),
+            Align::Short => align_of::<libc::c_short>(),
+            Align::Int => align_of::<libc::c_int>(),
+            Align::Double => align_of::<libc::c_double>(),
         }
     }
 

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -17,7 +17,6 @@ use crate::memcx::MemCx;
 use crate::pg_sys;
 use crate::seal::Sealed;
 use core::marker::PhantomData;
-use core::mem;
 use core::ptr::{self, NonNull};
 
 mod flat_list;
@@ -59,7 +58,7 @@ pub struct ListCell<T> {
 // Note: the size of `ListCell<T>`'s generic `T` doesn't matter,
 // thus it isn't acceptable to implement Enlist for a `T` larger than `pg_sys::ListCell`.
 const _: () = {
-    assert!(mem::size_of::<ListCell<u128>>() == mem::size_of::<pg_sys::ListCell>());
+    assert!(size_of::<ListCell<u128>>() == size_of::<pg_sys::ListCell>());
 };
 
 /// The bound to describe a type which may be used in a Postgres List

--- a/pgrx/src/list/flat_list.rs
+++ b/pgrx/src/list/flat_list.rs
@@ -116,8 +116,8 @@ impl<'cx, T: Enlist> List<'cx, T> {
                         mcx.alloc_bytes(list_size).unwrap().cast().as_ptr();
                     assert!(list.is_non_null());
                     (*list).type_ = T::LIST_TAG;
-                    (*list).max_length = ((list_size - mem::size_of::<pg_sys::List>())
-                        / mem::size_of::<pg_sys::ListCell>())
+                    (*list).max_length = ((list_size - size_of::<pg_sys::List>())
+                        / size_of::<pg_sys::ListCell>())
                         as _;
                     (*list).elements = ptr::addr_of_mut!((*list).initial_elements).cast();
                     T::endocytosis((*list).elements.as_mut().unwrap(), value);
@@ -311,7 +311,7 @@ impl<T: Enlist> ListHead<'_, T> {
 
 unsafe fn grow_list(list: &mut pg_sys::List, target: usize) {
     assert!((i32::MAX as usize) >= target, "Cannot allocate more than c_int::MAX elements");
-    let alloc_size = target * mem::size_of::<pg_sys::ListCell>();
+    let alloc_size = target * size_of::<pg_sys::ListCell>();
     if list.elements == ptr::addr_of_mut!(list.initial_elements).cast() {
         // first realloc, we can't dealloc the elements ptr, as it isn't its own alloc
         let context = pg_sys::GetMemoryChunkContext(list as *mut pg_sys::List as *mut _);

--- a/pgrx/src/memcxt.rs
+++ b/pgrx/src/memcxt.rs
@@ -479,7 +479,7 @@ impl PgMemoryContexts {
     /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
     /// borrow checker thinks it will.
     pub unsafe fn palloc_struct<T>(&mut self) -> *mut T {
-        unsafe { self.palloc(std::mem::size_of::<T>()) as *mut T }
+        unsafe { self.palloc(size_of::<T>()) as *mut T }
     }
 
     /// Allocate a struct in this memory context, returning a pointer to it.  The memory will be
@@ -494,7 +494,7 @@ impl PgMemoryContexts {
     /// We also cannot ensure that the result of this function will stay allocated as long as Rust's
     /// borrow checker thinks it will.
     pub unsafe fn palloc0_struct<T>(&mut self) -> *mut T {
-        unsafe { self.palloc0(std::mem::size_of::<T>()) as *mut T }
+        unsafe { self.palloc0(size_of::<T>()) as *mut T }
     }
 
     /// Allocate a slice in this context, which will be free'd whenever Postgres deletes this MemoryContext
@@ -509,7 +509,7 @@ impl PgMemoryContexts {
     /// borrow checker thinks it will.
     pub unsafe fn palloc_slice<'a, T>(&mut self, len: usize) -> &'a mut [T] {
         unsafe {
-            let buffer = self.palloc(std::mem::size_of::<T>() * len) as *mut T;
+            let buffer = self.palloc(size_of::<T>() * len) as *mut T;
             std::slice::from_raw_parts_mut(buffer, len)
         }
     }
@@ -526,7 +526,7 @@ impl PgMemoryContexts {
     /// borrow checker thinks it will.
     pub unsafe fn palloc0_slice<'a, T>(&mut self, len: usize) -> &'a mut [T] {
         unsafe {
-            let buffer = self.palloc0(std::mem::size_of::<T>() * len) as *mut T;
+            let buffer = self.palloc0(size_of::<T>() * len) as *mut T;
             std::slice::from_raw_parts_mut(buffer, len)
         }
     }

--- a/pgrx/src/pgbox.rs
+++ b/pgrx/src/pgbox.rs
@@ -173,9 +173,7 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     #[inline]
     pub unsafe fn alloc() -> PgBox<T, AllocatedByRust> {
         PgBox::<T, AllocatedByRust> {
-            ptr: Some(unsafe {
-                NonNull::new_unchecked(pg_sys::palloc(std::mem::size_of::<T>()) as *mut T)
-            }),
+            ptr: Some(unsafe { NonNull::new_unchecked(pg_sys::palloc(size_of::<T>()) as *mut T) }),
             __marker: PhantomData,
         }
     }
@@ -203,9 +201,7 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     #[inline]
     pub unsafe fn alloc0() -> PgBox<T, AllocatedByRust> {
         PgBox::<T, AllocatedByRust> {
-            ptr: Some(unsafe {
-                NonNull::new_unchecked(pg_sys::palloc0(std::mem::size_of::<T>()) as *mut T)
-            }),
+            ptr: Some(unsafe { NonNull::new_unchecked(pg_sys::palloc0(size_of::<T>()) as *mut T) }),
             __marker: PhantomData,
         }
     }
@@ -236,7 +232,7 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
             ptr: Some(unsafe {
                 NonNull::new_unchecked(pg_sys::MemoryContextAlloc(
                     memory_context.value(),
-                    std::mem::size_of::<T>(),
+                    size_of::<T>(),
                 ) as *mut T)
             }),
             __marker: PhantomData,
@@ -269,7 +265,7 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
             ptr: Some(unsafe {
                 NonNull::new_unchecked(pg_sys::MemoryContextAllocZero(
                     memory_context.value(),
-                    std::mem::size_of::<T>(),
+                    size_of::<T>(),
                 ) as *mut T)
             }),
             __marker: PhantomData,
@@ -383,7 +379,7 @@ where
                 // ensures that we have a fixed-size type can essentially be memcpy'd, which is what
                 // `.copy_ptr_into()` does.
                 let copy = PgMemoryContexts::CurrentMemoryContext
-                    .copy_ptr_into(self.as_ptr(), std::mem::size_of::<T>());
+                    .copy_ptr_into(self.as_ptr(), size_of::<T>());
 
                 PgBox::from_pg(copy)
             }

--- a/pgrx/src/rel.rs
+++ b/pgrx/src/rel.rs
@@ -129,7 +129,7 @@ impl PgRelation {
     /// nasty race conditions.
     ///
     /// As such, this function is unsafe as we cannot guarantee that this requirement is true.
-    pub unsafe fn open_with_name(relname: &str) -> std::result::Result<Self, &'static str> {
+    pub unsafe fn open_with_name(relname: &str) -> Result<Self, &'static str> {
         match direct_function_call::<pg_sys::Oid>(pg_sys::to_regclass, &[relname.into_datum()]) {
             Some(oid) => Ok(PgRelation::open(oid)),
             None => Err("no such relation"),
@@ -145,7 +145,7 @@ impl PgRelation {
     ///
     /// Additionally, the relation is closed via `pg_sys::RelationClose()` when this instance is
     /// dropped.
-    pub fn open_with_name_and_share_lock(relname: &str) -> std::result::Result<Self, &'static str> {
+    pub fn open_with_name_and_share_lock(relname: &str) -> Result<Self, &'static str> {
         unsafe {
             match direct_function_call::<pg_sys::Oid>(pg_sys::to_regclass, &[relname.into_datum()])
             {
@@ -205,10 +205,7 @@ impl PgRelation {
 
     /// Return an iterator of indices, as `PgRelation`s, attached to this relation
     #[cfg(feature = "cshim")]
-    pub fn indices(
-        &self,
-        lockmode: pg_sys::LOCKMODE,
-    ) -> impl std::iter::Iterator<Item = PgRelation> {
+    pub fn indices(&self, lockmode: pg_sys::LOCKMODE) -> impl Iterator<Item = PgRelation> {
         use crate::PgList;
         // SAFETY: we know self.boxed is a valid pointer as we created it
         let list = unsafe {

--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -60,9 +60,7 @@ impl<'conn> SpiClient<'conn> {
         query.execute(self, limit, args)
     }
 
-    pub(super) fn prepare_tuple_table(
-        status_code: i32,
-    ) -> std::result::Result<SpiTupleTable<'conn>, SpiError> {
+    pub(super) fn prepare_tuple_table(status_code: i32) -> Result<SpiTupleTable<'conn>, SpiError> {
         Ok(SpiTupleTable {
             status_code: Spi::check_status(status_code)?,
             // SAFETY: no concurrent access

--- a/pgrx/src/trigger_support/pg_trigger.rs
+++ b/pgrx/src/trigger_support/pg_trigger.rs
@@ -175,7 +175,7 @@ impl<'a> PgTrigger<'a> {
     }
 
     /// The `PgRelation` corresponding to the trigger.
-    pub fn relation(&self) -> Result<crate::PgRelation, PgTriggerError> {
+    pub fn relation(&self) -> Result<PgRelation, PgTriggerError> {
         // SAFETY:  The creator of this PgTrigger asserted they used a correctly initialized
         // "fcinfo" structures that represent a trigger and that Postgres was in the proper
         // state to call a trigger.  This includes that the relation is already open with at

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -121,11 +121,11 @@ pub unsafe fn vartag_is_expanded(tag: pg_sys::vartag_external::Type) -> bool {
 #[inline]
 pub unsafe fn vartag_size(tag: pg_sys::vartag_external::Type) -> usize {
     if tag == pg_sys::vartag_external::VARTAG_INDIRECT {
-        std::mem::size_of::<pg_sys::varatt_indirect>()
+        size_of::<pg_sys::varatt_indirect>()
     } else if vartag_is_expanded(tag) {
-        std::mem::size_of::<pg_sys::varatt_expanded>()
+        size_of::<pg_sys::varatt_expanded>()
     } else if tag == pg_sys::vartag_external::VARTAG_ONDISK {
-        std::mem::size_of::<pg_sys::varatt_external>()
+        size_of::<pg_sys::varatt_external>()
     } else {
         panic!("unrecognized TOAST vartag")
     }


### PR DESCRIPTION
This lint highlights inconsistencies within files - e.g. the same type is referenced in two different ways - with and without the namespace. This creates inconsistencies in code and potential for confusion.

* Add `unused-qualifications = warn` to all `[lints.rust]` in Cargo.tomls
* Sorted a few lint sections for consistency
* Removed all unneeded namespaces.