### PR TITLE
fix: don't allocate for static strings in `ereport!`

### DIFF
--- a/pgrx-pg-sys/src/submodules/elog.rs
+++ b/pgrx-pg-sys/src/submodules/elog.rs
@@ -128,10 +128,10 @@ pub trait IntoMessage {
     fn into_message(self) -> std::borrow::Cow<'static, str>;
 }
 
-impl IntoMessage for &str {
+impl IntoMessage for &'static str {
     #[inline]
     fn into_message(self) -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Owned(self.to_owned())
+        std::borrow::Cow::Borrowed(self)
     }
 }
 


### PR DESCRIPTION
This is a spin-off from https://github.com/pgcentralfoundation/pgrx/pull/2269; whereas in that PR we resolve the issue of eager allocation in high level logging macros (debug1, log, warning, etc.), there was one omission concerning only `ereport!`.

Namely, `ereport!` now uses `IntoMessage::into_message` to get the message from the input arg. When invoked indirectly via high level logging macros this is always `std::fmt::Arguments`, which in case of static strings results in a `std::borrow::Cow::Borrowed` message.

However, when `ereport!` is called directly with a static string this applies instead https://github.com/pgcentralfoundation/pgrx/blob/b2be3e1822b2e5769ba6253c828674d4c885ff01/pgrx-pg-sys/src/submodules/elog.rs#L131-L136

In other words, in this case we always allocate, even for static strings. The fix is simple: replace `impl IntoMessage for &str` with `impl IntoMessage for &'static str` (since Rust doesn't allow both to co-exist), which can then return `std::borrow::Cow::Borrowed` for `ereport!(..., "my string literal")`.

The only "downside" is that stuff like
```rust
      let msg = format!("table {} not found", table_name);
      ereport!(..., msg.as_str());
``` 
will error out during compilation. Arguably though this is for the better, since it forces the user to pass the string down, or call `clone()`/`to_string()`/`to_owned()`, making the allocation explicit.