### PR TITLE
Replace cargo-edit with crates-index and toml_edit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# https://git-scm.com/docs/gitattributes
+
+# Preserve LF line endings in golden files during checkout.
+/cargo-pgrx/tests/fixtures/**/*.toml text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -140,19 +140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.4.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
-dependencies = [
- "compression-codecs",
- "compression-core",
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,23 +148,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -255,7 +225,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -284,12 +254,6 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -304,15 +268,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -333,6 +288,17 @@ checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "bytes",
  "cfg_aliases",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -381,44 +347,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-edit"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b555c13b6b1030831129f212838d5e18d48e16053c3a9c941f210bdcf05177f8"
-dependencies = [
- "anyhow",
- "cargo_metadata 0.19.2",
- "clap",
- "clap-cargo 0.15.2",
- "concolor-control",
- "dunce",
- "hex",
- "home",
- "indexmap",
- "pathdiff",
- "semver",
- "serde",
- "serde_derive",
- "tame-index",
- "termcolor",
- "toml 0.8.23",
- "toml_edit",
- "url",
-]
-
-[[package]]
 name = "cargo-pgrx"
 version = "0.18.1"
 dependencies = [
  "bzip2",
- "cargo-edit",
- "cargo_metadata 0.23.1",
+ "cargo_metadata",
  "cargo_toml",
  "clap",
- "clap-cargo 0.18.3",
+ "clap-cargo",
  "color-eyre",
+ "crates-index",
  "env_proxy",
  "eyre",
+ "goldenfile",
  "is-terminal",
  "jobslot",
  "libc",
@@ -436,7 +377,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "toml 0.5.11",
+ "toml 1.1.2+spec-1.1.0",
  "toml_edit",
  "tracing",
  "tracing-error",
@@ -446,15 +387,6 @@ dependencies = [
  "uuid",
  "which",
  "zip",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -469,26 +401,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform 0.1.5",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform 0.3.3",
+ "cargo-platform",
  "semver",
  "serde",
  "serde_json",
@@ -567,7 +485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -604,7 +522,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -631,22 +549,12 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
-dependencies = [
- "anstyle",
- "clap",
-]
-
-[[package]]
-name = "clap-cargo"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
 dependencies = [
  "anstyle",
- "cargo_metadata 0.23.1",
+ "cargo_metadata",
  "clap",
  "serde",
  "serde_json",
@@ -751,38 +659,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "compression-codecs"
-version = "0.4.38"
+name = "console"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "compression-core",
- "flate2",
- "memchr",
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "compression-core"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
-
-[[package]]
-name = "concolor-control"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7104119c2f80d887239879d0c50e033cd40eac9a3f3561e0684ba7d5d654f4da"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "concolor-query",
-]
-
-[[package]]
-name = "concolor-query"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad159cc964ac8f9d407cbc0aa44b02436c054b541f2b4b5f06972e1efdc54bc7"
 
 [[package]]
 name = "const-oid"
@@ -829,20 +715,32 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crates-index"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2cb0f9440838694b31ff3787148d329e02f03c16ff96c28790261563e82174"
+dependencies = [
+ "hex",
+ "home",
+ "http",
+ "memchr",
+ "rustc-hash",
+ "rustc-stable-hash",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smol_str",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -888,63 +786,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "crypto-common"
@@ -1044,23 +889,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
  "zeroize",
 ]
@@ -1071,21 +906,21 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "objc2",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1139,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1282,12 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,23 +1135,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1332,10 +1149,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1345,11 +1160,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1381,22 +1194,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "h2"
-version = "0.4.14"
+name = "goldenfile"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "206600f27ef687e85a572315eb297c79f66620b2b3eeb3a6cde17f25e049ae5b"
 dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+ "scopeguard",
+ "similar-asserts",
+ "static_assertions",
+ "tempfile",
+ "yansi",
 ]
 
 [[package]]
@@ -1467,15 +1274,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -1485,6 +1283,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hmac"
@@ -1492,7 +1293,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1523,29 +1324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
-dependencies = [
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,67 +1336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
-]
-
-[[package]]
-name = "hyper"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2 0.6.4",
- "tokio",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1686,20 +1403,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1854,7 +1565,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.8.0",
@@ -1889,18 +1600,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "lzma-rust2"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
 dependencies = [
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -1925,7 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1933,15 +1638,6 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -2072,7 +1768,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "dispatch2",
  "objc2",
 ]
@@ -2089,7 +1785,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "objc2",
 ]
 
@@ -2168,7 +1864,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2263,12 +1959,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "pathsearch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,7 +1974,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.11.3",
+ "digest",
  "hmac",
 ]
 
@@ -2319,7 +2009,7 @@ dependencies = [
 name = "pgrx"
 version = "0.18.1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bitvec",
  "enum-map",
  "libc",
@@ -2386,7 +2076,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 0.5.11",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "winapi",
 ]
