### PR TITLE
fix: avoid heap allocation in elog macros for string literals

### DIFF
--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -96,195 +96,293 @@ impl From<i32> for PgLogLevel {
     }
 }
 
+// Checks whether a string literal contains `{` or `}` characters, indicating it may need
+// processing by `format!()`. Used by the elog macros to decide at compile time whether a
+// literal can be passed directly to `ereport!` (avoiding a heap allocation) or needs to go
+// through `format!()` first.
+//
+// This intentionally matches escaped braces (`{{`, `}}`) too, since `format!()` is still
+// needed to resolve those to single braces.
+//
+// This is a `const fn` so it can be evaluated inside `const { }` blocks in macros.
+#[doc(hidden)]
+pub const fn literal_has_format_args(s: &str) -> bool {
+    // `str::contains` is not const, so we scan bytes manually.
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' || bytes[i] == b'}' {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Log to Postgres' `debug5` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG5` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug5 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `debug4` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG4` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug4 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `debug3` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG3` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug3 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `debug2` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG2` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug2 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `debug1` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `DEBUG1` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug1 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `log` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 ///
 /// The output these logs goes to the PostgreSQL log file at `LOG` level, depending on how the
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! log {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::LOG, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::LOG, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::LOG, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::LOG, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `info` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! info {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::INFO, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::INFO, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::INFO, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::INFO, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `notice` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! notice {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `warning` log level.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! warning {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::WARNING, $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING, alloc::format!($($arg)*).as_str());
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::WARNING, $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::WARNING, $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING, $msg);
         }
-    )
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::WARNING, $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING, alloc::format!($($arg)*).as_str());
+    }};
 }
 
 /// Log to Postgres' `error` log level.  This will abort the current Postgres transaction.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! error {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::ERROR, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
-            unreachable!()
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::ERROR, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::ERROR, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, $msg);
         }
-    );
+        unreachable!()
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::ERROR, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
+        unreachable!()
+    }};
 }
 
 /// Log to Postgres' `fatal` log level.  This will abort the current Postgres backend connection process.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! FATAL {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::FATAL, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
-            unreachable!()
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::FATAL, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::FATAL, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, $msg);
         }
-    )
+        unreachable!()
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::FATAL, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
+        unreachable!()
+    }};
 }
 
 /// Log to Postgres' `panic` log level.  This will cause the entire Postgres cluster to crash.
 ///
-/// This macro accepts arguments like the [`println`] and [`format`] macros.
+/// Besides string literals, this macro accepts arguments like the [`println`] and [`format`] macros.
 /// See [`fmt`](std::fmt) for information about options.
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! PANIC {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::PANIC, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
-            unreachable!()
+    ($msg:literal) => {{
+        extern crate alloc;
+        if const { $crate::elog::literal_has_format_args($msg) } {
+            $crate::ereport!($crate::elog::PgLogLevel::PANIC, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($msg).as_str());
+        } else {
+            $crate::ereport!($crate::elog::PgLogLevel::PANIC, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, $msg);
         }
-    )
+        unreachable!()
+    }};
+    ($($arg:tt)*) => {{
+        extern crate alloc;
+        $crate::ereport!($crate::elog::PgLogLevel::PANIC, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
+        unreachable!()
+    }};
 }
 
 // shamelessly borrowed from https://docs.rs/stdext/0.2.1/src/stdext/macros.rs.html#61-72

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -456,63 +456,83 @@ macro_rules! ereport {
     };
 
     (WARNING, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::WARNING)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::WARNING as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::WARNING)
+        }
     };
 
     (NOTICE, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::NOTICE)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::NOTICE as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::NOTICE)
+        }
     };
 
     (INFO, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::INFO)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::INFO as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::INFO)
+        }
     };
 
     (LOG, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::LOG)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::LOG as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::LOG)
+        }
     };
 
     (DEBUG5, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG5)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG5 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG5)
+        }
     };
 
     (DEBUG4, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG4)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG4 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG4)
+        }
     };
 
     (DEBUG3, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG3)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG3 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG3)
