### PR TITLE
Remove yanked dependency core2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
- "rand 0.9.2",
+ "rand",
  "serde",
 ]
 
@@ -217,7 +217,7 @@ version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
- "rand 0.9.2",
+ "rand",
  "ureq",
 ]
 
@@ -830,15 +830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,7 +985,7 @@ version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
- "rand 0.9.2",
+ "rand",
 ]
 
 [[package]]
@@ -1889,25 +1880,25 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libflate"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
  "hashbrown 0.16.0",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -2066,6 +2057,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,7 +2123,7 @@ version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2423,7 +2423,7 @@ dependencies = [
  "pgrx-pg-config",
  "postgres",
  "proptest",
- "rand 0.9.2",
+ "rand",
  "regex",
  "shlex",
  "sysinfo",
@@ -2443,7 +2443,7 @@ dependencies = [
  "pgrx-macros",
  "pgrx-tests",
  "proptest",
- "rand 0.9.2",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -2559,7 +2559,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.2",
+ "rand",
  "sha2",
  "stringprep",
 ]
@@ -2628,8 +2628,8 @@ dependencies = [
  "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2681,7 +2681,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2730,33 +2730,12 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2766,16 +2745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2793,7 +2763,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -3352,7 +3322,7 @@ version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
- "rand 0.9.2",
+ "rand",
 ]
 
 [[package]]
@@ -3707,7 +3677,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand",
  "socket2",
  "tokio",
  "tokio-util",

--- a/pgrx-examples/arrays/Cargo.toml
+++ b/pgrx-examples/arrays/Cargo.toml
@@ -31,7 +31,7 @@ pg_test = []
 [dependencies]
 pgrx = { path = "../../pgrx" }
 serde = "1.0"
-rand = "*"
+rand = "0.9.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/bytea/Cargo.toml
+++ b/pgrx-examples/bytea/Cargo.toml
@@ -30,7 +30,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx" }
-libflate = "2.1.0"
+libflate = "2.3.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/numeric/Cargo.toml
+++ b/pgrx-examples/numeric/Cargo.toml
@@ -31,7 +31,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx" }
-rand = "0.8.5"
+rand = "0.9.0"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }


### PR DESCRIPTION
I noticed this during `cargo install cargo-pgrx`.

```console
$ cargo install --locked cargo-pgrx --git 'https://github.com/pgcentralfoundation/pgrx'
    Updating git repository `https://github.com/pgcentralfoundation/pgrx`
  Installing cargo-pgrx v0.17.0 (https://github.com/pgcentralfoundation/pgrx#265eb380)
    Updating crates.io index
warning: package `core2 v0.4.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
…
```

---

https://crates.io/crates/core2 &rarr; https://github.com/bbqsrc/core2

> No longer supported. Use `core` directly.

https://github.com/sile/libflate/releases/tag/v2.3.0

> Replace yanked core2 dependency