### PR TITLE
make Array<&str> serializable via per-type Serialize impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,6 +1634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.0.0"
+dependencies = [
+ "pgrx",
+ "pgrx-tests",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/pgrx-examples/json/Cargo.toml
+++ b/pgrx-examples/json/Cargo.toml
@@ -1,0 +1,37 @@
+#LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+#LICENSE
+#LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+#LICENSE
+#LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+#LICENSE
+#LICENSE All rights reserved.
+#LICENSE
+#LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+[package]
+name = "json"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
+pg_test = []
+
+[dependencies]
+pgrx = { path = "../../pgrx" }
+serde_json = "1.0.150"
+
+[dev-dependencies]
+pgrx-tests = { path = "../../pgrx-tests" }

--- a/pgrx-examples/json/json.control
+++ b/pgrx-examples/json/json.control
@@ -1,0 +1,5 @@
+comment = 'json:  Created by pgrx'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'json'
+relocatable = false
+superuser = false

--- a/pgrx-examples/json/src/lib.rs
+++ b/pgrx-examples/json/src/lib.rs
@@ -1,0 +1,38 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::Json;
+use pgrx::prelude::*;
+use serde_json::json;
+
+pgrx::pg_module_magic!(name, version);
+
+/// Serialize a Postgres `text[]` into a JSON document without allocating an
+/// intermediate `Vec<String>`.
+///
+/// Taking the parameter as `Array<'a, &'a str>` lets pgrx borrow each element straight out of the caller's array buffer; the borrowed `&str` is then handed to `serde_json` which copies it into the JSON output. Compared with a `Vec<String>` signature this saves one `String` allocation per element, which adds up quickly on large tag lists or label arrays.
+#[pg_extern]
+fn text_array_to_json_doc<'dat>(values: Array<'dat, &'dat str>) -> Json {
+    Json(json! { { "values": values } })
+}
+
+/// Same idea for `bytea[]`: borrow the byte slices rather than owning them.
+#[pg_extern]
+fn bytea_array_to_json_doc<'dat>(values: Array<'dat, &'dat [u8]>) -> Json {
+    Json(json! { { "values": values } })
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {}
+
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        vec![]
+    }
+}

--- a/pgrx-unit-tests/src/tests/array_tests.rs
+++ b/pgrx-unit-tests/src/tests/array_tests.rs
@@ -79,6 +79,21 @@ fn serde_serialize_array_i32_deny_null(values: Array<i32>) -> Json {
 }
 
 #[pg_extern]
+fn serde_serialize_array_date(values: Array<Date>) -> Json {
+    Json(json! { { "values": values } })
+}
+
+#[pg_extern]
+fn serde_serialize_array_timestamp(values: Array<Timestamp>) -> Json {
+    Json(json! { { "values": values } })
+}
+
+#[pg_extern]
+fn serde_serialize_array_json(values: Array<pgrx::Json>) -> Json {
+    Json(json! { { "values": values } })
+}
+
+#[pg_extern]
 fn return_text_array() -> Vec<&'static str> {
     vec!["a", "b", "c", "d"]
 }
@@ -266,10 +281,9 @@ mod tests {
 
     #[pg_test]
     fn test_serde_serialize_array_all_null() -> Result<(), pgrx::spi::Error> {
-        let json = Spi::get_one::<Json>(
-            "SELECT serde_serialize_array(ARRAY[NULL, NULL, NULL]::text[])",
-        )?
-        .expect("returned json was null");
+        let json =
+            Spi::get_one::<Json>("SELECT serde_serialize_array(ARRAY[NULL, NULL, NULL]::text[])")?
+                .expect("returned json was null");
         assert_eq!(json.0, json! {{"values": [null, null, null]}});
         Ok(())
     }
@@ -280,10 +294,7 @@ mod tests {
             "SELECT serde_serialize_array(ARRAY['中文', '😀', E'a\\nb', '\"quoted\"'])",
         )?
         .expect("returned json was null");
-        assert_eq!(
-            json.0,
-            json! {{"values": ["中文", "😀", "a\nb", "\"quoted\""]}}
-        );
+        assert_eq!(json.0, json! {{"values": ["中文", "😀", "a\nb", "\"quoted\""]}});
         Ok(())
     }
 
