### PR TITLE
`cargo pgrx test foo` treats non-pgXX first arg as testname filter

### DIFF
--- a/cargo-pgrx/src/command/test.rs
+++ b/cargo-pgrx/src/command/test.rs
@@ -7,6 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use cargo_toml::Manifest;
 use eyre::Context;
 use pgrx_pg_config::{PgConfig, Pgrx, get_target_dir};
 use std::path::{Path, PathBuf};
@@ -54,18 +55,13 @@ pub(crate) struct Test {
 
 impl CommandExecute for Test {
     #[tracing::instrument(level = "error", skip(self))]
-    fn execute(self) -> eyre::Result<()> {
-        #[tracing::instrument(level = "error", skip(me))]
-        fn perform(me: Test, pgrx: &Pgrx) -> eyre::Result<()> {
+    fn execute(mut self) -> eyre::Result<()> {
+        #[tracing::instrument(level = "error", skip(me, package_manifest))]
+        fn perform(me: Test, pgrx: &Pgrx, package_manifest: &Manifest) -> eyre::Result<()> {
             let mut features = me.features.clone();
-            let (package_manifest, _package_manifest_path) = get_package_manifest(
-                &me.features,
-                me.package.as_deref(),
-                me.manifest_path.as_deref(),
-            )?;
             let (pg_config, _pg_version) = pg_config_and_version(
                 pgrx,
-                &package_manifest,
+                package_manifest,
                 me.pg_version.clone(),
                 Some(&mut features),
                 true,
@@ -97,18 +93,27 @@ impl CommandExecute for Test {
             self.manifest_path.as_deref(),
         )?;
         let pgrx = Pgrx::from_config()?;
-        if self.pg_version == Some("all".to_string()) {
+
+        // If the first positional arg isn't a recognized PG version (pgXX or "all")
+        // and no testname was given, treat it as a testname filter
+        if let Some(ref v) = self.pg_version {
+            if v != "all" && !pgrx.is_feature_flag(v) && self.testname.is_none() {
+                self.testname = self.pg_version.take();
+            }
+        }
+
+        if self.pg_version.as_deref() == Some("all") {
             // run the tests for **all** the Postgres versions we know about
             for v in crate::manifest::all_pg_in_both_tomls(&package_manifest, &pgrx) {
                 let mut versioned_test = self.clone();
                 versioned_test.pg_version = Some(v?.label()?);
-                perform(versioned_test, &pgrx)?;
+                perform(versioned_test, &pgrx, &package_manifest)?;
             }
 
             Ok(())
         } else {
             // attempt to run the test for the Postgres version `run_test()` will figure out
-            perform(self, &pgrx)
+            perform(self, &pgrx, &package_manifest)
         }
     }
 }

--- a/skills/cargo-pgrx/test.md
+++ b/skills/cargo-pgrx/test.md
@@ -30,6 +30,11 @@ cargo pgrx test [OPTIONS] [PG_VERSION] [TESTNAME]
 | `PG_VERSION` | `pg13`, `pg14`, `pg15`, `pg16`, `pg17`, `pg18`, or `all`. Defaults to the first pgXX feature in Cargo.toml. Env: `PG_VERSION` |
 | `TESTNAME` | If specified, only run tests whose names contain this string |
 
+**Smart argument detection:** If the first positional argument is not a
+recognized Postgres version (`pgXX` or `all`), it is treated as `TESTNAME`
+and the default Postgres version is used. This means `cargo pgrx test foo`
+works as a shorthand for `cargo pgrx test pgXX foo`.
+
 ### Flags
 
 | Flag | Short | Description |
@@ -54,7 +59,10 @@ cargo pgrx test
 # Run all tests against Postgres 18
 cargo pgrx test pg18
 
-# Run only tests whose names contain "spi"
+# Run only tests whose names contain "spi" (using default PG version)
+cargo pgrx test spi
+
+# Run only tests whose names contain "spi" against Postgres 18
 cargo pgrx test pg18 spi
 
 # Run tests in release mode


### PR DESCRIPTION
Previously, `cargo pgrx test foo` interpreted "foo" as the Postgres version argument and failed with "Postgres `foo` is not managed by pgrx". Now, if the first positional argument isn't a recognized PG version (pgXX or "all") and no testname was provided, it's treated as a testname filter using the crate's default Postgres version.

Also fixes the duplicate "Auto-detected pgrx extension crate" message by passing the already-fetched manifest into perform() instead of calling get_package_manifest() a second time.