### PR TITLE
feat: include rewrite/rewriteManip.h 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,6 +2877,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rewrite_manip"
+version = "0.0.0"
+dependencies = [
+ "pgrx",
+ "pgrx-tests",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/pgrx-examples/rewrite_manip/Cargo.toml
+++ b/pgrx-examples/rewrite_manip/Cargo.toml
@@ -1,0 +1,34 @@
+#LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+#LICENSE
+#LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+#LICENSE
+#LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+#LICENSE
+#LICENSE All rights reserved.
+#LICENSE
+#LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+[package]
+name = "rewrite_manip"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg17"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
+pg_test = []
+
+[dependencies]
+pgrx = { path = "../../pgrx" }
+
+[dev-dependencies]
+pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/rewrite_manip/README.md
+++ b/pgrx-examples/rewrite_manip/README.md
@@ -1,0 +1,46 @@
+# rewrite_manip
+
+Demonstrates PostgreSQL's `rewrite/rewriteManip.h` query tree manipulation functions exposed through `pgrx::pg_sys`.
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `demo_change_var_nodes(old_varno, new_varno)` | Remaps a Var node's range table reference from one index to another |
+| `demo_offset_var_nodes(offset)` | Shifts a Var node's range table reference by a given offset |
+| `demo_range_table_entry_used(varno, check_rt_index)` | Checks if a specific range table entry is referenced in a node tree |
+| `demo_increment_var_sublevels_up(initial_level, delta)` | Increments the subquery nesting level of a Var node |
+
+## Background
+
+PostgreSQL's `rewriteManip.h` provides utilities for manipulating query trees during the rewrite phase. These functions operate on `Var` nodes — the internal representation of column references — and are essential for:
+
+- Combining range tables when flattening subqueries
+- Adjusting variable references after modifying FROM clauses
+- Checking which range table entries are actually referenced
+
+## Usage
+
+```sql
+-- Remap varno 1 to varno 5
+SELECT rewrite_manip.demo_change_var_nodes(1, 5);
+-- Returns: 5
+
+-- Offset varno by 3 (1 + 3 = 4)
+SELECT rewrite_manip.demo_offset_var_nodes(3);
+-- Returns: 4
+
+-- Check if rt_index 3 is used (varno=3, checking for 3)
+SELECT rewrite_manip.demo_range_table_entry_used(3, 3);
+-- Returns: true
+
+-- Increment sublevels_up by 2
+SELECT rewrite_manip.demo_increment_var_sublevels_up(0, 2);
+-- Returns: 2
+```
+
+## Running Tests
+
+```bash
+cargo test --features "pg17 pg_test" -- --test-threads=1
+```

--- a/pgrx-examples/rewrite_manip/rewrite_manip.control
+++ b/pgrx-examples/rewrite_manip/rewrite_manip.control
@@ -1,0 +1,6 @@
+comment = 'rewrite_manip:  Created by pgrx'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'rewrite_manip'
+relocatable = false
+superuser = false
+schema = 'rewrite_manip'

--- a/pgrx-examples/rewrite_manip/src/lib.rs
+++ b/pgrx-examples/rewrite_manip/src/lib.rs
@@ -18,11 +18,18 @@ pgrx::pg_module_magic!(name, version);
 #[pg_extern]
 fn demo_change_var_nodes(old_varno: i32, new_varno: i32) -> i32 {
     unsafe {
-        let var = pg_sys::makeVar(old_varno, 1, pg_sys::INT4OID, -1, pg_sys::InvalidOid, 0);
+        let var = pg_sys::makeVar(
+            old_varno.try_into().unwrap(),
+            1,
+            pg_sys::INT4OID,
+            -1,
+            pg_sys::InvalidOid,
+            0,
+        );
 
         pg_sys::ChangeVarNodes(var as *mut pg_sys::Node, old_varno, new_varno, 0);
 
-        (*var).varno
+        (*var).varno.try_into().unwrap()
     }
 }
 
@@ -37,7 +44,7 @@ fn demo_offset_var_nodes(offset: i32) -> i32 {
 
         pg_sys::OffsetVarNodes(var as *mut pg_sys::Node, offset, 0);
 
-        (*var).varno
+        (*var).varno.try_into().unwrap()
     }
 }
 
