### PR TITLE
Remove accidentally committed empty output.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ rustup-init.sh
 .codex/
 .agents/
 tmp/
+output.log


### PR DESCRIPTION
## Summary
- Removes the empty `output.log` file (0 bytes) that was accidentally committed in 6389adb1 (#2218)
- Adds `output.log` to `.gitignore` to prevent future accidental commits

## Details
The `output.log` file at the repository root is empty (0 bytes) and appears to have been committed unintentionally as part of PR #2218 ("Add `array::Element` and `callconv::DatumPass`"). It serves no purpose in the repository.

## Test plan
- [x] Verified the file is empty (`wc -c output.log` → 0)
- [x] Verified `.gitignore` is updated to prevent re-committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)