### PR TITLE
cargo-pgrx: build Postgres in parallel during `cargo pgrx init`

### DIFF
--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -104,10 +104,7 @@ impl CommandExecute for Init {
     #[tracing::instrument(level = "error", skip(self))]
     fn execute(self) -> eyre::Result<()> {
         self.jobserver
-            .set(
-                jobslot::Client::new(self.resolved_jobs())
-                    .expect("failed to create jobserver"),
-            )
+            .set(jobslot::Client::new(self.resolved_jobs()).expect("failed to create jobserver"))
             .unwrap();
 
         let mut versions = HashMap::new();

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -88,19 +88,25 @@ pub(crate) struct Init {
     jobserver: OnceLock<jobslot::Client>,
 }
 
+impl Init {
+    /// Resolve the make job count: explicit `--jobs`, else the host's
+    /// available parallelism, else 1. Used to size the jobserver and to
+    /// pass `-jN` to `make` (without `-jN`, GNU make ignores the jobserver
+    /// auth in MAKEFLAGS and stays serial).
+    fn resolved_jobs(&self) -> usize {
+        self.jobs
+            .or_else(|| std::thread::available_parallelism().map(NonZeroUsize::get).ok())
+            .unwrap_or(1)
+    }
+}
+
 impl CommandExecute for Init {
     #[tracing::instrument(level = "error", skip(self))]
     fn execute(self) -> eyre::Result<()> {
         self.jobserver
             .set(
-                jobslot::Client::new(
-                    self.jobs
-                        .or_else(|| {
-                            std::thread::available_parallelism().map(NonZeroUsize::get).ok()
-                        })
-                        .unwrap_or(1),
-                )
-                .expect("failed to create jobserver"),
+                jobslot::Client::new(self.resolved_jobs())
+                    .expect("failed to create jobserver"),
             )
             .unwrap();
 
@@ -497,6 +503,8 @@ fn make_postgres(pg_config: &PgConfig, pgdir: &Path, init: &Init) -> eyre::Resul
     let mut command = std::process::Command::new("make");
 
     command
+        .arg("-j")
+        .arg(init.resolved_jobs().to_string())
         .arg("world-bin")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -541,6 +549,8 @@ fn make_install_postgres(version: &PgConfig, pgdir: &Path, init: &Init) -> eyre:
     let mut command = std::process::Command::new("make");
 
     command
+        .arg("-j")
+        .arg(init.resolved_jobs().to_string())
         .arg("install-world-bin")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary

`cargo pgrx init` already takes `-j` / `--jobs` and uses it to size a `jobslot::Client`, which exposes the jobserver auth to child `make` processes via `MAKEFLAGS`. However, neither `make world-bin` nor `make install-world-bin` was given `-j` on its own argv, so GNU make ignored the jobserver and ran serially. Result: `cargo pgrx init` built Postgres single-threaded even on big hosts.

This PR:

- Extracts the existing job-count resolution into `Init::resolved_jobs()` (`--jobs` -> `available_parallelism()` -> `1`)
- Reuses it to seed the jobserver (no behavior change there)
- Passes `-jN` to both `make` invocations so GNU make actually parallelizes

No new flags; the existing `--jobs`/`-j` keeps working and now has an observable effect on the Postgres build, not just the jobserver token pool.

## Test plan

- [x] `cargo check -p cargo-pgrx` passes
- [x] `cargo pgrx init` rebuild is measurably faster on a multi-core host (verified locally by author)
- [x] `cargo pgrx init -j 1` produces a serial build (verified locally by author)