### PR TITLE
fix: bridge buffer page helpers via cshim on PG16+

### DIFF
--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -763,7 +763,7 @@ fn run_bindgen(
     eprintln!("pg_target_includes = {pg_target_includes:?}");
     let (autodetect, includes) = clang::detect_include_paths_for(preferred_clang);
     let mut binder = bindgen::Builder::default();
-    binder = add_blocklists(binder, major_version);
+    binder = add_blocklists(binder, major_version, enable_cshim);
     binder = add_allowlists(binder, pg_target_includes.iter().map(|x| x.as_str()));
     binder = add_derives(binder);
     if !autodetect {
@@ -800,11 +800,22 @@ fn run_bindgen(
     Ok(bindings.to_string())
 }
 
-fn add_blocklists(bind: bindgen::Builder, major_version: u16) -> bindgen::Builder {
+fn add_blocklists(
+    bind: bindgen::Builder,
+    major_version: u16,
+    enable_cshim: bool,
+) -> bindgen::Builder {
     let bind = if major_version >= 19 {
         // Postgres 19 turned these into `static inline` functions, so without the cshim there's
         // no symbol to link against.  We implement them ourselves, in Rust, in `port.rs`
         bind.blocklist_function("TransactionId(Precedes|PrecedesOrEquals|Follows|FollowsOrEquals)")
+    } else {
+        bind
+    };
+    let bind = if major_version < 16 || !enable_cshim {
+        // Before Postgres 16 these are macros. Without cshim, Postgres 16+ static inline
+        // functions have no symbol to link against. Use the Rust fallback in both cases.
+        bind.blocklist_function("BufferGetBlock").blocklist_function("BufferGetPage")
     } else {
         bind
     };
@@ -820,8 +831,6 @@ fn add_blocklists(bind: bindgen::Builder, major_version: u16) -> bindgen::Builde
         .blocklist_function("err(start|code|msg|detail|context_msg|hint|finish)")
         // These functions are already ported in Rust
         .blocklist_function("heap_getattr")
-        .blocklist_function("BufferGetBlock")
-        .blocklist_function("BufferGetPage")
         .blocklist_function("BufferIsLocal")
         .blocklist_function("GetMemoryChunkContext")
         .blocklist_function("GETSTRUCT")

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -39199,8 +39199,12 @@ unsafe extern "C-unwind" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
     #[link_name = "BufferIsValid__pgrx_cshim"]
     pub fn BufferIsValid(bufnum: Buffer) -> bool;
+    #[link_name = "BufferGetBlock__pgrx_cshim"]
+    pub fn BufferGetBlock(buffer: Buffer) -> Block;
     #[link_name = "BufferGetPageSize__pgrx_cshim"]
     pub fn BufferGetPageSize(buffer: Buffer) -> Size;
+    #[link_name = "BufferGetPage__pgrx_cshim"]
+    pub fn BufferGetPage(buffer: Buffer) -> Page;
     #[link_name = "TestForOldSnapshot__pgrx_cshim"]
     pub fn TestForOldSnapshot(snapshot: Snapshot, relation: Relation, page: Page);
     pub static mut InRecovery: bool;

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -39120,8 +39120,12 @@ unsafe extern "C-unwind" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
     #[link_name = "BufferIsValid__pgrx_cshim"]
     pub fn BufferIsValid(bufnum: Buffer) -> bool;
+    #[link_name = "BufferGetBlock__pgrx_cshim"]
+    pub fn BufferGetBlock(buffer: Buffer) -> Block;
     #[link_name = "BufferGetPageSize__pgrx_cshim"]
     pub fn BufferGetPageSize(buffer: Buffer) -> Size;
+    #[link_name = "BufferGetPage__pgrx_cshim"]
+    pub fn BufferGetPage(buffer: Buffer) -> Page;
     pub fn read_stream_begin_relation(
         flags: ::core::ffi::c_int,
         strategy: BufferAccessStrategy,

--- a/pgrx-pg-sys/src/include/pg18.rs
+++ b/pgrx-pg-sys/src/include/pg18.rs
@@ -41091,8 +41091,12 @@ unsafe extern "C-unwind" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
     #[link_name = "BufferIsValid__pgrx_cshim"]
     pub fn BufferIsValid(bufnum: Buffer) -> bool;
+    #[link_name = "BufferGetBlock__pgrx_cshim"]
+    pub fn BufferGetBlock(buffer: Buffer) -> Block;
     #[link_name = "BufferGetPageSize__pgrx_cshim"]
     pub fn BufferGetPageSize(buffer: Buffer) -> Size;
+    #[link_name = "BufferGetPage__pgrx_cshim"]
+    pub fn BufferGetPage(buffer: Buffer) -> Page;
     pub fn block_range_read_stream_cb(
         stream: *mut ReadStream,
         callback_private_data: *mut ::core::ffi::c_void,

--- a/pgrx-pg-sys/src/include/pg19.rs
+++ b/pgrx-pg-sys/src/include/pg19.rs
@@ -40932,8 +40932,12 @@ unsafe extern "C-unwind" {
     pub fn FreeAccessStrategy(strategy: BufferAccessStrategy);
     #[link_name = "BufferIsValid__pgrx_cshim"]
     pub fn BufferIsValid(bufnum: Buffer) -> bool;
+    #[link_name = "BufferGetBlock__pgrx_cshim"]
+    pub fn BufferGetBlock(buffer: Buffer) -> Block;
     #[link_name = "BufferGetPageSize__pgrx_cshim"]
     pub fn BufferGetPageSize(buffer: Buffer) -> Size;
+    #[link_name = "BufferGetPage__pgrx_cshim"]
+    pub fn BufferGetPage(buffer: Buffer) -> Page;
     pub fn block_range_read_stream_cb(
         stream: *mut ReadStream,
         callback_private_data: *mut ::core::ffi::c_void,

--- a/pgrx-pg-sys/src/port.rs
+++ b/pgrx-pg-sys/src/port.rs
@@ -340,6 +340,15 @@ pub unsafe fn type_is_array(typoid: super::Oid) -> bool {
 
 /// #define BufferGetPage(buffer) ((Page)BufferGetBlock(buffer))
 #[inline]
+#[cfg(any(
+    feature = "pg13",
+    feature = "pg14",
+    feature = "pg15",
+    all(
+        not(feature = "cshim"),
+        any(feature = "pg16", feature = "pg17", feature = "pg18", feature = "pg19")
+    )
+))]
 pub unsafe fn BufferGetPage(buffer: crate::Buffer) -> crate::Page {
     BufferGetBlock(buffer) as crate::Page
 }
@@ -353,6 +362,15 @@ pub unsafe fn BufferGetPage(buffer: crate::Buffer) -> crate::Page {
 ///            (Block) (BufferBlocks + ((Size) ((buffer) - 1)) * BLCKSZ) \
 /// )
 #[inline]
+#[cfg(any(
+    feature = "pg13",
+    feature = "pg14",
+    feature = "pg15",
+    all(
+        not(feature = "cshim"),
+        any(feature = "pg16", feature = "pg17", feature = "pg18", feature = "pg19")
+    )
+))]
 pub unsafe fn BufferGetBlock(buffer: crate::Buffer) -> crate::Block {
     if BufferIsLocal(buffer) {
         *crate::LocalBufferBlockPointers.offset(((-buffer) - 1) as isize)


### PR DESCRIPTION
## Summary

Use generated cshim bindings for BufferGetBlock and BufferGetPage on PostgreSQL 16 and newer when cshim is enabled. Keep the existing Rust fallback for older macro-only releases and for builds without cshim support.

## Testing

- cargo fmt
- git diff --check
- cargo check -p pgrx-bindgen
- PGRX_PG_CONFIG_PATH=/opt/homebrew/opt/postgresql@18/bin/pg_config cargo check -p pgrx-pg-sys --no-default-features --features pg18

PG18 with cshim generated the expected BufferGetBlock__pgrx_cshim and BufferGetPage__pgrx_cshim wrappers locally, but full cshim compilation was blocked by a Homebrew PostgreSQL SDK path pointing at a missing MacOSX26.sdk.