@@ -2423,7 +2113,7 @@ dependencies = [
 name = "pgrx-tests"
 version = "0.18.1"
 dependencies = [
- "clap-cargo 0.18.3",
+ "clap-cargo",
  "eyre",
  "libc",
  "owo-colors",
@@ -2469,7 +2159,7 @@ dependencies = [
  "glob",
  "owo-colors",
  "rustc-hash",
- "toml 0.5.11",
+ "toml 1.1.2+spec-1.1.0",
  "toml_edit",
  "walkdir",
 ]
@@ -2575,7 +2265,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand 0.10.1",
- "sha2 0.11.0",
+ "sha2",
  "stringprep",
 ]
 
@@ -2638,7 +2328,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha",
@@ -2662,61 +2352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.5.1",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.5.1",
- "tracing",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2810,32 +2445,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2844,7 +2459,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2875,48 +2490,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
 
 [[package]]
 name = "rewrite_manip"
@@ -2959,16 +2532,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc-stable-hash"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3004,7 +2583,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -3026,7 +2604,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3063,12 +2641,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3115,7 +2687,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3209,32 +2781,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3244,19 +2795,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3266,8 +2806,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3308,6 +2848,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+dependencies = [
+ "console",
+ "similar",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,16 +2893,6 @@ checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
  "borsh",
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
-dependencies = [
- "libc",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3385,6 +2935,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -3447,15 +3003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "syntect"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,32 +3039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tame-index"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1652caa3694d1e943523f689c6e1b259f9d4a90fad3b3b44f2b01dce0f4b138d"
-dependencies = [
- "bytes",
- "camino",
- "crossbeam-channel",
- "home",
- "http",
- "libc",
- "memchr",
- "rayon",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smol_str",
- "thiserror 2.0.18",
- "tokio",
- "toml-span",
- "twox-hash",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,7 +3071,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3689,7 +3210,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2",
  "windows-sys 0.61.2",
 ]
 
@@ -3713,20 +3234,10 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.10.1",
- "socket2 0.6.4",
+ "socket2",
  "tokio",
  "tokio-util",
  "whoami",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]
@@ -3745,34 +3256,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -3785,31 +3275,13 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml-span"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757f36f490e7b3a25ed9fb692d7a0beb1424eabec3f7e8f40f576bece9a8cdc5"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3832,16 +3304,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3854,66 +3325,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "async-compression",
- "bitflags 2.11.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3996,12 +3411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "trybuild"
 version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,12 +3424,6 @@ dependencies = [
  "termcolor",
  "toml 1.1.2+spec-1.1.0",
 ]
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-path"
@@ -4184,12 +3587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "versioned_custom_libname_so"
 version = "0.0.0"
 dependencies = [
@@ -4232,15 +3629,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -4296,18 +3684,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -4370,7 +3746,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4381,16 +3757,6 @@ name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4458,7 +3824,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4730,15 +4096,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -4810,7 +4176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -4873,6 +4239,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -47,15 +41,6 @@ dependencies = [
  "pgrx",
  "pgrx-tests",
  "serde",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -203,17 +188,17 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
- "object 0.32.2",
+ "miniz_oxide",
+ "object 0.37.3",
  "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -225,12 +210,6 @@ dependencies = [
  "rand 0.10.1",
  "ureq",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -290,27 +269,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -430,7 +394,7 @@ dependencies = [
  "dunce",
  "hex",
  "home",
- "indexmap 2.14.0",
+ "indexmap",
  "pathdiff",
  "semver",
  "serde",
@@ -448,10 +412,10 @@ version = "0.18.1"
 dependencies = [
  "bzip2",
  "cargo-edit",
- "cargo_metadata 0.18.1",
+ "cargo_metadata 0.23.1",
  "cargo_toml",
  "clap",
- "clap-cargo 0.14.1",
+ "clap-cargo 0.18.3",
  "color-eyre",
  "env_proxy",
  "eyre",
@@ -494,17 +458,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo_metadata"
-version = "0.18.1"
+name = "cargo-platform"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
- "camino",
- "cargo-platform",
- "semver",
  "serde",
- "serde_json",
- "thiserror 1.0.65",
+ "serde_core",
 ]
 
 [[package]]
@@ -514,7 +474,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.5",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.3",
  "semver",
  "serde",
  "serde_json",
@@ -657,23 +631,25 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
-dependencies = [
- "anstyle",
- "cargo_metadata 0.18.1",
- "clap",
-]
-
-[[package]]
-name = "clap-cargo"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
 dependencies = [
  "anstyle",
  "clap",
+]
+
+[[package]]
+name = "clap-cargo"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
+dependencies = [
+ "anstyle",
+ "cargo_metadata 0.23.1",
+ "clap",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1196,9 +1172,9 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "regex-automata",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1237,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "zlib-rs",
 ]
 
@@ -1394,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -1416,7 +1392,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1446,12 +1422,6 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1634,7 +1604,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1693,16 +1663,6 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -1889,12 +1849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bda4c6077b0b08da2c48b172195795498381a7c8988c9e6212a6c55c5b9bd70"
-
-[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,15 +1858,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.8.0",
-]
-
-[[package]]
-name = "line-wrap"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
-dependencies = [
- "safemem",
 ]
 
 [[package]]
@@ -2003,15 +1948,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2110,7 +2046,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2119,7 +2054,7 @@ version = "0.0.0"
 dependencies = [
  "pgrx",
  "pgrx-tests",
- "rand 0.8.6",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2190,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2376,7 +2311,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
 ]
 
@@ -2395,7 +2330,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "thiserror 1.0.65",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -2450,7 +2385,7 @@ dependencies = [
  "pathsearch",
  "serde",
  "serde_json",
- "thiserror 1.0.65",
+ "thiserror 2.0.18",
  "toml 0.5.11",
  "url",
  "winapi",
@@ -2480,7 +2415,7 @@ dependencies = [
  "quote",
  "syn",
  "syntect",
- "thiserror 1.0.65",
+ "thiserror 2.0.18",
  "unescape",
 ]
 
@@ -2488,7 +2423,7 @@ dependencies = [
 name = "pgrx-tests"
 version = "0.18.1"
 dependencies = [
- "clap-cargo 0.14.1",
+ "clap-cargo 0.18.3",
  "eyre",
  "libc",
  "owo-colors",
@@ -2502,7 +2437,7 @@ dependencies = [
  "shlex 2.0.1",
  "sysinfo",
  "tempfile",
- "thiserror 1.0.65",
+ "thiserror 2.0.18",
  "winapi",
 ]
 
@@ -2521,7 +2456,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 1.0.65",
+ "thiserror 2.0.18",
  "trybuild",
 ]
 
@@ -2601,16 +2536,15 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.3.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
- "base64 0.13.1",
- "indexmap 1.9.3",
- "line-wrap",
+ "base64",
+ "indexmap",
+ "quick-xml",
  "serde",
  "time",
- "xml-rs",
 ]
 
 [[package]]
@@ -2633,7 +2567,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2698,20 +2632,18 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set 0.5.3",
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
  "num-traits",
- "quick-error 2.0.1",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
+ "rand 0.9.4",
+ "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2724,10 +2656,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
+name = "quick-xml"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -2813,22 +2748,11 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2845,31 +2769,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2889,11 +2794,11 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2944,13 +2849,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "memchr",
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2959,16 +2865,10 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2982,7 +2882,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3159,7 +3059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -3169,12 +3069,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -3573,7 +3467,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "plist",
- "regex-syntax 0.8.10",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3876,7 +3770,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -3942,7 +3836,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -4209,7 +4103,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "der",
  "flate2",
  "log",
@@ -4230,7 +4124,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http",
  "httparse",
  "log",
@@ -4465,7 +4359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4478,7 +4372,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4886,7 +4780,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4917,7 +4811,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -4936,7 +4830,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -4972,12 +4866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
-name = "xml-rs"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
-
-[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,7 +4894,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.2",
  "hmac",
- "indexmap 2.14.0",
+ "indexmap",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,23 +46,23 @@ pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.18.1" 
 pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.18.1" }
 pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.18.1" }
 
-cargo_metadata = "0.18.0"
+cargo_metadata = "0.23.1"
 cargo-edit = "=0.13.2" # format-preserving edits to cargo.toml
 cargo_toml = "0.22" # used for building projects
-clap-cargo = { version = "0.14.0", features = ["cargo_metadata"] }
+clap-cargo = { version = "0.18.3", features = ["cargo_metadata"] }
 eyre = "~0.6.8" # simplifies error-handling
 libc = "0.2" # FFI compat
 owo-colors = { version = "4.0", features = ["supports-color"] } # for output highlighting
 proc-macro2 = { version = "1.0.101", features = ["span-locations"] }
 quote = "1.0.40"
-regex = "1.7" # used for build/test
+regex = "1.12" # used for build/test
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shlex = "2.0" # shell lexing, also used by many of our deps
 syn = { version = "2", features = ["extra-traits", "full", "parsing", "visit-mut"] }
 toml = "0.5.11" # our config files
 toml_edit = "0.22.27" # format-preserving edits to toml files, used with cargo-edit
-thiserror = "1"
+thiserror = "2"
 unescape = "0.1.0" # for escaped-character-handling
 url = "2.5.2" # the non-existent std::web
 walkdir = "2" # directory recursion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ members = [
     "pgrx-examples/*",
     "tools/version-updater",
 ]
+exclude = [
+    "cargo-pgrx/tests/fixtures/**",
+]
 
 [workspace.package]
 authors = ["PgCentral Foundation, Inc. <contact@pgcentral.org>"]
@@ -47,7 +50,6 @@ pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.18.1" }
 pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.18.1" }
 
 cargo_metadata = "0.23.1"
-cargo-edit = "=0.13.2" # format-preserving edits to cargo.toml
 cargo_toml = "0.22" # used for building projects
 clap-cargo = { version = "0.18.3", features = ["cargo_metadata"] }
 eyre = "~0.6.8" # simplifies error-handling
@@ -60,8 +62,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shlex = "2.0" # shell lexing, also used by many of our deps
 syn = { version = "2", features = ["extra-traits", "full", "parsing", "visit-mut"] }
-toml = "0.5.11" # our config files
-toml_edit = "0.22.27" # format-preserving edits to toml files, used with cargo-edit
+toml = "1" # our config files
+toml_edit = "0.25.12" # format-preserving edits to toml files
 thiserror = "2"
 unescape = "0.1.0" # for escaped-character-handling
 url = "2.5.2" # the non-existent std::web

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -28,7 +28,6 @@ pgrx-pg-config.workspace = true
 pgrx-sql-entity-graph.workspace = true
 
 cargo_metadata.workspace = true
-cargo-edit.workspace = true
 cargo_toml.workspace = true
 clap-cargo.workspace = true
 libc.workspace = true
@@ -37,6 +36,7 @@ toml.workspace = true
 toml_edit.workspace = true
 
 clap = { version = "4.4.2", features = ["env", "suggestions", "cargo", "derive", "wrap_help"] }
+crates-index = { version = "3", features = ["sparse"], default-features = false }
 # Keep the resolver off is-terminal 0.4.7, which pulls rustix 0.37 and breaks
 # current nightly via rustc_attrs.
 is-terminal = "=0.4.17"
@@ -77,6 +77,8 @@ features = [
     "coff", "elf", "macho", "pe", "xcoff", # support all object formats to allow cross-builds
 ]
 
+[dev-dependencies]
+goldenfile = "1.11"
 
 [features]
 default = ["rustls"]

--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -12,7 +12,7 @@ use crate::cargo::CargoProfile;
 use crate::command::get::{find_control_file, get_property};
 use crate::command::sudo_install::SudoInstall;
 use crate::manifest::{PgVersionSource, display_version_info};
-use cargo_metadata::Message as CargoMessage;
+use cargo_metadata::{CrateType, Message as CargoMessage};
 use cargo_toml::Manifest;
 use eyre::{WrapErr, eyre};
 use owo_colors::OwoColorize;
@@ -463,7 +463,7 @@ pub(crate) fn find_library_file(
         // normalize being flattened and low to the ground
         .find(|artifact| {
             artifact.manifest_path == manifest_path
-                && artifact.target.crate_types.iter().any(|s| s == "cdylib")
+                && artifact.target.crate_types.iter().any(|s| *s == CrateType::CDyLib)
         })
         .and_then(|artifact| {
             artifact

--- a/cargo-pgrx/src/command/upgrade.rs
+++ b/cargo-pgrx/src/command/upgrade.rs
@@ -7,11 +7,14 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use cargo_edit::{CertsSource, Dependency, IndexCache, LocalManifest, registry_url};
+use cargo_toml::{Dependency, DepsSet, Manifest};
+use crates_index::SparseIndex;
 use eyre::eyre;
-use std::path::{Path, PathBuf};
-use toml_edit::KeyMut;
-use tracing::{debug, error, info, warn};
+use std::collections::HashSet;
+use std::sync::LazyLock;
+use std::{fs, path::PathBuf};
+use toml_edit::DocumentMut;
+use tracing::info;
 
 use crate::CommandExecute;
 
@@ -47,283 +50,309 @@ pub(crate) struct Upgrade {
     pub(crate) dry_run: bool,
 }
 
-fn set_dep_source_version<A: AsRef<str>>(src: &mut cargo_edit::Source, new_version: A) {
-    match src {
-        cargo_edit::Source::Registry(reg) => reg.version = new_version.as_ref().to_string(),
-        cargo_edit::Source::Path(path) => path.version = Some(new_version.as_ref().to_string()),
-        cargo_edit::Source::Git(git) => git.version = Some(new_version.as_ref().to_string()),
-        cargo_edit::Source::Workspace(_ws) => {
-            error!(
-                "Cannot upgrade the version of \
-                a package because it is set in the \
-                workspace, please run `cargo pgrx \
-                upgrade` in the workspace directory."
-            );
-        }
-    }
-}
-fn get_dep_source_version(src: &cargo_edit::Source) -> Option<&String> {
-    match src {
-        cargo_edit::Source::Registry(reg) => Some(&reg.version),
-        cargo_edit::Source::Path(path) => path.version.as_ref(),
-        cargo_edit::Source::Git(git) => git.version.as_ref(),
-        cargo_edit::Source::Workspace(_ws) => {
-            error!(
-                "Cannot fetch the version of \
-                a package because it is set in the \
-                workspace, please run `cargo pgrx \
-                upgrade` in the workspace directory."
-            );
-            None
-        }
-    }
-}
-
-#[tracing::instrument(level = "error")]
-fn replace_version(
-    new_version: &str,
-    crate_root: &Path,
-    key: &mut toml_edit::KeyMut,
-    dep: &mut toml_edit::Item,
-    mut parsed_dep: Dependency,
-    mut source: cargo_edit::Source,
-) -> eyre::Result<()> {
-    let dep_name = key.get();
-    let ver_maybe = get_dep_source_version(&source);
-    match ver_maybe {
-        Some(v) => {
-            debug!("{dep_name} version is {v}")
-        }
-        None => return Err(eyre!("No version field for {dep_name}, cannot upgrade.")),
-    }
-    set_dep_source_version(&mut source, new_version);
-    parsed_dep = parsed_dep.set_source(source);
-
-    parsed_dep.update_toml(crate_root, key, dep);
-    Ok(())
-}
-impl Upgrade {
+impl CommandExecute for Upgrade {
     #[tracing::instrument(level = "error", skip(self))]
-    fn update_dep(
-        &self,
-        path: &PathBuf,
-        mut key: KeyMut,
-        dep: &mut toml_edit::Item,
-    ) -> eyre::Result<()> {
-        let mut index = IndexCache::new(CertsSource::Native);
-        let dep_name_string = key.get().to_string();
-        let dep_name = dep_name_string.as_str();
-        let parsed_dep: Dependency = match Dependency::from_toml(path.as_path(), dep_name, dep) {
-            Ok(dependency) => dependency,
-            Err(e) => {
-                return Err(eyre!(
-                    "Could not parse dependency \
-                entry for {dep_name} due to error: {e}"
-                ));
-            }
-        };
-        let reg_url = registry_url(path, parsed_dep.registry())
-            .map_err(|e| eyre!("Unable to fetch registry URL for path: {e}"))?;
-        let index =
-            index.index(&reg_url).map_err(|e| eyre!("Unable to get registry index: {e}"))?;
-        let target_version = match self.to {
-            Some(ref ver) => Some(ver.clone()),
-            None => {
-                let krate = index.krate(dep_name).map_err(|e| {
-                    eyre!("The crate `{dep_name}` could not be found in registry index due {e}.")
-                })?;
-                let versions = krate.as_ref().map(|k| k.versions.as_slice()).unwrap_or_default();
-                let dependency =
-                    cargo_edit::find_latest_version(versions, self.include_prereleases, None)
-                        .ok_or_else(|| {
-                            eyre!("Unable to fetch the latest version for crate {dep_name}.")
-                        })?;
+    fn execute(self) -> eyre::Result<()> {
+        let path = self.manifest_path.map_or_else(|| PathBuf::from("./Cargo.toml"), |p| p.clone());
+        let path = find_manifest_file(&path.canonicalize()?, self.package.as_ref())?;
 
-                dependency.version().map(|s| s.to_string())
-            }
-        };
-        let target_version = match target_version {
-            Some(ver) => ver,
-            None => {
-                return Err(eyre!(
-                    "Unable to update {dep_name} \
-                , no provided crate version and a latest version \
-                could not be retrieved from the registry."
-                ));
-            }
+        let version = if let Some(v) = &self.to {
+            TargetVersion::Exact(v.to_owned())
+        } else if self.include_prereleases {
+            TargetVersion::DiscoverPrerelease
+        } else {
+            TargetVersion::DiscoverReleased
         };
 
-        // As of cargo-edit version 0.12.2, dep.source will always be a Some()
-        // if the Dependency struct was instantiated via from_toml().
-        let source = match parsed_dep.source().cloned() {
-            Some(src) => src,
-            None => {
-                return Err(eyre!(
-                    "Dependency {dep_name}'s source was \
-                parsed as None by cargo-edit."
-                ));
+        let updated = process_manifest_file(&path, &version)?;
+
+        if self.dry_run {
+            Ok(println!("{}", updated.to_string()))
+        } else {
+            fs::write(&path, updated.to_string())
+                .map_err(|err| eyre!("Unable to write the updated Cargo.toml to disk: {err}"))
+        }
+    }
+}
+
+#[derive(Debug)]
+enum TargetVersion {
+    DiscoverPrerelease,
+    DiscoverReleased,
+    Exact(String),
+}
+
+/// Starting at path, search for the Cargo manifest containing package.
+#[tracing::instrument(level = "error")]
+fn find_manifest_file(path: &PathBuf, package: Option<&String>) -> eyre::Result<PathBuf> {
+    let (manifest_dirpath, manifest_filepath) = if fs::metadata(&path)?.is_dir() {
+        (path.clone(), path.join("Cargo.toml"))
+    } else {
+        (path.parent().expect("parent").to_path_buf(), path.clone())
+    };
+
+    let input = Manifest::from_path(&manifest_filepath)
+        .map_err(|e| eyre!("Error opening manifest: {e}"))?;
+
+    match (package, &input.workspace) {
+        // Without a package argument, the manifest argument is already correct.
+        (None, _) => Ok(manifest_filepath),
+
+        // With a package argument and no workspace, check the name in the manifest.
+        (Some(name), None) => {
+            if let Some(input_package) = &input.package
+                && input_package.name().to_lowercase() == name.to_lowercase()
+            {
+                Ok(manifest_filepath)
+            } else {
+                Err(eyre!("No package {name:?} in {:?}", manifest_filepath.file_name()))
             }
-        };
-        debug!(
-            "Found dependency {dep_name} with current \
-            source {source:#?}"
-        );
-        match &source {
-            cargo_edit::Source::Registry(_) => {
-                if get_dep_source_version(&source).is_some() {
-                    replace_version(
-                        target_version.as_str(),
-                        path.as_path(),
-                        &mut key,
-                        dep,
-                        parsed_dep,
-                        source,
-                    )?;
-                } else {
-                    info!("No version specified for {dep_name}, not upgrading.");
+        }
+
+        // With a package argument in a workspace, search among the workspace members.
+        // Report errors from each member when the package is not found.
+        (Some(name), Some(workspace)) => {
+            let mut errs = Vec::with_capacity(workspace.members.len());
+
+            for dir in &workspace.members {
+                match find_manifest_file(&manifest_dirpath.join(dir), package) {
+                    Ok(v) => return Ok(v),
+                    Err(e) => errs.push(format!("- {dir}: {e}")),
                 }
             }
-            cargo_edit::Source::Path(_) => {
-                warn!(
-                    "Cannot upgrade the version of \
-                        {dep_name} because it is a path (local) dependency."
-                )
-            }
-            cargo_edit::Source::Git(_) => {
-                warn!(
-                    "Cannot upgrade the version of \
-                        {dep_name} because it is a git dependency."
-                )
-            }
-            cargo_edit::Source::Workspace(_) => {
-                warn!(
-                    "Cannot upgrade the version of \
-                        {dep_name} because it is set in the \
-                        workspace, please run `cargo pgrx \
-                        upgrade` in the workspace directory."
-                )
-            }
+
+            Err(eyre!("No package {name:?} in {manifest_filepath:?}:\n{}", errs.join("\n")))
         }
-        Ok(())
+    }
+}
+
+/// Load the Cargo manifest at path and return a copy with updated dependency versions.
+#[tracing::instrument(level = "error")]
+fn process_manifest_file(path: &PathBuf, version: &TargetVersion) -> eyre::Result<DocumentMut> {
+    let input = Manifest::from_path(&path).map_err(|e| eyre!("Error opening manifest: {e}"))?;
+
+    let mut output: DocumentMut = fs::read_to_string(&path)
+        .map_err(|e| eyre!("Error opening manifest: {e}"))?
+        .parse()
+        .map_err(|e| eyre!("Error parsing manifest: {e}"))?;
+
+    update_manifest(&input, &mut output, &version)?;
+
+    Ok(output)
+}
+
+/// Update versions in the "dependencies", "dev-dependencies", and "workspace.dependencies" sections
+/// of a Cargo manifest loaded into source and sink.
+#[tracing::instrument(level = "error")]
+fn update_manifest(
+    source: &Manifest,
+    sink: &mut DocumentMut,
+    target: &TargetVersion,
+) -> eyre::Result<()> {
+    if !source.dependencies.is_empty() {
+        let section = sink["dependencies"].as_table_like_mut();
+        let section = section.expect("source and sink diverged");
+
+        update_manifest_section(section, &source.dependencies, target)?;
     }
 
-    #[allow(deprecated)] // the API changes to toml_edit are quite complex!
-    fn process_manifest(&self, path: &PathBuf, manifest: &mut LocalManifest) -> eyre::Result<()> {
-        const RELEVANT_PACKAGES: [&str; 6] = [
+    if !source.dev_dependencies.is_empty() {
+        let section = sink["dev-dependencies"].as_table_like_mut();
+        let section = section.expect("source and sink diverged");
+
+        update_manifest_section(section, &source.dev_dependencies, target)?;
+    }
+
+    if let Some(workspace) = &source.workspace
+        && !workspace.dependencies.is_empty()
+    {
+        let section = sink["workspace"]["dependencies"].as_table_like_mut();
+        let section = section.expect("source and sink diverged");
+
+        update_manifest_section(section, &workspace.dependencies, target)?;
+    }
+
+    Ok(())
+}
+
+/// Update dependency versions in a single section of a Cargo manifest.
+fn update_manifest_section<T: toml_edit::TableLike + ?Sized>(
+    section: &mut T,
+    dependencies: &DepsSet,
+    target: &TargetVersion,
+) -> eyre::Result<()> {
+    static RELEVANT_PACKAGES: LazyLock<HashSet<&str>> = LazyLock::new(|| {
+        HashSet::from([
             "pgrx",
+            "pgrx-bench",
             "pgrx-macros",
             "pgrx-pg-config",
             "pgrx-pg-sys",
             "pgrx-sql-entity-graph",
             "pgrx-tests",
-        ];
+        ])
+    });
 
-        for dep_table in manifest.get_dependency_tables_mut() {
-            for dep_name in RELEVANT_PACKAGES {
-                let decor = dep_table.key_decor(dep_name).cloned();
-                if let Some((key, dep)) = dep_table.get_key_value_mut(dep_name) {
-                    self.update_dep(path, key, dep)?;
-                    // Workaround since update_toml() doesn't preserve comments
-                    if let Some(dec) = dep_table.key_decor_mut(dep_name) {
-                        if let Some(prefix) = decor.as_ref().and_then(|val| val.prefix().cloned()) {
-                            dec.set_prefix(prefix)
-                        }
-                        if let Some(suffix) = decor.as_ref().and_then(|val| val.suffix().cloned()) {
-                            dec.set_suffix(suffix)
-                        }
-                    }
+    // Regex to capture any operators in the manifest version requirement.
+    static REQUIREMENT_REGEX: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"^([^0-9.]*)([0-9.].*)$").unwrap());
+
+    for (local_name, dependency) in dependencies {
+        let crate_name = match dependency {
+            Dependency::Inherited(_) => continue,
+            Dependency::Simple(_) => local_name,
+            Dependency::Detailed(detail) => {
+                if let Some(crate_name) = &detail.package {
+                    crate_name
                 } else {
-                    debug!(
-                        "Manifest does not contain a dependency entry for \
-                        {dep_name}"
-                    );
+                    local_name
                 }
             }
+        };
+
+        if !RELEVANT_PACKAGES.contains(crate_name.as_str()) {
+            continue;
         }
-        if !self.dry_run {
-            manifest
-                .write()
-                .map_err(|err| eyre!("Unable to write the updated Cargo.toml to disk: {err}"))?;
-        } else {
-            let generated_toml = manifest.to_string();
-            println!("{generated_toml}");
+
+        let index = match dependency {
+            Dependency::Inherited(_) => continue,
+            Dependency::Simple(_) => SparseIndex::new_cargo_default()?,
+            Dependency::Detailed(detail) => {
+                if let Some(registry) = &detail.registry {
+                    unimplemented!("custom registry {registry:?}")
+                } else {
+                    SparseIndex::new_cargo_default()?
+                }
+            }
+        };
+
+        let next_version = match target {
+            TargetVersion::Exact(specified) => specified,
+            TargetVersion::DiscoverPrerelease => {
+                let krate = index.crate_from_cache(crate_name)?;
+                let highest = krate.highest_version();
+                &(!highest.is_yanked())
+                    .then_some(highest.version())
+                    .ok_or_else(|| {
+                        eyre!("Latest version {:?} for {crate_name:?} is yanked", highest.version())
+                    })?
+                    .to_owned()
+            }
+            TargetVersion::DiscoverReleased => {
+                let krate = index.crate_from_cache(crate_name)?;
+                let highest = krate.highest_normal_version();
+                &highest
+                    .ok_or_else(|| eyre!("No released version for {crate_name:?}"))?
+                    .version()
+                    .to_owned()
+            }
+        };
+
+        match dependency {
+            Dependency::Inherited(_) => continue,
+            Dependency::Simple(requirement) => {
+                let next_requirement =
+                    REQUIREMENT_REGEX.replace(&requirement, format!("{}{}", "${1}", next_version));
+
+                section.insert(&local_name, next_requirement.into_owned().into());
+            }
+            Dependency::Detailed(detail) => {
+                let Some(requirement) = &detail.version else {
+                    info!("No version specified for {local_name}, not upgrading.");
+                    continue;
+                };
+                let next_requirement =
+                    REQUIREMENT_REGEX.replace(&requirement, format!("{}{}", "${1}", next_version));
+
+                let table = section.get_mut(&local_name).expect("source and sink diverged");
+                let table = table.as_table_like_mut().expect("source and sink diverged");
+                table.insert("version", next_requirement.into_owned().into());
+            }
         }
-        Ok(())
     }
+
+    Ok(())
 }
 
-impl CommandExecute for Upgrade {
-    #[tracing::instrument(level = "error", skip(self))]
-    fn execute(self) -> eyre::Result<()> {
-        // Canonicalize because cargo-edit does not accept relative paths.
-        let path = std::fs::canonicalize(
-            self.manifest_path.clone().unwrap_or(PathBuf::from("./Cargo.toml")),
-        )?;
+#[cfg(test)]
+mod tests {
+    use cargo_toml;
+    use goldenfile;
+    use std::fs;
 
-        let mut manifest = cargo_edit::LocalManifest::find(Some(&path))
-            .map_err(|e| eyre!("Error opening manifest: {e}"))?;
+    #[test]
+    fn find_package_manifest() {
+        let root_path = env!("CARGO_MANIFEST_DIR");
+        let fixtures_path = format!("{root_path}/tests/fixtures/package");
+        let manifest_path = format!("{fixtures_path}/expected-0.16.0.toml").into();
 
-        // Attempt to determine if this is a workspace and, if so, should we
-        // navigate to a crate contained within.
-        let parse_workspace = cargo_toml::Manifest::from_path(&path)
-            .map_err(|e| eyre!("Failed to parse workspace manifest using cargo_toml: {e}"))?;
+        let parsed = cargo_toml::Manifest::from_path(&manifest_path).expect("fixture exists");
+        assert!(parsed.package.is_some() && parsed.workspace.is_none(), "package manifest");
 
-        if let Some(package) = self.package.clone() {
-            // Equivalent to manifest.manifest.data.contains_table("workspace"); but more robust
-            let workspace = &parse_workspace.workspace;
+        let found = super::find_manifest_file(&manifest_path, None).unwrap();
+        assert_eq!(found, manifest_path);
 
-            match (parse_workspace.package.map(|pak| pak.name() == package.as_str()), workspace) {
-                // Name of the package matches the name of the root workspace
-                // crate, do not dig for a contained package.
-                (Some(true), _) => self.process_manifest(&path, &mut manifest),
-                // Contained package specified and this is a workspace,
-                // OR workspace has no root package name.
-                // find the correct manifest for the child crate.
-                (Some(false), Some(work)) | (None, Some(work)) => {
-                    // Unfortunately cargo_toml::Workspace provides the member
-                    // list as directories but not as package names, so we have
-                    // to do a little bit of finagling here.
-                    let mut child_path_maybe = None;
-                    for member in &work.members {
-                        if member == &package {
-                            // Canonicalized, should have a parent path
-                            let root_path = path.parent().ok_or(eyre!(
-                                "Failed to canonicalize path, no \
-                                parent directory found."
-                            ))?;
-                            let member_path = root_path.join(member).join("Cargo.toml");
-                            debug!("Generated child path {:#?}", &member_path);
-                            child_path_maybe = Some(member_path);
-                        }
-                    }
-                    let child_path = child_path_maybe
-                        .ok_or(eyre!("Package {package} not found in workspace {path:#?}"))?;
+        let found = super::find_manifest_file(&manifest_path, Some(&"package".to_owned())).unwrap();
+        assert_eq!(found, manifest_path);
 
-                    let mut child_manifest = LocalManifest::find(Some(&child_path))
-                        .map_err(|e| eyre!("Error opening manifest: {e}"))?;
+        let _ = super::find_manifest_file(&manifest_path, Some(&"other".to_owned())).unwrap_err();
+    }
 
-                    self.process_manifest(&child_path, &mut child_manifest)
-                }
-                // No name and this is not a workspace, why is a package name
-                // specified?
-                (None, None) => Err(eyre!(
-                    "Package argument provided but the
-                        manifest at the path {path:#?} has no name and 
-                        is not a workspace, please check Cargo.toml's 
-                        validity."
-                )),
-                // Non-workspace crate, and the name does not match.
-                (Some(false), None) => Err(eyre!(
-                    "Package argument provided but the
-                        manifest at the path {path:#?} appears to be a regular
-                        single-crate workspace, with no child crates."
-                )),
-            }
-        } else {
-            // No specified package, go right to the manifest at the
-            // specified directory.
-            self.process_manifest(&path, &mut manifest)?;
-            Ok(())
-        }
+    #[test]
+    fn find_package_manifest_in_workspace() {
+        let root_path = env!("CARGO_MANIFEST_DIR");
+        let fixtures_path = format!("{root_path}/tests/fixtures/workspace");
+        let manifest_path = format!("{fixtures_path}/Cargo.toml").into();
+
+        let parsed = cargo_toml::Manifest::from_path(&manifest_path).expect("fixture exists");
+        assert!(parsed.package.is_none() && parsed.workspace.is_some(), "workspace manifest");
+
+        let found = super::find_manifest_file(&manifest_path, None).unwrap();
+        assert_eq!(found, manifest_path);
+
+        let found = super::find_manifest_file(&manifest_path, Some(&"hello".to_owned())).unwrap();
+        assert_eq!(found, format!("{fixtures_path}/hello/Cargo.toml"));
+
+        let _ = super::find_manifest_file(&manifest_path, Some(&"other".to_owned())).unwrap_err();
+    }
+
+    #[test]
+    fn process_package_manifest() {
+        let root_path = env!("CARGO_MANIFEST_DIR");
+        let fixtures_path = format!("{root_path}/tests/fixtures/package");
+        let manifest_path = format!("{fixtures_path}/expected-0.16.0.toml");
+        let mut golden = goldenfile::Mint::new(&fixtures_path);
+
+        let parsed = cargo_toml::Manifest::from_path(&manifest_path).expect("fixture exists");
+        assert!(parsed.package.is_some() && parsed.workspace.is_none(), "package manifest");
+
+        let updated = super::process_manifest_file(
+            &manifest_path.into(),
+            &super::TargetVersion::Exact("0.16.1".into()),
+        )
+        .unwrap();
+
+        fs::write(golden.new_goldenpath("expected-0.16.1.toml").unwrap(), updated.to_string())
+            .unwrap();
+    }
+
+    #[test]
+    fn process_workspace_manifest() {
+        let root_path = env!("CARGO_MANIFEST_DIR");
+        let fixtures_path = format!("{root_path}/tests/fixtures/workspace");
+        let manifest_path = format!("{fixtures_path}/Cargo.toml");
+        let mut golden = goldenfile::Mint::new(&fixtures_path);
+
+        let parsed = cargo_toml::Manifest::from_path(&manifest_path).expect("fixture exists");
+        assert!(parsed.package.is_none() && parsed.workspace.is_some(), "workspace manifest");
+
+        let updated = super::process_manifest_file(
+            &manifest_path.into(),
+            &super::TargetVersion::Exact("0.18.1".into()),
+        )
+        .unwrap();
+
+        fs::write(golden.new_goldenpath("expected-0.18.1.toml").unwrap(), updated.to_string())
+            .unwrap();
     }
 }

--- a/cargo-pgrx/src/manifest.rs
+++ b/cargo-pgrx/src/manifest.rs
@@ -7,7 +7,7 @@
 //LICENSE All rights reserved.
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
-use cargo_metadata::Metadata;
+use cargo_metadata::{CrateType, Metadata};
 use cargo_toml::Manifest;
 use clap_cargo::Features;
 use eyre::{Context, eyre};
@@ -53,7 +53,7 @@ pub(crate) fn manifest_path(
         let found = metadata
             .packages
             .iter()
-            .find(|v| v.name == *package_name)
+            .find(|v| v.name == package_name)
             .ok_or_else(|| eyre!("Could not find package `{package_name}`"))?;
         tracing::debug!(manifest_path = %found.manifest_path, "Found workspace package");
         found.manifest_path.clone().into_std_path_buf()
@@ -72,7 +72,7 @@ pub(crate) fn manifest_path(
                 let is_cdylib = pkg
                     .targets
                     .iter()
-                    .any(|target| target.crate_types.iter().any(|ct| ct == "cdylib"));
+                    .any(|target| target.crate_types.iter().any(|ct| *ct == CrateType::CDyLib));
                 has_pgrx_dep && is_cdylib
             })
             .collect();

--- a/cargo-pgrx/tests/fixtures/package/.cargo/config.toml
+++ b/cargo-pgrx/tests/fixtures/package/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.'cfg(target_os="macos")']
+# Postgres symbols won't be available until runtime
+rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/cargo-pgrx/tests/fixtures/package/.gitignore
+++ b/cargo-pgrx/tests/fixtures/package/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock
+pg_regress/results
+pg_regress/regression.diffs
+pg_regress/regression.out

--- a/cargo-pgrx/tests/fixtures/package/expected-0.16.0.toml
+++ b/cargo-pgrx/tests/fixtures/package/expected-0.16.0.toml
@@ -1,0 +1,36 @@
+[package]
+name = "package"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[[bin]]
+name = "pgrx_embed_package"
+path = "./src/bin/pgrx_embed.rs"
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
+pg_test = []
+
+[dependencies]
+pgrx = "=0.16.0"
+
+[dev-dependencies]
+pgrx-tests = "=0.16.0"
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/cargo-pgrx/tests/fixtures/package/expected-0.16.1.toml
+++ b/cargo-pgrx/tests/fixtures/package/expected-0.16.1.toml
@@ -1,0 +1,36 @@
+[package]
+name = "package"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[[bin]]
+name = "pgrx_embed_package"
+path = "./src/bin/pgrx_embed.rs"
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
+pg_test = []
+
+[dependencies]
+pgrx = "=0.16.1"
+
+[dev-dependencies]
+pgrx-tests = "=0.16.1"
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/cargo-pgrx/tests/fixtures/package/expected-0.18.0.toml
+++ b/cargo-pgrx/tests/fixtures/package/expected-0.18.0.toml
@@ -1,0 +1,38 @@
+[package]
+name = "package"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
+pg_test = []
+pg_bench = ["dep:pgrx-bench"]
+
+[dependencies]
+pgrx = "=0.18.0"
+
+[dependencies.pgrx-bench]
+version = "=0.18.0"
+optional = true
+
+[dev-dependencies]
+[dev-dependencies.pgrx-tests]
+version = "=0.18.0"
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/cargo-pgrx/tests/fixtures/package/src/bin/pgrx_embed.rs
+++ b/cargo-pgrx/tests/fixtures/package/src/bin/pgrx_embed.rs
@@ -1,0 +1,1 @@
+::pgrx::pgrx_embed!();

--- a/cargo-pgrx/tests/fixtures/package/src/lib.rs
+++ b/cargo-pgrx/tests/fixtures/package/src/lib.rs
@@ -1,0 +1,48 @@
+use pgrx::prelude::*;
+
+::pgrx::pg_module_magic!(name, version);
+
+#[pg_extern]
+fn hello_package() -> &'static str {
+    "Hello, package"
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_hello_package() {
+        assert_eq!("Hello, package", crate::hello_package());
+    }
+}
+
+#[cfg(feature = "pg_bench")]
+#[pg_schema]
+mod benches {
+    use pgrx::prelude::*;
+    use pgrx_bench::{black_box, Bencher};
+
+    #[pg_bench]
+    fn bench_hello_package(b: &mut Bencher) {
+        b.iter(|| {
+            black_box(crate::hello_package());
+        });
+    }
+}
+
+/// This module is required by `cargo pgrx test` invocations.
+/// It must be visible at the root of your extension crate.
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    #[must_use]
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}

--- a/cargo-pgrx/tests/fixtures/workspace/.gitignore
+++ b/cargo-pgrx/tests/fixtures/workspace/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/cargo-pgrx/tests/fixtures/workspace/Cargo.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["hello"]
+
+[workspace.dependencies]
+pgrx = "=0.18.0"
+pgrx-bench = "=0.18.0"
+pgrx-macros = "=0.18.0"
+pgrx-pg-sys = "=0.18.0"
+pgrx-sql-entity-graph = { version = "=0.18.0" }
+pgrx-pg-config = { version = "=0.18.0" }

--- a/cargo-pgrx/tests/fixtures/workspace/expected-0.18.1.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/expected-0.18.1.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["hello"]
+
+[workspace.dependencies]
+pgrx = "=0.18.1"
+pgrx-bench = "=0.18.1"
+pgrx-macros = "=0.18.1"
+pgrx-pg-sys = "=0.18.1"
+pgrx-sql-entity-graph = { version = "=0.18.1" }
+pgrx-pg-config = { version = "=0.18.1" }

--- a/cargo-pgrx/tests/fixtures/workspace/hello/.cargo/config.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.'cfg(target_os="macos")']
+# Postgres symbols won't be available until runtime
+rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]

--- a/cargo-pgrx/tests/fixtures/workspace/hello/.gitignore
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock
+tests/pg_regress/results
+tests/pg_regress/regression.diffs
+tests/pg_regress/regression.out

--- a/cargo-pgrx/tests/fixtures/workspace/hello/Cargo.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "hello"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
+pg_test = []
+pg_bench = ["dep:pgrx-bench"]
+
+[dependencies]
+pgrx.workspace = true
+
+[dependencies.pgrx-bench]
+optional = true
+workspace = true
+
+[dev-dependencies]
+[dev-dependencies.pgrx-tests]
+version = "=0.18.0"
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/cargo-pgrx/tests/fixtures/workspace/hello/expected-0.18.1.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/expected-0.18.1.toml
@@ -1,0 +1,38 @@
+[package]
+name = "hello"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
+pg_test = []
+pg_bench = ["dep:pgrx-bench"]
+
+[dependencies]
+pgrx.workspace = true
+
+[dependencies.pgrx-bench]
+optional = true
+workspace = true
+
+[dev-dependencies]
+[dev-dependencies.pgrx-tests]
+version = "=0.18.1"
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/cargo-pgrx/tests/fixtures/workspace/hello/hello.control
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/hello.control
@@ -1,0 +1,6 @@
+comment = 'hello:  Created by pgrx'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'hello'
+relocatable = false
+superuser = true
+trusted = false

--- a/cargo-pgrx/tests/fixtures/workspace/hello/src/lib.rs
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/src/lib.rs
@@ -1,0 +1,48 @@
+use pgrx::prelude::*;
+
+::pgrx::pg_module_magic!(name, version);
+
+#[pg_extern]
+fn hello_hello() -> &'static str {
+    "Hello, hello"
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn test_hello_hello() {
+        assert_eq!("Hello, hello", crate::hello_hello());
+    }
+}
+
+#[cfg(feature = "pg_bench")]
+#[pg_schema]
+mod benches {
+    use pgrx::prelude::*;
+    use pgrx_bench::{black_box, Bencher};
+
+    #[pg_bench]
+    fn bench_hello_hello(b: &mut Bencher) {
+        b.iter(|| {
+            black_box(crate::hello_hello());
+        });
+    }
+}
+
+/// This module is required by `cargo pgrx test` invocations.
+/// It must be visible at the root of your extension crate.
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {
+        // perform one-off initialization when the pg_test framework starts
+    }
+
+    #[must_use]
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        // return any postgresql.conf settings that are required for your tests
+        vec![]
+    }
+}

--- a/pgrx-examples/numeric/Cargo.toml
+++ b/pgrx-examples/numeric/Cargo.toml
@@ -31,7 +31,7 @@ pg_test = []
 
 [dependencies]
 pgrx = { path = "../../pgrx" }
-rand = "0.8.6"
+rand = "0.10.1"
 
 [dev-dependencies]
 pgrx-tests = { path = "../../pgrx-tests" }


### PR DESCRIPTION
The `cargo-edit` crate is a CLI tool for editing Cargo.toml and does not intend for its packages to be used by other projects. We used it for two things: accessing remote registries and manipulating manifest files.

This change uses `crates-index` to read the [crates.io] index from Cargo's disk cache. I have omitted interactions with the network or other registries, though the crate supports both.

This change uses `cargo_toml` to parse manifest files and `toml_edit` to update them. The former provides a semantic view of the workspace and package dependencies, while the latter preserves TOML comments and formatting, like dotted keys and inline tables.

Removing `cargo-edit` as a dependency also eliminated a number of duplicate dependencies, resulting in ~10% fewer packages in the workspace lockfile.

[crates.io]: https://github.com/rust-lang/crates.io-index

Fixes: pgcentralfoundation/pgrx#2177