### PR TITLE
Fix binding of `struct Port` on pg17

### DIFF
--- a/pgrx-pg-sys/src/libpq.rs
+++ b/pgrx-pg-sys/src/libpq.rs
@@ -85,7 +85,6 @@ pub mod be {
         pub remote_hostname_resolv: core::ffi::c_int,
         pub remote_hostname_errcode: core::ffi::c_int,
         pub remote_port: *mut core::ffi::c_char,
-        pub canAcceptConnections: core::ffi::c_uint,
         pub database_name: *mut core::ffi::c_char,
         pub user_name: *mut core::ffi::c_char,
         pub cmdline_options: *mut core::ffi::c_char,


### PR DESCRIPTION
The `canAcceptConnections` field was removed in Postgres 17.

See: https://github.com/postgres/postgres/commit/d162c3a73bf14416ff4012de6f01c3d825610f70