### PR TITLE
chore: add examples PostgresType in/out variants and memory-context patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memory_contexts"
+version = "0.0.0"
+dependencies = [
+ "pgrx",
+ "pgrx-tests",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2453,15 @@ dependencies = [
  "serde_core",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "postgres_type_variants"
+version = "0.0.0"
+dependencies = [
+ "pgrx",
+ "pgrx-tests",
+ "serde",
 ]
 
 [[package]]

--- a/pgrx-examples/README.md
+++ b/pgrx-examples/README.md
@@ -9,7 +9,9 @@ This directory contains examples of how to work with various aspects of `pgrx`.
 - [bytea/](bytea/):  Working with Postgres' `bytea` type as `Vec<u8>` and `&[u8]` in Rust
 - [custom_types/](custom_types/): Create your own custom Postgres types backed by Rust structs/enums
 - [errors/](errors/):  Error handling using Postgres or Rust errors/panics
+- [memory_contexts/](memory_contexts/):  PgMemoryContext lifecycle and SRF/bgworker memory patterns
 - [operators/](operators/):  Creating operator functions and associated `CREATE OPERATOR/OPERATOR CLASS/OPERATOR FAMILY` DDL
+- [postgres_type_variants/](postgres_type_variants/):  Side-by-side examples of the four PostgresType in/out paths and related derives
 - [shmem/](shmem/):  Postgres Shared Memory support
 - [schemas/](schemas/):  How `pgrx` uses Postgres schemas
 - [srf/](srf/):  Set-Returning-Functions

--- a/pgrx-examples/memory_contexts/.gitignore
+++ b/pgrx-examples/memory_contexts/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.so
+sql/*.sql

--- a/pgrx-examples/memory_contexts/Cargo.toml
+++ b/pgrx-examples/memory_contexts/Cargo.toml
@@ -1,0 +1,36 @@
+#LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+#LICENSE
+#LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+#LICENSE
+#LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+#LICENSE
+#LICENSE All rights reserved.
+#LICENSE
+#LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+[package]
+name = "memory_contexts"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
+pg_test = []
+no-schema-generation = ["pgrx/no-schema-generation", "pgrx-tests/no-schema-generation"]
+
+[dependencies]
+pgrx = { path = "../../pgrx" }
+
+[dev-dependencies]
+pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/memory_contexts/README.md
+++ b/pgrx-examples/memory_contexts/README.md
@@ -1,0 +1,27 @@
+# memory_contexts
+
+Runnable examples of `PgMemoryContext` lifecycle and how memory contexts
+interact with SRFs and bgworkers.
+
+## Files
+
+| File | What it shows |
+|---|---|
+| `basics.rs` | Create a child `PgMemoryContexts`, `switch_to` for scoped allocation, `reset` to reclaim, anti-pattern (use-after-reset) explained in module docs. |
+| `srf_per_call.rs` | Two SRFs — one streaming (`SetOfIterator`), one materialized (`TableIterator`) — with notes on `multi_call_memory_ctx` vs `per_query_ctx` and what pgrx handles for you. |
+| `bgworker_state.rs` | Bgworker that allocates its long-lived counter under `TopMemoryContext`. Not exercised by `pg_test`; run manually with `cargo pgrx run pg17 memory_contexts` after adding the crate to `shared_preload_libraries`. |
+
+## Running
+
+```bash
+cargo pgrx test pg17 -p memory_contexts
+```
+
+The bgworker example does not run under `cargo pgrx test`. To exercise it:
+
+1. Add to `${PGRX_HOME}/data-17/postgresql.conf`:
+   ```
+   shared_preload_libraries = 'memory_contexts'
+   ```
+2. `cargo pgrx run pg17 memory_contexts`
+3. Watch the postmaster log for `memory_contexts demo worker tick N` lines.

--- a/pgrx-examples/memory_contexts/memory_contexts.control
+++ b/pgrx-examples/memory_contexts/memory_contexts.control
@@ -1,0 +1,6 @@
+comment = 'memory_contexts: PgMemoryContext lifecycle and SRF/bgworker state patterns'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'memory_contexts'
+relocatable = false
+superuser = false
+trusted = false

--- a/pgrx-examples/memory_contexts/src/basics.rs
+++ b/pgrx-examples/memory_contexts/src/basics.rs
@@ -1,0 +1,101 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # `PgMemoryContext` basics: switch / reset / drop
+//!
+//! Postgres allocates from whichever memory context is current. Pgrx surfaces
+//! that via [`PgMemoryContexts`]: a transient child context can be created under
+//! a parent, switched to, written to, then **reset** (memory reclaimed, context
+//! reusable) or **dropped** (context destroyed).
+//!
+//! The pattern below shows the safe shape:
+//!
+//! 1. Create a child context under `CurrentMemoryContext`.
+//! 2. `switch_to(|ctx| { ... })` — closure runs with the child as current.
+//! 3. After the closure returns, `CurrentMemoryContext` is restored automatically.
+//! 4. Calling `.reset()` reclaims everything allocated in the child without
+//!    destroying the context.
+//!
+//! ## Anti-pattern (DO NOT do this)
+//!
+//! ```ignore
+//! let mut child = PgMemoryContexts::new("scratch");
+//! let p: *mut u8 = child.switch_to(|ctx| ctx.palloc(64));
+//! child.reset();        // <-- p is now a dangling pointer
+//! unsafe { *p = 0; }    // use-after-free
+//! ```
+//!
+//! Anything you want to *survive* a reset must live in the *parent* context.
+//! That's the whole point of switching back before returning a value.
+
+use pgrx::PgMemoryContexts;
+use pgrx::prelude::*;
+
+/// Sums an `Array<i32>` using a temporary scratch context that is reset after
+/// the operation. The return value lives in the caller's context.
+#[pg_extern]
+fn sum_with_scratch(arr: Array<i32>) -> i64 {
+    let mut scratch = PgMemoryContexts::new("sum_with_scratch");
+
+    // The closure runs with `scratch` as CurrentMemoryContext. Any palloc done inside ends up in `scratch` and gets reclaimed on `reset`.
+    //
+    // SAFETY: the closure does not leak any Postgres-allocated pointers out of the scratch context; `acc` is a stack-resident `i64`.
+    let total: i64 = unsafe {
+        scratch.switch_to(|_ctx| {
+            let mut acc: i64 = 0;
+            for v in arr.iter().flatten() {
+                acc += v as i64;
+            }
+            acc
+        })
+    };
+
+    // Reclaim everything allocated inside the closure. The `total` returned above is on the stack, so this is safe.
+    //
+    // SAFETY: no live pointers into `scratch` exist past this point.
+    unsafe { scratch.reset() };
+
+    total
+}
+
+/// Demonstrates that a value moved *out* of the closure is fine — primitives go on the stack — but a Postgres-allocated payload would NOT survive `.reset()`.
+#[pg_extern]
+fn scratch_count(n: i32) -> i32 {
+    let mut scratch = PgMemoryContexts::new("scratch_count");
+    // SAFETY: the closure returns a primitive `i32`; no Postgres-allocated pointers escape `scratch`.
+    let c = unsafe {
+        scratch.switch_to(|_ctx| {
+            let v: Vec<i32> = (0..n).collect(); // Rust heap, not Postgres heap
+            v.len() as i32
+        })
+    };
+    // SAFETY: no live pointers into `scratch` exist past this point.
+    unsafe { scratch.reset() };
+    c
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn basics_sum() {
+        let total = Spi::get_one::<i64>("SELECT sum_with_scratch(ARRAY[1,2,3,4,5,6])")
+            .expect("query failed");
+        assert_eq!(total, Some(21));
+    }
+
+    #[pg_test]
+    fn basics_count() {
+        let c = Spi::get_one::<i32>("SELECT scratch_count(100)").expect("query failed");
+        assert_eq!(c, Some(100));
+    }
+}

--- a/pgrx-examples/memory_contexts/src/bgworker_state.rs
+++ b/pgrx-examples/memory_contexts/src/bgworker_state.rs
@@ -1,0 +1,80 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # Background worker state and `TopMemoryContext`
+//!
+//! A bgworker outlives transactions, queries, and even sessions. State that
+//! must persist across iterations of its main loop CANNOT live in the current
+//! per-transaction context — that context gets reset between transactions and
+//! the state would be silently freed.
+//!
+//! The right home for long-lived bgworker state is `TopMemoryContext`, which
+//! is never reset for the lifetime of the backend.
+//!
+//! This example registers a tiny worker that maintains a per-iteration counter
+//! and logs every wake-up. It does NOT include `#[pg_test]` because driving a
+//! bgworker reliably from inside the test framework requires infrastructure
+//! outside the scope of this example. To see it run:
+//!
+//! ```text
+//! # In ${PGRX_HOME}/data-17/postgresql.conf:
+//! shared_preload_libraries = 'memory_contexts'
+//! # Then:
+//! cargo pgrx run pg17 memory_contexts
+//! # Watch the postmaster log; you should see one line per 5s.
+//! ```
+
+use pgrx::PgMemoryContexts;
+use pgrx::bgworkers::*;
+use pgrx::prelude::*;
+use std::time::Duration;
+
+/// Called from `_PG_init`. Builds and `.load()`s the worker descriptor.
+pub fn register_bgworker() {
+    BackgroundWorkerBuilder::new("memory_contexts demo worker")
+        .set_function("memory_contexts_worker_main")
+        .set_library("memory_contexts")
+        .set_argument(123i32.into_datum())
+        .load();
+}
+
+#[pg_guard]
+#[unsafe(no_mangle)]
+pub extern "C-unwind" fn memory_contexts_worker_main(arg: pg_sys::Datum) {
+    BackgroundWorker::attach_signal_handlers(SignalWakeFlags::SIGHUP | SignalWakeFlags::SIGTERM);
+
+    // Round-trip the value passed via set_argument() — proves the builder's arg plumbing works and shows where you'd plug in worker-specific config (a queue id, a partition number, etc.).
+    let init_arg = unsafe { i32::from_polymorphic_datum(arg, false, pg_sys::INT4OID) };
+    log!(
+        "memory_contexts demo worker starting (arg={})",
+        init_arg.unwrap_or(-1)
+    );
+
+    // Allocate the long-lived counter under TopMemoryContext.
+    let counter: *mut i64 = unsafe {
+        PgMemoryContexts::TopMemoryContext.switch_to(|_ctx| {
+            // 8 bytes, zeroed
+            let p = pg_sys::palloc0(std::mem::size_of::<i64>()) as *mut i64;
+            *p = 0;
+            p
+        })
+    };
+
+    while BackgroundWorker::wait_latch(Some(Duration::from_secs(5))) {
+        // SAFETY: counter was allocated in TopMemoryContext above and is never freed for the lifetime of this backend.
+        let n = unsafe {
+            *counter += 1;
+            *counter
+        };
+        log!("memory_contexts demo worker tick {n}");
+    }
+
+    log!("memory_contexts demo worker exiting");
+}

--- a/pgrx-examples/memory_contexts/src/bgworker_state.rs
+++ b/pgrx-examples/memory_contexts/src/bgworker_state.rs
@@ -52,10 +52,7 @@ pub extern "C-unwind" fn memory_contexts_worker_main(arg: pg_sys::Datum) {
 
     // Round-trip the value passed via set_argument() — proves the builder's arg plumbing works and shows where you'd plug in worker-specific config (a queue id, a partition number, etc.).
     let init_arg = unsafe { i32::from_polymorphic_datum(arg, false, pg_sys::INT4OID) };
-    log!(
-        "memory_contexts demo worker starting (arg={})",
-        init_arg.unwrap_or(-1)
-    );
+    log!("memory_contexts demo worker starting (arg={})", init_arg.unwrap_or(-1));
 
     // Allocate the long-lived counter under TopMemoryContext.
     let counter: *mut i64 = unsafe {

--- a/pgrx-examples/memory_contexts/src/lib.rs
+++ b/pgrx-examples/memory_contexts/src/lib.rs
@@ -1,0 +1,33 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+mod basics;
+mod bgworker_state;
+mod srf_per_call;
+
+pgrx::pg_module_magic!(name, version);
+
+#[pg_guard]
+pub extern "C-unwind" fn _PG_init() {
+    // The bgworker example registers itself only when loaded via shared_preload_libraries. Outside that mode this is a no-op.
+    if unsafe { pgrx::pg_sys::process_shared_preload_libraries_in_progress } {
+        crate::bgworker_state::register_bgworker();
+    }
+}
+
+use pgrx::pg_guard;
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {}
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        vec!["shared_preload_libraries='memory_contexts'"]
+    }
+}

--- a/pgrx-examples/memory_contexts/src/srf_per_call.rs
+++ b/pgrx-examples/memory_contexts/src/srf_per_call.rs
@@ -1,0 +1,74 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # SRFs and memory-context lifetimes
+//!
+//! A Set-Returning Function in Postgres has two relevant contexts:
+//!
+//! * **`multi_call_memory_ctx`** — lives across all calls of the SRF for one row;
+//!   anything stored here must be safe to read on the *next* call.
+//! * **`per_query_ctx`** (effectively the executor's context) — lives for the
+//!   whole query; you can stash long-lived computed state here.
+//!
+//! When you write a pgrx SRF using `SetOfIterator` or `TableIterator`, pgrx
+//! handles the multi-call protocol AND the contexts for you: the iterator
+//! itself is materialized once, and per-row values are returned from inside
+//! the right context. You almost never need to touch the contexts directly
+//! from a Rust SRF — the framework does it.
+//!
+//! The two functions below make the contract explicit:
+//!
+//! 1. `iter_count` — a tiny SRF returning a known sequence; the underlying
+//!    iterator state lives in the multi-call context for the duration of the
+//!    SRF, and pgrx switches contexts on each call automatically.
+//! 2. `materialized_pairs` — pre-computes all rows in one shot; ideal for small
+//!    result sets where you don't want per-call work. Memory for the produced
+//!    `Vec` lives until the executor reclaims it after the query finishes.
+
+use pgrx::prelude::*;
+
+#[pg_extern]
+fn iter_count(start: i64, end: i64) -> SetOfIterator<'static, i64> {
+    SetOfIterator::new(start..end)
+}
+
+#[pg_extern]
+fn materialized_pairs(n: i32) -> TableIterator<'static, (name!(idx, i32), name!(square, i64))> {
+    let rows: Vec<(i32, i64)> = (0..n).map(|i| (i, (i as i64) * (i as i64))).collect();
+    TableIterator::new(rows.into_iter())
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn srf_iter_count_sum() {
+        let total = Spi::get_one::<i64>("SELECT sum(x)::bigint FROM iter_count(0, 5) AS x")
+            .expect("query failed");
+        // 0+1+2+3+4 = 10
+        assert_eq!(total, Some(10));
+    }
+
+    #[pg_test]
+    fn srf_materialized_pairs_count() {
+        let c = Spi::get_one::<i64>("SELECT count(*) FROM materialized_pairs(10)")
+            .expect("query failed");
+        assert_eq!(c, Some(10));
+    }
+
+    #[pg_test]
+    fn srf_materialized_pairs_value() {
+        let v = Spi::get_one::<i64>("SELECT square FROM materialized_pairs(10) WHERE idx = 7")
+            .expect("query failed");
+        assert_eq!(v, Some(49));
+    }
+}

--- a/pgrx-examples/postgres_type_variants/.gitignore
+++ b/pgrx-examples/postgres_type_variants/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.so
+sql/*.sql

--- a/pgrx-examples/postgres_type_variants/Cargo.toml
+++ b/pgrx-examples/postgres_type_variants/Cargo.toml
@@ -1,0 +1,37 @@
+#LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+#LICENSE
+#LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+#LICENSE
+#LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+#LICENSE
+#LICENSE All rights reserved.
+#LICENSE
+#LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+[package]
+name = "postgres_type_variants"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
+pg_test = []
+no-schema-generation = ["pgrx/no-schema-generation", "pgrx-tests/no-schema-generation"]
+
+[dependencies]
+pgrx = { path = "../../pgrx" }
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/postgres_type_variants/README.md
+++ b/pgrx-examples/postgres_type_variants/README.md
@@ -1,0 +1,34 @@
+# postgres_type_variants
+
+Side-by-side examples of the four ways pgrx lets you ship a custom Postgres type,
+plus `PostgresEnum` and the `PostgresEq`/`Ord`/`Hash` derive chain.
+
+## Which variant should I use?
+
+| File | Derive | I/O format | Pick when |
+|---|---|---|---|
+| `json_default.rs` | `#[derive(PostgresType, Serialize, Deserialize)]` | Serde JSON | The shape is JSON-friendly; you're prototyping; you don't need a custom textual form. |
+| `inoutfuncs_custom.rs` | `#[derive(PostgresType)] #[inoutfuncs]` + `impl InOutFuncs` | Custom text via `&CStr` / `StringInfo` | The SQL surface should look like a domain syntax (`"3+4i"`, `"R5C7"`). |
+| `varlena_zerocopy.rs` | `#[derive(PostgresType)] #[pgvarlena_inoutfuncs]` + `impl PgVarlenaInOutFuncs` | Fixed binary on disk; custom text at SQL boundary | High-volume reads; tight binary layout pays off; you can guarantee `#[repr(C)]`-stable fields. |
+| `handrolled_datum.rs` | None — manual `FromDatum`/`IntoDatum` + `extension_sql!` | Whatever you write | You need full control over the SQL representation, alignment, or storage class; or you're studying what the derive generates. |
+
+## Related derives
+
+| File | Derive(s) | What you get |
+|---|---|---|
+| `enum_and_ord.rs` | `PostgresEnum` | Rust unit-enum → SQL `ENUM` type |
+| `enum_and_ord.rs` | `PostgresEq` + `PostgresOrd` + `PostgresHash` | Working `=`, `<`, `ORDER BY`, btree/hash operator classes — i.e. you can `CREATE INDEX ... USING btree` on the type. |
+| `composite_and_array.rs` | `PostgresType` on a record-shaped struct | `Vec<T>` returns and `Array<T>` arguments work transparently. |
+
+## Running
+
+```bash
+cargo pgrx test pg17 -p postgres_type_variants
+```
+
+## Background
+
+This crate exists to answer
+[pgrx#1384](https://github.com/pgcentralfoundation/pgrx/issues/1384) — "what is
+`PostgresType` actually for?" — by demonstrating each of its in/out paths in the
+smallest possible runnable form.

--- a/pgrx-examples/postgres_type_variants/postgres_type_variants.control
+++ b/pgrx-examples/postgres_type_variants/postgres_type_variants.control
@@ -1,0 +1,6 @@
+comment = 'postgres_type_variants: side-by-side PostgresType in/out variants'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'postgres_type_variants'
+relocatable = false
+superuser = false
+trusted = false

--- a/pgrx-examples/postgres_type_variants/src/composite_and_array.rs
+++ b/pgrx-examples/postgres_type_variants/src/composite_and_array.rs
@@ -1,0 +1,82 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # Composite-shaped custom types and `Array<CustomType>`
+//!
+//! When a `PostgresType` is shaped like a record, you can still return `Vec<T>`
+//! from `#[pg_extern]` (mapping to a SQL array of the type) and accept an
+//! `Array<T>` in. This file demonstrates both directions, including null handling
+//! for arrays of nullable elements.
+
+use pgrx::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(PostgresType, Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct Pair {
+    pub a: i32,
+    pub b: String,
+}
+
+#[pg_extern]
+fn make_pairs() -> Vec<Pair> {
+    vec![Pair { a: 1, b: "one".into() }, Pair { a: 2, b: "two".into() }]
+}
+
+#[pg_extern]
+fn sum_pair_a(arr: Array<Pair>) -> i64 {
+    let mut total: i64 = 0;
+    for p in arr.iter().flatten() {
+        total += p.a as i64;
+    }
+    total
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn composite_returns_array() {
+        let pairs = Spi::get_one::<Vec<Pair>>("SELECT make_pairs()").expect("query failed");
+        assert_eq!(
+            pairs,
+            Some(vec![Pair { a: 1, b: "one".into() }, Pair { a: 2, b: "two".into() },])
+        );
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn composite_array_in() {
+        let total = Spi::get_one::<i64>(
+            r#"SELECT sum_pair_a(ARRAY[
+                '{"a":10,"b":"x"}'::Pair,
+                '{"a":32,"b":"y"}'::Pair
+            ])"#,
+        )
+        .expect("query failed");
+        assert_eq!(total, Some(42));
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn composite_array_with_nulls() {
+        // `flatten()` skips NULL entries.
+        let total = Spi::get_one::<i64>(
+            r#"SELECT sum_pair_a(ARRAY[
+                '{"a":7,"b":"k"}'::Pair,
+                NULL::Pair
+            ])"#,
+        )
+        .expect("query failed");
+        assert_eq!(total, Some(7));
+    }
+}

--- a/pgrx-examples/postgres_type_variants/src/handrolled_datum.rs
+++ b/pgrx-examples/postgres_type_variants/src/handrolled_datum.rs
@@ -1,0 +1,124 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # Variant 4: hand-rolled `FromDatum`/`IntoDatum`, no `PostgresType` derive
+//!
+//! You don't *need* `#[derive(PostgresType)]` to ship a custom type. This file
+//! demonstrates the minimum machinery: implement `FromDatum`, `IntoDatum`,
+//! `SqlTranslatable`, `ArgAbi`, `BoxRet`, write `*_in`/`*_out` `#[pg_extern]`s,
+//! and emit the `CREATE TYPE` SQL via `extension_sql!`.
+//!
+//! Use this when:
+//!
+//! * You want full control over the SQL representation (alignment, length).
+//! * The Serde JSON path is unacceptable AND `InOutFuncs`/`PgVarlena` don't fit.
+//! * You're studying what `derive(PostgresType)` actually generates (see #1384).
+
+use pgrx::callconv::{ArgAbi, BoxRet};
+use pgrx::datum::Datum;
+use pgrx::pg_sys::Oid;
+use pgrx::pgrx_sql_entity_graph::metadata::{
+    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
+};
+use pgrx::prelude::*;
+use pgrx::{StringInfo, rust_regtypein};
+use std::error::Error;
+use std::ffi::CStr;
+
+/// 24-bit unsigned integer stored as the low 24 bits of an `int4`.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct U24(pub u32);
+
+unsafe impl SqlTranslatable for U24 {
+    const TYPE_IDENT: &'static str = pgrx::pgrx_resolved_type!(U24);
+    const TYPE_ORIGIN: pgrx::pgrx_sql_entity_graph::metadata::TypeOrigin =
+        pgrx::pgrx_sql_entity_graph::metadata::TypeOrigin::ThisExtension;
+    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("u24"));
+    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
+        Ok(ReturnsRef::One(SqlMappingRef::literal("u24")));
+}
+
+impl FromDatum for U24 {
+    unsafe fn from_polymorphic_datum(datum: pg_sys::Datum, is_null: bool, _: Oid) -> Option<Self> {
+        if is_null { None } else { Some(U24(datum.value() as u32 & 0x00FF_FFFF)) }
+    }
+}
+
+impl IntoDatum for U24 {
+    fn into_datum(self) -> Option<pg_sys::Datum> {
+        Some(pg_sys::Datum::from(self.0 as i64))
+    }
+    fn type_oid() -> Oid {
+        rust_regtypein::<Self>()
+    }
+}
+
+unsafe impl<'fcx> ArgAbi<'fcx> for U24
+where
+    Self: 'fcx,
+{
+    unsafe fn unbox_arg_unchecked(arg: pgrx::callconv::Arg<'_, 'fcx>) -> Self {
+        unsafe { arg.unbox_arg_using_from_datum().unwrap() }
+    }
+}
+
+unsafe impl BoxRet for U24 {
+    unsafe fn box_into<'fcx>(self, fcinfo: &mut pgrx::callconv::FcInfo<'fcx>) -> Datum<'fcx> {
+        unsafe { fcinfo.return_raw_datum(pg_sys::Datum::from(self.0 as i64)) }
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, requires = ["u24_shell"])]
+fn u24_in(input: &CStr) -> Result<U24, Box<dyn Error>> {
+    let v: u32 = input.to_str()?.parse()?;
+    if v > 0x00FF_FFFF {
+        return Err("value exceeds 24 bits".into());
+    }
+    Ok(U24(v))
+}
+
+#[pg_extern(immutable, parallel_safe, requires = ["u24_shell"])]
+fn u24_out(value: U24) -> &'static CStr {
+    let mut s = StringInfo::new();
+    s.push_str(&value.0.to_string());
+    unsafe { s.leak_cstr() }
+}
+
+extension_sql!("CREATE TYPE u24;", name = "u24_shell", bootstrap);
+
+extension_sql!(
+    r#"
+CREATE TYPE u24 (
+    INPUT = u24_in,
+    OUTPUT = u24_out,
+    LIKE = int4
+);
+"#,
+    name = "u24_concrete",
+    creates = [Type(U24)],
+    requires = ["u24_shell", u24_in, u24_out],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[pg_test]
+    fn handrolled_in_out() -> Result<(), Box<dyn Error>> {
+        let v = Spi::get_one::<U24>("SELECT '16777215'::u24")?;
+        assert_eq!(v, Some(U24(0x00FF_FFFF)));
+        let s = Spi::get_one::<String>("SELECT '42'::u24::text")?;
+        assert_eq!(s.as_deref(), Some("42"));
+        Ok(())
+    }
+}

--- a/pgrx-examples/postgres_type_variants/src/inoutfuncs_custom.rs
+++ b/pgrx-examples/postgres_type_variants/src/inoutfuncs_custom.rs
@@ -1,0 +1,87 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # Variant 2: custom text format via `#[inoutfuncs]` + `InOutFuncs`
+//!
+//! Add `#[inoutfuncs]` to your `PostgresType` and implement `InOutFuncs` to define
+//! a custom textual representation. The generated `*_in`/`*_out` will call your
+//! `input(&CStr) -> Self` / `output(&self, &mut StringInfo)` instead of going through
+//! Serde JSON. Use this when the SQL surface should look like a domain-specific
+//! syntax (e.g. `"3+4i"` for complex numbers, `"R5C7"` for cell refs, etc.).
+
+use core::ffi::CStr;
+use pgrx::prelude::*;
+use pgrx::{InOutFuncs, StringInfo};
+use serde::{Deserialize, Serialize};
+
+#[derive(PostgresType, Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[inoutfuncs]
+pub struct Complex {
+    pub re: f64,
+    pub im: f64,
+}
+
+impl InOutFuncs for Complex {
+    fn input(input: &CStr) -> Self {
+        // Parses "<re>+<im>i" or "<re>-<im>i". Errors panic into Postgres ERROR.
+        let s = input.to_str().expect("invalid UTF-8");
+        let s = s.trim();
+        let i_pos = s.rfind('i').expect("expected trailing 'i'");
+        let body = &s[..i_pos];
+        let split = body
+            .rfind(['+', '-'])
+            .filter(|&p| p > 0)
+            .expect("expected sign between real and imaginary parts");
+        let re: f64 = body[..split].parse().expect("invalid real part");
+        let im: f64 = body[split..].parse().expect("invalid imaginary part");
+        Complex { re, im }
+    }
+
+    fn output(&self, buffer: &mut StringInfo) {
+        if self.im >= 0.0 {
+            buffer.push_str(&format!("{}+{}i", self.re, self.im));
+        } else {
+            buffer.push_str(&format!("{}{}i", self.re, self.im));
+        }
+    }
+}
+
+#[pg_extern]
+fn complex_add(a: Complex, b: Complex) -> Complex {
+    Complex { re: a.re + b.re, im: a.im + b.im }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn inoutfuncs_parse() {
+        let c = Spi::get_one::<Complex>("SELECT '3+4i'::Complex").expect("query failed");
+        assert_eq!(c, Some(Complex { re: 3.0, im: 4.0 }));
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn inoutfuncs_format() {
+        let s = Spi::get_one::<String>("SELECT '3-4i'::Complex::text").expect("query failed");
+        assert_eq!(s.as_deref(), Some("3-4i"));
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn inoutfuncs_add() {
+        let c = Spi::get_one::<Complex>("SELECT complex_add('1+2i'::Complex, '3+4i'::Complex)")
+            .expect("query failed");
+        assert_eq!(c, Some(Complex { re: 4.0, im: 6.0 }));
+    }
+}

--- a/pgrx-examples/postgres_type_variants/src/json_default.rs
+++ b/pgrx-examples/postgres_type_variants/src/json_default.rs
@@ -1,0 +1,62 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # Variant 1: default JSON in/out via Serde
+//!
+//! `#[derive(PostgresType)]` with no `#[inoutfuncs]` attribute and a `Serialize +
+//! Deserialize` bound emits `*_in`/`*_out` functions that go through Serde's JSON
+//! representation. Easiest path; ideal when the type is JSON-shaped or you don't
+//! care about a custom textual representation.
+//!
+//! See sibling modules for the other three variants.
+
+use pgrx::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// Note: we deliberately avoid the name `Point` because Postgres has a built-in `point` type (2D geometry), and a derived input function `point_in` would collide. Pick a name not already in pg_catalog when shipping a custom type.
+#[derive(PostgresType, Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct Coord {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[pg_extern]
+fn coord_origin() -> Coord {
+    Coord { x: 0.0, y: 0.0 }
+}
+
+#[pg_extern]
+fn coord_translate(p: Coord, dx: f64, dy: f64) -> Coord {
+    Coord { x: p.x + dx, y: p.y + dy }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn json_default_roundtrip() {
+        let p =
+            Spi::get_one::<Coord>(r#"SELECT '{"x":3.0,"y":4.0}'::Coord"#).expect("query failed");
+        assert_eq!(p, Some(Coord { x: 3.0, y: 4.0 }));
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn json_default_translate() {
+        let p = Spi::get_one::<Coord>(
+            r#"SELECT coord_translate('{"x":1.0,"y":2.0}'::Coord, 10.0, 20.0)"#,
+        )
+        .expect("query failed");
+        assert_eq!(p, Some(Coord { x: 11.0, y: 22.0 }));
+    }
+}

--- a/pgrx-examples/postgres_type_variants/src/lib.rs
+++ b/pgrx-examples/postgres_type_variants/src/lib.rs
@@ -1,0 +1,27 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// Each module demonstrates one PostgresType in/out path or a related derive
+// pattern. See README.md for a comparison table and selection criteria.
+mod composite_and_array;
+mod handrolled_datum;
+mod inoutfuncs_custom;
+mod json_default;
+mod varlena_zerocopy;
+
+pgrx::pg_module_magic!(name, version);
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {}
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        vec![]
+    }
+}

--- a/pgrx-examples/postgres_type_variants/src/varlena_zerocopy.rs
+++ b/pgrx-examples/postgres_type_variants/src/varlena_zerocopy.rs
@@ -1,0 +1,86 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! # Variant 3: zero-copy varlena via `PgVarlenaInOutFuncs`
+//!
+//! `#[pgvarlena_inoutfuncs]` makes the type an on-disk fixed binary layout that
+//! Postgres can store directly without serialization. Use this when:
+//!
+//! * The struct is `Copy` and `#[repr(C)]`-compatible.
+//! * You frequently read large numbers of rows and Serde JSON would dominate.
+//! * You're willing to define a textual form for I/O at SQL boundaries.
+//!
+//! The trade-off vs. variant 2 is performance (no parse on read) for cost
+//! (you must hand-write text I/O AND keep the binary layout stable).
+//!
+//! Note: `Rgb` is 3 bytes — a tight layout is the whole point of this variant.
+
+use core::ffi::CStr;
+use pgrx::datum::PgVarlena;
+use pgrx::prelude::*;
+use pgrx::{PgVarlenaInOutFuncs, StringInfo};
+
+#[derive(Copy, Clone, PostgresType)]
+#[bikeshed_postgres_type_manually_impl_from_into_datum]
+#[pgvarlena_inoutfuncs]
+pub struct Rgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl PgVarlenaInOutFuncs for Rgb {
+    fn input(input: &CStr) -> PgVarlena<Self> {
+        // Accepts "#rrggbb"
+        let s = input.to_str().expect("invalid UTF-8");
+        let hex = s.strip_prefix('#').expect("expected leading '#'");
+        assert_eq!(hex.len(), 6, "expected 6 hex digits");
+        let r = u8::from_str_radix(&hex[0..2], 16).expect("bad red");
+        let g = u8::from_str_radix(&hex[2..4], 16).expect("bad green");
+        let b = u8::from_str_radix(&hex[4..6], 16).expect("bad blue");
+        let mut v = PgVarlena::<Self>::new();
+        v.r = r;
+        v.g = g;
+        v.b = b;
+        v
+    }
+
+    fn output(&self, buffer: &mut StringInfo) {
+        buffer.push_str(&format!("#{:02x}{:02x}{:02x}", self.r, self.g, self.b));
+    }
+}
+
+#[pg_extern]
+fn rgb_luminance(c: PgVarlena<Rgb>) -> f64 {
+    // Rec. 601 luma — purely a demonstration; arithmetic happens directly on the varlena's fields with no copy or parse.
+    0.299 * c.r as f64 + 0.587 * c.g as f64 + 0.114 * c.b as f64
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn varlena_roundtrip() {
+        let s = Spi::get_one::<String>("SELECT '#ff8000'::Rgb::text").expect("query failed");
+        assert_eq!(s.as_deref(), Some("#ff8000"));
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn varlena_compute() {
+        let lum =
+            Spi::get_one::<f64>("SELECT rgb_luminance('#ffffff'::Rgb)").expect("query failed");
+        // 0.299 + 0.587 + 0.114 == 1.0; multiplied by 255.
+        assert!((lum.unwrap() - 255.0).abs() < 0.001);
+    }
+}

--- a/pgrx-unit-tests/src/tests/mod.rs
+++ b/pgrx-unit-tests/src/tests/mod.rs
@@ -52,6 +52,7 @@ mod pg_try_tests;
 mod pgbox_tests;
 mod pgrx_module_qualification;
 mod postgres_type_tests;
+mod postgres_type_variants_smoke;
 #[cfg(feature = "proptest")]
 mod proptests;
 mod range_tests;

--- a/pgrx-unit-tests/src/tests/postgres_type_variants_smoke.rs
+++ b/pgrx-unit-tests/src/tests/postgres_type_variants_smoke.rs
@@ -1,0 +1,107 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+//! Cross-cutting smoke test that exercises three `PostgresType` in/out variants
+//! in miniature. A failure here means the macro layer regressed independently
+//! of the `postgres_type_variants` example crate building.
+
+use core::ffi::CStr;
+use pgrx::datum::PgVarlena;
+use pgrx::prelude::*;
+use pgrx::{InOutFuncs, PgVarlenaInOutFuncs, StringInfo};
+use serde::{Deserialize, Serialize};
+
+#[derive(PostgresType, Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct SmokeJson {
+    pub n: i32,
+}
+
+#[pg_extern]
+fn smoke_json_id(j: SmokeJson) -> SmokeJson {
+    j
+}
+
+#[derive(PostgresType, Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[inoutfuncs]
+pub struct SmokeText {
+    pub s: String,
+}
+
+impl InOutFuncs for SmokeText {
+    fn input(input: &CStr) -> Self {
+        SmokeText { s: input.to_str().expect("utf-8").to_string() }
+    }
+    fn output(&self, buffer: &mut StringInfo) {
+        buffer.push_str(&self.s);
+    }
+}
+
+#[pg_extern]
+fn smoke_text_id(t: SmokeText) -> SmokeText {
+    t
+}
+
+#[derive(Copy, Clone, PostgresType)]
+#[bikeshed_postgres_type_manually_impl_from_into_datum]
+#[pgvarlena_inoutfuncs]
+pub struct SmokeVarlena {
+    pub a: u32,
+}
+
+impl PgVarlenaInOutFuncs for SmokeVarlena {
+    fn input(input: &CStr) -> PgVarlena<Self> {
+        let a: u32 = input.to_str().expect("utf-8").parse().expect("number");
+        let mut v = PgVarlena::<Self>::new();
+        v.a = a;
+        v
+    }
+    fn output(&self, buffer: &mut StringInfo) {
+        buffer.push_str(&self.a.to_string());
+    }
+}
+
+#[pg_extern]
+fn smoke_varlena_double(v: PgVarlena<SmokeVarlena>) -> i64 {
+    (v.a as i64).wrapping_mul(2)
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use crate as pgrx_unit_tests;
+
+    use super::*;
+    use pgrx::prelude::*;
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn smoke_json() {
+        let v = Spi::get_one::<SmokeJson>(r#"SELECT smoke_json_id('{"n":7}'::SmokeJson)"#)
+            .expect("query failed");
+        assert_eq!(v, Some(SmokeJson { n: 7 }));
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn smoke_text() {
+        let v = Spi::get_one::<SmokeText>("SELECT smoke_text_id('hello'::SmokeText)")
+            .expect("query failed");
+        assert_eq!(v, Some(SmokeText { s: "hello".into() }));
+    }
+
+    #[cfg(not(feature = "no-schema-generation"))]
+    #[pg_test]
+    fn smoke_varlena() {
+        let v = Spi::get_one::<i64>("SELECT smoke_varlena_double('21'::SmokeVarlena)")
+            .expect("query failed");
+        assert_eq!(v, Some(42));
+    }
+}


### PR DESCRIPTION
Adds two new pgrx-example crates plus targeted rustdoc to give users runnable, tested references for two areas that currently lack them.

`pgrx-examples/postgres_type_variants/` demonstrates the four ways to ship a custom Postgres type side-by-side.

* json_default.rs       — default Serde JSON in/out
* inoutfuncs_custom.rs  — #[inoutfuncs] + impl InOutFuncs
* varlena_zerocopy.rs   — #[pgvarlena_inoutfuncs] zero-copy layout
* handrolled_datum.rs   — no derive; FromDatum/IntoDatum by hand

`pgrx-examples/memory_contexts/` covers PgMemoryContext lifecycle:
