### PR TITLE
[Feature] Add support for ereport_domain macro

### DIFF
--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -428,7 +428,6 @@ pub fn interrupt_pending() -> bool {
 /// a text domain, analogous to Postgres' `ereport_domain` C macro.
 ///
 /// The argument order is:
-/// - `domain: &str` — the gettext text domain for message translation
 /// - `log_level: [PgLogLevel]`
 /// - `error_code: [PgSqlErrorCode]`
 /// - `message: String`
@@ -440,18 +439,18 @@ pub fn interrupt_pending() -> bool {
 /// # use pgrx_pg_sys::ereport_domain;
 /// # use pgrx_pg_sys::elog::PgLogLevel;
 /// # use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-/// ereport_domain!("my_extension", PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, "oh noes!");
+/// ereport_domain!(PgLogLevel::ERROR, "my_extension", PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, "oh noes!");
 /// ```
 ///
 /// ```rust,no_run
 /// # use pgrx_pg_sys::ereport_domain;
 /// # use pgrx_pg_sys::elog::PgLogLevel;
 /// # use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-/// ereport_domain!("my_extension", PgLogLevel::LOG, PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, "translated message");
+/// ereport_domain!(PgLogLevel::LOG, "my_extension", PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, "translated message");
 /// ```
 #[macro_export]
 macro_rules! ereport_domain {
-    ($domain:expr, ERROR, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (ERROR, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
@@ -459,7 +458,7 @@ macro_rules! ereport_domain {
         unreachable!();
     };
 
-    ($domain:expr, PANIC, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (PANIC, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
@@ -467,7 +466,7 @@ macro_rules! ereport_domain {
         unreachable!();
     };
 
-    ($domain:expr, FATAL, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (FATAL, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
@@ -475,70 +474,70 @@ macro_rules! ereport_domain {
         unreachable!();
     };
 
-    ($domain:expr, WARNING, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (WARNING, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::WARNING)
     };
 
-    ($domain:expr, NOTICE, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (NOTICE, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::NOTICE)
     };
 
-    ($domain:expr, INFO, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (INFO, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::INFO)
     };
 
-    ($domain:expr, LOG, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (LOG, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::LOG)
     };
 
-    ($domain:expr, DEBUG5, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (DEBUG5, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG5)
     };
 
-    ($domain:expr, DEBUG4, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (DEBUG4, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG4)
     };
 
-    ($domain:expr, DEBUG3, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (DEBUG3, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG3)
     };
 
-    ($domain:expr, DEBUG2, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (DEBUG2, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG2)
     };
 
-    ($domain:expr, DEBUG1, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    (DEBUG1, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::DEBUG1)
     };
 
-    ($domain:expr, $loglevel:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+    ($loglevel:expr, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
         $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -424,6 +424,128 @@ pub fn interrupt_pending() -> bool {
     unsafe { crate::InterruptPending != 0 }
 }
 
+/// Send some kind of message to Postgres similar to the ereport macro, while specifying
+/// a text domain, analogous to Postgres' `ereport_domain` C macro.
+///
+/// The argument order is:
+/// - `domain: &str` — the gettext text domain for message translation
+/// - `log_level: [PgLogLevel]`
+/// - `error_code: [PgSqlErrorCode]`
+/// - `message: String`
+/// - (optional) `detail: String`
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # use pgrx_pg_sys::ereport_domain;
+/// # use pgrx_pg_sys::elog::PgLogLevel;
+/// # use pgrx_pg_sys::errcodes::PgSqlErrorCode;
+/// ereport_domain!("my_extension", PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, "oh noes!");
+/// ```
+///
+/// ```rust,no_run
+/// # use pgrx_pg_sys::ereport_domain;
+/// # use pgrx_pg_sys::elog::PgLogLevel;
+/// # use pgrx_pg_sys::errcodes::PgSqlErrorCode;
+/// ereport_domain!("my_extension", PgLogLevel::LOG, PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, "translated message");
+/// ```
+#[macro_export]
+macro_rules! ereport_domain {
+    ($domain:expr, ERROR, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::ERROR);
+        unreachable!();
+    };
+
+    ($domain:expr, PANIC, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::PANIC);
+        unreachable!();
+    };
+
+    ($domain:expr, FATAL, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::FATAL);
+        unreachable!();
+    };
+
+    ($domain:expr, WARNING, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::WARNING)
+    };
+
+    ($domain:expr, NOTICE, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::NOTICE)
+    };
+
+    ($domain:expr, INFO, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::INFO)
+    };
+
+    ($domain:expr, LOG, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::LOG)
+    };
+
+    ($domain:expr, DEBUG5, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::DEBUG5)
+    };
+
+    ($domain:expr, DEBUG4, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::DEBUG4)
+    };
+
+    ($domain:expr, DEBUG3, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::DEBUG3)
+    };
+
+    ($domain:expr, DEBUG2, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::DEBUG2)
+    };
+
+    ($domain:expr, DEBUG1, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($crate::elog::PgLogLevel::DEBUG1)
+    };
+
+    ($domain:expr, $loglevel:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
+        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+            .set_domain($domain)
+            $(.set_detail($detail))?
+            .report($loglevel);
+    };
+}
+
 /// If an interrupt is pending (perhaps a user-initiated "cancel query" message to this backend),
 /// this will safely abort the current transaction
 #[macro_export]

