### PR TITLE
Fix docs.rs build by localizing docsrs cfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,16 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "annotate-snippets"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
-dependencies = [
- "anstyle",
- "unicode-width",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,7 +276,6 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "annotate-snippets",
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
@@ -4171,12 +4160,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -17,7 +17,7 @@ regex.workspace = true
 syn.workspace = true
 walkdir.workspace = true
 
-bindgen = { version = "0.72.1", default-features = false, features = ["experimental", "runtime"] }
+bindgen = { version = "0.72.1", default-features = false, features = ["runtime"] }
 clang-sys = { version = "1", features = ["clang_6_0", "runtime"] }
 quote = "1.0.45"
 shlex = "2.0" # shell lexing, also used by many of our deps

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -147,7 +147,11 @@ impl bindgen::callbacks::ParseCallbacks for BindingOverride {
 }
 
 pub fn main() -> eyre::Result<()> {
+    println!("cargo:rustc-check-cfg=cfg(docsrs)");
+    println!("cargo:rerun-if-env-changed=DOCS_RS");
+
     if env_tracked("DOCS_RS").as_deref() == Some("1") {
+        println!("cargo:rustc-cfg=docsrs");
         return Ok(());
     }
 

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -23,10 +23,6 @@ edition.workspace = true
 [lib]
 proc-macro = true
 
-[package.metadata.docs.rs]
-# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
-rustc-args = ["--cfg", "docsrs"]
-
 [features]
 no-schema-generation = ["pgrx-sql-entity-graph/no-schema-generation"]
 

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -36,9 +36,6 @@ cshim = []
 features = ["pg14", "cshim"]
 no-default-features = true
 targets = ["x86_64-unknown-linux-gnu"]
-# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 pgrx-macros.workspace = true

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -42,9 +42,6 @@ nightly = ["pgrx/nightly"]
 features = ["pg14", "proptest"]
 no-default-features = true
 targets = ["x86_64-unknown-linux-gnu"]
-# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 pgrx-macros.workspace = true

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -42,8 +42,6 @@ nightly = []    # For features and functionality which require nightly Rust - fo
 [package.metadata.docs.rs]
 features = ["pg14", "cshim"]
 no-default-features = true
-# Enable `#[cfg(docsrs)]` (https://docs.rs/about/builds#cross-compiling)
-rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 pgrx-macros.workspace = true


### PR DESCRIPTION
docs.rs was invoking rustdoc with `--cfg docsrs` from package metadata. Cargo applies those rustflags to the whole build graph, not only pgrx/pgrx-pg-sys, so third-party crates also observed cfg(docsrs). bindgen's experimental feature pulled annotate-snippets 0.11.5, whose docsrs cfg enables feature(doc_auto_cfg), removed in rustc 1.92 and rejected by the current docs.rs nightly. That caused pgrx docs build #3444463 to fail before rustdoc reached our crate.

Only `pgrx-pg-sys` needs `cfg(docsrs)`, and only to select the checked-in bindings instead of running bindgen/Postgres discovery. Have its build script emit `cargo:rustc-cfg=docsrs` when `DOCS_RS=1`, plus check-cfg and rerun tracking, and remove global docs.rs rustc/rustdoc args from member manifests.

Also stop enabling bindgen's experimental feature. `pgrx-bindgen` uses the stable builder APIs needed for `wrap_static_fns`, and dropping experimental removes `annotate-snippets/unicode-width` from the lockfile entirely.
