### PR TITLE
Quiet two errors from rust-analyzer

### DIFF
--- a/pgrx-examples/rewrite_manip/Cargo.toml
+++ b/pgrx-examples/rewrite_manip/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg17"]
+default = ["pg13"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]

--- a/pgrx-examples/subtrans_infos/Cargo.toml
+++ b/pgrx-examples/subtrans_infos/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 
 [features]
-default = ["pg14"]
+default = ["pg13"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"] 
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,4 +1,4 @@
-cargo.allFeatures = false
+cargo.features = []
 cargo.buildScripts.overrideCommand = [
   "cargo",
   "check",


### PR DESCRIPTION
While developing locally, rust-analyzer consistently emits two errors at startup:

 1. invalid config value: cargo/allFeatures: unexpected field

    This was a valid setting in the past; `true` meant `--all-features`. The `features` field does that now when set to `"all"`.

 2. FetchBuildDataError: error: failed to run custom build command for pgrx-pg-sys v0.18.1
    …
    Error: Multiple `pg$VERSION` features found. `--no-default-features` may be required. Found: pg13, pg14, pg17
    Location: pgrx-bindgen/src/lib.rs:64:28

    This was caused by differing default features across examples.