### PR TITLE
Fix "PostgresSQL" typo to "PostgreSQL" in test code

### DIFF
--- a/pgrx-pg-config/src/lib.rs
+++ b/pgrx-pg-config/src/lib.rs
@@ -926,13 +926,13 @@ fn parse_version() {
     // Check some invalid version strings
     let _ = PgConfig::parse_version_str("10.22").expect_err("Parsed invalid version string");
     let _ =
-        PgConfig::parse_version_str("PostgresSQL 10").expect_err("Parsed invalid version string");
+        PgConfig::parse_version_str("PostgreSQL 10").expect_err("Parsed invalid version string");
     let _ =
-        PgConfig::parse_version_str("PostgresSQL 10.").expect_err("Parsed invalid version string");
+        PgConfig::parse_version_str("PostgreSQL 10.").expect_err("Parsed invalid version string");
     let _ =
-        PgConfig::parse_version_str("PostgresSQL 12.f").expect_err("Parsed invalid version string");
+        PgConfig::parse_version_str("PostgreSQL 12.f").expect_err("Parsed invalid version string");
     let _ =
-        PgConfig::parse_version_str("PostgresSQL .53").expect_err("Parsed invalid version string");
+        PgConfig::parse_version_str("PostgreSQL .53").expect_err("Parsed invalid version string");
 }
 
 #[test]
@@ -945,7 +945,7 @@ fn from_empty_env() -> eyre::Result<()> {
     unsafe {
         // but now we can
         std::env::set_var("PGRX_PG_CONFIG_AS_ENV", "true");
-        std::env::set_var("PGRX_PG_CONFIG_VERSION", "PostgresSQL 15.1");
+        std::env::set_var("PGRX_PG_CONFIG_VERSION", "PostgreSQL 15.1");
         std::env::set_var("PGRX_PG_CONFIG_INCLUDEDIR-SERVER", "/path/to/server/headers");
         std::env::set_var("PGRX_PG_CONFIG_CPPFLAGS", "some cpp flags");
     }


### PR DESCRIPTION
## Summary
- Fixes 5 instances of "PostgresSQL" (double S) to the correct spelling "PostgreSQL" in test code

## Details
In `pgrx-pg-config/src/lib.rs`, several test cases used the misspelling "PostgresSQL" instead of "PostgreSQL":

- **Lines 929, 931, 933, 935** (`parse_invalid` test): Version strings used "PostgresSQL" prefix. While these test invalid version *formats* (not the prefix), using the correct spelling makes the tests more realistic.
- **Line 948** (`from_empty_env` test): The `PGRX_PG_CONFIG_VERSION` env var was set to `"PostgresSQL 15.1"` but is expected to parse successfully. Using the correct spelling ensures the test matches real PostgreSQL output.

## Test plan
- [x] No code logic changed, only test string literals
- [x] Verified zero remaining instances of "PostgresSQL" in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)