### PR TITLE
Add impl_sql_translatable! macro for downstream use

### DIFF
--- a/pgrx-sql-entity-graph/src/metadata/mod.rs
+++ b/pgrx-sql-entity-graph/src/metadata/mod.rs
@@ -22,6 +22,7 @@ mod function_metadata;
 mod return_variant;
 mod sql_translatable;
 
+pub use crate::impl_sql_translatable;
 pub use entity::{
     FunctionMetadataEntity, FunctionMetadataTypeEntity, FunctionMetadataTypeResolutionEntity,
     TypeOrigin,

--- a/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
+++ b/pgrx-sql-entity-graph/src/metadata/sql_translatable.rs
@@ -212,8 +212,77 @@ pub const fn table_item_sql(
     }
 }
 
+/// Implements `SqlTranslatable` for a type with a fixed external SQL mapping.
+///
+/// This macro uses `pgrx_resolved_type!(T)` for `TYPE_IDENT`, sets
+/// `TYPE_ORIGIN` to `TypeOrigin::External`, and fills in the const SQL metadata
+/// for the common "map this Rust wrapper to an existing SQL type" case.
+///
+/// Write the `unsafe impl SqlTranslatable` by hand when the type is owned by
+/// this extension, or when argument and return SQL need different mappings.
+///
+/// This macro is re-exported by `pgrx`, and also available through
+/// `pgrx::prelude::*`.
+///
+/// # Examples
+///
+/// A wrapper that maps to the existing `uuid` type:
+///
+/// ```ignore
+/// use pgrx::prelude::*;
+///
+/// pub struct UuidWrapper(uuid::Uuid);
+///
+/// impl_sql_translatable!(UuidWrapper, "uuid");
+/// ```
+///
+/// An argument-only wrapper for a pseudo-type:
+///
+/// ```ignore
+/// use pgrx::prelude::*;
+///
+/// pub struct InternalArg(*mut core::ffi::c_void);
+///
+/// impl_sql_translatable!(InternalArg, arg_only = "internal");
+/// ```
+#[macro_export]
+macro_rules! impl_sql_translatable {
+    ($ty:ty, $sql:literal) => {
+        unsafe impl $crate::metadata::SqlTranslatable for $ty {
+            const TYPE_IDENT: &'static str = $crate::pgrx_resolved_type!($ty);
+            const TYPE_ORIGIN: $crate::metadata::TypeOrigin =
+                $crate::metadata::TypeOrigin::External;
+            const ARGUMENT_SQL: Result<
+                $crate::metadata::SqlMappingRef,
+                $crate::metadata::ArgumentError,
+            > = Ok($crate::metadata::SqlMappingRef::literal($sql));
+            const RETURN_SQL: Result<$crate::metadata::ReturnsRef, $crate::metadata::ReturnsError> =
+                Ok($crate::metadata::ReturnsRef::One($crate::metadata::SqlMappingRef::literal(
+                    $sql,
+                )));
+        }
+    };
+    ($ty:ty, arg_only = $sql:literal) => {
+        unsafe impl $crate::metadata::SqlTranslatable for $ty {
+            const TYPE_IDENT: &'static str = $crate::pgrx_resolved_type!($ty);
+            const TYPE_ORIGIN: $crate::metadata::TypeOrigin =
+                $crate::metadata::TypeOrigin::External;
+            const ARGUMENT_SQL: Result<
+                $crate::metadata::SqlMappingRef,
+                $crate::metadata::ArgumentError,
+            > = Ok($crate::metadata::SqlMappingRef::literal($sql));
+            const RETURN_SQL: Result<$crate::metadata::ReturnsRef, $crate::metadata::ReturnsError> =
+                Err($crate::metadata::ReturnsError::Datum);
+        }
+    };
+}
+
 /**
 A value which can be represented in SQL
+
+If you need the common "fixed external SQL type" case, prefer
+`impl_sql_translatable!`. Write the trait impl by hand when the type is owned
+by this extension, or when argument and return SQL differ.
 
 # Safety
 
@@ -357,6 +426,43 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct MacroExternalType;
+    impl_sql_translatable!(MacroExternalType, "uuid");
+
+    struct MacroArgOnlyType;
+    impl_sql_translatable!(MacroArgOnlyType, arg_only = "internal");
+
+    #[test]
+    fn impl_sql_translatable_sets_external_defaults() {
+        assert_eq!(
+            <MacroExternalType as SqlTranslatable>::TYPE_IDENT,
+            concat!(module_path!(), "::", "MacroExternalType")
+        );
+        assert_eq!(<MacroExternalType as SqlTranslatable>::TYPE_ORIGIN, TypeOrigin::External);
+        assert_eq!(
+            <MacroExternalType as SqlTranslatable>::ARGUMENT_SQL,
+            Ok(SqlMappingRef::literal("uuid"))
+        );
+        assert_eq!(
+            <MacroExternalType as SqlTranslatable>::RETURN_SQL,
+            Ok(ReturnsRef::One(SqlMappingRef::literal("uuid")))
+        );
+    }
+
+    #[test]
+    fn impl_sql_translatable_supports_arg_only_types() {
+        assert_eq!(
+            <MacroArgOnlyType as SqlTranslatable>::TYPE_IDENT,
+            concat!(module_path!(), "::", "MacroArgOnlyType")
+        );
+        assert_eq!(<MacroArgOnlyType as SqlTranslatable>::TYPE_ORIGIN, TypeOrigin::External);
+        assert_eq!(
+            <MacroArgOnlyType as SqlTranslatable>::ARGUMENT_SQL,
+            Ok(SqlMappingRef::literal("internal"))
+        );
+        assert_eq!(<MacroArgOnlyType as SqlTranslatable>::RETURN_SQL, Err(ReturnsError::Datum));
+    }
 
     #[test]
     fn array_argument_sql_wraps_scalar_kinds() {

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -31,6 +31,8 @@ use std::sync::LazyLock as Lazy;
 // expose our various derive macros
 pub use pgrx_macros;
 pub use pgrx_macros::*;
+#[doc(inline)]
+pub use pgrx_sql_entity_graph::metadata::impl_sql_translatable;
 pub use pgrx_sql_entity_graph::pgrx_resolved_type;
 
 /// The PGRX prelude includes necessary imports to make extensions work.

--- a/pgrx/src/prelude.rs
+++ b/pgrx/src/prelude.rs
@@ -17,7 +17,7 @@ pub use crate::pg_sys;
 pub use crate::pg_module_magic;
 
 // Necessary local macros:
-pub use crate::{default, name};
+pub use crate::{default, impl_sql_translatable, name};
 
 // Needed for variant RETURNS
 pub use crate::iter::{SetOfIterator, TableIterator};
@@ -63,3 +63,31 @@ pub use crate::pg_sys::{
     FATAL, PANIC, check_for_interrupts, debug1, debug2, debug3, debug4, debug5, ereport,
     ereport_domain, error, function_name, info, log, notice, warning,
 };
+
+#[cfg(test)]
+mod tests {
+    use crate::pgrx_sql_entity_graph::metadata::{
+        ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
+    };
+    use crate::prelude::*;
+
+    struct PreludeMacroType;
+    impl_sql_translatable!(PreludeMacroType, "uuid");
+
+    #[test]
+    fn prelude_reexports_impl_sql_translatable() {
+        assert_eq!(
+            <PreludeMacroType as SqlTranslatable>::TYPE_IDENT,
+            concat!(module_path!(), "::", "PreludeMacroType")
+        );
+        assert_eq!(<PreludeMacroType as SqlTranslatable>::TYPE_ORIGIN, TypeOrigin::External);
+        assert_eq!(
+            <PreludeMacroType as SqlTranslatable>::ARGUMENT_SQL,
+            Ok(SqlMappingRef::literal("uuid"))
+        );
+        assert_eq!(
+            <PreludeMacroType as SqlTranslatable>::RETURN_SQL,
+            Ok(ReturnsRef::One(SqlMappingRef::literal("uuid")))
+        );
+    }
+}

--- a/v18-ONE-COMPILE-CHANGELOG.md
+++ b/v18-ONE-COMPILE-CHANGELOG.md
@@ -90,6 +90,10 @@ same spelled name but different module paths don't collapse onto the same graph 
 words, resolution is now keyed by a qualified Rust identity instead of a loosely inferred SQL
 name.
 
+For the common "this Rust wrapper maps to an existing SQL type" case, the branch
+also adds `impl_sql_translatable!`. That helper lives with `SqlTranslatable`,
+is re-exported by `pgrx`, and is available from `pgrx::prelude::*`.
+
 The branch also routed concrete type producers and consumers through that model consistently.
 Derived SQL entities, manual `SqlTranslatable` impls, and graph lookups all speak the same
 identity language now.
@@ -276,6 +280,7 @@ For extension authors, the branch leaves a few clear takeaways:
 - treat missing embedded schema metadata as a build problem, not something `cargo pgrx schema`
   should paper over
 - on manual `SqlTranslatable` impls, define `TYPE_IDENT`
+- for fixed external SQL mappings, prefer `impl_sql_translatable!(T, "...")`
 - don't rely on wrappers to make a non-SQL leaf type acceptable
 - use `extension_sql!(..., creates = ...)` only for extension-owned, concrete SQL types or enums
 - expect explicit `composite_type!(...)` declarations to stay SQL-only unless there is a real

--- a/v18-TYPE-RESOLUTION.md
+++ b/v18-TYPE-RESOLUTION.md
@@ -159,6 +159,13 @@ unsafe trait SqlTranslatable {
 
 This is the actual contract.
 
+For the common "fixed external SQL type" case, you usually don't need to write
+all four consts by hand. `impl_sql_translatable!(T, "uuid")`, re-exported by
+`pgrx::prelude::*`, expands to the same contract with
+`TYPE_IDENT = pgrx_resolved_type!(T)`, `TYPE_ORIGIN = TypeOrigin::External`,
+and matching argument and return SQL. The `arg_only = "..."` form keeps the
+same external identity but leaves the return mapping invalid.
+
 ### `TYPE_IDENT`
 
 `TYPE_IDENT` is the graph identity for the Rust type.
@@ -477,21 +484,11 @@ while the emitted SQL text is `complex`.
 ### Example 2: Manual wrapper for an existing SQL type
 
 ```rust
-use pgrx::pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-    TypeOrigin,
-};
+use pgrx::prelude::*;
 
 pub struct UuidWrapper;
 
-unsafe impl SqlTranslatable for UuidWrapper {
-    const TYPE_IDENT: &'static str = pgrx::pgrx_resolved_type!(UuidWrapper);
-    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("uuid"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("uuid")));
-}
+impl_sql_translatable!(UuidWrapper, "uuid");
 
 #[pg_extern]
 fn echo_uuid(value: UuidWrapper) -> UuidWrapper {
@@ -501,7 +498,7 @@ fn echo_uuid(value: UuidWrapper) -> UuidWrapper {
 
 What happens:
 
-- the Rust identity is `my_extension::UuidWrapper`
+- the macro sets the Rust identity to `my_extension::UuidWrapper`
 - there is no requirement for a local type owner because the origin is
   `External`
 - the emitted SQL type is `uuid`

--- a/v18.0-MIGRATION.md
+++ b/v18.0-MIGRATION.md
@@ -153,6 +153,36 @@ error[E0046]: not all trait items implemented, missing: `TYPE_IDENT`,
 
 this is the fix.
 
+### Use `impl_sql_translatable!` for fixed external mappings
+
+If your wrapper maps to an existing SQL type and the argument and return SQL are
+the same, you don't need to write the full `unsafe impl`.
+
+Use the helper macro from `pgrx::prelude::*`:
+
+```rust
+use pgrx::prelude::*;
+
+pub struct UuidWrapper;
+
+impl_sql_translatable!(UuidWrapper, "uuid");
+```
+
+There is also an argument-only form for pseudo-types:
+
+```rust
+use pgrx::prelude::*;
+
+pub struct InternalArg(*mut core::ffi::c_void);
+
+impl_sql_translatable!(InternalArg, arg_only = "internal");
+```
+
+The helper always uses `pgrx_resolved_type!(T)` for `TYPE_IDENT` and
+`TypeOrigin::External` for `TYPE_ORIGIN`. If the type is owned by this
+extension, or if the argument and return SQL differ, keep writing the
+`SqlTranslatable` impl by hand.
+
 ## `TYPE_IDENT` Should Come From `pgrx_resolved_type!`
 
 Don't hard-code a bare string unless you have a very specific reason and know
@@ -326,26 +356,19 @@ unsafe impl SqlTranslatable for UuidWrapper {
 After:
 
 ```rust
-use pgrx::pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-    TypeOrigin,
-};
+use pgrx::prelude::*;
 
 pub struct UuidWrapper;
 
-unsafe impl SqlTranslatable for UuidWrapper {
-    const TYPE_IDENT: &'static str = pgrx::pgrx_resolved_type!(UuidWrapper);
-    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("uuid"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("uuid")));
-}
+impl_sql_translatable!(UuidWrapper, "uuid");
 ```
 
 With that setup, a later `#[pg_extern]` that takes `UuidWrapper` will render its
 SQL argument as `uuid`. No `CREATE TYPE uuid_wrapper` statement is emitted,
 because you are not defining a new SQL type.
+
+Under the hood, the macro still sets `TYPE_IDENT` with
+`pgrx_resolved_type!(UuidWrapper)` and marks the mapping as `External`.
 
 If you had old code that did both, a `CREATE TYPE uuid_wrapper` declaration and
 an `argument_sql()` that returned `"uuid"`, decide which behavior you actually


### PR DESCRIPTION
## Summary
- Adds a `#[macro_export]` `impl_sql_translatable!` macro that downstream crates can use to register external types with the SQL entity graph
- Two variants: standard (same SQL type for arguments and returns) and `arg_only` (for pseudo-type wrappers where the return type is not valid)
- Per @eeeebbbbrrrr's feedback on https://github.com/paradedb/paradedb/pull/4602 to upstream this from ParadeDB into pgrx