### PR TITLE
cargo-pgrx: add --valgrind flag to `cargo pgrx regress`

### DIFF
--- a/cargo-pgrx/src/command/regress.rs
+++ b/cargo-pgrx/src/command/regress.rs
@@ -98,6 +98,10 @@ pub(crate) struct Regress {
     /// Run the test suite this many times (default: 1)
     #[clap(long, default_value_t = 1, value_name = "N")]
     pub(crate) repeat: u32,
+
+    /// Run Postgres under valgrind while executing the regression tests
+    #[clap(long)]
+    pub(crate) valgrind: bool,
 }
 
 impl Regress {

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -72,7 +72,7 @@ impl From<&Regress> for Run {
             verbose: regress.verbose,
             pgcli: false,
             install_only: false,
-            valgrind: false,
+            valgrind: regress.valgrind,
         }
     }
 }


### PR DESCRIPTION
## Summary

`cargo pgrx start` and `cargo pgrx run` already accept `--valgrind`, and the underlying `start_postgres` already knows how to launch Postgres under valgrind. But the flag was not exposed on `cargo pgrx regress` — `From<&Regress> for Run` hardcoded `valgrind: false`, so there was no way to run the regression suite under valgrind without manually starting Postgres beforehand.

This adds `--valgrind` to `Regress` and propagates it through to `Run`. No new mechanism — just plumbing.

```
$ cargo pgrx regress --valgrind
```

## Test plan

- [x] `cargo check -p cargo-pgrx` passes
- [x] `cargo pgrx regress --help` shows the new `--valgrind` flag
- [x] `cargo pgrx regress --valgrind` runs the regression suite under valgrind end-to-end