### PR TITLE
refactor remove redundant casts and improve safety in varlena functions

### DIFF
--- a/pgrx/src/datum/varlena.rs
+++ b/pgrx/src/datum/varlena.rs
@@ -397,7 +397,7 @@ pub unsafe fn cbor_decode<'de, T>(input: *mut pg_sys::varlena) -> T
 where
     T: Deserialize<'de>,
 {
-    let varlena = pg_sys::pg_detoast_datum_packed(input as *mut pg_sys::varlena);
+    let varlena = pg_sys::pg_detoast_datum_packed(input);
     let len = varsize_any_exhdr(varlena);
     let data = vardata_any(varlena);
     let slice = std::slice::from_raw_parts(data as *const u8, len);
@@ -415,7 +415,7 @@ where
 {
     memory_context.switch_to(|_| {
         // this gets the varlena Datum copied into this memory context
-        let varlena = pg_sys::pg_detoast_datum_copy(input as *mut pg_sys::varlena);
+        let varlena = pg_sys::pg_detoast_datum_copy(input);
         cbor_decode(varlena)
     })
 }

--- a/pgrx/src/heap_tuple.rs
+++ b/pgrx/src/heap_tuple.rs
@@ -478,6 +478,12 @@ impl<'mcx, AllocatedBy: WhoAllocated> PgHeapTuple<'mcx, AllocatedBy> {
         self.tupdesc.len()
     }
 
+    /// Returns `true` if this [`PgHeapTuple`] has no attributes.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.tupdesc.len() == 0
+    }
+
     /// Returns an iterator over the attributes in this [`PgHeapTuple`].
     ///
     /// The return value is `(attribute_number: NonZeroUsize, attribute_info: &pg_sys::FormData_pg_attribute)`.

