### PR TITLE
feat: avoid eager allocation of log messages on the heap

### DIFF
--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -96,6 +96,28 @@ impl From<i32> for PgLogLevel {
     }
 }
 
+impl PgLogLevel {
+    /// Denotes whether this log level will be logged to the server/client log, or would it result
+    /// in a no-op.
+    #[doc(hidden)]
+    #[inline]
+    pub fn is_interesting(&self) -> bool {
+        #[cfg(not(feature = "pg13"))]
+        {
+            unsafe { crate::message_level_is_interesting(*self as _) }
+        }
+        #[cfg(feature = "pg13")]
+        {
+            let level = *self as i32;
+            unsafe {
+                level >= crate::PGERROR as i32
+                    || level >= crate::log_min_messages
+                    || level >= crate::client_min_messages
+            }
+        }
+    }
+}
+
 // Trait used by the elog/ereport macros to convert message arguments into
 // `Cow<'static, str>` for `ErrorReport`. This allows:
 //   - `fmt::Arguments` for plain literals → `Cow::Borrowed` via `as_str()` (zero allocation)
@@ -332,7 +354,7 @@ macro_rules! ereport {
     };
 
     (WARNING, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::WARNING as _) } {
+        if $crate::elog::PgLogLevel::WARNING.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::WARNING)
@@ -340,7 +362,7 @@ macro_rules! ereport {
     };
 
     (NOTICE, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::NOTICE as _) } {
+        if $crate::elog::PgLogLevel::NOTICE.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::NOTICE)
@@ -348,7 +370,7 @@ macro_rules! ereport {
     };
 
     (INFO, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::INFO as _) } {
+        if $crate::elog::PgLogLevel::INFO.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::INFO)
@@ -356,7 +378,7 @@ macro_rules! ereport {
     };
 
     (LOG, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::LOG as _) } {
+        if $crate::elog::PgLogLevel::LOG.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::LOG)
@@ -364,7 +386,7 @@ macro_rules! ereport {
     };
 
     (DEBUG5, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG5 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG5.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::DEBUG5)
@@ -372,7 +394,7 @@ macro_rules! ereport {
     };
 
     (DEBUG4, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG4 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG4.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::DEBUG4)
@@ -380,7 +402,7 @@ macro_rules! ereport {
     };
 
     (DEBUG3, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG3 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG3.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::DEBUG3)
@@ -388,7 +410,7 @@ macro_rules! ereport {
     };
 
     (DEBUG2, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG2 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG2.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::DEBUG2)