@@ -46,7 +53,14 @@ fn demo_offset_var_nodes(offset: i32) -> i32 {
 #[pg_extern]
 fn demo_range_table_entry_used(varno: i32, check_rt_index: i32) -> bool {
     unsafe {
-        let var = pg_sys::makeVar(varno, 1, pg_sys::INT4OID, -1, pg_sys::InvalidOid, 0);
+        let var = pg_sys::makeVar(
+            varno.try_into().unwrap(),
+            1,
+            pg_sys::INT4OID,
+            -1,
+            pg_sys::InvalidOid,
+            0,
+        );
 
         pg_sys::rangeTableEntry_used(var as *mut pg_sys::Node, check_rt_index, 0)
     }

--- a/pgrx-examples/rewrite_manip/src/lib.rs
+++ b/pgrx-examples/rewrite_manip/src/lib.rs
@@ -1,0 +1,150 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::prelude::*;
+
+pgrx::pg_module_magic!(name, version);
+
+/// Demonstrates ChangeVarNodes by creating a Var node and remapping its varno.
+///
+/// Creates a Var referencing range table entry `old_varno`, then uses
+/// ChangeVarNodes to remap it to `new_varno`. Returns the resulting varno.
+#[pg_extern]
+fn demo_change_var_nodes(old_varno: i32, new_varno: i32) -> i32 {
+    unsafe {
+        let var = pg_sys::makeVar(old_varno, 1, pg_sys::INT4OID, -1, pg_sys::InvalidOid, 0);
+
+        pg_sys::ChangeVarNodes(var as *mut pg_sys::Node, old_varno, new_varno, 0);
+
+        (*var).varno
+    }
+}
+
+/// Demonstrates OffsetVarNodes by creating a Var node and shifting its varno
+/// by the given offset.
+///
+/// Creates a Var with varno=1, then offsets it. Returns the resulting varno.
+#[pg_extern]
+fn demo_offset_var_nodes(offset: i32) -> i32 {
+    unsafe {
+        let var = pg_sys::makeVar(1, 1, pg_sys::INT4OID, -1, pg_sys::InvalidOid, 0);
+
+        pg_sys::OffsetVarNodes(var as *mut pg_sys::Node, offset, 0);
+
+        (*var).varno
+    }
+}
+
+/// Demonstrates rangeTableEntry_used by creating a Var node referencing a
+/// specific range table index, then checking if that index is used.
+#[pg_extern]
+fn demo_range_table_entry_used(varno: i32, check_rt_index: i32) -> bool {
+    unsafe {
+        let var = pg_sys::makeVar(varno, 1, pg_sys::INT4OID, -1, pg_sys::InvalidOid, 0);
+
+        pg_sys::rangeTableEntry_used(var as *mut pg_sys::Node, check_rt_index, 0)
+    }
+}
+
+/// Demonstrates IncrementVarSublevelsUp by creating a Var and incrementing
+/// its varlevelsup field.
+#[pg_extern]
+fn demo_increment_var_sublevels_up(initial_level: i32, delta: i32) -> i32 {
+    unsafe {
+        let var = pg_sys::makeVar(
+            1,
+            1,
+            pg_sys::INT4OID,
+            -1,
+            pg_sys::InvalidOid,
+            initial_level as pg_sys::Index,
+        );
+
+        pg_sys::IncrementVarSublevelsUp(var as *mut pg_sys::Node, delta, 0);
+
+        (*var).varlevelsup as i32
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_change_var_nodes() {
+        let result = Spi::get_one::<i32>("SELECT rewrite_manip.demo_change_var_nodes(1, 5)")
+            .expect("SPI failed")
+            .expect("null result");
+        assert_eq!(result, 5, "varno should be remapped from 1 to 5");
+    }
+
+    #[pg_test]
+    fn test_change_var_nodes_no_match() {
+        let result = Spi::get_one::<i32>("SELECT rewrite_manip.demo_change_var_nodes(1, 5)")
+            .expect("SPI failed")
+            .expect("null result");
+        assert_eq!(result, 5);
+
+        let result2 = Spi::get_one::<i32>("SELECT rewrite_manip.demo_change_var_nodes(2, 5)")
+            .expect("SPI failed")
+            .expect("null result");
+        assert_eq!(result2, 5, "varno 2 should be remapped to 5");
+    }
+
+    #[pg_test]
+    fn test_offset_var_nodes() {
+        let result = Spi::get_one::<i32>("SELECT rewrite_manip.demo_offset_var_nodes(3)")
+            .expect("SPI failed")
+            .expect("null result");
+        assert_eq!(result, 4, "varno should be 1 + 3 = 4");
+    }
+
+    #[pg_test]
+    fn test_offset_var_nodes_zero() {
+        let result = Spi::get_one::<i32>("SELECT rewrite_manip.demo_offset_var_nodes(0)")
+            .expect("SPI failed")
+            .expect("null result");
+        assert_eq!(result, 1, "varno should remain 1 with offset 0");
+    }
+
+    #[pg_test]
+    fn test_range_table_entry_used_match() {
+        let result = Spi::get_one::<bool>("SELECT rewrite_manip.demo_range_table_entry_used(3, 3)")
+            .expect("SPI failed")
+            .expect("null result");
+        assert!(result, "rt_index 3 should be found when Var has varno=3");
+    }
+
+    #[pg_test]
+    fn test_range_table_entry_used_no_match() {
+        let result = Spi::get_one::<bool>("SELECT rewrite_manip.demo_range_table_entry_used(3, 5)")
+            .expect("SPI failed")
+            .expect("null result");
+        assert!(!result, "rt_index 5 should not be found when Var has varno=3");
+    }
+
+    #[pg_test]
+    fn test_increment_var_sublevels_up() {
+        let result =
+            Spi::get_one::<i32>("SELECT rewrite_manip.demo_increment_var_sublevels_up(0, 2)")
+                .expect("SPI failed")
+                .expect("null result");
+        assert_eq!(result, 2, "varlevelsup should be 0 + 2 = 2");
+    }
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {}
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        vec![]
+    }
+}

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -151,6 +151,7 @@
 #include "replication/syncrep.h"
 #include "replication/walsender_private.h"
 #include "rewrite/rewriteHandler.h"
+#include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "statistics/statistics.h"
 #include "storage/block.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -152,6 +152,7 @@
 #include "replication/syncrep.h"
 #include "replication/walsender_private.h"
 #include "rewrite/rewriteHandler.h"
+#include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "statistics/statistics.h"
 #include "storage/block.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -153,6 +153,7 @@
 #include "replication/syncrep.h"
 #include "replication/walsender_private.h"
 #include "rewrite/rewriteHandler.h"
+#include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "statistics/statistics.h"
 #include "storage/block.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -155,6 +155,7 @@
 #include "replication/syncrep.h"
 #include "replication/walsender_private.h"
 #include "rewrite/rewriteHandler.h"
+#include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "statistics/statistics.h"
 #include "storage/block.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -155,6 +155,7 @@
 #include "replication/syncrep.h"
 #include "replication/walsender_private.h"
 #include "rewrite/rewriteHandler.h"
+#include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "statistics/statistics.h"
 #include "storage/block.h"

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -155,6 +155,7 @@
 #include "replication/syncrep.h"
 #include "replication/walsender_private.h"
 #include "rewrite/rewriteHandler.h"
+#include "rewrite/rewriteManip.h"
 #include "rewrite/rowsecurity.h"
 #include "storage/block.h"
 #include "storage/buf_internals.h"


### PR DESCRIPTION
* Exposes ChangeVarNodes, OffsetVarNodes, and other query tree manipulation functions from PostgreSQL's rewrite/rewriteManip.h via pgrx::pg_sys.
* Demonstrates ChangeVarNodes, OffsetVarNodes, and rangeTableEntry_used by parsing SQL queries and manipulating the resulting node trees.

for #2232