--- a/pgrx/src/list.rs
+++ b/pgrx/src/list.rs
@@ -142,6 +142,11 @@ impl<'cx, T> List<'cx, T> {
     }
 
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        matches!(self, List::Nil)
+    }
+
+    #[inline]
     pub fn capacity(&self) -> usize {
         match self {
             List::Nil => 0,
@@ -210,5 +215,42 @@ impl<T> ListHead<'_, T> {
     #[inline]
     pub fn len(&self) -> usize {
         unsafe { (*self.list.as_ptr()).length as usize }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_nil_is_default() {
+        let list: List<'_, *mut core::ffi::c_void> = List::default();
+        assert!(matches!(list, List::Nil));
+    }
+
+    #[test]
+    fn list_nil_is_empty() {
+        let list: List<'_, *mut core::ffi::c_void> = List::Nil;
+        assert!(list.is_empty());
+        assert_eq!(list.len(), 0);
+        assert_eq!(list.capacity(), 0);
+    }
+
+    #[test]
+    fn list_nil_as_ptr_is_null() {
+        let list: List<'_, *mut core::ffi::c_void> = List::Nil;
+        assert!(list.as_ptr().is_null());
+    }
+
+    #[test]
+    fn list_nil_into_ptr_is_null() {
+        let mut list: List<'_, *mut core::ffi::c_void> = List::Nil;
+        assert!(list.as_mut_ptr().is_null());
+        assert!(list.into_ptr().is_null());
     }
 }

--- a/pgrx/src/nullable.rs
+++ b/pgrx/src/nullable.rs
@@ -243,6 +243,11 @@ where
     /// (as in, the thing accessed by get_raw) but instead represents the
     /// length of the array including skipped nulls.
     fn len(&'mcx self) -> usize;
+
+    /// Returns `true` if the container has no elements.
+    fn is_empty(&'mcx self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Bitmap of null slots on a container.

--- a/pgrx/src/pgbox.rs
+++ b/pgrx/src/pgbox.rs
@@ -326,8 +326,8 @@ impl<T, AllocatedBy: WhoAllocated> PgBox<T, AllocatedBy> {
     /// Return the boxed pointer, so that it can be passed back into a Postgres function
     #[inline]
     pub fn as_ptr(&self) -> *mut T {
-        match self.ptr.as_ref() {
-            Some(ptr) => unsafe { ptr.clone().as_mut() as *mut T },
+        match self.ptr {
+            Some(ptr) => ptr.as_ptr(),
             None => std::ptr::null_mut(),
         }
     }
@@ -470,4 +470,51 @@ unsafe impl<T: SqlTranslatable> SqlTranslatable for PgBox<T, AllocatedByRust> {
     const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin = T::TYPE_ORIGIN;
     const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = T::ARGUMENT_SQL;
     const RETURN_SQL: Result<ReturnsRef, ReturnsError> = T::RETURN_SQL;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_pg_null_is_null() {
+        let pgbox: PgBox<i32> = unsafe { PgBox::from_pg(std::ptr::null_mut()) };
+        assert!(pgbox.is_null());
+    }
+
+    #[test]
+    fn from_pg_null_as_ptr_returns_null() {
+        let pgbox: PgBox<i32> = unsafe { PgBox::from_pg(std::ptr::null_mut()) };
+        assert!(pgbox.as_ptr().is_null());
+    }
+
+    #[test]
+    fn from_pg_non_null_is_not_null() {
+        let mut value: i32 = 42;
+        let pgbox: PgBox<i32> = unsafe { PgBox::from_pg(&mut value as *mut i32) };
+        assert!(!pgbox.is_null());
+        assert_eq!(pgbox.as_ptr(), &mut value as *mut i32);
+    }
+
+    #[test]
+    fn from_pg_non_null_as_ptr_matches() {
+        let mut value: i32 = 99;
+        let ptr = &mut value as *mut i32;
+        let pgbox: PgBox<i32> = unsafe { PgBox::from_pg(ptr) };
+        assert_eq!(pgbox.as_ptr(), ptr);
+    }
+
+    #[test]
+    fn into_pg_null_returns_null() {
+        let pgbox: PgBox<i32> = unsafe { PgBox::from_pg(std::ptr::null_mut()) };
+        assert!(pgbox.into_pg().is_null());
+    }
+
+    #[test]
+    fn into_pg_non_null_returns_same_ptr() {
+        let mut value: i32 = 7;
+        let ptr = &mut value as *mut i32;
+        let pgbox: PgBox<i32> = unsafe { PgBox::from_pg(ptr) };
+        assert_eq!(pgbox.into_pg(), ptr);
+    }
 }

--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -367,8 +367,7 @@ pub unsafe fn varsize_any_exhdr(ptr: *const pg_sys::varlena) -> usize {
 #[inline]
 pub unsafe fn vardata_1b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
     let va1b = ptr as *const pg_sys::varattrib_1b;
-    (*va1b).va_data.as_slice(varsize_1b(ptr as *const pg_sys::varlena) as usize).as_ptr()
-        as *const std::os::raw::c_char
+    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
 }
 
 /// ```c
@@ -378,8 +377,7 @@ pub unsafe fn vardata_1b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_
 #[inline]
 pub unsafe fn vardata_4b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
     let va1b = ptr as *const pg_sys::varattrib_4b__bindgen_ty_1; // 4byte
-    (*va1b).va_data.as_slice(varsize_1b(ptr as *const pg_sys::varlena) as usize).as_ptr()
-        as *const std::os::raw::c_char
+    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
 }
 
 /// ```c
@@ -389,8 +387,7 @@ pub unsafe fn vardata_4b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_
 #[inline]
 pub unsafe fn vardata_4b_c(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
     let va1b = ptr as *const pg_sys::varattrib_4b__bindgen_ty_2; // compressed
-    (*va1b).va_data.as_slice(varsize_1b(ptr as *const pg_sys::varlena) as usize).as_ptr()
-        as *const std::os::raw::c_char
+    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
 }
 
 /// ```c
@@ -400,8 +397,7 @@ pub unsafe fn vardata_4b_c(ptr: *const pg_sys::varlena) -> *const std::os::raw::
 #[inline]
 pub unsafe fn vardata_1b_e(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
     let va1b = ptr as *const pg_sys::varattrib_1b_e;
-    (*va1b).va_data.as_slice(varsize_1b(ptr as *const pg_sys::varlena) as usize).as_ptr()
-        as *const std::os::raw::c_char
+    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
 }
 
 /// ```c
@@ -469,9 +465,9 @@ pub unsafe fn varlena_to_byte_slice<'a>(varlena: *const pg_sys::varlena) -> &'a 
 pub fn rust_str_to_text_p(s: &str) -> PgBox<pg_sys::varlena> {
     let bytea = rust_byte_slice_to_bytea(s.as_bytes());
 
-    // a pg_sys::bytea is a type alias for pg_sys::varlena so this cast is fine
+    // a pg_sys::bytea is a type alias for pg_sys::varlena so no cast is needed
     // SAFETY: bytea will be a valid pointer
-    unsafe { PgBox::from_pg(bytea.as_ptr() as *mut pg_sys::varlena) }
+    unsafe { PgBox::from_pg(bytea.as_ptr()) }
 }
 
 /// Convert a Rust `&[u8]` into a Postgres `bytea *` (which is really a varchar)
@@ -485,5 +481,92 @@ pub fn rust_byte_slice_to_bytea(slice: &[u8]) -> PgBox<pg_sys::bytea> {
             slice.as_ptr() as *const std::os::raw::c_char,
             slice.len() as i32,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_vlen_4b_known_values() {
+        #[cfg(target_endian = "little")]
+        {
+            assert_eq!(encode_vlen_4b(0), 0);
+            assert_eq!(encode_vlen_4b(1), 4);
+            assert_eq!(encode_vlen_4b(4), 16);
+            assert_eq!(encode_vlen_4b(255), 1020);
+        }
+        #[cfg(target_endian = "big")]
+        {
+            assert_eq!(encode_vlen_4b(0), 0);
+            assert_eq!(encode_vlen_4b(1), 1);
+            assert_eq!(encode_vlen_4b(0x3FFFFFFF), 0x3FFFFFFF);
+        }
+    }
+
+    #[test]
+    fn encode_vlen_4b_roundtrip() {
+        for len in [0, 1, 4, 8, 127, 255, 1024, 65535, 0x3FFFFFFF_i32] {
+            let encoded = encode_vlen_4b(len);
+            #[cfg(target_endian = "little")]
+            {
+                let decoded = ((encoded >> 2) & 0x3FFF_FFFF) as i32;
+                assert_eq!(decoded, len, "roundtrip failed for len={len}");
+            }
+            #[cfg(target_endian = "big")]
+            {
+                let decoded = (encoded & 0x3FFF_FFFF) as i32;
+                assert_eq!(decoded, len, "roundtrip failed for len={len}");
+            }
+        }
+    }
+
+    #[test]
+    fn encode_vlen_1b_known_values() {
+        #[cfg(target_endian = "little")]
+        {
+            assert_eq!(encode_vlen_1b(1), 0x03);
+            assert_eq!(encode_vlen_1b(2), 0x05);
+            assert_eq!(encode_vlen_1b(127), 0xFF);
+        }
+        #[cfg(target_endian = "big")]
+        {
+            assert_eq!(encode_vlen_1b(0), 0x80);
+            assert_eq!(encode_vlen_1b(1), 0x81);
+            assert_eq!(encode_vlen_1b(127), 0xFF);
+        }
+    }
+
+    #[test]
+    fn encode_vlen_1b_roundtrip() {
+        for len in 0..=127_i32 {
+            let encoded = encode_vlen_1b(len);
+            #[cfg(target_endian = "little")]
+            {
+                let decoded = ((encoded >> 1) & 0x7F) as i32;
+                assert_eq!(decoded, len, "roundtrip failed for len={len}");
+            }
+            #[cfg(target_endian = "big")]
+            {
+                let decoded = (encoded & 0x7F) as i32;
+                assert_eq!(decoded, len, "roundtrip failed for len={len}");
+            }
+        }
+    }
+
+    #[test]
+    fn encode_vlen_1b_always_sets_short_flag() {
+        for len in 0..=127_i32 {
+            let encoded = encode_vlen_1b(len);
+            #[cfg(target_endian = "little")]
+            {
+                assert_ne!(encoded & 0x01, 0, "short flag not set for len={len}");
+            }
+            #[cfg(target_endian = "big")]
+            {
+                assert_ne!(encoded & 0x80, 0, "short flag not set for len={len}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

  - Remove redundant identity casts in varlena functions (`ptr as *const pg_sys::varlena` where ptr is already that type, `as
  usize` where return is already usize, `as *mut pg_sys::varlena` where bytea = varlena)
  - Simplify `PgBox::as_ptr()` — use `NonNull::as_ptr()` directly instead of clone + as_mut (NonNull is Copy)
  - Add `is_empty()` methods to `List`, `ListHead`, `PgHeapTuple`, and `NullableContainer` trait (clippy: len-without-is-empty)
  - Add unit tests for `encode_vlen_4b`, `encode_vlen_1b`, `List::Nil`, and `PgBox` pointer semantics

  ## Motivation

  - Identity casts add noise and can mask real type mismatches during refactoring
  - `NonNull::clone()` is semantically misleading (it's Copy, clone is a no-op)
  - Missing `is_empty()` on types with `len()` triggers clippy warnings and forces callers to write `x.len() == 0`

  ## Test plan

  - [x] `cargo check --no-default-features --features pg17` passes
  - [x] `cargo check --no-default-features --features "pg17 cshim"` passes
  - [x] `cargo test --no-default-features --features pg17 -p pgrx --lib` passes