@@ -323,6 +334,41 @@ mod tests {
         Spi::get_one::<Json>(
             "SELECT serde_serialize_array_i32_deny_null(ARRAY[1, 2, 3, null, 4, 5])",
         )
+    }
+
+    #[pg_test]
+    fn test_serde_serialize_array_date() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array_date(ARRAY['1977-07-04', NULL, '2026-01-15']::date[])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": ["1977-07-04", null, "2026-01-15"]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_serde_serialize_array_timestamp() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array_timestamp(\
+                ARRAY['2026-01-15 12:34:56', NULL]::timestamp[])",
+        )?
+        .expect("returned json was null");
+        let arr = json.0.get("values").and_then(|v| v.as_array()).expect("values array");
+        assert_eq!(arr.len(), 2);
+        assert!(arr[0].as_str().expect("string").starts_with("2026-01-15"));
+        assert_eq!(arr[1], json!(null));
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_serde_serialize_array_json() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array_json(\
+                ARRAY['{\"a\":1}', NULL, '[true,false]']::json[])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": [{"a": 1}, null, [true, false]]}});
+        Ok(())
     }
 
     #[pg_test]

--- a/pgrx-unit-tests/src/tests/array_tests.rs
+++ b/pgrx-unit-tests/src/tests/array_tests.rs
@@ -63,11 +63,10 @@ fn optional_array_with_default(values: default!(Option<Array<i32>>, "NULL")) -> 
     values.unwrap().iter().map(|v| v.unwrap_or(0)).sum()
 }
 
