### PR TITLE
fix: provide the test stubs for pg_sys extern statics via pg_module_magic! macro

### DIFF
--- a/pgrx-tests/src/lib.rs
+++ b/pgrx-tests/src/lib.rs
@@ -16,3 +16,50 @@ mod framework;
 pub use framework::*;
 #[cfg(feature = "proptest")]
 pub mod proptest;
+
+// ── Test stubs ──────────────────────────────────────────────────────────────
+// When a test binary links pgrx-pg-sys, all the extern "C" statics declared in
+// the generated bindings become undefined symbols.  Normally --gc-sections
+// prunes unreachable references, but #[typetag::serde] / inventory::submit!
+// ctors run before main() and pull pg_sys symbols into the live set.
+//
+// Because pgrx-tests is a dev-dependency, it is linked into test binaries but
+// NOT into the extension .so.  These #[unsafe(no_mangle)] statics satisfy the linker
+// without ever shadowing the real PostgreSQL symbols at runtime.
+// ─────────────────────────────────────────────────────────────────────────────
+mod stubs {
+    use pgrx::pg_sys;
+
+    #[unsafe(no_mangle)]
+    pub static mut CurrentMemoryContext: pg_sys::MemoryContext = std::ptr::null_mut();
+
+    #[unsafe(no_mangle)]
+    pub static mut error_context_stack: *mut pg_sys::ErrorContextCallback = std::ptr::null_mut();
+
+    #[unsafe(no_mangle)]
+    pub static mut PG_exception_stack: *mut pg_sys::sigjmp_buf = std::ptr::null_mut();
+
+    #[unsafe(no_mangle)]
+    pub static mut emit_log_hook: pg_sys::emit_log_hook_type = None;
+
+    #[unsafe(no_mangle)]
+    pub static mut Log_error_verbosity: std::ffi::c_int = 0;
+
+    #[unsafe(no_mangle)]
+    pub static mut Log_line_prefix: *mut std::ffi::c_char = std::ptr::null_mut();
+
+    #[unsafe(no_mangle)]
+    pub static mut Log_destination: std::ffi::c_int = 0;
+
+    #[unsafe(no_mangle)]
+    pub static mut Log_destination_string: *mut std::ffi::c_char = std::ptr::null_mut();
+
+    #[unsafe(no_mangle)]
+    pub static mut syslog_sequence_numbers: bool = false;
+
+    #[unsafe(no_mangle)]
+    pub static mut syslog_split_messages: bool = false;
+
+    #[unsafe(no_mangle)]
+    pub static mut BufferBlocks: *mut std::ffi::c_void = std::ptr::null_mut();
+}

--- a/pgrx/src/lib.rs
+++ b/pgrx/src/lib.rs
@@ -354,6 +354,49 @@ macro_rules! pg_magic_func {
             // return the magic
             &MY_MAGIC.0
         }
+
+        // ── Test stubs ──
+        // When the test binary links, all extern "C" statics from
+        // pgrx-pg-sys become undefined symbols.  #[typetag::serde]
+        // ctors pull them into the live set, defeating --gc-sections.
+        // These stubs compile ON THE EXTENSION SIDE where #[cfg(test)]
+        // actually fires, and provide #[unsafe(no_mangle)] definitions that
+        // satisfy the linker without shadowing PG's real symbols in the .so.
+        #[cfg(test)]
+        mod __pgrx_test_stubs {
+            #[unsafe(no_mangle)]
+            pub static mut CurrentMemoryContext: $crate::pg_sys::MemoryContext = std::ptr::null_mut();
+
+            #[unsafe(no_mangle)]
+            pub static mut error_context_stack: *mut $crate::pg_sys::ErrorContextCallback = std::ptr::null_mut();
+
+            #[unsafe(no_mangle)]
+            pub static mut PG_exception_stack: *mut $crate::pg_sys::sigjmp_buf = std::ptr::null_mut();
+
+            #[unsafe(no_mangle)]
+            pub static mut emit_log_hook: $crate::pg_sys::emit_log_hook_type = None;
+
+            #[unsafe(no_mangle)]
+            pub static mut Log_error_verbosity: std::ffi::c_int = 0;
+
+            #[unsafe(no_mangle)]
+            pub static mut Log_line_prefix: *mut std::ffi::c_char = std::ptr::null_mut();
+
+            #[unsafe(no_mangle)]
+            pub static mut Log_destination: std::ffi::c_int = 0;
+
+            #[unsafe(no_mangle)]
+            pub static mut Log_destination_string: *mut std::ffi::c_char = std::ptr::null_mut();
+
+            #[unsafe(no_mangle)]
+            pub static mut syslog_sequence_numbers: bool = false;
+
+            #[unsafe(no_mangle)]
+            pub static mut syslog_split_messages: bool = false;
+
+            #[unsafe(no_mangle)]
+            pub static mut BufferBlocks: *mut std::ffi::c_void = std::ptr::null_mut();
+        }
     };
 }
 


### PR DESCRIPTION
Fixes https://github.com/pgcentralfoundation/pgrx/issues/2281

A pgrx extension is compiled as a `.so` or `.dylib` that gets `dlopen`'d into PostgreSQL at runtime. All the PostgreSQL symbols like `CurrentMemoryContext` and `BufferBlocks` are provided by the running PostgreSQL process so the `.so` doesn't need to define them.

When `cargo test` runs, Rust produces a standalone test executable  which is not loaded into PostgreSQL. Those symbols don't exist anywhere so the linker fails with `undefined symbol`.

Normally `--gc-sections` prunes all unreferenced `pg_sys` extern declarations. But `#[typetag::serde]` uses `inventory::submit!()` to register trait implementations via a "life before main" constructor and that constructor unconditionally references the trait impl methods, which reference `pg_sys` symbols, pulling them into the live-code set and defeating dead code elimination.

In this PR:

The fix adds `#[unsafe(no_mangle)]` stub definitions for the commonly-leaked `pg_sys` extern statics `CurrentMemoryContext`, `error_context_stack`, `PG_exception_stack`, `emit_log_hook`, `Log_error_verbosity`, `Log_line_prefix`, `Log_destination`, `Log_destination_string`, `syslog_sequence_numbers`, `syslog_split_messages` and `BufferBlocks` inside the `pg_magic_func!()` macro, gated behind `#[cfg(test)]`.

Why the macro?

* `#[cfg(test)]` only fires in the crate under test so dependencies like `pgrx-pg-sys` are never compiled with `cfg(test)` by Cargo so placing the stubs in the macro ensures they expand in the extension's own source, where `cfg(test)` actually works.
* Every extension already calls `pg_module_magic!()` 
* The `.so` build never includes the stubs (no `cfg(test)`) so PostgreSQL's real symbols are never shadowed.