### PR TITLE
tell pg_ctl we want core files

### DIFF
--- a/cargo-pgrx/src/command/start.rs
+++ b/cargo-pgrx/src/command/start.rs
@@ -178,6 +178,7 @@ pub(crate) fn start_postgres(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .arg("start")
+        .arg("--core-files")
         .arg("-o")
         .arg(postmaster_args.join(" "))
         .arg("-D")


### PR DESCRIPTION
Telling `pg_ctl ` we want the postgres it spawns to create core files is very, very, very useful.