### PR TITLE
Add mapping from PostgreSQL's CIRCLE type to Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ cargo pgrx init
 | `anyarray`                 | `pgrx::AnyArray`                                        |
 | `anyelement`               | `pgrx::AnyElement`                                      |
 | `box`                      | `pgrx::pg_sys::BOX`                                     |
+| `circle`                   | `pgrx::pg_sys::CIRCLE`                                  |
 | `point`                    | `pgrx::pg_sys::Point`                                   |
 | `tid`                      | `pgrx::pg_sys::ItemPointerData`                         |
 | `cstring`                  | `&core::ffi::CStr`                                      |

--- a/pgrx-pg-sys/src/submodules/cmp.rs
+++ b/pgrx-pg-sys/src/submodules/cmp.rs
@@ -1,4 +1,4 @@
-use crate::{BOX, Point};
+use crate::{BOX, CIRCLE, Point};
 
 impl PartialEq for Point {
     #[inline]
@@ -15,3 +15,11 @@ impl PartialEq for BOX {
     }
 }
 impl Eq for BOX {}
+
+impl PartialEq for CIRCLE {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.center == other.center && self.radius == other.radius
+    }
+}
+impl Eq for CIRCLE {}

--- a/pgrx-pg-sys/src/submodules/sql_translatable.rs
+++ b/pgrx-pg-sys/src/submodules/sql_translatable.rs
@@ -65,6 +65,15 @@ unsafe impl SqlTranslatable for crate::BOX {
     }
 }
 
+unsafe impl SqlTranslatable for crate::CIRCLE {
+    fn argument_sql() -> Result<SqlMapping, ArgumentError> {
+        Ok(SqlMapping::literal("circle"))
+    }
+    fn return_sql() -> Result<Returns, ReturnsError> {
+        Ok(Returns::One(SqlMapping::literal("circle")))
+    }
+}
+
 unsafe impl SqlTranslatable for crate::Point {
     fn argument_sql() -> Result<SqlMapping, ArgumentError> {
         Ok(SqlMapping::literal("point"))

--- a/pgrx-tests/src/tests/geo_tests.rs
+++ b/pgrx-tests/src/tests/geo_tests.rs
@@ -33,4 +33,14 @@ mod tests {
         assert_eq!(b.low.y, 2.0);
         Ok(())
     }
+
+    #[pg_test]
+    fn test_circle_into_datum() -> spi::Result<()> {
+        let c =
+            Spi::get_one::<pg_sys::CIRCLE>("SELECT '1,2,3'::circle")?.expect("SPI result was null");
+        assert_eq!(c.center.x, 1.0);
+        assert_eq!(c.center.y, 2.0);
+        assert_eq!(c.radius, 3.0);
+        Ok(())
+    }
 }

--- a/pgrx/src/datum/geo.rs
+++ b/pgrx/src/datum/geo.rs
@@ -72,3 +72,35 @@ impl IntoDatum for pg_sys::Point {
         pg_sys::POINTOID
     }
 }
+
+impl FromDatum for pg_sys::CIRCLE {
+    unsafe fn from_polymorphic_datum(
+        datum: pg_sys::Datum,
+        is_null: bool,
+        _: pg_sys::Oid,
+    ) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if is_null {
+            None
+        } else {
+            let the_box = datum.cast_mut_ptr::<pg_sys::CIRCLE>();
+            Some(the_box.read())
+        }
+    }
+}
+
+impl IntoDatum for pg_sys::CIRCLE {
+    fn into_datum(mut self) -> Option<pg_sys::Datum> {
+        unsafe {
+            let ptr = PgMemoryContexts::CurrentMemoryContext
+                .copy_ptr_into(&mut self, std::mem::size_of::<pg_sys::CIRCLE>());
+            Some(ptr.into())
+        }
+    }
+
+    fn type_oid() -> pg_sys::Oid {
+        pg_sys::CIRCLEOID
+    }
+}


### PR DESCRIPTION
Hi, 

We are adding point anonymisation functions in [PostgreSQL anonymizer](https://gitlab.com/dalibo/postgresql_anonymizer/-/merge_requests/629) and I noticed that the PostgreSQL's `Circle` type is not mapped to the rust `CIRCLE` type  whereas `BOX` and `Point` are.  This patch attempts to add support for this.