### PR TITLE
docs(spi): clarify SpiClient::select vs update for read-only vs writable SPI

### DIFF
--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -39,7 +39,30 @@ impl<'conn> SpiClient<'conn> {
         query.prepare_mut(self, args)
     }
 
-    /// Perform a SELECT statement.
+    /// Perform a `SELECT` statement in **read-only** SPI mode.
+    ///
+    /// Read-only execution is cheaper (no per-statement snapshot work) but it
+    /// inherits PostgreSQL's volatility constraints: the query cannot use a
+    /// locking clause (`FOR UPDATE`, `FOR SHARE`, `SKIP LOCKED`, `NOWAIT`),
+    /// cannot call `VOLATILE` functions that depend on a writable snapshot,
+    /// and cannot run DML (`INSERT`, `UPDATE`, `DELETE`).  Trying to do any
+    /// of those through this method will surface as an error from Postgres,
+    /// most commonly:
+    ///
+    /// > ERROR: SELECT FOR UPDATE is not allowed in a non-volatile function
+    ///
+    /// Use [`SpiClient::update`] for those cases — it switches the rest of
+    /// the transaction to writable SPI execution.
+    ///
+    /// Whether the underlying `SPI_execute*` call is invoked with
+    /// `read_only = true` is decided by [`Spi::is_xact_still_immutable`].
+    /// Once any prior statement in this transaction has been executed via
+    /// [`SpiClient::update`] (or [`Spi::mark_mutable`] has been called
+    /// directly), subsequent `select` calls in the same transaction will
+    /// *also* run with `read_only = false` — pgrx does not flip the SPI
+    /// mode back inside one transaction.  This matches the Postgres
+    /// guidance that mixing read-only and read-write SPI commands in a
+    /// single function is unwise.
     pub fn select<'mcx, Q: Query<'conn>>(
         &self,
         query: Q,
@@ -49,7 +72,22 @@ impl<'conn> SpiClient<'conn> {
         query.execute(self, limit, args)
     }
 
-    /// Perform any query (including utility statements) that modify the database in some way.
+    /// Perform any query that requires **writable** SPI execution.
+    ///
+    /// This is the right method for the obvious writers — `INSERT`,
+    /// `UPDATE`, `DELETE`, and utility statements (`CREATE`, `ALTER`,
+    /// `DROP`, …) — but it is *also* the right method for any `SELECT`
+    /// that uses a locking clause (`FOR UPDATE`, `FOR SHARE`, `SKIP
+    /// LOCKED`, `NOWAIT`) or that calls a function whose volatility
+    /// requires a writable snapshot.  The first call in a transaction
+    /// invokes [`Spi::mark_mutable`], which forces a real `TransactionId`
+    /// to be assigned; from that point forward `SPI_execute*` is invoked
+    /// with `read_only = false` and the rest of the transaction's SPI
+    /// runs writable.
+    ///
+    /// If you only need a plain `SELECT` and don't intend to write or
+    /// lock, prefer [`SpiClient::select`] — it leaves the transaction in
+    /// read-only mode and is cheaper.
     pub fn update<'mcx, Q: Query<'conn>>(
         &mut self,
         query: Q,


### PR DESCRIPTION
Pure docs change. No behaviour change.

## Motivation

The current docstrings on `SpiClient::select` and `SpiClient::update` frame the distinction as "read query vs write query":

```rust
/// Perform a SELECT statement.
pub fn select<…>(…) -> SpiResult<…> { … }

/// Perform any query (including utility statements) that modify the database in some way.
pub fn update<…>(…) -> SpiResult<…> { Spi::mark_mutable(); … }
```

That framing is incomplete. `select` runs the underlying `SPI_execute*` with `read_only = is_xact_still_immutable()`, which on a fresh BGW transaction means `read_only = true`. PostgreSQL then rejects any locking clause — including on a plain SELECT — with:

```
ERROR: SELECT FOR UPDATE is not allowed in a non-volatile function
```

A reader who writes `client.select("SELECT id FROM t ORDER BY id LIMIT 5 FOR UPDATE SKIP LOCKED", …)` because it "is a SELECT" hits this error. In a BGW the abort path turns it into a panic-while-handling-panic, the worker SIGABRTs, and the postmaster crash-recovers. The fix is mechanical (`connect` → `connect_mut`, `select` → `update`), but the docs don't currently nudge the reader toward it.

I had this exact misread last week and filed it as a bug ([#2327](https://github.com/pgcentralfoundation/pgrx/issues/2327)) before re-reading `client.update` and realising pgrx had the right shape all along. Closed the issue as user error. This PR is a follow-up to make the next person less likely to make the same mistake.

## What this PR does

- Adds a paragraph to `SpiClient::select` describing the read-only-SPI execution mode, the specific error message a misuse produces, and the pointer to `SpiClient::update`.
- Adds a paragraph to `SpiClient::update` explicitly listing the locking clauses (`FOR UPDATE`, `FOR SHARE`, `SKIP LOCKED`, `NOWAIT`) as cases that need writable SPI even when the statement looks like a SELECT.
- Cross-links to [`Spi::is_xact_still_immutable`] and [`Spi::mark_mutable`] from both docstrings so the `read_only` flag's lifecycle is discoverable.

Intra-doc link format matches the existing pgrx convention (`[`Spi::foo`]`). No code changes; `rustfmt --check` clean.

## Why not a code change

The behaviour is correct — `client.update` calls `Spi::mark_mutable()` first, so locking clauses work through that path. The gap is purely doc-level.

If you'd prefer different wording (terser, or with a runnable example, or moved to `Spi::connect` / `Spi::connect_mut` instead of the client methods), happy to revise.

Closes the docs side of #2327.