### PR TITLE
Include "libpq/oauth.h" for OAuth validators

### DIFF
--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -101,6 +101,7 @@
 #include "foreign/foreign.h"
 #include "jit/jit.h"
 #include "lib/stringinfo.h"
+#include "libpq/oauth.h"
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "nodes/execnodes.h"


### PR DESCRIPTION
OAuth validator modules are shared libraries that validate OAuth tokens as part of the `oauth` authentication method introduced in Postgres 18.

When a connection matches an `oauth` HBA rule, Postgres loads one of the modules listed in the `oauth_validator_libraries` GUC and calls its exported `_PG_oauth_validator_module_init` function.

That function must return a populated `OAuthValidatorCallbacks` struct with the module's compile-time `PG_OAUTH_VALIDATOR_MAGIC` constant. These and other validator types are defined in `libpq/oauth.h`.

See: https://www.postgresql.org/docs/current/auth-oauth.html
See: https://www.postgresql.org/docs/current/oauth-validators.html

---

e.g. https://github.com/percona/pg_oidc_validator/blob/0.2/src/pg_oidc_validator.cpp#L15

With this, I see new types and constants in `pg18.rs`:

- `pub const PG_OAUTH_VALIDATOR_MAGIC`
- `pub struct OAuthValidatorCallbacks`
- `pub type OAuthValidatorModuleInit` (fn)
- `pub struct ValidatorModuleResult`
- `pub struct ValidatorModuleState`
- `pub type ValidatorShutdownCB` (fn)
- `pub type ValidatorStartupCB` (fn)
- `pub type ValidatorValidateCB` (fn)