### PR TITLE
ci: pass `--locked` to `cargo install --path cargo-pgrx`

### DIFF
--- a/.github/workflows/package-test.yaml
+++ b/.github/workflows/package-test.yaml
@@ -90,7 +90,7 @@ jobs:
           pg_config --version
 
       - name: Install cargo pgrx
-        run: cargo +nightly install --path cargo-pgrx --debug
+        run: cargo +nightly install --path cargo-pgrx --debug --locked
 
       - name: cargo pgrx init
         run: cargo +nightly pgrx init "--pg$PG_VER=$(which pg_config)"

--- a/.github/workflows/runas.yml
+++ b/.github/workflows/runas.yml
@@ -92,7 +92,7 @@ jobs:
           rustup component add clippy
 
       - name: Install cargo pgrx
-        run: cd cargo-pgrx && cargo install --path . --debug
+        run: cd cargo-pgrx && cargo install --path . --debug --locked
 
       - name: cargo pgrx init
         run: cargo pgrx init --pg14=$(which pg_config)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,7 +230,7 @@ jobs:
           rustup component add clippy
 
       - name: Install cargo-pgrx
-        run: cargo install --path cargo-pgrx/ --debug --force
+        run: cargo install --path cargo-pgrx/ --debug --force --locked
 
       - name: Run 'cargo pgrx init' against system-level ${{ matrix.postgres }}
         run: cargo pgrx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
@@ -390,7 +390,7 @@ jobs:
           key: pgrx-arm64-cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/tests.yml') }}
 
       - name: Install cargo-pgrx
-        run: cargo install --path cargo-pgrx/ --debug --force
+        run: cargo install --path cargo-pgrx/ --debug --force --locked
 
       - name: Run 'cargo pgrx init' against system-level ${{ matrix.postgres }}
         run: cargo pgrx init --pg$PG_VER /usr/lib/postgresql/$PG_VER/bin/pg_config
@@ -494,7 +494,7 @@ jobs:
           rustup component add clippy
 
       - name: Install cargo-pgrx
-        run: cargo install --path cargo-pgrx/ --debug --force
+        run: cargo install --path cargo-pgrx/ --debug --force --locked
 
       - name: Run 'cargo pgrx init'
         run: cargo pgrx init --pg$PG_VER download
@@ -621,7 +621,7 @@ jobs:
           rustup component add clippy
 
       - name: Install cargo-pgrx
-        run: cargo install --path cargo-pgrx/ --debug --force
+        run: cargo install --path cargo-pgrx/ --debug --force --locked
 
       - name: Print sccache stats
         run: sccache --show-stats
@@ -698,7 +698,7 @@ jobs:
         run: sccache --show-stats
 
       - name: Install cargo-pgrx
-        run: cargo install --path cargo-pgrx/ --debug --force
+        run: cargo install --path cargo-pgrx/ --debug --force --locked
 
       - name: Install rustfmt & clippy
         run: |


### PR DESCRIPTION
## Summary

Fix the CI

## Test plan

- [x] \`grep -rn "cargo install" .github/workflows/\` confirms every \`--path cargo-pgrx\` invocation now passes \`--locked\`
- [x] CI on this PR builds green (will verify once it runs)