### PR TITLE
Add #[pg_guc_hook] macro for simple GUC hooks

### DIFF
--- a/pgrx-macros/README.md
+++ b/pgrx-macros/README.md
@@ -6,6 +6,7 @@ Provides:
 
     - #[pg_extern]
     - #[pg_guard]
+    - #[pg_guc_hook]
     - #[pg_test]
     - #[derive(PostgresType)]
     - #[derive(PostgresEnum)]

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1430,6 +1430,197 @@ pub fn pgrx(_attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /**
+Declare a function as a GUC hook. This takes one argument: `show`, `check`, or `assign`.
+
+The first parameter of `check` and `assign` hooks must implement `pgrx::guc::GucValue`.
+
+Examples:
+```rust,ignore
+#[pg_guc_hook(show)]
+fn my_show_hook() -> String {
+    "CUSTOM_VALUE".to_string()
+}
+
+#[pg_guc_hook(check)]
+fn my_check_hook(newval: i32) -> Result<(), GucCheckError> {
+    // accept or reject newval
+}
+
+#[pg_guc_hook(assign)]
+fn my_assign_hook(newval: i32) {
+    // do more now that every change is accepted
+}
+```
+
+# Check Hooks
+
+This macro adapts check hooks of multiple forms.
+
+The simplest of these takes a single argument and returns a `bool`.
+- `true` means the value is valid, and Postgres will store that value in the GUC variable.
+- `false` means the value is invalid, and Postgres will produce an error message automatically.
+
+```rust,ignore
+#[pg_guc_hook(check)]
+fn my_check_hook(newval: i32) -> bool { newval > 0 }
+```
+
+To apply your own error message for an invalid value, return a `Result<(), GucCheckError>`.
+- `Ok` means the value is valid.
+- `Err` means the value is invalid, and `pgrx` will pass the contents of `GucCheckError` to Postgres.
+
+```rust,ignore
+#[pg_guc_hook(check)]
+fn my_check_hook(newval: i32) -> Result<(), GucCheckError> {
+    if newval > 0 {
+        Ok(())
+    } else {
+        Err(
+            GucCheckError::new("value cannot be negative")
+            .with_hint("to configure the opposite behavior, set other_param"),
+        )
+    }
+}
+```
+
+A check hook can also accept a second argument that indicates when the parameter is changing.
+Like the examples above, this can return a bool or a Result.
+
+```rust,ignore
+#[pg_guc_hook(check)]
+fn my_check_hook(newval: i32, source: pg_sys::GucSource::Type) -> bool { true }
+```
+*/
+#[proc_macro_attribute]
+pub fn pg_guc_hook(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let hook_type = parse_macro_input!(attr as syn::Ident);
+    let mut func = parse_macro_input!(item as syn::ItemFn);
+
+    // Rename the original function and use its name.
+    let original_ident = func.sig.ident.clone();
+    let inner_ident = format_ident!("{}_INNER", original_ident);
+    func.sig.ident = inner_ident.clone();
+
+    // Remove the original visibility and use it.
+    let vis = &func.vis;
+    let mut inner_func = func.clone();
+    inner_func.vis = syn::Visibility::Inherited;
+
+    let wrapper = match hook_type.to_string().as_str() {
+        "show" => {
+            quote! {
+                #[::pgrx::pg_guard]
+                #vis unsafe extern "C-unwind" fn #original_ident() -> *const ::core::ffi::c_char {
+                    #[inline(always)]
+                    #inner_func
+
+                    let show = #inner_ident();
+                    ::pgrx::pg_sys::AsPgCStr::as_pg_cstr(&show)
+                }
+            }
+        }
+        "check" => {
+            let invoke_inner = match func.sig.inputs.len() {
+                1 => quote! { #inner_ident(value) },
+                2 => quote! { #inner_ident(value, source) },
+                _ => {
+                    return syn::Error::new(
+                        func.sig.span(),
+                        "check hook must have one or two arguments",
+                    )
+                    .into_compile_error()
+                    .into();
+                }
+            };
+
+            let arg_type = match func.sig.inputs.first() {
+                Some(syn::FnArg::Typed(pat_type)) => &pat_type.ty,
+                _ => {
+                    return syn::Error::new(
+                        func.sig.span(),
+                        "check hook first argument must implement GucValue",
+                    )
+                    .into_compile_error()
+                    .into();
+                }
+            };
+
+            // The original function may return bool or Result. Pass bool through directly and apply
+            // any details present in GucCheckError.
+            let invoke_to_bool = if let syn::ReturnType::Type(_, return_type) = &func.sig.output
+                && let syn::Type::Path(type_path) = &**return_type
+                && type_path.path.segments.last().map_or(false, |seg| seg.ident == "bool")
+            {
+                quote! { #invoke_inner }
+            } else {
+                quote! {
+                    match #invoke_inner {
+                        Ok(()) => true,
+                        Err(err) => {
+                            unsafe { ::pgrx::guc::GucCheckError::apply(err) };
+                            false
+                        }
+                    }
+                }
+            };
+
+            quote! {
+                #[::pgrx::pg_guard]
+                #vis unsafe extern "C-unwind" fn #original_ident(
+                    newval: *mut <#arg_type as ::pgrx::guc::GucValue>::Raw,
+                    extra: *mut *mut ::core::ffi::c_void,
+                    source: ::pgrx::pg_sys::GucSource::Type,
+                ) -> bool {
+                    #[inline(always)]
+                    #inner_func
+
+                    debug_assert!(!newval.is_null());
+                    let value = unsafe { <#arg_type as ::pgrx::guc::GucValue>::from_raw(*newval) };
+                    #invoke_to_bool
+                }
+            }
+        }
+        "assign" => {
+            let arg_type = match func.sig.inputs.first() {
+                Some(syn::FnArg::Typed(pat_type)) => &pat_type.ty,
+                _ => {
+                    return syn::Error::new(
+                        func.sig.span(),
+                        "assign hook first argument must implement GucValue",
+                    )
+                    .into_compile_error()
+                    .into();
+                }
+            };
+
+            quote! {
+                #[::pgrx::pg_guard]
+                #vis unsafe extern "C-unwind" fn #original_ident(
+                    newval: <#arg_type as ::pgrx::guc::GucValue>::Raw,
+                    extra: *mut ::core::ffi::c_void,
+                ) {
+                    #[inline(always)]
+                    #inner_func
+
+                    let value = unsafe { <#arg_type as ::pgrx::guc::GucValue>::from_raw(newval) };
+                    #inner_ident(value);
+                }
+            }
+        }
+        _ => {
+            return syn::Error::new(
+                hook_type.span(),
+                "Unknown GUC hook type. Expected 'show', 'check', or 'assign'",
+            )
+            .into_compile_error()
+            .into();
+        }
+    };
+
+    wrapper.into()
+}
+
+/**
 Create a [PostgreSQL trigger function](https://www.postgresql.org/docs/current/plpgsql-trigger.html)
 
 Review the `pgrx::trigger_support::PgTrigger` documentation for use.

--- a/pgrx-unit-tests/src/tests/guc_tests.rs
+++ b/pgrx-unit-tests/src/tests/guc_tests.rs
@@ -244,10 +244,10 @@ mod tests {
             _extra: *mut *mut std::ffi::c_void,
             _source: pg_sys::GucSource::Type,
         ) -> bool {
-            if *newval {
+            if unsafe { *newval } {
                 *SIDE_EFFECT.write().unwrap() += 1;
             }
-            *newval
+            unsafe { *newval }
         }
 
         // Create and register GUC with hooks. As default is true, SIDE_EFFECT will be 1.
@@ -288,10 +288,10 @@ mod tests {
             _extra: *mut *mut std::ffi::c_void,
             _source: pg_sys::GucSource::Type,
         ) -> bool {
-            if *newval {
+            if unsafe { *newval } {
                 panic!("should panic!");
             }
-            *newval
+            unsafe { *newval }
         }
 
         static GUARDED_GUC: GucSetting<bool> = GucSetting::<bool>::new(true);
@@ -375,5 +375,218 @@ mod tests {
             let value: &str = r.first().get_one::<&str>().unwrap().unwrap();
             assert_eq!(value, "CUSTOM_SHOW_HOOK");
         });
+    }
+
+    #[pg_test]
+    fn test_pg_guc_hook_macros() {
+        static GUC: GucSetting<i32> = GucSetting::<i32>::new(100);
+        static SIDE_EFFECT: std::sync::RwLock<i32> = std::sync::RwLock::new(0);
+
+        #[pg_guc_hook(show)]
+        fn my_show_hook() -> String {
+            "SHOW_MACRO".to_owned()
+        }
+
+        #[pg_guc_hook(check)]
+        fn my_check_hook(_newval: i32) -> Result<(), GucCheckError> {
+            *SIDE_EFFECT.write().unwrap() += 1;
+            Ok(())
+        }
+
+        #[pg_guc_hook(assign)]
+        fn my_assign_hook(newval: i32) {
+            if newval > 200 {
+                *SIDE_EFFECT.write().unwrap() += newval;
+            }
+        }
+
+        unsafe {
+            GucRegistry::define_int_guc_with_hooks(
+                c"test.hook_macros",
+                c"test hook macros",
+                c"test hook macros",
+                &GUC,
+                -100,
+                2000,
+                GucContext::Userset,
+                GucFlags::default(),
+                Some(my_check_hook),
+                Some(my_assign_hook),
+                Some(my_show_hook),
+            );
+        }
+
+        // Check hook accept default
+        assert_eq!(GUC.get(), 100);
+        assert_eq!(*SIDE_EFFECT.read().unwrap(), 1);
+
+        Spi::connect_mut(|client| {
+            let r = client.update("SHOW test.hook_macros", None, &[]).expect("SPI failed");
+            let value: &str = r.first().get_one::<&str>().unwrap().unwrap();
+            assert_eq!(value, "SHOW_MACRO");
+        });
+        assert_eq!(*SIDE_EFFECT.read().unwrap(), 1);
+
+        // Check hook accept followed by assign hook
+        Spi::run("SET test.hook_macros = 500").unwrap();
+        assert_eq!(GUC.get(), 500);
+        assert_eq!(*SIDE_EFFECT.read().unwrap(), 502);
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "value cannot be negative")]
+    fn test_pg_guc_hook_macro_check_message() {
+        static GUC: GucSetting<i32> = GucSetting::<i32>::new(100);
+
+        #[pg_guc_hook(check)]
+        fn my_check_hook(newval: i32) -> Result<(), GucCheckError> {
+            if newval < 0 { Err(GucCheckError::new("value cannot be negative")) } else { Ok(()) }
+        }
+
+        unsafe {
+            GucRegistry::define_int_guc_with_hooks(
+                c"test.hook_macro_check_message",
+                c"test hook macro check message",
+                c"test hook macro check message",
+                &GUC,
+                -100,
+                2000,
+                GucContext::Userset,
+                GucFlags::default(),
+                Some(my_check_hook),
+                None,
+                None,
+            );
+        }
+
+        // Check hook reject with message
+        let _ = Spi::run("SET test.hook_macro_check_message = -10");
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "positive")]
+    fn test_pg_guc_hook_macro_check_hint() {
+        static GUC: GucSetting<i32> = GucSetting::<i32>::new(100);
+
+        #[pg_guc_hook(check)]
+        fn my_check_hook(newval: i32) -> Result<(), GucCheckError> {
+            if newval < 0 {
+                Err(GucCheckError::new("negative").with_hint("positive"))
+            } else {
+                Ok(())
+            }
+        }
+
+        unsafe {
+            GucRegistry::define_int_guc_with_hooks(
+                c"test.hook_macro_check_hint",
+                c"test hook macro check hint",
+                c"test hook macro check hint",
+                &GUC,
+                -100,
+                2000,
+                GucContext::Userset,
+                GucFlags::default(),
+                Some(my_check_hook),
+                None,
+                None,
+            );
+        }
+
+        // Check hook reject with hint
+        let _ = Spi::run("SET test.hook_macro_check_hint = -10");
+    }
+
+    #[pg_test]
+    fn test_pg_guc_hook_macro_check_source_argument() {
+        static GUC: GucSetting<i32> = GucSetting::<i32>::new(100);
+        static SIDE_EFFECT: std::sync::RwLock<pg_sys::GucSource::Type> =
+            std::sync::RwLock::new(100);
+
+        #[pg_guc_hook(check)]
+        fn my_check_hook(
+            _newval: i32,
+            source: pg_sys::GucSource::Type,
+        ) -> Result<(), GucCheckError> {
+            *SIDE_EFFECT.write().unwrap() = source;
+            Ok(())
+        }
+
+        unsafe {
+            GucRegistry::define_int_guc_with_hooks(
+                c"test.hook_macro_check_two_args",
+                c"test hook macro check two args",
+                c"test hook macro check two args",
+                &GUC,
+                -100,
+                2000,
+                GucContext::Userset,
+                GucFlags::default(),
+                Some(my_check_hook),
+                None,
+                None,
+            );
+        }
+
+        Spi::run("SET test.hook_macro_check_two_args = 50").unwrap();
+        assert_eq!(*SIDE_EFFECT.read().unwrap(), pg_sys::GucSource::PGC_S_SESSION);
+    }
+
+    #[pg_test]
+    fn test_pg_guc_hook_macro_check_bool_accept() {
+        static GUC: GucSetting<i32> = GucSetting::<i32>::new(100);
+
+        #[pg_guc_hook(check)]
+        fn my_check_hook(newval: i32) -> bool {
+            newval >= 0
+        }
+
+        unsafe {
+            GucRegistry::define_int_guc_with_hooks(
+                c"test.hook_macro_check_bool_accept",
+                c"test hook macro check bool accept",
+                c"test hook macro check bool accept",
+                &GUC,
+                -100,
+                2000,
+                GucContext::Userset,
+                GucFlags::default(),
+                Some(my_check_hook),
+                None,
+                None,
+            );
+        }
+
+        Spi::run("SET test.hook_macro_check_bool_accept = 50").unwrap();
+        assert_eq!(GUC.get(), 50);
+    }
+
+    #[pg_test]
+    #[should_panic(expected = "invalid value")]
+    fn test_pg_guc_hook_macro_check_bool_reject() {
+        static GUC: GucSetting<i32> = GucSetting::<i32>::new(100);
+
+        #[pg_guc_hook(check)]
+        fn my_check_hook(newval: i32) -> bool {
+            newval >= 0
+        }
+
+        unsafe {
+            GucRegistry::define_int_guc_with_hooks(
+                c"test.hook_macro_check_bool_reject",
+                c"test hook macro check bool reject",
+                c"test hook macro check bool reject",
+                &GUC,
+                -100,
+                2000,
+                GucContext::Userset,
+                GucFlags::default(),
+                Some(my_check_hook),
+                None,
+                None,
+            );
+        }
+
+        let _ = Spi::run("SET test.hook_macro_check_bool_reject = -50");
     }
 }

--- a/pgrx-unit-tests/src/tests/postgres_type_variants_smoke.rs
+++ b/pgrx-unit-tests/src/tests/postgres_type_variants_smoke.rs
@@ -79,7 +79,6 @@ mod tests {
     use crate as pgrx_unit_tests;
 
     use super::*;
-    use pgrx::prelude::*;
 
     #[cfg(not(feature = "no-schema-generation"))]
     #[pg_test]

--- a/pgrx/src/guc.rs
+++ b/pgrx/src/guc.rs
@@ -8,7 +8,8 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 //! Provides a safe interface into Postgres' Configuration System (GUC)
-use crate::pg_sys;
+use crate::pg_sys::{self, AsPgCStr};
+use crate::pgbox::{AllocatedByRust, PgBox};
 use core::ffi::CStr;
 pub use pgrx_macros::PostgresGucEnum;
 use std::cell::Cell;
@@ -100,6 +101,58 @@ bitflags! {
         /// `RUNTIME_COMPUTED` is intended for runtime-computed GUCs that are only available via
         /// `postgres -C` if the server is not running
         const RUNTIME_COMPUTED = pg_sys::GUC_RUNTIME_COMPUTED as i32;
+    }
+}
+
+#[derive(Default)]
+pub struct GucCheckError {
+    errcode: Option<i32>,
+    message: Option<PgBox<core::ffi::c_char, AllocatedByRust>>,
+    detail: Option<PgBox<core::ffi::c_char, AllocatedByRust>>,
+    hint: Option<PgBox<core::ffi::c_char, AllocatedByRust>>,
+}
+
+impl GucCheckError {
+    pub fn new<S: AsPgCStr>(message: S) -> Self {
+        Self {
+            message: Some(unsafe { PgBox::<_, AllocatedByRust>::from_rust(message.as_pg_cstr()) }),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_detail<S: AsPgCStr>(mut self, detail: S) -> Self {
+        self.detail = Some(unsafe { PgBox::<_, AllocatedByRust>::from_rust(detail.as_pg_cstr()) });
+        self
+    }
+
+    pub fn with_hint<S: AsPgCStr>(mut self, hint: S) -> Self {
+        self.hint = Some(unsafe { PgBox::<_, AllocatedByRust>::from_rust(hint.as_pg_cstr()) });
+        self
+    }
+
+    pub fn with_errcode(mut self, errcode: i32) -> Self {
+        self.errcode = Some(errcode);
+        self
+    }
+
+    /// Set the PostgreSQL GUC check error state from this error.
+    ///
+    /// # Safety
+    ///
+    /// This should only be called from within a GUC `check_hook`.
+    pub unsafe fn apply(self) {
+        if let Some(errcode) = self.errcode {
+            unsafe { pg_sys::GUC_check_errcode(errcode) }
+        }
+        if let Some(message) = self.message {
+            unsafe { pg_sys::GUC_check_errmsg_string = message.into_pg() }
+        }
+        if let Some(detail) = self.detail {
+            unsafe { pg_sys::GUC_check_errdetail_string = detail.into_pg() }
+        }
+        if let Some(hint) = self.hint {
+            unsafe { pg_sys::GUC_check_errhint_string = hint.into_pg() }
+        }
     }
 }
 


### PR DESCRIPTION
This adds a `#[pg_guc_hook]` attribute macro that wraps a Rust function to do the unsafe work of converting to and from `GucValue` types. With this macro, a check hook can return a `GucCheckError` type to populate the error code, detail, and hint when rejecting a value.
    
The signatures of `GucRegistry::define_*_guc_with_hooks` do not change.