--- a/pgrx-pg-sys/src/submodules/ffi.rs
+++ b/pgrx-pg-sys/src/submodules/ffi.rs
@@ -213,6 +213,11 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
             } else {
                 CStr::from_ptr(errdata.message).to_string_lossy().to_string()
             };
+            let domain = if errdata.domain.is_null() {
+                None
+            } else {
+                { Some(CStr::from_ptr(errdata.domain).to_string_lossy().to_string()) }
+            };
             let detail = if errdata.detail.is_null() {
                 None
             } else {
@@ -250,6 +255,7 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
                     message,
                     detail,
                     hint,
+                    domain,
                     location: ErrorReportLocation { file, funcname, line, col: 0, backtrace: None },
                 },
             }))

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -126,6 +126,7 @@ pub struct ErrorReport {
     pub(crate) message: String,
     pub(crate) hint: Option<String>,
     pub(crate) detail: Option<String>,
+    pub(crate) domain: Option<String>,
     pub(crate) location: ErrorReportLocation,
 }
 
@@ -206,6 +207,11 @@ impl ErrorReportWithLevel {
         self.inner.hint()
     }
 
+    /// Returns the domain of this error report, if set
+    pub fn domain(&self) -> Option<&str> {
+        self.inner.domain()
+    }
+
     /// Returns the name of the source file that generated this error report
     pub fn file(&self) -> &str {
         &self.inner.location.file
@@ -247,7 +253,7 @@ impl ErrorReport {
         let mut location: ErrorReportLocation = Location::caller().into();
         location.funcname = Some(funcname.to_string());
 
-        Self { sqlerrcode, message: message.into(), hint: None, detail: None, location }
+        Self { sqlerrcode, message: message.into(), hint: None, detail: None, domain: None, location }
     }
 
     /// Create an [ErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
@@ -259,7 +265,7 @@ impl ErrorReport {
         message: S,
         location: ErrorReportLocation,
     ) -> Self {
-        Self { sqlerrcode, message: message.into(), hint: None, detail: None, location }
+        Self { sqlerrcode, message: message.into(), hint: None, detail: None, domain: None, location }
     }
 
     /// Set the `detail` property, whose default is `None`
@@ -271,6 +277,16 @@ impl ErrorReport {
     /// Set the `hint` property, whose default is `None`
     pub fn set_hint<S: Into<String>>(mut self, hint: S) -> Self {
         self.hint = Some(hint.into());
+        self
+    }
+
+    /// Set the `domain` property for message translation/internationalization, whose default is `None`.
+    ///
+    /// This corresponds to the `domain` argument in Postgres' `ereport_domain` C macro.
+    /// When set, the domain is passed to `errstart()` to indicate the gettext text domain
+    /// for message translation.
+    pub fn set_domain<S: Into<String>>(mut self, domain: S) -> Self {
+        self.domain = Some(domain.into());
         self
     }
 
@@ -287,6 +303,11 @@ impl ErrorReport {
     /// Returns the hint message of this error report
     pub fn hint(&self) -> Option<&str> {
         self.hint.as_deref()
+    }
+
+    /// Returns the domain of this error report, if set
+    pub fn domain(&self) -> Option<&str> {
+        self.domain.as_deref()
     }
 
     /// Report this [ErrorReport], which will ultimately be reported by Postgres at the specified [PgLogLevel]
@@ -497,7 +518,7 @@ pub(crate) fn downcast_panic_payload(e: Box<dyn Any + Send>) -> CaughtError {
 /// trying to roll their own error handling.
 fn do_ereport(ereport: ErrorReportWithLevel) {
     const PERCENT_S: &CStr = c"%s";
-    const DOMAIN: *const ::std::os::raw::c_char = std::ptr::null_mut();
+    const DEFAULT_DOMAIN: *const ::std::os::raw::c_char = std::ptr::null_mut();
 
     // the following code is definitely thread-unsafe -- not-the-main-thread can't be creating Postgres
     // ereports.  Our secret `extern "C"` definitions aren't wrapped by #[pg_guard] so we need to
@@ -530,8 +551,15 @@ fn do_ereport(ereport: ErrorReportWithLevel) {
     }
 
     let level = ereport.level();
+
+    // Use the domain from the ErrorReport if one was set, otherwise use the null default
+    let domain_cstring = ereport.inner.domain.as_ref().map(|d| {
+        std::ffi::CString::new(d.as_str()).expect("domain must not contain interior NUL bytes")
+    });
+    let domain_ptr = domain_cstring.as_ref().map_or(DEFAULT_DOMAIN, |c| c.as_ptr());
+
     unsafe {
-        if errstart(level as _, DOMAIN) {
+        if errstart(level as _, domain_ptr) {
             let sqlerrcode = ereport.sql_error_code();
             let message = ereport.message().as_pg_cstr();
             let detail = ereport.detail_with_backtrace().as_pg_cstr();

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -253,7 +253,14 @@ impl ErrorReport {
         let mut location: ErrorReportLocation = Location::caller().into();
         location.funcname = Some(funcname.to_string());
 
-        Self { sqlerrcode, message: message.into(), hint: None, detail: None, domain: None, location }
+        Self {
+            sqlerrcode,
+            message: message.into(),
+            hint: None,
+            detail: None,
+            domain: None,
+            location,
+        }
     }
 
     /// Create an [ErrorReport] which can be raised via Rust's [std::panic::panic_any()] or as
@@ -265,7 +272,14 @@ impl ErrorReport {
         message: S,
         location: ErrorReportLocation,
     ) -> Self {
-        Self { sqlerrcode, message: message.into(), hint: None, detail: None, domain: None, location }
+        Self {
+            sqlerrcode,
+            message: message.into(),
+            hint: None,
+            detail: None,
+            domain: None,
+            location,
+        }
     }
 
     /// Set the `detail` property, whose default is `None`

--- a/pgrx-tests/src/tests/log_tests.rs
+++ b/pgrx-tests/src/tests/log_tests.rs
@@ -84,6 +84,32 @@ mod tests {
         )
     }
 
+    #[pg_test]
+    fn test_ereport_domain_value() {
+        let caught = pgrx::PgTryBuilder::new(|| -> Option<pgrx::pg_sys::panic::CaughtError> {
+            pgrx::ereport_domain!(
+                PgLogLevel::ERROR,
+                "test_extension_domain",
+                PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+                "ereport error"
+            );
+            None
+        })
+        .catch_when(PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, |e| Some(e))
+        .execute();
+
+        match caught {
+            Some(pgrx::pg_sys::panic::CaughtError::ErrorReport(report))
+            | Some(pgrx::pg_sys::panic::CaughtError::PostgresError(report)) => {
+                assert_eq!(report.sql_error_code(), PgSqlErrorCode::ERRCODE_INTERNAL_ERROR);
+                assert_eq!(report.message(), "ereport error");
+                assert_eq!(report.domain(), Some("test_extension_domain"));
+            }
+            Some(other) => panic!("unexpected error kind: {other:?}"),
+            None => panic!("expected error, but code returned normally"),
+        }
+    }
+
     #[pg_test(error = "panic message")]
     fn test_panic() {
         panic!("panic message")

--- a/pgrx-tests/src/tests/log_tests.rs
+++ b/pgrx-tests/src/tests/log_tests.rs
@@ -74,6 +74,16 @@ mod tests {
         pgrx::ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, "ereport error")
     }
 
+    #[pg_test(error = "ereport error")]
+    fn test_ereport_domain() {
+        pgrx::ereport_domain!(
+            PgLogLevel::ERROR,
+            "test_extension_domain",
+            PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
+            "ereport error"
+        )
+    }
+
     #[pg_test(error = "panic message")]
     fn test_panic() {
         panic!("panic message")

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -124,8 +124,8 @@ pub use pg_sys::panic::pgrx_extern_c_guard;
 pub use pg_sys::pg_try::PgTryBuilder;
 pub use pg_sys::utils::name_data_to_str;
 pub use pg_sys::{
-    FATAL, PANIC, check_for_interrupts, debug1, debug2, debug3, debug4, debug5, ereport, error,
-    function_name, info, log, notice, warning,
+    FATAL, PANIC, check_for_interrupts, debug1, debug2, debug3, debug4, debug5, ereport,
+    ereport_domain, error, function_name, info, log, notice, warning,
 };
 
 #[doc(hidden)]

--- a/pgrx/src/prelude.rs
+++ b/pgrx/src/prelude.rs
@@ -60,6 +60,6 @@ pub use crate::spi::Spi;
 pub use crate::pg_sys::elog::PgLogLevel;
 pub use crate::pg_sys::errcodes::PgSqlErrorCode;
 pub use crate::pg_sys::{
-    FATAL, PANIC, check_for_interrupts, debug1, debug2, debug3, debug4, debug5, ereport, error,
-    function_name, info, log, notice, warning,
+    FATAL, PANIC, check_for_interrupts, debug1, debug2, debug3, debug4, debug5, ereport,
+    ereport_domain, error, function_name, info, log, notice, warning,
 };


### PR DESCRIPTION
**What is the problem**
Postgres provides the TEXTDOMAIN macro and ereport_domain macro to allow a domain to be specified for log messages.
It could be read from edata->domain. This might be a feature that people building extensions want to use (or misuse).

Currently pgrx hardcodes the domain as NULL. It would be great if it could provide some way for people to specify it.

Issue [here](https://github.com/pgcentralfoundation/pgrx/issues/2255) 

**How does this PR solves this**
This is a small PR that modifies the `ErrorReport` struct to add the `domain` field, and defines the ereport_domain macros.  