@@ -396,7 +418,7 @@ macro_rules! ereport {
     };
 
     (DEBUG1, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG1 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG1.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($crate::elog::PgLogLevel::DEBUG1)
@@ -404,7 +426,7 @@ macro_rules! ereport {
     };
 
     ($loglevel:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($loglevel as _) } {
+        if $loglevel.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 $(.set_detail($detail))?
                 .report($loglevel);
@@ -469,7 +491,7 @@ macro_rules! ereport_domain {
     };
 
     (WARNING, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::WARNING as _) } {
+        if $crate::elog::PgLogLevel::WARNING.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -478,7 +500,7 @@ macro_rules! ereport_domain {
     };
 
     (NOTICE, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::NOTICE as _) } {
+        if $crate::elog::PgLogLevel::NOTICE.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -487,7 +509,7 @@ macro_rules! ereport_domain {
     };
 
     (INFO, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::INFO as _) } {
+        if $crate::elog::PgLogLevel::INFO.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -496,7 +518,7 @@ macro_rules! ereport_domain {
     };
 
     (LOG, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::LOG as _) } {
+        if $crate::elog::PgLogLevel::LOG.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -505,7 +527,7 @@ macro_rules! ereport_domain {
     };
 
     (DEBUG5, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG5 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG5.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -514,7 +536,7 @@ macro_rules! ereport_domain {
     };
 
     (DEBUG4, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG4 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG4.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -523,7 +545,7 @@ macro_rules! ereport_domain {
     };
 
     (DEBUG3, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG3 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG3.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -532,7 +554,7 @@ macro_rules! ereport_domain {
     };
 
     (DEBUG2, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG2 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG2.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -541,7 +563,7 @@ macro_rules! ereport_domain {
     };
 
     (DEBUG1, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG1 as _) } {
+        if $crate::elog::PgLogLevel::DEBUG1.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?
@@ -550,7 +572,7 @@ macro_rules! ereport_domain {
     };
 
     ($loglevel:expr, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        if unsafe { $crate::message_level_is_interesting($loglevel as _) } {
+        if $loglevel.is_interesting() {
             $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
                 .set_domain($domain)
                 $(.set_detail($detail))?

--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -96,6 +96,43 @@ impl From<i32> for PgLogLevel {
     }
 }
 
+// Trait used by the elog/ereport macros to convert message arguments into
+// `Cow<'static, str>` for `ErrorReport`. This allows:
+//   - `fmt::Arguments` for plain literals → `Cow::Borrowed` via `as_str()` (zero allocation)
+//   - `fmt::Arguments` with placeholders → `Cow::Owned` via `.to_string()` (one allocation)
+//   - `String` → `Cow::Owned` (zero extra allocation, moved)
+#[doc(hidden)]
+pub trait IntoMessage {
+    fn into_message(self) -> std::borrow::Cow<'static, str>;
+}
+
+impl IntoMessage for &str {
+    #[inline]
+    fn into_message(self) -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Owned(self.to_owned())
+    }
+}
+
+impl IntoMessage for String {
+    #[inline]
+    fn into_message(self) -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Owned(self)
+    }
+}
+
+impl IntoMessage for std::fmt::Arguments<'_> {
+    #[inline]
+    fn into_message(self) -> std::borrow::Cow<'static, str> {
+        // `as_str()` returns `Some(&'static str)` for plain literals (e.g. `format_args!("hello")`)
+        // avoiding heap allocation entirely via `Cow::Borrowed`.
+        // For format strings with placeholders it returns `None`, falling back to `.to_string()`.
+        match self.as_str() {
+            Some(s) => std::borrow::Cow::Borrowed(s),
+            None => std::borrow::Cow::Owned(self.to_string()),
+        }
+    }
+}
+
 /// Log to Postgres' `debug5` log level.
 ///
 /// This macro accepts arguments like the [`println`] and [`format`] macros.
@@ -105,12 +142,7 @@ impl From<i32> for PgLogLevel {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug5 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::DEBUG5, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `debug4` log level.
@@ -122,12 +154,7 @@ macro_rules! debug5 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug4 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::DEBUG4, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `debug3` log level.
@@ -139,12 +166,7 @@ macro_rules! debug4 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug3 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::DEBUG3, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `debug2` log level.
@@ -156,12 +178,7 @@ macro_rules! debug3 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug2 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::DEBUG2, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `debug1` log level.
@@ -173,12 +190,7 @@ macro_rules! debug2 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! debug1 {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::DEBUG1, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `log` log level.
@@ -190,12 +202,7 @@ macro_rules! debug1 {
 /// [PostgreSQL settings](https://www.postgresql.org/docs/current/runtime-config-logging.html) are configured.
 #[macro_export]
 macro_rules! log {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::LOG, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::LOG, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `info` log level.
@@ -204,12 +211,7 @@ macro_rules! log {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! info {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::INFO, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::INFO, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `notice` log level.
@@ -218,12 +220,7 @@ macro_rules! info {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! notice {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::NOTICE, $crate::errcodes::PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `warning` log level.
@@ -232,12 +229,7 @@ macro_rules! notice {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! warning {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::WARNING, $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING, alloc::format!($($arg)*).as_str());
-        }
-    )
+    ($($arg:tt)*) => { $crate::ereport!($crate::elog::PgLogLevel::WARNING, $crate::errcodes::PgSqlErrorCode::ERRCODE_WARNING, format_args!($($arg)*)) };
 }
 
 /// Log to Postgres' `error` log level.  This will abort the current Postgres transaction.
@@ -246,13 +238,7 @@ macro_rules! warning {
 /// See [`fmt`](std::fmt) for information about options.
 #[macro_export]
 macro_rules! error {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::ERROR, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
-            unreachable!()
-        }
-    );
+    ($($arg:tt)*) => {{ $crate::ereport!($crate::elog::PgLogLevel::ERROR, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, format_args!($($arg)*)); unreachable!() }};
 }
 
 /// Log to Postgres' `fatal` log level.  This will abort the current Postgres backend connection process.
@@ -262,13 +248,7 @@ macro_rules! error {
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! FATAL {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::FATAL, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
-            unreachable!()
-        }
-    )
+    ($($arg:tt)*) => {{ $crate::ereport!($crate::elog::PgLogLevel::FATAL, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, format_args!($($arg)*)); unreachable!() }};
 }
 
 /// Log to Postgres' `panic` log level.  This will cause the entire Postgres cluster to crash.
@@ -278,13 +258,7 @@ macro_rules! FATAL {
 #[allow(non_snake_case)]
 #[macro_export]
 macro_rules! PANIC {
-    ($($arg:tt)*) => (
-        {
-            extern crate alloc;
-            $crate::ereport!($crate::elog::PgLogLevel::PANIC, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, alloc::format!($($arg)*).as_str());
-            unreachable!()
-        }
-    )
+    ($($arg:tt)*) => {{ $crate::ereport!($crate::elog::PgLogLevel::PANIC, $crate::errcodes::PgSqlErrorCode::ERRCODE_INTERNAL_ERROR, format_args!($($arg)*)); unreachable!() }};
 }
 
 // shamelessly borrowed from https://docs.rs/stdext/0.2.1/src/stdext/macros.rs.html#61-72
@@ -337,84 +311,104 @@ macro_rules! function_name {
 #[macro_export]
 macro_rules! ereport {
     (ERROR, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+        $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::ERROR);
         unreachable!();
     };
 
     (PANIC, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+        $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::PANIC);
         unreachable!();
     };
 
     (FATAL, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+        $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::FATAL);
         unreachable!();
     };
 
     (WARNING, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::WARNING)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::WARNING as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::WARNING)
+        }
     };
 
     (NOTICE, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::NOTICE)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::NOTICE as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::NOTICE)
+        }
     };
 
     (INFO, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::INFO)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::INFO as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::INFO)
+        }
     };
 
     (LOG, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::LOG)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::LOG as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::LOG)
