### PR TITLE
Fix README version range inconsistency (17 → 18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
    + `cargo pgrx package`: Create installation packages for your extension
    + More in the [`README.md`](cargo-pgrx/README.md)!
 - **Target Multiple Postgres Versions**
-   + Support from Postgres 13 to Postgres 17 from the same codebase
+   + Support from Postgres 13 to Postgres 18 from the same codebase
    + Use Rust feature gating to use version-specific APIs
    + Seamlessly test against all versions
 - **Automatic Schema Generation**


### PR DESCRIPTION
## Summary
- Updates the version range in README.md line 34 from "Postgres 13 to Postgres 17" to "Postgres 13 to Postgres 18" to match line 16

## Details
The README has two statements about supported PostgreSQL versions that were inconsistent:
- **Line 16** (correct): "`pgrx` supports Postgres 13 through Postgres 18."
- **Line 34** (outdated): "Support from Postgres 13 to Postgres 17 from the same codebase"

Since pgrx 0.18.0 added support for Postgres 18, line 34 should be updated accordingly.

## Test plan
- [x] Verified both version references in README now consistently say "Postgres 18"

🤖 Generated with [Claude Code](https://claude.com/claude-code)