### PR TITLE
Fix version-updater not updating [workspace.package].version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ repository = "https://github.com/pgcentralfoundation/pgrx/"
 homepage = "https://github.com/pgcentralfoundation/pgrx/"
 # TODO: all crates should use this version rather than copy it
 #   See https://github.com/pgcentralfoundation/pgrx/pull/2100 comments
-version = "0.16.0"
+version = "0.17.0"
 
 [workspace.metadata.local-install]
 cargo-pgrx = { path = "cargo-pgrx" }

--- a/tools/version-updater/src/main.rs
+++ b/tools/version-updater/src/main.rs
@@ -267,6 +267,15 @@ fn update_files(args: &UpdateFilesArgs) {
             {
                 *package_version = value(args.update_version.clone());
             }
+
+            // Also bump [workspace.package].version if present (e.g. the root Cargo.toml)
+            if let Some(workspace_package_version) = doc
+                .get_mut("workspace")
+                .and_then(|w| w.get_mut("package"))
+                .and_then(|p| p.get_mut("version"))
+            {
+                *workspace_package_version = value(args.update_version.clone());
+            }
         }
 
         let update_package_version = |item: &mut Item| {


### PR DESCRIPTION
The `version-updater` only looked for `[package].version` when bumping versions, missing the `[workspace.package].version` field in the root Cargo.toml. This caused it to fall behind across releases.

Also bumps the stale `workspace.package` version from 0.16.0 to 0.17.0.

Closes #2249