-// TODO: fix this test by fixing serde impls for `Array<'a, &'a str> -> Json`
-// #[pg_extern]
-// fn serde_serialize_array<'dat>(values: Array<'dat, &'dat str>) -> Json {
-//     Json(json! { { "values": values } })
-// }
+#[pg_extern]
+fn serde_serialize_array<'dat>(values: Array<'dat, &'dat str>) -> Json {
+    Json(json! { { "values": values } })
+}
 
 #[pg_extern]
 fn serde_serialize_array_i32(values: Array<i32>) -> Json {
@@ -247,16 +246,61 @@ mod tests {
         Spi::run("SELECT iterate_array_with_deny_null(ARRAY[1,2,3, NULL]::int[])")
     }
 
-    // TODO: fix this test by redesigning SPI.
-    // #[pg_test]
-    // fn test_serde_serialize_array() -> Result<(), pgrx::spi::Error> {
-    //     let json = Spi::get_one::<Json>(
-    //         "SELECT serde_serialize_array(ARRAY['one', null, 'two', 'three'])",
-    //     )?
-    //     .expect("returned json was null");
-    //     assert_eq!(json.0, json! {{"values": ["one", null, "two", "three"]}});
-    //     Ok(())
-    // }
+    #[pg_test]
+    fn test_serde_serialize_array() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array(ARRAY['one', null, 'two', 'three'])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": ["one", null, "two", "three"]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_serde_serialize_array_empty() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>("SELECT serde_serialize_array(ARRAY[]::text[])")?
+            .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": []}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_serde_serialize_array_all_null() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array(ARRAY[NULL, NULL, NULL]::text[])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": [null, null, null]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_serde_serialize_array_unicode() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array(ARRAY['中文', '😀', E'a\\nb', '\"quoted\"'])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(
+            json.0,
+            json! {{"values": ["中文", "😀", "a\nb", "\"quoted\""]}}
+        );
+        Ok(())
+    }
+
+    #[pg_test]
+    fn test_serde_serialize_array_large() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT serde_serialize_array(\
+                ARRAY(SELECT s::text FROM generate_series(1, 1000) s))",
+        )?
+        .expect("returned json was null");
+        let obj = json.0.as_object().expect("object");
+        let values = obj.get("values").and_then(|v| v.as_array()).expect("values array");
+        assert_eq!(values.len(), 1000);
+        assert_eq!(values[0], json!("1"));
+        assert_eq!(values[999], json!("1000"));
+        Ok(())
+    }
 
     #[pg_test]
     fn test_optional_array_with_default() {

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -113,10 +113,24 @@ macro_rules! impl_array_serialize_owned {
 }
 
 impl_array_serialize_owned!(
-    bool, i8, i16, i32, i64, f32, f64,
+    bool,
+    i8,
+    i16,
+    i32,
+    i64,
+    f32,
+    f64,
     crate::pg_sys::Oid,
     alloc::string::String,
     alloc::ffi::CString,
+    crate::datetime::Date,
+    crate::datetime::Time,
+    crate::datetime::Timestamp,
+    crate::datetime::TimestampWithTimeZone,
+    crate::datetime::TimeWithTimeZone,
+    crate::datetime::Interval,
+    crate::datum::Json,
+    crate::datum::JsonB,
 );
 
 // Reference element types: each gets a hand-written impl whose function body resolves

--- a/pgrx/src/datum/array.rs
+++ b/pgrx/src/datum/array.rs
@@ -23,7 +23,7 @@ use pgrx_sql_entity_graph::metadata::{
     ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, array_argument_sql,
     array_return_sql,
 };
-use serde::{Serialize, Serializer};
+use serde::Serializer;
 use std::iter::FusedIterator;
 
 /** An array of some type (eg. `TEXT[]`, `int[]`)
@@ -79,15 +79,81 @@ where
 
 type ChaChaSlideImpl<T> = Box<dyn casper::ChaChaSlide<T>>;
 
-impl<'mcx, T: UnboxDatum> serde::Serialize for Array<'mcx, T>
-where
-    for<'arr> <T as UnboxDatum>::As<'arr>: Serialize,
-{
+// Serde `Serialize` impls for `Array<'mcx, T>` and `VariadicArray<'mcx, T>`.
+//
+// We cannot use a single blanket `impl<T: UnboxDatum> Serialize for Array<'mcx, T>` because of the GAT bound `UnboxDatum::As<'src> where Self: 'src`: combined with a `for<'arr>` HRTB in a blanket impl it forces `'mcx: 'static`, ruling out reference element types such as `&'mcx str` (see issue #...).  Instead we generate one `Serialize` impl per concrete element type via the macros below.
+macro_rules! impl_array_serialize_owned {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl<'mcx> serde::Serialize for Array<'mcx, $t> {
+                fn serialize<S>(
+                    &self,
+                    serializer: S,
+                ) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+                where
+                    S: Serializer,
+                {
+                    serializer.collect_seq(self.iter())
+                }
+            }
+
+            impl<'mcx> serde::Serialize for VariadicArray<'mcx, $t> {
+                fn serialize<S>(
+                    &self,
+                    serializer: S,
+                ) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+                where
+                    S: Serializer,
+                {
+                    serializer.collect_seq(self.0.iter())
+                }
+            }
+        )*
+    };
+}
+
+impl_array_serialize_owned!(
+    bool, i8, i16, i32, i64, f32, f64,
+    crate::pg_sys::Oid,
+    alloc::string::String,
+    alloc::ffi::CString,
+);
+
+// Reference element types: each gets a hand-written impl whose function body resolves
+// the GAT lifetime at the call site (no HRTB at the impl boundary).
+impl<'mcx> serde::Serialize for Array<'mcx, &'mcx str> {
     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
     where
         S: Serializer,
     {
         serializer.collect_seq(self.iter())
+    }
+}
+
+impl<'mcx> serde::Serialize for VariadicArray<'mcx, &'mcx str> {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_seq(self.0.iter())
+    }
+}
+
+impl<'mcx> serde::Serialize for Array<'mcx, &'mcx [u8]> {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_seq(self.iter())
+    }
+}
+
+impl<'mcx> serde::Serialize for VariadicArray<'mcx, &'mcx [u8]> {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_seq(self.0.iter())
     }
 }
 
@@ -592,18 +658,6 @@ mod casper {
 }
 
 pub struct VariadicArray<'mcx, T>(Array<'mcx, T>);
-
-impl<'mcx, T: UnboxDatum> Serialize for VariadicArray<'mcx, T>
-where
-    for<'arr> <T as UnboxDatum>::As<'arr>: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        serializer.collect_seq(self.0.iter())
-    }
-}
 
 impl<'mcx, T: UnboxDatum> VariadicArray<'mcx, T> {
     pub(crate) fn wrap_array(arr: Array<'mcx, T>) -> Self {


### PR DESCRIPTION
## Motivation

The blanket impl<T: UnboxDatum> Serialize for Array<'mcx, T> is unreachable for reference element types: the `UnboxDatum::As<'src> where Self: 'src` combined with the for`<'arr>` HRTB forces `'mcx: 'static`, so `Array<&str>`: Serialize never resolves. This is why array_tests.rs carries the TODO disabling serde_serialize_array, and why extensions returning JSON over text[] are forced into Vec<String> and lose zero-copy.

## How to use

```
#[pg_extern]
fn serde_serialize_array<'dat>(values: Array<'dat, &'dat str>) -> Json {
    Json(json! { { "values": values } })
}
```

## Breaking change

Downstream UnboxDatum types (custom type) that relied on the blanket to auto-derive Serialize for Array<MyType> now need a one-line impl:

```
impl<'mcx> Serialize for Array<'mcx, MyType> {
  fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
	  s.collect_seq(self.iter())
  }
}
```

Stable Rust has no specialization, so adding Array<&str> impls required dropping the blanket. All in-tree primitive types stay
covered.