+        }
     };
 
     (DEBUG2, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG2)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG2 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG2)
+        }
     };
 
     (DEBUG1, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG1)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG1 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG1)
+        }
     };
 
     ($loglevel:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($loglevel);
+        if unsafe { $crate::message_level_is_interesting($loglevel as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($loglevel);
+        }
     };
 }
 
@@ -573,73 +593,93 @@ macro_rules! ereport_domain {
     };
 
     (WARNING, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::WARNING)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::WARNING as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::WARNING)
+        }
     };
 
     (NOTICE, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::NOTICE)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::NOTICE as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::NOTICE)
+        }
     };
 
     (INFO, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::INFO)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::INFO as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::INFO)
+        }
     };
 
     (LOG, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::LOG)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::LOG as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::LOG)
+        }
     };
 
     (DEBUG5, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG5)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG5 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG5)
+        }
     };
 
     (DEBUG4, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG4)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG4 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG4)
+        }
     };
 
     (DEBUG3, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG3)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG3 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG3)
+        }
     };
 
     (DEBUG2, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG2)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG2 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG2)
+        }
     };
 
     (DEBUG1, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG1)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG1 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG1)
+        }
     };
 
     ($loglevel:expr, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($loglevel);
+        if unsafe { $crate::message_level_is_interesting($loglevel as _) } {
+            $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($loglevel);
+        }
     };
 }
 

--- a/pgrx-tests/src/tests/log_tests.rs
+++ b/pgrx-tests/src/tests/log_tests.rs
@@ -13,6 +13,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_tests;
     use pgrx::prelude::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[pg_test]
     fn test_info() {
@@ -113,5 +114,40 @@ mod tests {
     #[pg_test(error = "panic message")]
     fn test_panic() {
         panic!("panic message")
+    }
+
+    static FORMAT_ARG_EVALUATED: AtomicBool = AtomicBool::new(false);
+
+    fn evaluate_format_arg() -> &'static str {
+        FORMAT_ARG_EVALUATED.store(true, Ordering::SeqCst);
+        "evaluated"
+    }
+
+    // With default settings (log_min_messages=WARNING, client_min_messages=NOTICE),
+    // DEBUG-level messages are not interesting, so we shouldn't be evaluating format arguments
+    // eagerly.
+    #[pg_test]
+    fn test_debug_skips_arg_evaluation() {
+        FORMAT_ARG_EVALUATED.store(false, Ordering::SeqCst);
+        debug5!("{}", evaluate_format_arg());
+        debug4!("{}", evaluate_format_arg());
+        debug3!("{}", evaluate_format_arg());
+        debug2!("{}", evaluate_format_arg());
+        debug1!("{}", evaluate_format_arg());
+        assert!(
+            !FORMAT_ARG_EVALUATED.load(Ordering::SeqCst),
+            "DEBUG-level messages should not evaluate format arguments eagerly at default log level"
+        );
+    }
+
+    #[pg_test]
+    fn test_warning_evaluates_args() {
+        // WARNING is interesting at default settings (log_min_messages=WARNING)
+        FORMAT_ARG_EVALUATED.store(false, Ordering::SeqCst);
+        warning!("{}", evaluate_format_arg());
+        assert!(
+            FORMAT_ARG_EVALUATED.load(Ordering::SeqCst),
+            "warning! should evaluate format arguments at default log level"
+        );
     }
 }


### PR DESCRIPTION
Currently all calls to logging macros will unconditionally allocate a String via `format!` just to then pass a pointer to it via `.as_str()`.

This is fine for formatted arguments (e.g. `debug3!("x={}", val)`), where a String allocation is needed, but is wasteful for string literal arguments (e.g. `debug3!("some message")`), since we effectively do `&'static str` => `String` => `&str` then.

This problem is compounded by https://github.com/pgcentralfoundation/pgrx/issues/2267, so that even when we have e.g. `debug3!("my message")` but log level is set to info we will be doing redundant heap allocations.

This PR alleviates the problem by adding another arm in the macro that matches the string literal invocation.