+        }
     };
 
     (DEBUG5, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG5)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG5 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG5)
+        }
     };
 
     (DEBUG4, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG4)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG4 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG4)
+        }
     };
 
     (DEBUG3, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG3)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG3 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG3)
+        }
     };
 
     (DEBUG2, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG2)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG2 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG2)
+        }
     };
 
     (DEBUG1, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG1)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG1 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG1)
+        }
     };
 
     ($loglevel:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            $(.set_detail($detail))?
-            .report($loglevel);
+        if unsafe { $crate::message_level_is_interesting($loglevel as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                $(.set_detail($detail))?
+                .report($loglevel);
+        }
     };
 }
 
@@ -451,7 +445,7 @@ pub fn interrupt_pending() -> bool {
 #[macro_export]
 macro_rules! ereport_domain {
     (ERROR, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+        $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::ERROR);
@@ -459,7 +453,7 @@ macro_rules! ereport_domain {
     };
 
     (PANIC, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+        $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::PANIC);
@@ -467,7 +461,7 @@ macro_rules! ereport_domain {
     };
 
     (FATAL, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
+        $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
             .set_domain($domain)
             $(.set_detail($detail))?
             .report($crate::elog::PgLogLevel::FATAL);
@@ -475,73 +469,93 @@ macro_rules! ereport_domain {
     };
 
     (WARNING, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::WARNING)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::WARNING as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::WARNING)
+        }
     };
 
     (NOTICE, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::NOTICE)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::NOTICE as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::NOTICE)
+        }
     };
 
     (INFO, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::INFO)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::INFO as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::INFO)
+        }
     };
 
     (LOG, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::LOG)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::LOG as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::LOG)
+        }
     };
 
     (DEBUG5, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG5)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG5 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG5)
+        }
     };
 
     (DEBUG4, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG4)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG4 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG4)
+        }
     };
 
     (DEBUG3, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG3)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG3 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG3)
+        }
     };
 
     (DEBUG2, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG2)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG2 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG2)
+        }
     };
 
     (DEBUG1, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($crate::elog::PgLogLevel::DEBUG1)
+        if unsafe { $crate::message_level_is_interesting($crate::elog::PgLogLevel::DEBUG1 as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($crate::elog::PgLogLevel::DEBUG1)
+        }
     };
 
     ($loglevel:expr, $domain:expr, $errcode:expr, $message:expr $(, $detail:expr)? $(,)?) => {
-        $crate::panic::ErrorReport::new($errcode, $message, $crate::function_name!())
-            .set_domain($domain)
-            $(.set_detail($detail))?
-            .report($loglevel);
+        if unsafe { $crate::message_level_is_interesting($loglevel as _) } {
+            $crate::panic::ErrorReport::new($errcode, $crate::elog::IntoMessage::into_message($message), $crate::function_name!())
+                .set_domain($domain)
+                $(.set_detail($detail))?
+                .report($loglevel);
+        }
     };
 }
 

--- a/pgrx-pg-sys/src/submodules/ffi.rs
+++ b/pgrx-pg-sys/src/submodules/ffi.rs
@@ -255,7 +255,7 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
                 level,
                 inner: ErrorReport {
                     sqlerrcode,
-                    message,
+                    message: message.into(),
                     detail,
                     hint,
                     domain,

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -12,6 +12,7 @@
 
 use core::ffi::CStr;
 use std::any::Any;
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::fmt::{Display, Formatter};
 use std::hint::unreachable_unchecked;
@@ -50,7 +51,7 @@ where
                 any.downcast::<ErrorReport>().unwrap().report(PgLogLevel::ERROR);
                 unreachable!();
             } else {
-                ereport!(ERROR, PgSqlErrorCode::ERRCODE_DATA_EXCEPTION, &format!("{e}"));
+                ereport!(ERROR, PgSqlErrorCode::ERRCODE_DATA_EXCEPTION, format!("{e}"));
             }
         })
     }
