### PR TITLE
Use zip instead of deprecated zip-extract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
  "url",
  "uuid",
  "which",
- "zip-extract",
+ "zip",
 ]
 
 [[package]]
@@ -4852,17 +4852,6 @@ dependencies = [
  "zeroize",
  "zopfli",
  "zstd",
-]
-
-[[package]]
-name = "zip-extract"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d94e397dd6d0273e6747e46e7aa0289bfd9736ba8772f2fe948bc4adc3f73"
-dependencies = [
- "log",
- "thiserror 2.0.16",
- "zip",
 ]
 
 [[package]]

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -59,7 +59,7 @@ tar = "0.4.44"
 ureq = { version = "3.0.10", default-features = false, features = ["gzip", "platform-verifier", "rustls"] }
 url.workspace = true
 which = "7.0.3"
-zip-extract = "0.2.2"
+zip = "5.1.1"
 postgres = { version = "0.19.10", features = ["with-serde_json-1", "with-uuid-1"] }
 uuid = { version = "1.16.0", features = ["v4"] }
 

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -302,7 +302,7 @@ fn untar(bytes: &[u8], pgrxdir: &Path, pg_config: &PgConfig, init: &Init) -> eyr
     {
         // it's a zip download from EDB
         use std::io::Cursor;
-        zip_extract::extract(Cursor::new(bytes), &unpackdir, false)?;
+        zip::ZipArchive::new(Cursor::new(bytes))?.extract(&unpackdir)?;
     } else {
         let mut tar_decoder = Archive::new(BzDecoder::new(bytes));
         tar_decoder.unpack(&unpackdir)?;

--- a/pgrx-examples/hooks/src/lib.rs
+++ b/pgrx-examples/hooks/src/lib.rs
@@ -109,7 +109,7 @@ unsafe fn register_hooks() {
     #[pg_guard]
     unsafe extern "C-unwind" fn process_utility_hook(
         pstmt: *mut pg_sys::PlannedStmt,
-        query_string: *const i8,
+        query_string: *const core::ffi::c_char,
         context: pg_sys::ProcessUtilityContext::Type,
         params: *mut pg_sys::ParamListInfoData,
         query_env: *mut pg_sys::QueryEnvironment,
@@ -144,7 +144,7 @@ unsafe fn register_hooks() {
     #[pg_guard]
     unsafe extern "C-unwind" fn process_utility_hook(
         pstmt: *mut pg_sys::PlannedStmt,
-        query_string: *const i8,
+        query_string: *const core::ffi::c_char,
         read_only_tree: bool,
         context: pg_sys::ProcessUtilityContext::Type,
         params: *mut pg_sys::ParamListInfoData,


### PR DESCRIPTION
A small cleanup I noticed while reviewing dependencies.

The zip-extract crate was [deprecated last year](https://crates.io/crates/zip-extract/0.4.1) because the upstream zip crate improved its API.