### PR TITLE
`cargo pgrx run foo` treats non-pgXX first arg as dbname

### DIFF
--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -84,6 +84,15 @@ impl Run {
         postgresql_conf: &HashMap<String, String>,
     ) -> eyre::Result<(PgConfig, String)> {
         let pgrx = Pgrx::from_config()?;
+
+        // If the first positional arg isn't a recognized PG version (pgXX)
+        // and no dbname was given, treat it as a dbname
+        if let Some(ref v) = self.pg_version {
+            if !pgrx.is_feature_flag(v) && self.dbname.is_none() {
+                self.dbname = self.pg_version.take();
+            }
+        }
+
         let (package_manifest, package_manifest_path) = get_package_manifest(
             &self.features,
             self.package.as_deref(),

--- a/skills/cargo-pgrx/run.md
+++ b/skills/cargo-pgrx/run.md
@@ -27,6 +27,11 @@ cargo pgrx run [OPTIONS] [PG_VERSION] [DBNAME]
 | `PG_VERSION` | `pg13`..`pg18`. Defaults to first pgXX feature in Cargo.toml. Env: `PG_VERSION` |
 | `DBNAME` | Database to connect to (and create if needed). Defaults to the extension name |
 
+**Smart argument detection:** If the first positional argument is not a
+recognized Postgres version (`pgXX`), it is treated as `DBNAME` and the
+default Postgres version is used. This means `cargo pgrx run mydb` works
+as a shorthand for `cargo pgrx run pgXX mydb`.
+
 ### Flags
 
 | Flag | Short | Description |
@@ -48,6 +53,9 @@ cargo pgrx run [OPTIONS] [PG_VERSION] [DBNAME]
 ```bash
 # Build, install, and open psql against default Postgres
 cargo pgrx run
+
+# Connect to a specific database (using default PG version)
+cargo pgrx run mydb
 
 # Target a specific Postgres version and database
 cargo pgrx run pg18 mydb


### PR DESCRIPTION
Previously, `cargo pgrx run foo` interpreted "foo" as the Postgres version argument and failed with "Postgres `foo` is not managed by pgrx". Now, if the first positional argument isn't a recognized PG version (pgXX) and no dbname was provided, it's treated as a dbname using the crate's default Postgres version.