### PR TITLE
cargo-pgrx: use zip instead of zip-extract

### DIFF
--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -59,7 +59,7 @@ tar = "0.4.44"
 ureq = { version = "3.0.10", default-features = false, features = ["gzip", "platform-verifier", "rustls"] }
 url.workspace = true
 which = "7.0.3"
-zip-extract = "0.2.2"
+zip = "8.6.0"
 postgres = { version = "0.19.10", features = ["with-serde_json-1", "with-uuid-1"] }
 uuid = { version = "1.16.0", features = ["v4"] }
 

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -302,7 +302,7 @@ fn untar(bytes: &[u8], pgrxdir: &Path, pg_config: &PgConfig, init: &Init) -> eyr
     {
         // it's a zip download from EDB
         use std::io::Cursor;
-        zip_extract::extract(Cursor::new(bytes), &unpackdir, false)?;
+        zip::ZipArchive::new(Cursor::new(bytes))?.extract(&unpackdir)?;
     } else {
         let mut tar_decoder = Archive::new(BzDecoder::new(bytes));
         tar_decoder.unpack(&unpackdir)?;


### PR DESCRIPTION
While packaging `pgrx` for Debian in order to allow Postgres extensions written with it to be added to `apt.postgresql.org` and Debian itself, we found that `zip-extract` has been deprecated a year ago.

This change trivially replaces it with the `zip` crate recommended by the `zip-extract` maintainers.
