### PR TITLE
isolate test framework Postgres instances for parallel execution

### DIFF
--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -125,6 +125,7 @@ pub struct PgConfig {
     known_props: Option<BTreeMap<String, String>>,
     base_port: u16,
     base_testing_port: u16,
+    test_port_override: Option<u16>,
 }
 
 impl Display for PgConfig {
@@ -141,6 +142,7 @@ impl Default for PgConfig {
             known_props: None,
             base_port: BASE_POSTGRES_PORT_NO,
             base_testing_port: BASE_POSTGRES_TESTING_PORT_NO,
+            test_port_override: None,
         }
     }
 }
@@ -159,6 +161,7 @@ impl PgConfig {
             known_props: None,
             base_port,
             base_testing_port,
+            test_port_override: None,
         }
     }
 
@@ -169,6 +172,7 @@ impl PgConfig {
             known_props: None,
             base_port: BASE_POSTGRES_PORT_NO,
             base_testing_port: BASE_POSTGRES_TESTING_PORT_NO,
+            test_port_override: None,
         }
     }
 
@@ -202,6 +206,7 @@ impl PgConfig {
                 known_props: Some(known_props),
                 base_port: 0,
                 base_testing_port: 0,
+                test_port_override: None,
             })
         }
     }
@@ -338,7 +343,16 @@ impl PgConfig {
     }
 
     pub fn test_port(&self) -> eyre::Result<u16> {
-        Ok(self.base_testing_port + self.major_version()?)
+        match self.test_port_override {
+            Some(port) => Ok(port),
+            None => Ok(self.base_testing_port + self.major_version()?),
+        }
+    }
+
+    /// Return a clone of this config that always returns `port` from [`test_port()`].
+    pub fn with_test_port(mut self, port: u16) -> Self {
+        self.test_port_override = Some(port);
+        self
     }
 
     pub fn host(&self) -> &'static str {

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -43,17 +43,26 @@ static TEST_MUTEX: OnceLock<Mutex<SetupState>> = OnceLock::new();
 /// Set once during test framework initialization, read by every connection.
 static TEST_PORT: OnceLock<u16> = OnceLock::new();
 