@@ -123,7 +124,7 @@ impl From<&PanicHookInfo<'_>> for ErrorReportLocation {
 #[derive(Debug)]
 pub struct ErrorReport {
     pub(crate) sqlerrcode: PgSqlErrorCode,
-    pub(crate) message: String,
+    pub(crate) message: Cow<'static, str>,
     pub(crate) hint: Option<String>,
     pub(crate) detail: Option<String>,
     pub(crate) domain: Option<String>,
@@ -245,7 +246,7 @@ impl ErrorReport {
     ///
     /// Embedded "file:line:col" location information is taken from the caller's location
     #[track_caller]
-    pub fn new<S: Into<String>>(
+    pub fn new<S: Into<Cow<'static, str>>>(
         sqlerrcode: PgSqlErrorCode,
         message: S,
         funcname: &'static str,
@@ -267,7 +268,7 @@ impl ErrorReport {
     /// a specific Postgres "ereport()` level via [ErrorReport::unwrap_or_report(self, PgLogLevel)].
     ///
     /// For internal use only
-    fn with_location<S: Into<String>>(
+    fn with_location<S: Into<Cow<'static, str>>>(
         sqlerrcode: PgSqlErrorCode,
         message: S,
         location: ErrorReportLocation,
@@ -493,7 +494,7 @@ pub(crate) fn downcast_panic_payload(e: Box<dyn Any + Send>) -> CaughtError {
                 level: PgLogLevel::ERROR,
                 inner: ErrorReport::with_location(
                     PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
-                    *message,
+                    message.to_string(),
                     take_panic_location(),
                 ),
             },
@@ -506,7 +507,7 @@ pub(crate) fn downcast_panic_payload(e: Box<dyn Any + Send>) -> CaughtError {
                 level: PgLogLevel::ERROR,
                 inner: ErrorReport::with_location(
                     PgSqlErrorCode::ERRCODE_INTERNAL_ERROR,
-                    message,
+                    message.clone(),
                     take_panic_location(),
                 ),
             },

--- a/pgrx-unit-tests/src/tests/log_tests.rs
+++ b/pgrx-unit-tests/src/tests/log_tests.rs
@@ -13,6 +13,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate as pgrx_unit_tests;
     use pgrx::prelude::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[pg_test]
     fn test_info() {
@@ -113,5 +114,40 @@ mod tests {
     #[pg_test(error = "panic message")]
     fn test_panic() {
         panic!("panic message")
+    }
+
+    static FORMAT_ARG_EVALUATED: AtomicBool = AtomicBool::new(false);
+
+    fn evaluate_format_arg() -> &'static str {
+        FORMAT_ARG_EVALUATED.store(true, Ordering::SeqCst);
+        "evaluated"
+    }
+
+    // With default settings (log_min_messages=WARNING, client_min_messages=NOTICE),
+    // DEBUG-level messages are not interesting, so we shouldn't be evaluating format arguments
+    // eagerly.
+    #[pg_test]
+    fn test_debug_skips_arg_evaluation() {
+        FORMAT_ARG_EVALUATED.store(false, Ordering::SeqCst);
+        debug5!("{}", evaluate_format_arg());
+        debug4!("{}", evaluate_format_arg());
+        debug3!("{}", evaluate_format_arg());
+        debug2!("{}", evaluate_format_arg());
+        debug1!("{}", evaluate_format_arg());
+        assert!(
+            !FORMAT_ARG_EVALUATED.load(Ordering::SeqCst),
+            "DEBUG-level messages should not evaluate format arguments eagerly at default log level"
+        );
+    }
+
+    #[pg_test]
+    fn test_warning_evaluates_args() {
+        // WARNING is interesting at default settings (log_min_messages=WARNING)
+        FORMAT_ARG_EVALUATED.store(false, Ordering::SeqCst);
+        warning!("{}", evaluate_format_arg());
+        assert!(
+            FORMAT_ARG_EVALUATED.load(Ordering::SeqCst),
+            "warning! should evaluate format arguments at default log level"
+        );
     }
 }


### PR DESCRIPTION
Closes https://github.com/pgcentralfoundation/pgrx/issues/2267

Alternative to https://github.com/pgcentralfoundation/pgrx/pull/2266.

Lazily allocate log messages by introducing a `IntoMessage` trait. 

For `format!`-like arguments it will skip allocations for static literals, since we can detect a lack of arguments to be interpolated via `fmt::Argumetns::as_str` which returns `Some(&'static str)` in that case.

Also skips the entire process early if log level is below the "interesting" threshold. 