-/// Bind an ephemeral port and return the listener that holds it open.
-///
-/// The caller must keep the returned `TcpListener` alive until Postgres
-/// is about to start, then drop it so Postgres can bind the same port.
-/// This prevents another process from claiming the port during the
-/// (potentially long) install + initdb window.
-fn reserve_test_port() -> eyre::Result<(std::net::TcpListener, u16)> {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0")
-        .wrap_err("failed to bind to an ephemeral port for test Postgres")?;
-    let port = listener.local_addr()?.port();
-    Ok((listener, port))
+/// A reserved TCP port held open by a bound listener. Dropping the
+/// reservation releases the port so Postgres (or anything else) can
+/// bind it.
+struct PortReservation {
+    _listener: std::net::TcpListener,
+    port: u16,
+}
+
+impl PortReservation {
+    /// Bind an ephemeral port and hold it open until this value is dropped.
+    fn new() -> eyre::Result<Self> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .wrap_err("failed to bind to an ephemeral port for test Postgres")?;
+        let port = listener.local_addr()?.port();
+        Ok(Self { _listener: listener, port })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
 }
 
 // The goal of this closure is to allow "wrapping" of anything that might issue
@@ -244,15 +253,15 @@ fn initialize_test_framework(
     shutdown::register_shutdown_hook();
 
     // reserve a free port for this test binary's postgres instance.
-    // the listener holds the port open through install + initdb so
+    // the reservation holds the port open through install + initdb so
     // nothing else can claim it before postgres starts.
-    let (port_guard, port) = reserve_test_port()?;
-    TEST_PORT.set(port).expect("TEST_PORT already initialized");
+    let port_reservation = PortReservation::new()?;
+    TEST_PORT.set(port_reservation.port()).expect("TEST_PORT already initialized");
 
     install_extension()?;
     initdb(postgresql_conf)?;
 
-    let system_session_id = start_pg(state.loglines.clone(), port_guard)?;
+    let system_session_id = start_pg(state.loglines.clone(), port_reservation)?;
     let pg_config = get_pg_config()?;
     dropdb()?;
     createdb(&pg_config, get_pg_dbname(), true, false, get_runas())?;
@@ -557,7 +566,7 @@ fn modify_postgresql_conf(pgdata: PathBuf, postgresql_conf: Vec<&'static str>) -
     Ok(())
 }
 
-fn start_pg(loglines: LogLines, port_guard: std::net::TcpListener) -> eyre::Result<String> {
+fn start_pg(loglines: LogLines, port_reservation: PortReservation) -> eyre::Result<String> {
     wait_for_pidfile()?;
 
     #[cfg(target_family = "unix")]
@@ -671,7 +680,7 @@ fn start_pg(loglines: LogLines, port_guard: std::net::TcpListener) -> eyre::Resu
     let command_str = format!("{command:?}");
 
     // release the port so postgres can bind it
-    drop(port_guard);
+    drop(port_reservation);
 
     #[cfg(target_family = "unix")]
     let (output, mut pipe) = {

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -39,6 +39,23 @@ struct SetupState {
 
 static TEST_MUTEX: OnceLock<Mutex<SetupState>> = OnceLock::new();
 
+/// The dynamically chosen port for this test binary's Postgres instance.
+/// Set once during test framework initialization, read by every connection.
+static TEST_PORT: OnceLock<u16> = OnceLock::new();
+
+/// Bind an ephemeral port and return the listener that holds it open.
+///
+/// The caller must keep the returned `TcpListener` alive until Postgres
+/// is about to start, then drop it so Postgres can bind the same port.
+/// This prevents another process from claiming the port during the
+/// (potentially long) install + initdb window.
+fn reserve_test_port() -> eyre::Result<(std::net::TcpListener, u16)> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .wrap_err("failed to bind to an ephemeral port for test Postgres")?;
+    let port = listener.local_addr()?.port();
+    Ok((listener, port))
+}
+
 // The goal of this closure is to allow "wrapping" of anything that might issue
 // an SQL simple_query or query using either a postgres::Client or
 // postgres::Transaction and capture the output. The use of this wrapper is
@@ -225,10 +242,17 @@ fn initialize_test_framework(
     postgresql_conf: Vec<&'static str>,
 ) -> eyre::Result<()> {
     shutdown::register_shutdown_hook();
+
+    // reserve a free port for this test binary's postgres instance.
+    // the listener holds the port open through install + initdb so
+    // nothing else can claim it before postgres starts.
+    let (port_guard, port) = reserve_test_port()?;
+    TEST_PORT.set(port).expect("TEST_PORT already initialized");
+
     install_extension()?;
     initdb(postgresql_conf)?;
 
-    let system_session_id = start_pg(state.loglines.clone())?;
+    let system_session_id = start_pg(state.loglines.clone(), port_guard)?;
     let pg_config = get_pg_config()?;
     dropdb()?;
     createdb(&pg_config, get_pg_dbname(), true, false, get_runas())?;
@@ -243,13 +267,18 @@ fn get_pg_config() -> eyre::Result<PgConfig> {
 
     let pg_version = pg_sys::get_pg_major_version_num();
 
-    let pg_config = pgrx
+    let mut pg_config = pgrx
         .get(&format!("pg{pg_version}"))
         .wrap_err_with(|| {
             format!("Error getting pg_config: {pg_version} is not a valid postgres version")
         })
         .unwrap()
         .clone();
+
+    // if a dynamic test port was chosen, override the default
+    if let Some(&port) = TEST_PORT.get() {
+        pg_config = pg_config.with_test_port(port);
+    }
 
     Ok(pg_config)
 }
@@ -528,7 +557,7 @@ fn modify_postgresql_conf(pgdata: PathBuf, postgresql_conf: Vec<&'static str>) -
     Ok(())
 }
 
-fn start_pg(loglines: LogLines) -> eyre::Result<String> {
+fn start_pg(loglines: LogLines, port_guard: std::net::TcpListener) -> eyre::Result<String> {
     wait_for_pidfile()?;
 
     #[cfg(target_family = "unix")]
@@ -572,10 +601,17 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
         None
     };
 
+    let test_port = pg_config.test_port().expect("unable to determine test port");
+    println!(
+        "{} test Postgres on port {}",
+        "    Starting".bold().green(),
+        test_port.to_string().bold().cyan()
+    );
+
     let postmaster_args = vec![
         "-i".into(),
         "-p".into(),
-        pg_config.test_port().expect("unable to determine test port").to_string(),
+        test_port.to_string(),
         "-h".into(),
         pg_config.host().into(),
         "-c".into(),
@@ -634,6 +670,9 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
 
     let command_str = format!("{command:?}");
 
+    // release the port so postgres can bind it
+    drop(port_guard);
+
     #[cfg(target_family = "unix")]
     let (output, mut pipe) = {
         let output = command.output();
@@ -674,6 +713,8 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
     }
 
     add_shutdown_hook(|| {
+        let pgdata = get_pgdata_path().unwrap();
+
         let pg_config = get_pg_config().unwrap();
         let pg_ctl = pg_config.pg_ctl_path().unwrap();
 
@@ -689,7 +730,7 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
             .stderr(Stdio::piped())
             .arg("stop")
             .arg("-D")
-            .arg(get_pgdata_path().unwrap().to_str().unwrap())
+            .arg(pgdata.to_str().unwrap())
             .arg("-m")
             .arg("fast");
         let command_str = format!("{command:?}");
@@ -701,6 +742,9 @@ fn start_pg(loglines: LogLines) -> eyre::Result<String> {
                 String::from_utf8(output.stderr).unwrap()
             );
         }
+
+        // clean up the per-invocation PGDATA directory
+        let _ = std::fs::remove_dir_all(&pgdata);
     });
 
     let (sender, receiver) = std::sync::mpsc::channel();
@@ -869,8 +913,8 @@ fn get_pgdata_path() -> eyre::Result<PathBuf> {
             target_dir
         });
 
-    // append the postgres version number
-    pgdata_base.push(format!("{}", pg_sys::get_pg_major_version_num()));
+    // each invocation gets its own PGDATA so parallel test runs don't collide
+    pgdata_base.push(format!("{}-{}", pg_sys::get_pg_major_version_num(), std::process::id()));
     Ok(pgdata_base)
 }
 


### PR DESCRIPTION
AI coding agents (Claude Code, Codex, etc.) commonly invoke `cargo pgrx test` for multiple tests or crates in parallel. This clobbers because every invocation starts a Postgres instance on the same deterministic port (32200 + pg_major_version) with the same PGDATA directory (target/test-pgdata/<version>/). Two instances can't share a port or a data directory, so the second invocation fails.

Fix both collision vectors:

Port: bind an ephemeral port (port 0) and hold the TcpListener open through the install + initdb window so nothing else can claim it. The listener is dropped immediately before pg_ctl start. The chosen port is injected into PgConfig via a new `test_port_override` field, which flows through all callers of `pg_config.test_port()` (start_pg, client, dropdb, createdb) without changing their call sites.

PGDATA: include the process ID in the directory name (target/test-pgdata/<version>-<pid>/) so every invocation gets its own data directory. The shutdown hook removes it after pg_ctl stop.