### PR TITLE
Update version to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-pgrx"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "bzip2",
  "cargo_metadata",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "bitflags 2.13.0",
  "bitvec",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bench"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "criterion",
  "oorandom",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "cargo_toml",
  "codepage",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "cee-scape",
  "libc",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "convert_case",
  "eyre",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "pgrx-unit-tests"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "eyre",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,18 +37,18 @@ repository = "https://github.com/pgcentralfoundation/pgrx/"
 homepage = "https://github.com/pgcentralfoundation/pgrx/"
 # TODO: all crates should use this version rather than copy it
 #   See https://github.com/pgcentralfoundation/pgrx/pull/2100 comments
-version = "0.18.1"
+version = "0.19.0"
 
 [workspace.metadata.local-install]
 cargo-pgrx = { path = "cargo-pgrx" }
 
 [workspace.dependencies]
-pgrx-bench = { path = "./pgrx-bench", version = "=0.18.1" }
-pgrx-macros = { path = "./pgrx-macros", version = "=0.18.1" }
-pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.18.1" }
-pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.18.1" }
-pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.18.1" }
-pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.18.1" }
+pgrx-bench = { path = "./pgrx-bench", version = "=0.19.0" }
+pgrx-macros = { path = "./pgrx-macros", version = "=0.19.0" }
+pgrx-pg-sys = { path = "./pgrx-pg-sys", version = "=0.19.0" }
+pgrx-sql-entity-graph = { path = "./pgrx-sql-entity-graph", version = "=0.19.0" }
+pgrx-pg-config = { path = "./pgrx-pg-config", version = "=0.19.0" }
+pgrx-bindgen = { path = "./pgrx-bindgen", version = "=0.19.0" }
 
 cargo_metadata = "0.23.1"
 cargo_toml = "0.22" # used for building projects

--- a/cargo-pgrx/Cargo.toml
+++ b/cargo-pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "cargo-pgrx"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "Cargo subcommand for 'pgrx' to make Postgres extension development easy"

--- a/cargo-pgrx/src/templates/cargo_toml
+++ b/cargo-pgrx/src/templates/cargo_toml
@@ -19,15 +19,15 @@ pg_test = []
 pg_bench = ["dep:pgrx-bench"]
 
 [dependencies]
-pgrx = "=0.18.1"
+pgrx = "=0.19.0"
 
 [dependencies.pgrx-bench]
-version = "=0.18.1"
+version = "=0.19.0"
 optional = true
 
 [dev-dependencies]
 [dev-dependencies.pgrx-tests]
-version = "=0.18.1"
+version = "=0.19.0"
 
 [profile.dev]
 panic = "unwind"

--- a/cargo-pgrx/tests/fixtures/workspace/Cargo.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/Cargo.toml
@@ -5,7 +5,6 @@ members = ["hello"]
 [workspace.package]
 edition = "2024"
 rust-version = "1.96"
-version = "0.19.0"
 
 [workspace.dependencies]
 pgrx = "=0.19.0"

--- a/cargo-pgrx/tests/fixtures/workspace/Cargo.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/Cargo.toml
@@ -5,11 +5,12 @@ members = ["hello"]
 [workspace.package]
 edition = "2024"
 rust-version = "1.96"
+version = "0.19.0"
 
 [workspace.dependencies]
-pgrx = "=0.18.0"
-pgrx-bench = "=0.18.0"
-pgrx-macros = "=0.18.0"
-pgrx-pg-sys = "=0.18.0"
-pgrx-sql-entity-graph = { version = "=0.18.0" }
-pgrx-pg-config = { version = "=0.18.0" }
+pgrx = "=0.19.0"
+pgrx-bench = "=0.19.0"
+pgrx-macros = "=0.19.0"
+pgrx-pg-sys = "=0.19.0"
+pgrx-sql-entity-graph = { version = "=0.19.0" }
+pgrx-pg-config = { version = "=0.19.0" }

--- a/cargo-pgrx/tests/fixtures/workspace/hello/Cargo.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello"
-version = "0.0.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 
@@ -27,7 +27,7 @@ workspace = true
 
 [dev-dependencies]
 [dev-dependencies.pgrx-tests]
-version = "=0.18.0"
+version = "=0.19.0"
 
 [profile.dev]
 panic = "unwind"

--- a/cargo-pgrx/tests/fixtures/workspace/hello/Cargo.toml
+++ b/cargo-pgrx/tests/fixtures/workspace/hello/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello"
-version = "0.19.0"
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/pgrx-bench/Cargo.toml
+++ b/pgrx-bench/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-bench"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "Benchmark runtime support for pgrx extensions"

--- a/pgrx-bindgen/Cargo.toml
+++ b/pgrx-bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pgrx-bindgen"
 description = "additional bindgen support for pgrx"
-version = "0.18.1"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/pgrx-macros/Cargo.toml
+++ b/pgrx-macros/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-macros"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "Proc Macros for 'pgrx'"

--- a/pgrx-pg-config/Cargo.toml
+++ b/pgrx-pg-config/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-config"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "A Postgres pg_config wrapper for 'pgrx'"

--- a/pgrx-pg-sys/Cargo.toml
+++ b/pgrx-pg-sys/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-pg-sys"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "Generated Rust bindings for Postgres internals, for use with 'pgrx'"

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -47,7 +47,11 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -23450,6 +23454,16 @@ impl Default for ControlFileData {
         }
     }
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PGLZ_Strategy {
+    pub min_input_size: int32,
+    pub max_input_size: int32,
+    pub min_comp_rate: int32,
+    pub first_success_by: int32,
+    pub match_size_good: int32,
+    pub match_size_drop: int32,
+}
 pub type bgworker_main_type = ::core::option::Option<unsafe extern "C-unwind" fn(main_arg: Datum)>;
 pub mod BgWorkerStartTime {
     pub type Type = ::core::ffi::c_uint;
@@ -30390,7 +30404,7 @@ unsafe extern "C-unwind" {
     pub fn pfree(pointer: *mut ::core::ffi::c_void);
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-    -> *mut ::core::ffi::c_void;
+        -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -30613,7 +30627,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-    -> FullTransactionId;
+        -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdAdvance__pgrx_cshim"]
@@ -30707,7 +30721,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-    -> bool;
+        -> bool;
     pub fn nocachegetattr(tup: HeapTuple, attnum: ::core::ffi::c_int, att: TupleDesc) -> Datum;
     pub fn heap_getsysattr(
         tup: HeapTuple,
@@ -30904,7 +30918,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-    -> *mut TupleConversionMap;
+        -> *mut TupleConversionMap;
     pub fn execute_attr_map_tuple(tuple: HeapTuple, map: *mut TupleConversionMap) -> HeapTuple;
     pub fn execute_attr_map_slot(
         attrMap: *mut AttrMap,
@@ -30912,7 +30926,7 @@ unsafe extern "C-unwind" {
         out_slot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot;
     pub fn execute_attr_map_cols(attrMap: *mut AttrMap, inbitmap: *mut Bitmapset)
-    -> *mut Bitmapset;
+        -> *mut Bitmapset;
     pub fn free_conversion_map(map: *mut TupleConversionMap);
     pub static mut pgBufferUsage: BufferUsage;
     pub static mut pgWalUsage: WalUsage;
@@ -31117,7 +31131,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-    -> Datum;
+        -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -31522,7 +31536,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-    -> *mut TBMSharedIterator;
+        -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -31537,7 +31551,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -31765,7 +31779,7 @@ unsafe extern "C-unwind" {
         name: *const ::core::ffi::c_char,
     ) -> File;
     pub fn SharedFileSetOpen(fileset: *mut SharedFileSet, name: *const ::core::ffi::c_char)
-    -> File;
+        -> File;
     pub fn SharedFileSetDelete(
         fileset: *mut SharedFileSet,
         name: *const ::core::ffi::c_char,
@@ -32177,7 +32191,7 @@ unsafe extern "C-unwind" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
     pub fn MemoryContextCheck(context: MemoryContext);
     pub fn MemoryContextContains(context: MemoryContext, pointer: *mut ::core::ffi::c_void)
-    -> bool;
+        -> bool;
     pub fn MemoryContextCreate(
         node: MemoryContext,
         tag: NodeTag,
@@ -32375,7 +32389,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-    -> *mut ExecAuxRowMark;
+        -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -34790,7 +34804,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-    -> bool;
+        -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -34819,7 +34833,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-    -> Size;
+        -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -36895,7 +36909,7 @@ unsafe extern "C-unwind" {
     pub fn smgrDoPendingDeletes(isCommit: bool);
     pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
     pub fn smgrGetPendingDeletes(forCommit: bool, ptr: *mut *mut RelFileNode)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn AtSubCommit_smgr();
     pub fn AtSubAbort_smgr();
     pub fn PostPrepare_smgr();
@@ -36961,7 +36975,7 @@ unsafe extern "C-unwind" {
     ) -> Oid;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-    -> ObjectAddress;
+        -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn check_encoding_locale_matches(
@@ -37869,6 +37883,22 @@ unsafe extern "C-unwind" {
         ControlFile: *mut ControlFileData,
         do_sync: bool,
     );
+    pub static PGLZ_strategy_default: *const PGLZ_Strategy;
+    pub static PGLZ_strategy_always: *const PGLZ_Strategy;
+    pub fn pglz_compress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        strategy: *const PGLZ_Strategy,
+    ) -> int32;
+    pub fn pglz_decompress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        rawsize: int32,
+        check_complete: bool,
+    ) -> int32;
+    pub fn pglz_maximum_compressed_size(rawsize: int32, total_compressed_size: int32) -> int32;
     pub fn RegisterBackgroundWorker(worker: *mut BackgroundWorker);
     pub fn RegisterDynamicBackgroundWorker(
         worker: *mut BackgroundWorker,
@@ -38238,7 +38268,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -38252,7 +38282,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -38414,7 +38444,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-    -> bool;
+        -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -38521,7 +38551,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-    -> ::core::ffi::c_ushort;
+        -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -39389,7 +39419,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(query: *mut Query, node: *mut Node) -> *mut Node;
     pub fn compare_path_costs(
@@ -39600,7 +39630,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-    -> Relids;
+        -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -39848,7 +39878,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-    -> *mut ParamPathInfo;
+        -> *mut ParamPathInfo;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
         outer_rel: *mut RelOptInfo,
@@ -40363,7 +40393,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-    -> bool;
+        -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -40433,12 +40463,12 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-    -> *mut List;
+        -> *mut List;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-    -> Oid;
+        -> Oid;
     pub static mut operator_precedence_warning: bool;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
@@ -41299,7 +41329,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-    -> *const ::core::ffi::c_char;
+        -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -41659,7 +41689,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -45330,7 +45360,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-    -> bool;
+        -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,

--- a/pgrx-pg-sys/src/include/pg13.rs
+++ b/pgrx-pg-sys/src/include/pg13.rs
@@ -47,11 +47,7 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val {
-            byte | mask
-        } else {
-            byte & !mask
-        }
+        if val { byte | mask } else { byte & !mask }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -30404,7 +30400,7 @@ unsafe extern "C-unwind" {
     pub fn pfree(pointer: *mut ::core::ffi::c_void);
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-        -> *mut ::core::ffi::c_void;
+    -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -30627,7 +30623,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-        -> FullTransactionId;
+    -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdAdvance__pgrx_cshim"]
@@ -30721,7 +30717,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-        -> bool;
+    -> bool;
     pub fn nocachegetattr(tup: HeapTuple, attnum: ::core::ffi::c_int, att: TupleDesc) -> Datum;
     pub fn heap_getsysattr(
         tup: HeapTuple,
@@ -30918,7 +30914,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-        -> *mut TupleConversionMap;
+    -> *mut TupleConversionMap;
     pub fn execute_attr_map_tuple(tuple: HeapTuple, map: *mut TupleConversionMap) -> HeapTuple;
     pub fn execute_attr_map_slot(
         attrMap: *mut AttrMap,
@@ -30926,7 +30922,7 @@ unsafe extern "C-unwind" {
         out_slot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot;
     pub fn execute_attr_map_cols(attrMap: *mut AttrMap, inbitmap: *mut Bitmapset)
-        -> *mut Bitmapset;
+    -> *mut Bitmapset;
     pub fn free_conversion_map(map: *mut TupleConversionMap);
     pub static mut pgBufferUsage: BufferUsage;
     pub static mut pgWalUsage: WalUsage;
@@ -31131,7 +31127,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-        -> Datum;
+    -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -31536,7 +31532,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-        -> *mut TBMSharedIterator;
+    -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -31551,7 +31547,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -31779,7 +31775,7 @@ unsafe extern "C-unwind" {
         name: *const ::core::ffi::c_char,
     ) -> File;
     pub fn SharedFileSetOpen(fileset: *mut SharedFileSet, name: *const ::core::ffi::c_char)
-        -> File;
+    -> File;
     pub fn SharedFileSetDelete(
         fileset: *mut SharedFileSet,
         name: *const ::core::ffi::c_char,
@@ -32191,7 +32187,7 @@ unsafe extern "C-unwind" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
     pub fn MemoryContextCheck(context: MemoryContext);
     pub fn MemoryContextContains(context: MemoryContext, pointer: *mut ::core::ffi::c_void)
-        -> bool;
+    -> bool;
     pub fn MemoryContextCreate(
         node: MemoryContext,
         tag: NodeTag,
@@ -32389,7 +32385,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-        -> *mut ExecAuxRowMark;
+    -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -34804,7 +34800,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-        -> bool;
+    -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -34833,7 +34829,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-        -> Size;
+    -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -36909,7 +36905,7 @@ unsafe extern "C-unwind" {
     pub fn smgrDoPendingDeletes(isCommit: bool);
     pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
     pub fn smgrGetPendingDeletes(forCommit: bool, ptr: *mut *mut RelFileNode)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn AtSubCommit_smgr();
     pub fn AtSubAbort_smgr();
     pub fn PostPrepare_smgr();
@@ -36975,7 +36971,7 @@ unsafe extern "C-unwind" {
     ) -> Oid;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-        -> ObjectAddress;
+    -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn check_encoding_locale_matches(
@@ -38268,7 +38264,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -38282,7 +38278,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -38444,7 +38440,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-        -> bool;
+    -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -38551,7 +38547,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-        -> ::core::ffi::c_ushort;
+    -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -39419,7 +39415,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(query: *mut Query, node: *mut Node) -> *mut Node;
     pub fn compare_path_costs(
@@ -39630,7 +39626,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-        -> Relids;
+    -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -39878,7 +39874,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-        -> *mut ParamPathInfo;
+    -> *mut ParamPathInfo;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
         outer_rel: *mut RelOptInfo,
@@ -40393,7 +40389,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
+    -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -40463,12 +40459,12 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-        -> *mut List;
+    -> *mut List;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-        -> Oid;
+    -> Oid;
     pub static mut operator_precedence_warning: bool;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
@@ -41329,7 +41325,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-        -> *const ::core::ffi::c_char;
+    -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -41689,7 +41685,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -45360,7 +45356,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-        -> bool;
+    -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -47,11 +47,7 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val {
-            byte | mask
-        } else {
-            byte & !mask
-        }
+        if val { byte | mask } else { byte & !mask }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -32515,7 +32511,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-        -> *mut ::core::ffi::c_void;
+    -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -32748,7 +32744,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-        -> FullTransactionId;
+    -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -32853,7 +32849,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-        -> bool;
+    -> bool;
     pub fn nocachegetattr(tup: HeapTuple, attnum: ::core::ffi::c_int, att: TupleDesc) -> Datum;
     pub fn heap_getsysattr(
         tup: HeapTuple,
@@ -33050,7 +33046,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-        -> *mut TupleConversionMap;
+    -> *mut TupleConversionMap;
     pub fn execute_attr_map_tuple(tuple: HeapTuple, map: *mut TupleConversionMap) -> HeapTuple;
     pub fn execute_attr_map_slot(
         attrMap: *mut AttrMap,
@@ -33058,7 +33054,7 @@ unsafe extern "C-unwind" {
         out_slot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot;
     pub fn execute_attr_map_cols(attrMap: *mut AttrMap, inbitmap: *mut Bitmapset)
-        -> *mut Bitmapset;
+    -> *mut Bitmapset;
     pub fn free_conversion_map(map: *mut TupleConversionMap);
     pub static mut pgBufferUsage: BufferUsage;
     pub static mut pgWalUsage: WalUsage;
@@ -33265,7 +33261,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-        -> Datum;
+    -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -33730,7 +33726,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-        -> *mut TBMSharedIterator;
+    -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -33745,7 +33741,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -34423,7 +34419,7 @@ unsafe extern "C-unwind" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
     pub fn MemoryContextCheck(context: MemoryContext);
     pub fn MemoryContextContains(context: MemoryContext, pointer: *mut ::core::ffi::c_void)
-        -> bool;
+    -> bool;
     pub fn MemoryContextCreate(
         node: MemoryContext,
         tag: NodeTag,
@@ -34618,7 +34614,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-        -> *mut ExecAuxRowMark;
+    -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -36970,7 +36966,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-        -> bool;
+    -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -36999,7 +36995,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-        -> Size;
+    -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -39066,7 +39062,7 @@ unsafe extern "C-unwind" {
     pub fn smgrDoPendingDeletes(isCommit: bool);
     pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
     pub fn smgrGetPendingDeletes(forCommit: bool, ptr: *mut *mut RelFileNode)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn AtSubCommit_smgr();
     pub fn AtSubAbort_smgr();
     pub fn PostPrepare_smgr();
@@ -39146,7 +39142,7 @@ unsafe extern "C-unwind" {
     ) -> Oid;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-        -> ObjectAddress;
+    -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn check_encoding_locale_matches(
@@ -40539,7 +40535,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -40553,7 +40549,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -40715,7 +40711,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-        -> bool;
+    -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -40842,7 +40838,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-        -> ::core::ffi::c_ushort;
+    -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -41754,7 +41750,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(query: *mut Query, node: *mut Node) -> *mut Node;
     pub fn compare_path_costs(
@@ -41979,7 +41975,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-        -> Relids;
+    -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -42227,7 +42223,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-        -> *mut ParamPathInfo;
+    -> *mut ParamPathInfo;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
         outer_rel: *mut RelOptInfo,
@@ -42736,7 +42732,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
+    -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -42817,14 +42813,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-        -> *mut List;
+    -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-        -> *mut SortGroupClause;
+    -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-        -> Oid;
+    -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -43454,7 +43450,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-        -> PartitionDirectory;
+    -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -43687,7 +43683,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-        -> *const ::core::ffi::c_char;
+    -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -43996,7 +43992,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(out: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-        -> TransactionId;
+    -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -44246,7 +44242,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -48248,7 +48244,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-        -> bool;
+    -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -48406,7 +48402,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(string: *const ::core::ffi::c_char) -> *mut List;
     pub fn format_procedure(procedure_oid: Oid) -> *mut ::core::ffi::c_char;

--- a/pgrx-pg-sys/src/include/pg14.rs
+++ b/pgrx-pg-sys/src/include/pg14.rs
@@ -47,7 +47,11 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -24615,6 +24619,16 @@ impl Default for ControlFileData {
         }
     }
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PGLZ_Strategy {
+    pub min_input_size: int32,
+    pub max_input_size: int32,
+    pub min_comp_rate: int32,
+    pub first_success_by: int32,
+    pub match_size_good: int32,
+    pub match_size_drop: int32,
+}
 pub type bgworker_main_type = ::core::option::Option<unsafe extern "C-unwind" fn(main_arg: Datum)>;
 pub mod BgWorkerStartTime {
     pub type Type = ::core::ffi::c_uint;
@@ -32501,7 +32515,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-    -> *mut ::core::ffi::c_void;
+        -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -32734,7 +32748,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-    -> FullTransactionId;
+        -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -32839,7 +32853,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-    -> bool;
+        -> bool;
     pub fn nocachegetattr(tup: HeapTuple, attnum: ::core::ffi::c_int, att: TupleDesc) -> Datum;
     pub fn heap_getsysattr(
         tup: HeapTuple,
@@ -33036,7 +33050,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-    -> *mut TupleConversionMap;
+        -> *mut TupleConversionMap;
     pub fn execute_attr_map_tuple(tuple: HeapTuple, map: *mut TupleConversionMap) -> HeapTuple;
     pub fn execute_attr_map_slot(
         attrMap: *mut AttrMap,
@@ -33044,7 +33058,7 @@ unsafe extern "C-unwind" {
         out_slot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot;
     pub fn execute_attr_map_cols(attrMap: *mut AttrMap, inbitmap: *mut Bitmapset)
-    -> *mut Bitmapset;
+        -> *mut Bitmapset;
     pub fn free_conversion_map(map: *mut TupleConversionMap);
     pub static mut pgBufferUsage: BufferUsage;
     pub static mut pgWalUsage: WalUsage;
@@ -33251,7 +33265,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-    -> Datum;
+        -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -33716,7 +33730,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-    -> *mut TBMSharedIterator;
+        -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -33731,7 +33745,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -34409,7 +34423,7 @@ unsafe extern "C-unwind" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
     pub fn MemoryContextCheck(context: MemoryContext);
     pub fn MemoryContextContains(context: MemoryContext, pointer: *mut ::core::ffi::c_void)
-    -> bool;
+        -> bool;
     pub fn MemoryContextCreate(
         node: MemoryContext,
         tag: NodeTag,
@@ -34604,7 +34618,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-    -> *mut ExecAuxRowMark;
+        -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -36956,7 +36970,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-    -> bool;
+        -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -36985,7 +36999,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-    -> Size;
+        -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -39052,7 +39066,7 @@ unsafe extern "C-unwind" {
     pub fn smgrDoPendingDeletes(isCommit: bool);
     pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
     pub fn smgrGetPendingDeletes(forCommit: bool, ptr: *mut *mut RelFileNode)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn AtSubCommit_smgr();
     pub fn AtSubAbort_smgr();
     pub fn PostPrepare_smgr();
@@ -39132,7 +39146,7 @@ unsafe extern "C-unwind" {
     ) -> Oid;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-    -> ObjectAddress;
+        -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn check_encoding_locale_matches(
@@ -40012,6 +40026,22 @@ unsafe extern "C-unwind" {
         ControlFile: *mut ControlFileData,
         do_sync: bool,
     );
+    pub static PGLZ_strategy_default: *const PGLZ_Strategy;
+    pub static PGLZ_strategy_always: *const PGLZ_Strategy;
+    pub fn pglz_compress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        strategy: *const PGLZ_Strategy,
+    ) -> int32;
+    pub fn pglz_decompress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        rawsize: int32,
+        check_complete: bool,
+    ) -> int32;
+    pub fn pglz_maximum_compressed_size(rawsize: int32, total_compressed_size: int32) -> int32;
     pub fn RegisterBackgroundWorker(worker: *mut BackgroundWorker);
     pub fn RegisterDynamicBackgroundWorker(
         worker: *mut BackgroundWorker,
@@ -40509,7 +40539,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -40523,7 +40553,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -40685,7 +40715,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-    -> bool;
+        -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -40812,7 +40842,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-    -> ::core::ffi::c_ushort;
+        -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -41724,7 +41754,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(query: *mut Query, node: *mut Node) -> *mut Node;
     pub fn compare_path_costs(
@@ -41949,7 +41979,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-    -> Relids;
+        -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -42197,7 +42227,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-    -> *mut ParamPathInfo;
+        -> *mut ParamPathInfo;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
         outer_rel: *mut RelOptInfo,
@@ -42706,7 +42736,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-    -> bool;
+        -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -42787,14 +42817,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-    -> *mut List;
+        -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-    -> *mut SortGroupClause;
+        -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-    -> Oid;
+        -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -43424,7 +43454,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-    -> PartitionDirectory;
+        -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -43657,7 +43687,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-    -> *const ::core::ffi::c_char;
+        -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -43966,7 +43996,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(out: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-    -> TransactionId;
+        -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -44216,7 +44246,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -48218,7 +48248,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-    -> bool;
+        -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -48376,7 +48406,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(string: *const ::core::ffi::c_char) -> *mut List;
     pub fn format_procedure(procedure_oid: Oid) -> *mut ::core::ffi::c_char;

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -47,7 +47,11 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -24918,6 +24922,16 @@ impl Default for ConfigData {
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PGLZ_Strategy {
+    pub min_input_size: int32,
+    pub max_input_size: int32,
+    pub min_comp_rate: int32,
+    pub first_success_by: int32,
+    pub match_size_good: int32,
+    pub match_size_drop: int32,
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AggStatePerTransData {
     pub aggref: *mut Aggref,
@@ -32641,7 +32655,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-    -> *mut ::core::ffi::c_void;
+        -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -32875,7 +32889,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-    -> FullTransactionId;
+        -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -32980,7 +32994,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-    -> bool;
+        -> bool;
     pub fn nocachegetattr(tup: HeapTuple, attnum: ::core::ffi::c_int, att: TupleDesc) -> Datum;
     pub fn heap_getsysattr(
         tup: HeapTuple,
@@ -33184,7 +33198,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-    -> *mut TupleConversionMap;
+        -> *mut TupleConversionMap;
     pub fn execute_attr_map_tuple(tuple: HeapTuple, map: *mut TupleConversionMap) -> HeapTuple;
     pub fn execute_attr_map_slot(
         attrMap: *mut AttrMap,
@@ -33192,7 +33206,7 @@ unsafe extern "C-unwind" {
         out_slot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot;
     pub fn execute_attr_map_cols(attrMap: *mut AttrMap, inbitmap: *mut Bitmapset)
-    -> *mut Bitmapset;
+        -> *mut Bitmapset;
     pub fn free_conversion_map(map: *mut TupleConversionMap);
     pub static mut pgBufferUsage: BufferUsage;
     pub static mut pgWalUsage: WalUsage;
@@ -33399,7 +33413,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-    -> Datum;
+        -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -33868,7 +33882,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-    -> *mut TBMSharedIterator;
+        -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -33883,7 +33897,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -34592,7 +34606,7 @@ unsafe extern "C-unwind" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
     pub fn MemoryContextCheck(context: MemoryContext);
     pub fn MemoryContextContains(context: MemoryContext, pointer: *mut ::core::ffi::c_void)
-    -> bool;
+        -> bool;
     pub fn MemoryContextCreate(
         node: MemoryContext,
         tag: NodeTag,
@@ -34798,7 +34812,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-    -> *mut ExecAuxRowMark;
+        -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -37259,7 +37273,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-    -> bool;
+        -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -37288,7 +37302,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-    -> Size;
+        -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -39442,7 +39456,7 @@ unsafe extern "C-unwind" {
     pub fn smgrDoPendingDeletes(isCommit: bool);
     pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
     pub fn smgrGetPendingDeletes(forCommit: bool, ptr: *mut *mut RelFileNode)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn AtSubCommit_smgr();
     pub fn AtSubAbort_smgr();
     pub fn PostPrepare_smgr();
@@ -39523,7 +39537,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-    -> ObjectAddress;
+        -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn check_encoding_locale_matches(
@@ -40706,6 +40720,22 @@ unsafe extern "C-unwind" {
         ControlFile: *mut ControlFileData,
         do_sync: bool,
     );
+    pub static PGLZ_strategy_default: *const PGLZ_Strategy;
+    pub static PGLZ_strategy_always: *const PGLZ_Strategy;
+    pub fn pglz_compress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        strategy: *const PGLZ_Strategy,
+    ) -> int32;
+    pub fn pglz_decompress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        rawsize: int32,
+        check_complete: bool,
+    ) -> int32;
+    pub fn pglz_maximum_compressed_size(rawsize: int32, total_compressed_size: int32) -> int32;
     pub fn ExecInitAgg(
         node: *mut Agg,
         estate: *mut EState,
@@ -41004,7 +41034,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -41018,7 +41048,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -41179,7 +41209,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-    -> bool;
+        -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -41306,7 +41336,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-    -> ::core::ffi::c_ushort;
+        -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -42221,7 +42251,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(query: *mut Query, node: *mut Node) -> *mut Node;
     pub fn compare_path_costs(
@@ -42446,7 +42476,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-    -> Relids;
+        -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -42697,7 +42727,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-    -> *mut ParamPathInfo;
+        -> *mut ParamPathInfo;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
         outer_rel: *mut RelOptInfo,
@@ -43206,7 +43236,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-    -> bool;
+        -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -43304,14 +43334,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-    -> *mut List;
+        -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-    -> *mut SortGroupClause;
+        -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-    -> Oid;
+        -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -43938,7 +43968,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-    -> PartitionDirectory;
+        -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -44171,7 +44201,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-    -> *const ::core::ffi::c_char;
+        -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -44527,7 +44557,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(out: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-    -> TransactionId;
+        -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -44782,7 +44812,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -48826,7 +48856,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-    -> bool;
+        -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -48984,7 +49014,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(string: *const ::core::ffi::c_char) -> *mut List;
     pub fn format_procedure(procedure_oid: Oid) -> *mut ::core::ffi::c_char;

--- a/pgrx-pg-sys/src/include/pg15.rs
+++ b/pgrx-pg-sys/src/include/pg15.rs
@@ -47,11 +47,7 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val {
-            byte | mask
-        } else {
-            byte & !mask
-        }
+        if val { byte | mask } else { byte & !mask }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -32655,7 +32651,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-        -> *mut ::core::ffi::c_void;
+    -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -32889,7 +32885,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-        -> FullTransactionId;
+    -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -32994,7 +32990,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-        -> bool;
+    -> bool;
     pub fn nocachegetattr(tup: HeapTuple, attnum: ::core::ffi::c_int, att: TupleDesc) -> Datum;
     pub fn heap_getsysattr(
         tup: HeapTuple,
@@ -33198,7 +33194,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-        -> *mut TupleConversionMap;
+    -> *mut TupleConversionMap;
     pub fn execute_attr_map_tuple(tuple: HeapTuple, map: *mut TupleConversionMap) -> HeapTuple;
     pub fn execute_attr_map_slot(
         attrMap: *mut AttrMap,
@@ -33206,7 +33202,7 @@ unsafe extern "C-unwind" {
         out_slot: *mut TupleTableSlot,
     ) -> *mut TupleTableSlot;
     pub fn execute_attr_map_cols(attrMap: *mut AttrMap, inbitmap: *mut Bitmapset)
-        -> *mut Bitmapset;
+    -> *mut Bitmapset;
     pub fn free_conversion_map(map: *mut TupleConversionMap);
     pub static mut pgBufferUsage: BufferUsage;
     pub static mut pgWalUsage: WalUsage;
@@ -33413,7 +33409,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-        -> Datum;
+    -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -33882,7 +33878,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-        -> *mut TBMSharedIterator;
+    -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -33897,7 +33893,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -34606,7 +34602,7 @@ unsafe extern "C-unwind" {
     pub fn MemoryContextAllowInCriticalSection(context: MemoryContext, allow: bool);
     pub fn MemoryContextCheck(context: MemoryContext);
     pub fn MemoryContextContains(context: MemoryContext, pointer: *mut ::core::ffi::c_void)
-        -> bool;
+    -> bool;
     pub fn MemoryContextCreate(
         node: MemoryContext,
         tag: NodeTag,
@@ -34812,7 +34808,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-        -> *mut ExecAuxRowMark;
+    -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -37273,7 +37269,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-        -> bool;
+    -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -37302,7 +37298,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-        -> Size;
+    -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -39456,7 +39452,7 @@ unsafe extern "C-unwind" {
     pub fn smgrDoPendingDeletes(isCommit: bool);
     pub fn smgrDoPendingSyncs(isCommit: bool, isParallelWorker: bool);
     pub fn smgrGetPendingDeletes(forCommit: bool, ptr: *mut *mut RelFileNode)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn AtSubCommit_smgr();
     pub fn AtSubAbort_smgr();
     pub fn PostPrepare_smgr();
@@ -39537,7 +39533,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-        -> ObjectAddress;
+    -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn check_encoding_locale_matches(
@@ -41034,7 +41030,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -41048,7 +41044,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -41209,7 +41205,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-        -> bool;
+    -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -41336,7 +41332,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-        -> ::core::ffi::c_ushort;
+    -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -42251,7 +42247,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(query: *mut Query, node: *mut Node) -> *mut Node;
     pub fn compare_path_costs(
@@ -42476,7 +42472,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-        -> Relids;
+    -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -42727,7 +42723,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-        -> *mut ParamPathInfo;
+    -> *mut ParamPathInfo;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
         outer_rel: *mut RelOptInfo,
@@ -43236,7 +43232,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
+    -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -43334,14 +43330,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-        -> *mut List;
+    -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-        -> *mut SortGroupClause;
+    -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-        -> Oid;
+    -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -43968,7 +43964,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-        -> PartitionDirectory;
+    -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -44201,7 +44197,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-        -> *const ::core::ffi::c_char;
+    -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -44557,7 +44553,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(out: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-        -> TransactionId;
+    -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -44812,7 +44808,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -48856,7 +48852,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-        -> bool;
+    -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -49014,7 +49010,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(string: *const ::core::ffi::c_char) -> *mut List;
     pub fn format_procedure(procedure_oid: Oid) -> *mut ::core::ffi::c_char;

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -47,7 +47,11 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -25598,6 +25602,16 @@ impl Default for ConfigData {
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PGLZ_Strategy {
+    pub min_input_size: int32,
+    pub max_input_size: int32,
+    pub min_comp_rate: int32,
+    pub first_success_by: int32,
+    pub match_size_good: int32,
+    pub match_size_drop: int32,
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AggStatePerTransData {
     pub aggref: *mut Aggref,
@@ -33600,7 +33614,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-    -> *mut ::core::ffi::c_void;
+        -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -33948,7 +33962,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-    -> FullTransactionId;
+        -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -34113,7 +34127,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-    -> bool;
+        -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -34319,7 +34333,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-    -> *mut TupleConversionMap;
+        -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name_attrmap(
         indesc: TupleDesc,
         outdesc: TupleDesc,
@@ -34542,7 +34556,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-    -> Datum;
+        -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -35076,7 +35090,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-    -> *mut TBMSharedIterator;
+        -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -35091,7 +35105,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -36076,7 +36090,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-    -> *mut ExecAuxRowMark;
+        -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -38102,7 +38116,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-    -> bool;
+        -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -38131,7 +38145,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-    -> Size;
+        -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -40280,7 +40294,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-    -> ObjectAddress;
+        -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn have_createdb_privilege() -> bool;
@@ -42002,6 +42016,22 @@ unsafe extern "C-unwind" {
         ControlFile: *mut ControlFileData,
         do_sync: bool,
     );
+    pub static PGLZ_strategy_default: *const PGLZ_Strategy;
+    pub static PGLZ_strategy_always: *const PGLZ_Strategy;
+    pub fn pglz_compress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        strategy: *const PGLZ_Strategy,
+    ) -> int32;
+    pub fn pglz_decompress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        rawsize: int32,
+        check_complete: bool,
+    ) -> int32;
+    pub fn pglz_maximum_compressed_size(rawsize: int32, total_compressed_size: int32) -> int32;
     pub fn ExecInitAgg(
         node: *mut Agg,
         estate: *mut EState,
@@ -42314,7 +42344,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -42328,7 +42358,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -42489,7 +42519,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-    -> bool;
+        -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -42617,7 +42647,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-    -> ::core::ffi::c_ushort;
+        -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -43593,7 +43623,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -43823,7 +43853,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-    -> Relids;
+        -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -44078,7 +44108,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-    -> *mut ParamPathInfo;
+        -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -44593,7 +44623,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-    -> bool;
+        -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -44688,14 +44718,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-    -> *mut List;
+        -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-    -> *mut SortGroupClause;
+        -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-    -> Oid;
+        -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -45336,7 +45366,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-    -> PartitionDirectory;
+        -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -45572,7 +45602,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-    -> *const ::core::ffi::c_char;
+        -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -45936,7 +45966,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-    -> TransactionId;
+        -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -46204,7 +46234,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -50535,7 +50565,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-    -> bool;
+        -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -50701,7 +50731,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg16.rs
+++ b/pgrx-pg-sys/src/include/pg16.rs
@@ -47,11 +47,7 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val {
-            byte | mask
-        } else {
-            byte & !mask
-        }
+        if val { byte | mask } else { byte & !mask }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -33614,7 +33610,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-        -> *mut ::core::ffi::c_void;
+    -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -33962,7 +33958,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-        -> FullTransactionId;
+    -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -34127,7 +34123,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-        -> bool;
+    -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -34333,7 +34329,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-        -> *mut TupleConversionMap;
+    -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name_attrmap(
         indesc: TupleDesc,
         outdesc: TupleDesc,
@@ -34556,7 +34552,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-        -> Datum;
+    -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -35090,7 +35086,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-        -> *mut TBMSharedIterator;
+    -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     #[link_name = "tas__pgrx_cshim"]
     pub fn tas(lock: *mut slock_t) -> ::core::ffi::c_int;
@@ -35105,7 +35101,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -36090,7 +36086,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-        -> *mut ExecAuxRowMark;
+    -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -38116,7 +38112,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-        -> bool;
+    -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -38145,7 +38141,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-        -> Size;
+    -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -40294,7 +40290,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-        -> ObjectAddress;
+    -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn have_createdb_privilege() -> bool;
@@ -42344,7 +42340,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -42358,7 +42354,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -42519,7 +42515,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_uchar;
     pub fn utf8_to_unicode(c: *const ::core::ffi::c_uchar) -> pg_wchar;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-        -> bool;
+    -> bool;
     pub fn pg_utf_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -42647,7 +42643,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-        -> ::core::ffi::c_ushort;
+    -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -43623,7 +43619,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -43853,7 +43849,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-        -> Relids;
+    -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -44108,7 +44104,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-        -> *mut ParamPathInfo;
+    -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -44623,7 +44619,7 @@ unsafe extern "C-unwind" {
         otherquals: *mut *mut List,
     );
     pub fn has_pseudoconstant_clauses(root: *mut PlannerInfo, restrictinfo_list: *mut List)
-        -> bool;
+    -> bool;
     pub fn join_clause_is_movable_to(rinfo: *mut RestrictInfo, baserel: *mut RelOptInfo) -> bool;
     pub fn join_clause_is_movable_into(
         rinfo: *mut RestrictInfo,
@@ -44718,14 +44714,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-        -> *mut List;
+    -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-        -> *mut SortGroupClause;
+    -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-        -> Oid;
+    -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -45366,7 +45362,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-        -> PartitionDirectory;
+    -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -45602,7 +45598,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-        -> *const ::core::ffi::c_char;
+    -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -45966,7 +45962,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-        -> TransactionId;
+    -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -46234,7 +46230,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -50565,7 +50561,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-        -> bool;
+    -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -50731,7 +50727,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -47,11 +47,7 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val {
-            byte | mask
-        } else {
-            byte & !mask
-        }
+        if val { byte | mask } else { byte & !mask }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -34506,7 +34502,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-        -> *mut ::core::ffi::c_void;
+    -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -34858,7 +34854,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-        -> FullTransactionId;
+    -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -35030,7 +35026,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-        -> bool;
+    -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -35239,7 +35235,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-        -> *mut TupleConversionMap;
+    -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name_attrmap(
         indesc: TupleDesc,
         outdesc: TupleDesc,
@@ -35462,7 +35458,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-        -> Datum;
+    -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -36016,7 +36012,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-        -> *mut TBMSharedIterator;
+    -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     pub static mut MyProcNumber: ProcNumber;
     pub static mut ParallelLeaderProcNumber: ProcNumber;
@@ -36032,7 +36028,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -37028,7 +37024,7 @@ unsafe extern "C-unwind" {
     >;
     pub fn pg_popcount_avx512_available() -> bool;
     pub fn pg_popcount_avx512(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int)
-        -> uint64;
+    -> uint64;
     pub fn pg_popcount_masked_avx512(
         buf: *const ::core::ffi::c_char,
         bytes: ::core::ffi::c_int,
@@ -37377,7 +37373,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-        -> *mut ExecAuxRowMark;
+    -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -39463,7 +39459,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-        -> bool;
+    -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -39492,7 +39488,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-        -> Size;
+    -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -41551,7 +41547,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-        -> ObjectAddress;
+    -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn have_createdb_privilege() -> bool;
@@ -43700,7 +43696,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -43714,7 +43710,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -43876,11 +43872,11 @@ unsafe extern "C-unwind" {
     pub fn pg_encoding_max_length(encoding: ::core::ffi::c_int) -> ::core::ffi::c_int;
     pub fn pg_valid_client_encoding(name: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
     pub fn pg_valid_server_encoding_private(name: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn is_encoding_supported_by_icu(encoding: ::core::ffi::c_int) -> bool;
     pub fn get_encoding_name_for_icu(encoding: ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-        -> bool;
+    -> bool;
     pub fn pg_utf_mblen_private(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -44008,7 +44004,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-        -> ::core::ffi::c_ushort;
+    -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -45001,7 +44997,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -45235,7 +45231,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-        -> Relids;
+    -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -45497,7 +45493,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-        -> *mut ParamPathInfo;
+    -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -46133,14 +46129,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-        -> *mut List;
+    -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-        -> *mut SortGroupClause;
+    -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-        -> Oid;
+    -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -46782,7 +46778,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-        -> PartitionDirectory;
+    -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -46992,7 +46988,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-        -> *const ::core::ffi::c_char;
+    -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -47364,7 +47360,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-        -> TransactionId;
+    -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -47663,7 +47659,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -52093,7 +52089,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-        -> bool;
+    -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -52261,7 +52257,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg17.rs
+++ b/pgrx-pg-sys/src/include/pg17.rs
@@ -47,7 +47,11 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -26531,6 +26535,16 @@ impl Default for ConfigData {
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PGLZ_Strategy {
+    pub min_input_size: int32,
+    pub max_input_size: int32,
+    pub min_comp_rate: int32,
+    pub first_success_by: int32,
+    pub match_size_good: int32,
+    pub match_size_drop: int32,
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AggStatePerTransData {
     pub aggref: *mut Aggref,
@@ -34492,7 +34506,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-    -> *mut ::core::ffi::c_void;
+        -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -34844,7 +34858,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tuple: HeapTupleHeader) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-    -> FullTransactionId;
+        -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -35016,7 +35030,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-    -> bool;
+        -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -35225,7 +35239,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-    -> *mut TupleConversionMap;
+        -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name_attrmap(
         indesc: TupleDesc,
         outdesc: TupleDesc,
@@ -35448,7 +35462,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-    -> Datum;
+        -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -36002,7 +36016,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_iterate(iterator: *mut TBMIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-    -> *mut TBMSharedIterator;
+        -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: f64) -> ::core::ffi::c_long;
     pub static mut MyProcNumber: ProcNumber;
     pub static mut ParallelLeaderProcNumber: ProcNumber;
@@ -36018,7 +36032,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -37014,7 +37028,7 @@ unsafe extern "C-unwind" {
     >;
     pub fn pg_popcount_avx512_available() -> bool;
     pub fn pg_popcount_avx512(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int)
-    -> uint64;
+        -> uint64;
     pub fn pg_popcount_masked_avx512(
         buf: *const ::core::ffi::c_char,
         bytes: ::core::ffi::c_int,
@@ -37363,7 +37377,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-    -> *mut ExecAuxRowMark;
+        -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -39449,7 +39463,7 @@ unsafe extern "C-unwind" {
     );
     #[link_name = "table_scan_bitmap_next_block__pgrx_cshim"]
     pub fn table_scan_bitmap_next_block(scan: TableScanDesc, tbmres: *mut TBMIterateResult)
-    -> bool;
+        -> bool;
     #[link_name = "table_scan_bitmap_next_tuple__pgrx_cshim"]
     pub fn table_scan_bitmap_next_tuple(
         scan: TableScanDesc,
@@ -39478,7 +39492,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-    -> Size;
+        -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -41537,7 +41551,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-    -> ObjectAddress;
+        -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn have_createdb_privilege() -> bool;
@@ -43341,6 +43355,22 @@ unsafe extern "C-unwind" {
         ControlFile: *mut ControlFileData,
         do_sync: bool,
     );
+    pub static PGLZ_strategy_default: *const PGLZ_Strategy;
+    pub static PGLZ_strategy_always: *const PGLZ_Strategy;
+    pub fn pglz_compress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        strategy: *const PGLZ_Strategy,
+    ) -> int32;
+    pub fn pglz_decompress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        rawsize: int32,
+        check_complete: bool,
+    ) -> int32;
+    pub fn pglz_maximum_compressed_size(rawsize: int32, total_compressed_size: int32) -> int32;
     pub fn ExecInitAgg(
         node: *mut Agg,
         estate: *mut EState,
@@ -43670,7 +43700,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -43684,7 +43714,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -43846,11 +43876,11 @@ unsafe extern "C-unwind" {
     pub fn pg_encoding_max_length(encoding: ::core::ffi::c_int) -> ::core::ffi::c_int;
     pub fn pg_valid_client_encoding(name: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
     pub fn pg_valid_server_encoding_private(name: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn is_encoding_supported_by_icu(encoding: ::core::ffi::c_int) -> bool;
     pub fn get_encoding_name_for_icu(encoding: ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-    -> bool;
+        -> bool;
     pub fn pg_utf_mblen_private(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -43978,7 +44008,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-    -> ::core::ffi::c_ushort;
+        -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -44971,7 +45001,7 @@ unsafe extern "C-unwind" {
     pub fn contain_var_clause(node: *mut Node) -> bool;
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -45205,7 +45235,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-    -> Relids;
+        -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -45467,7 +45497,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-    -> *mut ParamPathInfo;
+        -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -46103,14 +46133,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-    -> *mut List;
+        -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-    -> *mut SortGroupClause;
+        -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-    -> Oid;
+        -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -46752,7 +46782,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-    -> PartitionDirectory;
+        -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -46962,7 +46992,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-    -> *const ::core::ffi::c_char;
+        -> *const ::core::ffi::c_char;
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_dumptree(func: *mut PLpgSQL_function);
     pub fn plpgsql_base_yylex() -> ::core::ffi::c_int;
@@ -47334,7 +47364,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-    -> TransactionId;
+        -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -47633,7 +47663,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -52063,7 +52093,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-    -> bool;
+        -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -52231,7 +52261,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg18.rs
+++ b/pgrx-pg-sys/src/include/pg18.rs
@@ -47,7 +47,11 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -27837,6 +27841,16 @@ impl Default for ConfigData {
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PGLZ_Strategy {
+    pub min_input_size: int32,
+    pub max_input_size: int32,
+    pub min_comp_rate: int32,
+    pub first_success_by: int32,
+    pub match_size_good: int32,
+    pub match_size_drop: int32,
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AggStatePerTransData {
     pub aggref: *mut Aggref,
@@ -35892,7 +35906,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-    -> *mut ::core::ffi::c_void;
+        -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -36135,12 +36149,12 @@ unsafe extern "C-unwind" {
     pub fn verify_compact_attribute(arg1: TupleDesc, attnum: ::core::ffi::c_int);
     #[link_name = "TupleDescCompactAttr__pgrx_cshim"]
     pub fn TupleDescCompactAttr(tupdesc: TupleDesc, i: ::core::ffi::c_int)
-    -> *mut CompactAttribute;
+        -> *mut CompactAttribute;
     pub fn CreateTemplateTupleDesc(natts: ::core::ffi::c_int) -> TupleDesc;
     pub fn CreateTupleDesc(natts: ::core::ffi::c_int, attrs: *mut Form_pg_attribute) -> TupleDesc;
     pub fn CreateTupleDescCopy(tupdesc: TupleDesc) -> TupleDesc;
     pub fn CreateTupleDescTruncatedCopy(tupdesc: TupleDesc, natts: ::core::ffi::c_int)
-    -> TupleDesc;
+        -> TupleDesc;
     pub fn CreateTupleDescCopyConstr(tupdesc: TupleDesc) -> TupleDesc;
     pub fn TupleDescCopy(dst: TupleDesc, src: TupleDesc);
     pub fn TupleDescCopyEntry(
@@ -36254,7 +36268,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tup: *const HeapTupleHeaderData) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-    -> FullTransactionId;
+        -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -36537,7 +36551,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-    -> bool;
+        -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -36749,7 +36763,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-    -> *mut TupleConversionMap;
+        -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name_attrmap(
         indesc: TupleDesc,
         outdesc: TupleDesc,
@@ -36971,7 +36985,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-    -> Datum;
+        -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -37556,7 +37570,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_private_iterate(iterator: *mut TBMPrivateIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-    -> *mut TBMSharedIterator;
+        -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: Size) -> ::core::ffi::c_int;
     pub fn tbm_begin_iterate(
         tbm: *mut TIDBitmap,
@@ -37581,7 +37595,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -38643,7 +38657,7 @@ unsafe extern "C-unwind" {
     >;
     pub fn pg_popcount_avx512_available() -> bool;
     pub fn pg_popcount_avx512(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int)
-    -> uint64;
+        -> uint64;
     pub fn pg_popcount_masked_avx512(
         buf: *const ::core::ffi::c_char,
         bytes: ::core::ffi::c_int,
@@ -38992,7 +39006,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-    -> *mut ExecAuxRowMark;
+        -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -41462,7 +41476,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-    -> Size;
+        -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -43405,7 +43419,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-    -> ObjectAddress;
+        -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn have_createdb_privilege() -> bool;
@@ -45296,6 +45310,22 @@ unsafe extern "C-unwind" {
         ControlFile: *mut ControlFileData,
         do_sync: bool,
     );
+    pub static PGLZ_strategy_default: *const PGLZ_Strategy;
+    pub static PGLZ_strategy_always: *const PGLZ_Strategy;
+    pub fn pglz_compress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        strategy: *const PGLZ_Strategy,
+    ) -> int32;
+    pub fn pglz_decompress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        rawsize: int32,
+        check_complete: bool,
+    ) -> int32;
+    pub fn pglz_maximum_compressed_size(rawsize: int32, total_compressed_size: int32) -> int32;
     pub fn ExecInitAgg(
         node: *mut Agg,
         estate: *mut EState,
@@ -45630,7 +45660,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -45644,7 +45674,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -45806,11 +45836,11 @@ unsafe extern "C-unwind" {
     pub fn pg_encoding_max_length(encoding: ::core::ffi::c_int) -> ::core::ffi::c_int;
     pub fn pg_valid_client_encoding(name: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
     pub fn pg_valid_server_encoding_private(name: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn is_encoding_supported_by_icu(encoding: ::core::ffi::c_int) -> bool;
     pub fn get_encoding_name_for_icu(encoding: ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-    -> bool;
+        -> bool;
     pub fn pg_utf_mblen_private(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -45938,7 +45968,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-    -> ::core::ffi::c_ushort;
+        -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -46954,7 +46984,7 @@ unsafe extern "C-unwind" {
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn contain_vars_returning_old_or_new(node: *mut Node) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -47198,7 +47228,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-    -> Relids;
+        -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -47460,7 +47490,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-    -> *mut ParamPathInfo;
+        -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -48163,14 +48193,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-    -> *mut List;
+        -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-    -> *mut SortGroupClause;
+        -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-    -> Oid;
+        -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -48817,7 +48847,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-    -> PartitionDirectory;
+        -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -49042,7 +49072,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-    -> *const ::core::ffi::c_char;
+        -> *const ::core::ffi::c_char;
     pub fn plpgsql_mark_local_assignment_targets(func: *mut PLpgSQL_function);
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_delete_callback(cfunc: *mut CachedFunction);
@@ -49454,7 +49484,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-    -> TransactionId;
+        -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -49717,7 +49747,7 @@ unsafe extern "C-unwind" {
         yyscanner: yyscan_t,
     ) -> ::core::ffi::c_int;
     pub fn replication_yylex(yylval_param: *mut YYSTYPE, yyscanner: yyscan_t)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn replication_yyerror(
         replication_parse_result_p: *mut *mut Node,
         yyscanner: yyscan_t,
@@ -49813,7 +49843,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -54320,7 +54350,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-    -> bool;
+        -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -54490,7 +54520,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg18.rs
+++ b/pgrx-pg-sys/src/include/pg18.rs
@@ -47,11 +47,7 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val {
-            byte | mask
-        } else {
-            byte & !mask
-        }
+        if val { byte | mask } else { byte & !mask }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -35906,7 +35902,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-        -> *mut ::core::ffi::c_void;
+    -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -36149,12 +36145,12 @@ unsafe extern "C-unwind" {
     pub fn verify_compact_attribute(arg1: TupleDesc, attnum: ::core::ffi::c_int);
     #[link_name = "TupleDescCompactAttr__pgrx_cshim"]
     pub fn TupleDescCompactAttr(tupdesc: TupleDesc, i: ::core::ffi::c_int)
-        -> *mut CompactAttribute;
+    -> *mut CompactAttribute;
     pub fn CreateTemplateTupleDesc(natts: ::core::ffi::c_int) -> TupleDesc;
     pub fn CreateTupleDesc(natts: ::core::ffi::c_int, attrs: *mut Form_pg_attribute) -> TupleDesc;
     pub fn CreateTupleDescCopy(tupdesc: TupleDesc) -> TupleDesc;
     pub fn CreateTupleDescTruncatedCopy(tupdesc: TupleDesc, natts: ::core::ffi::c_int)
-        -> TupleDesc;
+    -> TupleDesc;
     pub fn CreateTupleDescCopyConstr(tupdesc: TupleDesc) -> TupleDesc;
     pub fn TupleDescCopy(dst: TupleDesc, src: TupleDesc);
     pub fn TupleDescCopyEntry(
@@ -36268,7 +36264,7 @@ unsafe extern "C-unwind" {
     pub fn HeapTupleGetUpdateXid(tup: *const HeapTupleHeaderData) -> TransactionId;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-        -> FullTransactionId;
+    -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -36551,7 +36547,7 @@ unsafe extern "C-unwind" {
         bit: *mut bits8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-        -> bool;
+    -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -36763,7 +36759,7 @@ unsafe extern "C-unwind" {
         msg: *const ::core::ffi::c_char,
     ) -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name(indesc: TupleDesc, outdesc: TupleDesc)
-        -> *mut TupleConversionMap;
+    -> *mut TupleConversionMap;
     pub fn convert_tuples_by_name_attrmap(
         indesc: TupleDesc,
         outdesc: TupleDesc,
@@ -36985,7 +36981,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-        -> Datum;
+    -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -37570,7 +37566,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_private_iterate(iterator: *mut TBMPrivateIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-        -> *mut TBMSharedIterator;
+    -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: Size) -> ::core::ffi::c_int;
     pub fn tbm_begin_iterate(
         tbm: *mut TIDBitmap,
@@ -37595,7 +37591,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -38657,7 +38653,7 @@ unsafe extern "C-unwind" {
     >;
     pub fn pg_popcount_avx512_available() -> bool;
     pub fn pg_popcount_avx512(buf: *const ::core::ffi::c_char, bytes: ::core::ffi::c_int)
-        -> uint64;
+    -> uint64;
     pub fn pg_popcount_masked_avx512(
         buf: *const ::core::ffi::c_char,
         bytes: ::core::ffi::c_int,
@@ -39006,7 +39002,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-        -> *mut ExecAuxRowMark;
+    -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -41476,7 +41472,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-        -> Size;
+    -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -43419,7 +43415,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-        -> ObjectAddress;
+    -> ObjectAddress;
     pub fn get_database_oid(dbname: *const ::core::ffi::c_char, missing_ok: bool) -> Oid;
     pub fn get_database_name(dbid: Oid) -> *mut ::core::ffi::c_char;
     pub fn have_createdb_privilege() -> bool;
@@ -45660,7 +45656,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -45674,7 +45670,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -45836,11 +45832,11 @@ unsafe extern "C-unwind" {
     pub fn pg_encoding_max_length(encoding: ::core::ffi::c_int) -> ::core::ffi::c_int;
     pub fn pg_valid_client_encoding(name: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
     pub fn pg_valid_server_encoding_private(name: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn is_encoding_supported_by_icu(encoding: ::core::ffi::c_int) -> bool;
     pub fn get_encoding_name_for_icu(encoding: ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-        -> bool;
+    -> bool;
     pub fn pg_utf_mblen_private(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mule_mblen(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
@@ -45968,7 +45964,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-        -> ::core::ffi::c_ushort;
+    -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -46984,7 +46980,7 @@ unsafe extern "C-unwind" {
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn contain_vars_returning_old_or_new(node: *mut Node) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -47228,7 +47224,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-        -> Relids;
+    -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -47490,7 +47486,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-        -> *mut ParamPathInfo;
+    -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -48193,14 +48189,14 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-        -> *mut List;
+    -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-        -> *mut SortGroupClause;
+    -> *mut SortGroupClause;
     pub fn assign_query_collations(pstate: *mut ParseState, query: *mut Query);
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-        -> Oid;
+    -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -48847,7 +48843,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-        -> PartitionDirectory;
+    -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -49072,7 +49068,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-        -> *const ::core::ffi::c_char;
+    -> *const ::core::ffi::c_char;
     pub fn plpgsql_mark_local_assignment_targets(func: *mut PLpgSQL_function);
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_delete_callback(cfunc: *mut CachedFunction);
@@ -49484,7 +49480,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-        -> TransactionId;
+    -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -49747,7 +49743,7 @@ unsafe extern "C-unwind" {
         yyscanner: yyscan_t,
     ) -> ::core::ffi::c_int;
     pub fn replication_yylex(yylval_param: *mut YYSTYPE, yyscanner: yyscan_t)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn replication_yyerror(
         replication_parse_result_p: *mut *mut Node,
         yyscanner: yyscan_t,
@@ -49843,7 +49839,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -54350,7 +54346,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-        -> bool;
+    -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -54520,7 +54516,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: bits16)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: bits16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg19.rs
+++ b/pgrx-pg-sys/src/include/pg19.rs
@@ -47,11 +47,7 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val {
-            byte | mask
-        } else {
-            byte & !mask
-        }
+        if val { byte | mask } else { byte & !mask }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -36366,7 +36362,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-        -> *mut ::core::ffi::c_void;
+    -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -36621,12 +36617,12 @@ unsafe extern "C-unwind" {
     pub fn verify_compact_attribute(arg1: TupleDesc, attnum: ::core::ffi::c_int);
     #[link_name = "TupleDescCompactAttr__pgrx_cshim"]
     pub fn TupleDescCompactAttr(tupdesc: TupleDesc, i: ::core::ffi::c_int)
-        -> *mut CompactAttribute;
+    -> *mut CompactAttribute;
     pub fn CreateTemplateTupleDesc(natts: ::core::ffi::c_int) -> TupleDesc;
     pub fn CreateTupleDesc(natts: ::core::ffi::c_int, attrs: *mut Form_pg_attribute) -> TupleDesc;
     pub fn CreateTupleDescCopy(tupdesc: TupleDesc) -> TupleDesc;
     pub fn CreateTupleDescTruncatedCopy(tupdesc: TupleDesc, natts: ::core::ffi::c_int)
-        -> TupleDesc;
+    -> TupleDesc;
     pub fn CreateTupleDescCopyConstr(tupdesc: TupleDesc) -> TupleDesc;
     pub fn TupleDescCopy(dst: TupleDesc, src: TupleDesc);
     pub fn TupleDescCopyEntry(
@@ -36911,7 +36907,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-        -> Datum;
+    -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -37974,7 +37970,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-        -> *mut ExecAuxRowMark;
+    -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -39387,7 +39383,7 @@ unsafe extern "C-unwind" {
     pub fn get_backup_status() -> SessionBackupState::Type;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-        -> FullTransactionId;
+    -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -40442,7 +40438,7 @@ unsafe extern "C-unwind" {
         bit: *mut uint8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-        -> bool;
+    -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -40539,7 +40535,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_private_iterate(iterator: *mut TBMPrivateIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-        -> *mut TBMSharedIterator;
+    -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: Size) -> ::core::ffi::c_int;
     pub fn tbm_begin_iterate(
         tbm: *mut TIDBitmap,
@@ -40562,7 +40558,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -41408,7 +41404,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-        -> Size;
+    -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -42357,7 +42353,7 @@ unsafe extern "C-unwind" {
     pub static mut replorigin_xact_state: ReplOriginXactState;
     pub static mut max_active_replication_origins: ::core::ffi::c_int;
     pub fn replorigin_by_name(roname: *const ::core::ffi::c_char, missing_ok: bool)
-        -> ReplOriginId;
+    -> ReplOriginId;
     pub fn replorigin_create(roname: *const ::core::ffi::c_char) -> ReplOriginId;
     pub fn replorigin_drop_by_name(
         name: *const ::core::ffi::c_char,
@@ -43444,7 +43440,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-        -> ObjectAddress;
+    -> ObjectAddress;
     pub fn have_createdb_privilege() -> bool;
     pub fn check_encoding_locale_matches(
         encoding: ::core::ffi::c_int,
@@ -45625,7 +45621,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -45639,7 +45635,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -45805,11 +45801,11 @@ unsafe extern "C-unwind" {
     pub fn pg_encoding_max_length(encoding: ::core::ffi::c_int) -> ::core::ffi::c_int;
     pub fn pg_valid_client_encoding(name: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
     pub fn pg_valid_server_encoding_private(name: *const ::core::ffi::c_char)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn is_encoding_supported_by_icu(encoding: ::core::ffi::c_int) -> bool;
     pub fn get_encoding_name_for_icu(encoding: ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-        -> bool;
+    -> bool;
     pub fn pg_utf_mblen_private(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar_with_len(
@@ -45936,7 +45932,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-        -> ::core::ffi::c_ushort;
+    -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -46929,7 +46925,7 @@ unsafe extern "C-unwind" {
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn contain_vars_returning_old_or_new(node: *mut Node) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -47180,7 +47176,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-        -> Relids;
+    -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -47447,7 +47443,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-        -> *mut ParamPathInfo;
+    -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -48179,9 +48175,9 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-        -> *mut List;
+    -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-        -> *mut SortGroupClause;
+    -> *mut SortGroupClause;
     pub fn constructSetOpTargetlist(
         pstate: *mut ParseState,
         op: *mut SetOperationStmt,
@@ -48195,7 +48191,7 @@ unsafe extern "C-unwind" {
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-        -> Oid;
+    -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -48865,7 +48861,7 @@ unsafe extern "C-unwind" {
     );
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-        -> PartitionDirectory;
+    -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -49090,7 +49086,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-        -> *const ::core::ffi::c_char;
+    -> *const ::core::ffi::c_char;
     pub fn plpgsql_mark_local_assignment_targets(func: *mut PLpgSQL_function);
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_delete_callback(cfunc: *mut CachedFunction);
@@ -49537,7 +49533,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-        -> TransactionId;
+    -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -49860,7 +49856,7 @@ unsafe extern "C-unwind" {
         yyscanner: yyscan_t,
     ) -> ::core::ffi::c_int;
     pub fn replication_yylex(yylval_param: *mut YYSTYPE, yyscanner: yyscan_t)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn replication_yyerror(
         replication_parse_result_p: *mut *mut Node,
         yyscanner: yyscan_t,
@@ -49956,7 +49952,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -50248,7 +50244,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn FileSize(file: File) -> pgoff_t;
     pub fn FileTruncate(file: File, offset: pgoff_t, wait_event_info: uint32)
-        -> ::core::ffi::c_int;
+    -> ::core::ffi::c_int;
     pub fn FileWriteback(file: File, offset: pgoff_t, nbytes: pgoff_t, wait_event_info: uint32);
     pub fn FilePathName(file: File) -> *mut ::core::ffi::c_char;
     pub fn FileGetRawDesc(file: File) -> ::core::ffi::c_int;
@@ -54830,7 +54826,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-        -> bool;
+    -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -55009,7 +55005,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: uint16)
-        -> *mut ::core::ffi::c_char;
+    -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: uint16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-pg-sys/src/include/pg19.rs
+++ b/pgrx-pg-sys/src/include/pg19.rs
@@ -47,7 +47,11 @@ where
     fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
         let bit_index = if cfg!(target_endian = "big") { 7 - (index % 8) } else { index % 8 };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -158,7 +162,7 @@ pub const ALIGNOF_SHORT: u32 = 2;
 pub const BLCKSZ: u32 = 8192;
 pub const DEF_PGPORT: u32 = 28819;
 pub const DEF_PGPORT_STR: &::core::ffi::CStr = c"28819";
-pub const DLSUFFIX: &::core::ffi::CStr = c".dylib";
+pub const DLSUFFIX: &::core::ffi::CStr = c".so";
 pub const MAXIMUM_ALIGNOF: u32 = 8;
 pub const MEMSET_LOOP_LIMIT: u32 = 1024;
 pub const PACKAGE_BUGREPORT: &::core::ffi::CStr = c"pgsql-bugs@lists.postgresql.org";
@@ -173,7 +177,7 @@ pub const PG_MAJORVERSION_NUM: u32 = 19;
 pub const PG_MINORVERSION_NUM: u32 = 0;
 pub const PG_VERSION: &::core::ffi::CStr = c"19beta1";
 pub const PG_VERSION_NUM: u32 = 190000;
-pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 19beta1 on aarch64-apple-darwin25.4.0, compiled by Apple clang version 21.0.0 (clang-2100.0.123.102), 64-bit" ;
+pub const PG_VERSION_STR : & :: core :: ffi :: CStr = c"PostgreSQL 19beta1 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0, 64-bit" ;
 pub const RELSEG_SIZE: u32 = 131072;
 pub const SIZEOF_INTMAX_T: u32 = 8;
 pub const SIZEOF_LONG: u32 = 8;
@@ -182,14 +186,14 @@ pub const SIZEOF_OFF_T: u32 = 8;
 pub const SIZEOF_SIZE_T: u32 = 8;
 pub const SIZEOF_VOID_P: u32 = 8;
 pub const STDC_HEADERS: u32 = 1;
-pub const STRERROR_R_INT: u32 = 1;
-pub const USE_ARMV8_CRC32C: u32 = 1;
 pub const USE_ASSERT_CHECKING: u32 = 1;
+pub const USE_AVX2_WITH_RUNTIME_CHECK: u32 = 1;
+pub const USE_AVX512_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
+pub const USE_AVX512_POPCNT_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_ICU: u32 = 1;
-pub const USE_PMULL_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
-pub const USE_SVE_POPCNT_WITH_RUNTIME_CHECK: u32 = 1;
-pub const USE_SYSV_SEMAPHORES: u32 = 1;
+pub const USE_SSE42_CRC32C_WITH_RUNTIME_CHECK: u32 = 1;
 pub const USE_SYSV_SHARED_MEMORY: u32 = 1;
+pub const USE_UNNAMED_POSIX_SEMAPHORES: u32 = 1;
 pub const XLOG_BLCKSZ: u32 = 8192;
 pub const DEFAULT_XLOG_SEG_SIZE: u32 = 16777216;
 pub const SLRU_PAGES_PER_SEGMENT: u32 = 32;
@@ -203,56 +207,16 @@ pub const MAXPGPATH: u32 = 1024;
 pub const BITS_PER_BYTE: u32 = 8;
 pub const ALIGNOF_BUFFER: u32 = 32;
 pub const DEFAULT_BACKEND_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 0;
-pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 0;
+pub const DEFAULT_BGWRITER_FLUSH_AFTER: u32 = 64;
+pub const DEFAULT_CHECKPOINT_FLUSH_AFTER: u32 = 32;
 pub const WRITEBACK_MAX_PENDING_FLUSHES: u32 = 256;
 pub const DEFAULT_PGSOCKET_DIR: &::core::ffi::CStr = c"/tmp";
 pub const DEFAULT_EVENT_SOURCE: &::core::ffi::CStr = c"PostgreSQL";
 pub const PG_CACHE_LINE_SIZE: u32 = 128;
 pub const PG_IO_ALIGN_SIZE: u32 = 4096;
-pub const __darwin__: u32 = 1;
 pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const SIGEV_KEVENT: u32 = 4;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SIGSTKSZ: u32 = 131072;
+pub const SIG_ATOMIC_WIDTH: u32 = 32;
 pub const PG_DIAG_SEVERITY: u8 = 83u8;
 pub const PG_DIAG_SEVERITY_NONLOCALIZED: u8 = 86u8;
 pub const PG_DIAG_SQLSTATE: u8 = 67u8;
@@ -271,9 +235,9 @@ pub const PG_DIAG_CONSTRAINT_NAME: u8 = 110u8;
 pub const PG_DIAG_SOURCE_FILE: u8 = 70u8;
 pub const PG_DIAG_SOURCE_LINE: u8 = 76u8;
 pub const PG_DIAG_SOURCE_FUNCTION: u8 = 82u8;
-pub const INT64_FORMAT: &::core::ffi::CStr = c"%lld";
-pub const UINT64_FORMAT: &::core::ffi::CStr = c"%llu";
-pub const OID8_FORMAT: &::core::ffi::CStr = c"%llu";
+pub const INT64_FORMAT: &::core::ffi::CStr = c"%ld";
+pub const UINT64_FORMAT: &::core::ffi::CStr = c"%lu";
+pub const OID8_FORMAT: &::core::ffi::CStr = c"%lu";
 pub const PG_INT8_MIN: i32 = -128;
 pub const PG_INT8_MAX: u32 = 127;
 pub const PG_UINT8_MAX: u32 = 255;
@@ -283,11 +247,7 @@ pub const PG_UINT16_MAX: u32 = 65535;
 pub const PG_INT32_MIN: i32 = -2147483648;
 pub const PG_INT32_MAX: u32 = 2147483647;
 pub const PG_UINT32_MAX: u32 = 4294967295;
-pub const PG_INT64_MIN: i64 = -9223372036854775808;
-pub const PG_INT64_MAX: u64 = 9223372036854775807;
-pub const PG_UINT64_MAX: i32 = -1;
 pub const FLOAT8PASSBYVAL: u32 = 1;
-pub const OID8_MAX: i32 = -1;
 pub const HIGHBIT: u32 = 128;
 pub const ESCAPE_STRING_SYNTAX: u8 = 69u8;
 pub const STATUS_OK: u32 = 0;
@@ -394,10 +354,6 @@ pub const SECS_PER_MINUTE: u32 = 60;
 pub const MINS_PER_HOUR: u32 = 60;
 pub const MAX_TZDISP_HOUR: u32 = 15;
 pub const TZDISP_LIMIT: u32 = 57600;
-pub const TIMESTAMP_MINUS_INFINITY: i64 = -9223372036854775808;
-pub const TIMESTAMP_INFINITY: u64 = 9223372036854775807;
-pub const DT_NOBEGIN: i64 = -9223372036854775808;
-pub const DT_NOEND: u64 = 9223372036854775807;
 pub const JULIAN_MINYEAR: i32 = -4713;
 pub const JULIAN_MINMONTH: u32 = 11;
 pub const JULIAN_MINDAY: u32 = 24;
@@ -483,7 +439,7 @@ pub const PG_DYNSHMEM_DIR: &::core::ffi::CStr = c"pg_dynshmem";
 pub const PG_DYNSHMEM_MMAP_FILE_PREFIX: &::core::ffi::CStr = c"mmap.";
 pub const DSM_CREATE_NULL_IF_MAXSEGMENTS: u32 = 1;
 pub const SIZEOF_DSA_POINTER: u32 = 8;
-pub const DSA_POINTER_FORMAT: &::core::ffi::CStr = c"%016llx";
+pub const DSA_POINTER_FORMAT: &::core::ffi::CStr = c"%016lx";
 pub const DSA_ALLOC_HUGE: u32 = 1;
 pub const DSA_ALLOC_NO_OOM: u32 = 2;
 pub const DSA_ALLOC_ZERO: u32 = 4;
@@ -622,7 +578,6 @@ pub const CURSOR_OPT_FAST_PLAN: u32 = 256;
 pub const CURSOR_OPT_GENERIC_PLAN: u32 = 512;
 pub const CURSOR_OPT_CUSTOM_PLAN: u32 = 1024;
 pub const CURSOR_OPT_PARALLEL_OK: u32 = 2048;
-pub const FETCH_ALL: u64 = 9223372036854775807;
 pub const MaxAllocHugeSize: u32 = 0;
 pub const InvalidAllocSize: i32 = -1;
 pub const ALLOCSET_DEFAULT_MINSIZE: u32 = 0;
@@ -646,6 +601,44 @@ pub const EIIT_NO_DUPE_ERROR: u32 = 2;
 pub const EIIT_ONLY_SUMMARIZING: u32 = 4;
 pub const MAT_SRF_USE_EXPECTED_DESC: u32 = 1;
 pub const MAT_SRF_BLESS: u32 = 2;
+pub const SIGINT: u32 = 2;
+pub const SIGILL: u32 = 4;
+pub const SIGABRT: u32 = 6;
+pub const SIGFPE: u32 = 8;
+pub const SIGSEGV: u32 = 11;
+pub const SIGTERM: u32 = 15;
+pub const SIGHUP: u32 = 1;
+pub const SIGQUIT: u32 = 3;
+pub const SIGTRAP: u32 = 5;
+pub const SIGKILL: u32 = 9;
+pub const SIGPIPE: u32 = 13;
+pub const SIGALRM: u32 = 14;
+pub const SIGIOT: u32 = 6;
+pub const SIGSTKFLT: u32 = 16;
+pub const SIGPWR: u32 = 30;
+pub const SIGBUS: u32 = 7;
+pub const SIGSYS: u32 = 31;
+pub const SIGURG: u32 = 23;
+pub const SIGSTOP: u32 = 19;
+pub const SIGTSTP: u32 = 20;
+pub const SIGCONT: u32 = 18;
+pub const SIGCHLD: u32 = 17;
+pub const SIGTTIN: u32 = 21;
+pub const SIGTTOU: u32 = 22;
+pub const SIGPOLL: u32 = 29;
+pub const SIGXFSZ: u32 = 25;
+pub const SIGXCPU: u32 = 24;
+pub const SIGVTALRM: u32 = 26;
+pub const SIGPROF: u32 = 27;
+pub const SIGUSR1: u32 = 10;
+pub const SIGUSR2: u32 = 12;
+pub const SIGWINCH: u32 = 28;
+pub const SIGIO: u32 = 29;
+pub const SIGCLD: u32 = 17;
+pub const SIG_BLOCK: u32 = 0;
+pub const SIG_UNBLOCK: u32 = 1;
+pub const SIG_SETMASK: u32 = 2;
+pub const SIGSTKSZ: u32 = 8192;
 pub const TZ_STRLEN_MAX: u32 = 255;
 pub const InvalidPid: i32 = -1;
 pub const USE_POSTGRES_DATES: u32 = 0;
@@ -671,9 +664,12 @@ pub const INIT_PG_LOAD_SESSION_LIBS: u32 = 1;
 pub const INIT_PG_OVERRIDE_ALLOW_CONNS: u32 = 2;
 pub const INIT_PG_OVERRIDE_ROLE_LOGIN: u32 = 4;
 pub const TICKS_TO_NS_SHIFT: u32 = 14;
-pub const PG_INSTR_TICKS_TO_NS: u32 = 0;
-pub const PG_INSTR_TSC_CLOCK: u32 = 0;
-pub const PG_INSTR_SYSTEM_CLOCK_NAME: &::core::ffi::CStr = c"clock_gettime (CLOCK_MONOTONIC_RAW)";
+pub const PG_INSTR_TICKS_TO_NS: u32 = 1;
+pub const PG_INSTR_TSC_CLOCK: u32 = 1;
+pub const PG_INSTR_SYSTEM_CLOCK: u32 = 1;
+pub const PG_INSTR_SYSTEM_CLOCK_NAME: &::core::ffi::CStr = c"clock_gettime (CLOCK_MONOTONIC)";
+pub const PG_INSTR_TSC_CLOCK_NAME_FAST: &::core::ffi::CStr = c"RDTSC";
+pub const PG_INSTR_TSC_CLOCK_NAME: &::core::ffi::CStr = c"RDTSCP";
 pub const MIN_XFN_CHARS: u32 = 16;
 pub const MAX_XFN_CHARS: u32 = 40;
 pub const VALID_XFN_CHARS: &::core::ffi::CStr = c"0123456789ABCDEF.history.backup.partial";
@@ -2309,7 +2305,6 @@ pub const RI_TRIGGER_PK: u32 = 1;
 pub const RI_TRIGGER_FK: u32 = 2;
 pub const RI_TRIGGER_NONE: u32 = 0;
 pub const MAX_ENCRYPTED_PASSWORD_LEN: u32 = 512;
-pub const MAX_KILOBYTES: u32 = 2147483647;
 pub const PG_AUTOCONF_FILENAME: &::core::ffi::CStr = c"postgresql.auto.conf";
 pub const GUC_QUALIFIER_SEPARATOR: u8 = 46u8;
 pub const GUC_LIST_INPUT: u32 = 1;
@@ -2594,7 +2589,7 @@ pub const IO_DIRECT_DATA: u32 = 1;
 pub const IO_DIRECT_WAL: u32 = 2;
 pub const IO_DIRECT_WAL_INIT: u32 = 4;
 pub const DEFAULT_FILE_EXTEND_METHOD: u32 = 0;
-pub const PG_O_DIRECT: u32 = 2147483648;
+pub const PG_O_DIRECT: u32 = 16384;
 pub const DSHASH_INSERT_NO_OOM: u32 = 1;
 pub const XLOG_STANDBY_LOCK: u32 = 0;
 pub const XLOG_RUNNING_XACTS: u32 = 16;
@@ -6256,100 +6251,76 @@ pub const RANGESTRAT_CONTAINS: u32 = 7;
 pub const RANGESTRAT_CONTAINED_BY: u32 = 8;
 pub const RANGESTRAT_CONTAINS_ELEM: u32 = 16;
 pub const RANGESTRAT_EQ: u32 = 18;
-pub type __uint8_t = ::core::ffi::c_uchar;
 pub type __uint16_t = ::core::ffi::c_ushort;
-pub type __int32_t = ::core::ffi::c_int;
 pub type __uint32_t = ::core::ffi::c_uint;
-pub type __int64_t = ::core::ffi::c_longlong;
-pub type __uint64_t = ::core::ffi::c_ulonglong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
+pub type __uint64_t = ::core::ffi::c_ulong;
+pub type __uint_least16_t = __uint16_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __uid_t = ::core::ffi::c_uint;
+pub type __gid_t = ::core::ffi::c_uint;
+pub type __ino_t = ::core::ffi::c_ulong;
+pub type __mode_t = ::core::ffi::c_uint;
+pub type __off_t = ::core::ffi::c_long;
+pub type __off64_t = ::core::ffi::c_long;
+pub type __pid_t = ::core::ffi::c_int;
+pub type __socklen_t = ::core::ffi::c_uint;
+pub type __sig_atomic_t = ::core::ffi::c_int;
+pub type __gnuc_va_list = __builtin_va_list;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::core::ffi::c_long,
-    pub __opaque: [::core::ffi::c_char; 56usize],
-}
-impl Default for _opaque_pthread_mutex_t {
-    fn default() -> Self {
-        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type va_list = __darwin_va_list;
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::core::ffi::c_uchar,
-    pub _size: ::core::ffi::c_int,
-}
-impl Default for __sbuf {
-    fn default() -> Self {
-        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::core::ffi::c_uchar,
-    pub _r: ::core::ffi::c_int,
-    pub _w: ::core::ffi::c_int,
-    pub _flags: ::core::ffi::c_short,
-    pub _file: ::core::ffi::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::core::ffi::c_int,
-    pub _cookie: *mut ::core::ffi::c_void,
-    pub _close: ::core::option::Option<
-        unsafe extern "C-unwind" fn(arg1: *mut ::core::ffi::c_void) -> ::core::ffi::c_int,
-    >,
-    pub _read: ::core::option::Option<
-        unsafe extern "C-unwind" fn(
-            arg1: *mut ::core::ffi::c_void,
-            arg2: *mut ::core::ffi::c_char,
-            __n: ::core::ffi::c_int,
-        ) -> ::core::ffi::c_int,
-    >,
-    pub _seek: ::core::option::Option<
-        unsafe extern "C-unwind" fn(
-            arg1: *mut ::core::ffi::c_void,
-            arg2: fpos_t,
-            arg3: ::core::ffi::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::core::option::Option<
-        unsafe extern "C-unwind" fn(
-            arg1: *mut ::core::ffi::c_void,
-            arg2: *const ::core::ffi::c_char,
-            __n: ::core::ffi::c_int,
-        ) -> ::core::ffi::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::core::ffi::c_int,
-    pub _ubuf: [::core::ffi::c_uchar; 3usize],
-    pub _nbuf: [::core::ffi::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::core::ffi::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
 }
-impl Default for __sFILE {
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::core::ffi::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::core::ffi::c_int,
+    pub _IO_read_ptr: *mut ::core::ffi::c_char,
+    pub _IO_read_end: *mut ::core::ffi::c_char,
+    pub _IO_read_base: *mut ::core::ffi::c_char,
+    pub _IO_write_base: *mut ::core::ffi::c_char,
+    pub _IO_write_ptr: *mut ::core::ffi::c_char,
+    pub _IO_write_end: *mut ::core::ffi::c_char,
+    pub _IO_buf_base: *mut ::core::ffi::c_char,
+    pub _IO_buf_end: *mut ::core::ffi::c_char,
+    pub _IO_save_base: *mut ::core::ffi::c_char,
+    pub _IO_backup_base: *mut ::core::ffi::c_char,
+    pub _IO_save_end: *mut ::core::ffi::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::core::ffi::c_int,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
+    pub _short_backupbuf: [::core::ffi::c_char; 1usize],
+    pub _old_offset: __off_t,
+    pub _cur_column: ::core::ffi::c_ushort,
+    pub _vtable_offset: ::core::ffi::c_schar,
+    pub _shortbuf: [::core::ffi::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::core::ffi::c_void,
+    pub _prevchain: *mut *mut _IO_FILE,
+    pub _mode: ::core::ffi::c_int,
+    pub _unused3: ::core::ffi::c_int,
+    pub _total_written: __uint64_t,
+    pub _unused2: [::core::ffi::c_char; 8usize],
+}
+impl Default for _IO_FILE {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -6358,11 +6329,61 @@ impl Default for __sFILE {
         }
     }
 }
-pub type FILE = __sFILE;
-pub type off_t = __darwin_off_t;
-pub type pid_t = __darwin_pid_t;
-pub type sig_atomic_t = ::core::ffi::c_int;
-pub type mode_t = __darwin_mode_t;
+impl _IO_FILE {
+    #[inline]
+    pub fn _flags2(&self) -> ::core::ffi::c_int {
+        unsafe { ::core::mem::transmute(self._bitfield_1.get(0usize, 24u8) as u32) }
+    }
+    #[inline]
+    pub fn set__flags2(&mut self, val: ::core::ffi::c_int) {
+        unsafe {
+            let val: u32 = ::core::mem::transmute(val);
+            self._bitfield_1.set(0usize, 24u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn _flags2_raw(this: *const Self) -> ::core::ffi::c_int {
+        unsafe {
+            ::core::mem::transmute(<__BindgenBitfieldUnit<[u8; 3usize]>>::raw_get(
+                ::core::ptr::addr_of!((*this)._bitfield_1),
+                0usize,
+                24u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set__flags2_raw(this: *mut Self, val: ::core::ffi::c_int) {
+        unsafe {
+            let val: u32 = ::core::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 3usize]>>::raw_set(
+                ::core::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                24u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(_flags2: ::core::ffi::c_int) -> __BindgenBitfieldUnit<[u8; 3usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 24u8, {
+            let _flags2: u32 = unsafe { ::core::mem::transmute(_flags2) };
+            _flags2 as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type va_list = __gnuc_va_list;
+pub type off_t = __off_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::core::ffi::c_ulong; 16usize],
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct lconv {
@@ -6385,8 +6406,8 @@ pub struct lconv {
     pub p_sign_posn: ::core::ffi::c_char,
     pub n_sign_posn: ::core::ffi::c_char,
     pub int_p_cs_precedes: ::core::ffi::c_char,
-    pub int_n_cs_precedes: ::core::ffi::c_char,
     pub int_p_sep_by_space: ::core::ffi::c_char,
+    pub int_n_cs_precedes: ::core::ffi::c_char,
     pub int_n_sep_by_space: ::core::ffi::c_char,
     pub int_p_sign_posn: ::core::ffi::c_char,
     pub int_n_sign_posn: ::core::ffi::c_char,
@@ -6557,9 +6578,17 @@ pub type pqsigfunc = ::core::option::Option<
         pg_siginfo: *const pg_signal_info,
     ),
 >;
-pub type char16_t = u16;
-pub type char32_t = u32;
-pub type sigjmp_buf = [::core::ffi::c_int; 49usize];
+pub type char16_t = __uint_least16_t;
+pub type char32_t = __uint_least32_t;
+pub type __jmp_buf = [::core::ffi::c_long; 8usize];
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __jmp_buf_tag {
+    pub __jmpbuf: __jmp_buf,
+    pub __mask_was_saved: ::core::ffi::c_int,
+    pub __saved_mask: __sigset_t,
+}
+pub type sigjmp_buf = [__jmp_buf_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StringInfoData {
@@ -7707,6 +7736,21 @@ impl Default for TupleDescData {
     }
 }
 pub type TupleDesc = *mut TupleDescData;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct iovec {
+    pub iov_base: *mut ::core::ffi::c_void,
+    pub iov_len: usize,
+}
+impl Default for iovec {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 pub type XLogRecPtr = uint64;
 pub type XLogSegNo = uint64;
 pub type TimeLineID = uint32;
@@ -11257,7 +11301,7 @@ pub type on_dsm_detach_callback =
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct pg_atomic_flag {
-    pub value: ::core::ffi::c_int,
+    pub value: ::core::ffi::c_char,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -18582,6 +18626,15 @@ pub mod TypeFuncClass {
     pub const TYPEFUNC_RECORD: Type = 3;
     pub const TYPEFUNC_OTHER: Type = 4;
 }
+pub type sig_atomic_t = __sig_atomic_t;
+pub mod _bindgen_ty_13 {
+    pub type Type = ::core::ffi::c_uint;
+    pub const SIGEV_SIGNAL: Type = 0;
+    pub const SIGEV_NONE: Type = 1;
+    pub const SIGEV_THREAD: Type = 2;
+    pub const SIGEV_THREAD_ID: Type = 4;
+}
+pub type socklen_t = __socklen_t;
 pub type pg_time_t = int64;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -18663,6 +18716,23 @@ pub mod TimingClockSourceType {
     pub type Type = ::core::ffi::c_uint;
     pub const TIMING_CLOCK_SOURCE_AUTO: Type = 0;
     pub const TIMING_CLOCK_SOURCE_SYSTEM: Type = 1;
+    pub const TIMING_CLOCK_SOURCE_TSC: Type = 2;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct TscClockSourceInfo {
+    pub frequency_khz: int32,
+    pub calibrated_frequency_khz: int32,
+    pub frequency_source: [::core::ffi::c_char; 128usize],
+}
+impl Default for TscClockSourceInfo {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
 pub mod ConflictType {
     pub type Type = ::core::ffi::c_uint;
@@ -18730,31 +18800,13 @@ pub mod ProgressCommandType {
     pub const PROGRESS_COMMAND_REPACK: Type = 6;
     pub const PROGRESS_COMMAND_DATACHECKSUMS: Type = 7;
 }
-pub type sa_family_t = __uint8_t;
-pub type socklen_t = __darwin_socklen_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct iovec {
-    pub iov_base: *mut ::core::ffi::c_void,
-    pub iov_len: usize,
-}
-impl Default for iovec {
-    fn default() -> Self {
-        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type sa_family_t = ::core::ffi::c_ushort;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
-    pub ss_len: __uint8_t,
     pub ss_family: sa_family_t,
-    pub __ss_pad1: [::core::ffi::c_char; 6usize],
-    pub __ss_align: __int64_t,
-    pub __ss_pad2: [::core::ffi::c_char; 112usize],
+    pub __ss_padding: [::core::ffi::c_char; 118usize],
+    pub __ss_align: ::core::ffi::c_ulong,
 }
 impl Default for sockaddr_storage {
     fn default() -> Self {
@@ -21834,7 +21886,7 @@ impl Default for TBMIterateResult {
         }
     }
 }
-pub type slock_t = ::core::ffi::c_int;
+pub type slock_t = ::core::ffi::c_uchar;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SpinDelayStatus {
@@ -27930,6 +27982,16 @@ impl Default for ConfigData {
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct PGLZ_Strategy {
+    pub min_input_size: int32,
+    pub max_input_size: int32,
+    pub min_comp_rate: int32,
+    pub first_success_by: int32,
+    pub match_size_good: int32,
+    pub match_size_drop: int32,
+}
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AggStatePerTransData {
     pub aggref: *mut Aggref,
@@ -30909,7 +30971,7 @@ pub mod PLpgSQL_stmt_type {
     pub const PLPGSQL_STMT_COMMIT: Type = 25;
     pub const PLPGSQL_STMT_ROLLBACK: Type = 26;
 }
-pub mod _bindgen_ty_1 {
+pub mod _bindgen_ty_26 {
     pub type Type = ::core::ffi::c_uint;
     pub const PLPGSQL_RC_OK: Type = 0;
     pub const PLPGSQL_RC_EXIT: Type = 1;
@@ -32101,7 +32163,7 @@ pub struct PipeProtoHeader {
 #[repr(C)]
 pub union PipeProtoChunk {
     pub proto: ::core::mem::ManuallyDrop<PipeProtoHeader>,
-    pub filler: ::core::mem::ManuallyDrop<[::core::ffi::c_char; 512usize]>,
+    pub filler: ::core::mem::ManuallyDrop<[::core::ffi::c_char; 4096usize]>,
 }
 impl Default for PipeProtoChunk {
     fn default() -> Self {
@@ -33617,12 +33679,11 @@ pub mod StartBufferIOResult {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dirent {
-    pub d_ino: __uint64_t,
-    pub d_seekoff: __uint64_t,
-    pub d_reclen: __uint16_t,
-    pub d_namlen: __uint16_t,
-    pub d_type: __uint8_t,
-    pub d_name: [::core::ffi::c_char; 1024usize],
+    pub d_ino: __ino_t,
+    pub d_off: __off_t,
+    pub d_reclen: ::core::ffi::c_ushort,
+    pub d_type: ::core::ffi::c_uchar,
+    pub d_name: [::core::ffi::c_char; 256usize],
 }
 impl Default for dirent {
     fn default() -> Self {
@@ -33635,36 +33696,15 @@ impl Default for dirent {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _telldir {
+pub struct __dirstream {
     _unused: [u8; 0],
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct DIR {
-    pub __dd_fd: ::core::ffi::c_int,
-    pub __dd_loc: usize,
-    pub __dd_size: usize,
-    pub __dd_buf: *mut ::core::ffi::c_char,
-    pub __dd_len: ::core::ffi::c_int,
-    pub __dd_seek: ::core::ffi::c_long,
-    pub __padding: ::core::ffi::c_long,
-    pub __dd_flags: ::core::ffi::c_int,
-    pub __dd_lock: __darwin_pthread_mutex_t,
-    pub __dd_td: *mut _telldir,
-}
-impl Default for DIR {
-    fn default() -> Self {
-        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
+pub type DIR = __dirstream;
 pub type File = ::core::ffi::c_int;
 pub mod FileExtendMethod {
     pub type Type = ::core::ffi::c_uint;
-    pub const FILE_EXTEND_METHOD_WRITE_ZEROS: Type = 0;
+    pub const FILE_EXTEND_METHOD_POSIX_FALLOCATE: Type = 0;
+    pub const FILE_EXTEND_METHOD_WRITE_ZEROS: Type = 1;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -35773,7 +35813,24 @@ impl Default for ClosestMatchState {
         }
     }
 }
-pub type __builtin_va_list = *mut ::core::ffi::c_char;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::core::ffi::c_uint,
+    pub fp_offset: ::core::ffi::c_uint,
+    pub overflow_arg_area: *mut ::core::ffi::c_void,
+    pub reg_save_area: *mut ::core::ffi::c_void,
+}
+impl Default for __va_list_tag {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AttrMissing {
@@ -35871,7 +35928,6 @@ unsafe extern "C-unwind" {
         fileName: *const ::core::ffi::c_char,
         lineNumber: ::core::ffi::c_int,
     );
-    pub fn fdatasync(fd: ::core::ffi::c_int) -> ::core::ffi::c_int;
     pub fn pg_set_noblock(sock: pgsocket) -> bool;
     pub fn pg_set_block(sock: pgsocket) -> bool;
     pub fn has_drive_prefix(path: *const ::core::ffi::c_char) -> bool;
@@ -35982,7 +36038,7 @@ unsafe extern "C-unwind" {
         str_: *mut ::core::ffi::c_char,
         count: usize,
         fmt: *const ::core::ffi::c_char,
-        args: va_list,
+        args: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
     pub fn pg_snprintf(
         str_: *mut ::core::ffi::c_char,
@@ -35993,7 +36049,7 @@ unsafe extern "C-unwind" {
     pub fn pg_vsprintf(
         str_: *mut ::core::ffi::c_char,
         fmt: *const ::core::ffi::c_char,
-        args: va_list,
+        args: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
     pub fn pg_sprintf(
         str_: *mut ::core::ffi::c_char,
@@ -36003,14 +36059,17 @@ unsafe extern "C-unwind" {
     pub fn pg_vfprintf(
         stream: *mut FILE,
         fmt: *const ::core::ffi::c_char,
-        args: va_list,
+        args: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
     pub fn pg_fprintf(
         stream: *mut FILE,
         fmt: *const ::core::ffi::c_char,
         ...
     ) -> ::core::ffi::c_int;
-    pub fn pg_vprintf(fmt: *const ::core::ffi::c_char, args: va_list) -> ::core::ffi::c_int;
+    pub fn pg_vprintf(
+        fmt: *const ::core::ffi::c_char,
+        args: *mut __va_list_tag,
+    ) -> ::core::ffi::c_int;
     pub fn pg_printf(fmt: *const ::core::ffi::c_char, ...) -> ::core::ffi::c_int;
     pub fn pg_strfromd(
         str_: *mut ::core::ffi::c_char,
@@ -36027,7 +36086,16 @@ unsafe extern "C-unwind" {
     pub fn pg_strsignal(signum: ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn pclose_check(stream: *mut FILE) -> ::core::ffi::c_int;
     pub fn rmtree(path: *const ::core::ffi::c_char, rmtopdir: bool) -> bool;
-    pub fn explicit_bzero(buf: *mut ::core::ffi::c_void, len: usize);
+    pub fn getpeereid(
+        sock: ::core::ffi::c_int,
+        uid: *mut uid_t,
+        gid: *mut gid_t,
+    ) -> ::core::ffi::c_int;
+    pub fn timingsafe_bcmp(
+        b1: *const ::core::ffi::c_void,
+        b2: *const ::core::ffi::c_void,
+        n: usize,
+    ) -> ::core::ffi::c_int;
     pub fn pg_qsort(
         base: *mut ::core::ffi::c_void,
         nel: usize,
@@ -36128,7 +36196,7 @@ unsafe extern "C-unwind" {
     pub fn appendStringInfoVA(
         str_: StringInfo,
         fmt: *const ::core::ffi::c_char,
-        args: va_list,
+        args: *mut __va_list_tag,
     ) -> ::core::ffi::c_int;
     pub fn appendStringInfoString(str_: StringInfo, s: *const ::core::ffi::c_char);
     pub fn appendStringInfoChar(str_: StringInfo, ch: ::core::ffi::c_char);
@@ -36241,7 +36309,7 @@ unsafe extern "C-unwind" {
     pub fn write_csvlog(edata: *mut ErrorData);
     pub fn write_jsonlog(edata: *mut ErrorData);
     pub fn write_stderr(fmt: *const ::core::ffi::c_char, ...);
-    pub fn vwrite_stderr(fmt: *const ::core::ffi::c_char, ap: va_list);
+    pub fn vwrite_stderr(fmt: *const ::core::ffi::c_char, ap: *mut __va_list_tag);
     pub static mut CurrentMemoryContext: MemoryContext;
     pub fn MemoryContextAlloc(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocZero(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
@@ -36298,7 +36366,7 @@ unsafe extern "C-unwind" {
     ) -> *mut ::core::ffi::c_void;
     pub fn MemoryContextAllocHuge(context: MemoryContext, size: Size) -> *mut ::core::ffi::c_void;
     pub fn repalloc_huge(pointer: *mut ::core::ffi::c_void, size: Size)
-    -> *mut ::core::ffi::c_void;
+        -> *mut ::core::ffi::c_void;
     pub fn MemoryContextRegisterResetCallback(
         context: MemoryContext,
         cb: *mut MemoryContextCallback,
@@ -36319,7 +36387,7 @@ unsafe extern "C-unwind" {
         buf: *mut ::core::ffi::c_char,
         len: usize,
         fmt: *const ::core::ffi::c_char,
-        args: va_list,
+        args: *mut __va_list_tag,
     ) -> usize;
     #[link_name = "DatumGetBool__pgrx_cshim"]
     pub fn DatumGetBool(X: Datum) -> bool;
@@ -36553,12 +36621,12 @@ unsafe extern "C-unwind" {
     pub fn verify_compact_attribute(arg1: TupleDesc, attnum: ::core::ffi::c_int);
     #[link_name = "TupleDescCompactAttr__pgrx_cshim"]
     pub fn TupleDescCompactAttr(tupdesc: TupleDesc, i: ::core::ffi::c_int)
-    -> *mut CompactAttribute;
+        -> *mut CompactAttribute;
     pub fn CreateTemplateTupleDesc(natts: ::core::ffi::c_int) -> TupleDesc;
     pub fn CreateTupleDesc(natts: ::core::ffi::c_int, attrs: *mut Form_pg_attribute) -> TupleDesc;
     pub fn CreateTupleDescCopy(tupdesc: TupleDesc) -> TupleDesc;
     pub fn CreateTupleDescTruncatedCopy(tupdesc: TupleDesc, natts: ::core::ffi::c_int)
-    -> TupleDesc;
+        -> TupleDesc;
     pub fn CreateTupleDescCopyConstr(tupdesc: TupleDesc) -> TupleDesc;
     pub fn TupleDescCopy(dst: TupleDesc, src: TupleDesc);
     pub fn TupleDescCopyEntry(
@@ -36843,7 +36911,7 @@ unsafe extern "C-unwind" {
     pub fn OidFunctionCall0Coll(functionId: Oid, collation: Oid) -> Datum;
     pub fn OidFunctionCall1Coll(functionId: Oid, collation: Oid, arg1: Datum) -> Datum;
     pub fn OidFunctionCall2Coll(functionId: Oid, collation: Oid, arg1: Datum, arg2: Datum)
-    -> Datum;
+        -> Datum;
     pub fn OidFunctionCall3Coll(
         functionId: Oid,
         collation: Oid,
@@ -37230,40 +37298,42 @@ unsafe extern "C-unwind" {
         arg: Datum,
     );
     pub fn reset_on_dsm_detach();
+    #[link_name = "pg_spin_delay_impl__pgrx_cshim"]
+    pub fn pg_spin_delay_impl();
     #[link_name = "pg_atomic_test_set_flag_impl__pgrx_cshim"]
     pub fn pg_atomic_test_set_flag_impl(ptr: *mut pg_atomic_flag) -> bool;
-    #[link_name = "pg_atomic_unlocked_test_flag_impl__pgrx_cshim"]
-    pub fn pg_atomic_unlocked_test_flag_impl(ptr: *mut pg_atomic_flag) -> bool;
     #[link_name = "pg_atomic_clear_flag_impl__pgrx_cshim"]
     pub fn pg_atomic_clear_flag_impl(ptr: *mut pg_atomic_flag);
-    #[link_name = "pg_atomic_init_flag_impl__pgrx_cshim"]
-    pub fn pg_atomic_init_flag_impl(ptr: *mut pg_atomic_flag);
     #[link_name = "pg_atomic_compare_exchange_u32_impl__pgrx_cshim"]
     pub fn pg_atomic_compare_exchange_u32_impl(
         ptr: *mut pg_atomic_uint32,
         expected: *mut uint32,
         newval: uint32,
     ) -> bool;
-    #[link_name = "pg_atomic_exchange_u32_impl__pgrx_cshim"]
-    pub fn pg_atomic_exchange_u32_impl(ptr: *mut pg_atomic_uint32, newval: uint32) -> uint32;
     #[link_name = "pg_atomic_fetch_add_u32_impl__pgrx_cshim"]
     pub fn pg_atomic_fetch_add_u32_impl(ptr: *mut pg_atomic_uint32, add_: int32) -> uint32;
-    #[link_name = "pg_atomic_fetch_sub_u32_impl__pgrx_cshim"]
-    pub fn pg_atomic_fetch_sub_u32_impl(ptr: *mut pg_atomic_uint32, sub_: int32) -> uint32;
-    #[link_name = "pg_atomic_fetch_and_u32_impl__pgrx_cshim"]
-    pub fn pg_atomic_fetch_and_u32_impl(ptr: *mut pg_atomic_uint32, and_: uint32) -> uint32;
-    #[link_name = "pg_atomic_fetch_or_u32_impl__pgrx_cshim"]
-    pub fn pg_atomic_fetch_or_u32_impl(ptr: *mut pg_atomic_uint32, or_: uint32) -> uint32;
     #[link_name = "pg_atomic_compare_exchange_u64_impl__pgrx_cshim"]
     pub fn pg_atomic_compare_exchange_u64_impl(
         ptr: *mut pg_atomic_uint64,
         expected: *mut uint64,
         newval: uint64,
     ) -> bool;
-    #[link_name = "pg_atomic_exchange_u64_impl__pgrx_cshim"]
-    pub fn pg_atomic_exchange_u64_impl(ptr: *mut pg_atomic_uint64, newval: uint64) -> uint64;
     #[link_name = "pg_atomic_fetch_add_u64_impl__pgrx_cshim"]
     pub fn pg_atomic_fetch_add_u64_impl(ptr: *mut pg_atomic_uint64, add_: int64) -> uint64;
+    #[link_name = "pg_atomic_unlocked_test_flag_impl__pgrx_cshim"]
+    pub fn pg_atomic_unlocked_test_flag_impl(ptr: *mut pg_atomic_flag) -> bool;
+    #[link_name = "pg_atomic_init_flag_impl__pgrx_cshim"]
+    pub fn pg_atomic_init_flag_impl(ptr: *mut pg_atomic_flag);
+    #[link_name = "pg_atomic_exchange_u32_impl__pgrx_cshim"]
+    pub fn pg_atomic_exchange_u32_impl(ptr: *mut pg_atomic_uint32, newval: uint32) -> uint32;
+    #[link_name = "pg_atomic_fetch_sub_u32_impl__pgrx_cshim"]
+    pub fn pg_atomic_fetch_sub_u32_impl(ptr: *mut pg_atomic_uint32, sub_: int32) -> uint32;
+    #[link_name = "pg_atomic_fetch_and_u32_impl__pgrx_cshim"]
+    pub fn pg_atomic_fetch_and_u32_impl(ptr: *mut pg_atomic_uint32, and_: uint32) -> uint32;
+    #[link_name = "pg_atomic_fetch_or_u32_impl__pgrx_cshim"]
+    pub fn pg_atomic_fetch_or_u32_impl(ptr: *mut pg_atomic_uint32, or_: uint32) -> uint32;
+    #[link_name = "pg_atomic_exchange_u64_impl__pgrx_cshim"]
+    pub fn pg_atomic_exchange_u64_impl(ptr: *mut pg_atomic_uint64, newval: uint64) -> uint64;
     #[link_name = "pg_atomic_fetch_sub_u64_impl__pgrx_cshim"]
     pub fn pg_atomic_fetch_sub_u64_impl(ptr: *mut pg_atomic_uint64, sub_: int64) -> uint64;
     #[link_name = "pg_atomic_fetch_and_u64_impl__pgrx_cshim"]
@@ -37904,7 +37974,7 @@ unsafe extern "C-unwind" {
     ) -> LockTupleMode::Type;
     pub fn ExecFindRowMark(estate: *mut EState, rti: Index, missing_ok: bool) -> *mut ExecRowMark;
     pub fn ExecBuildAuxRowMark(erm: *mut ExecRowMark, targetlist: *mut List)
-    -> *mut ExecAuxRowMark;
+        -> *mut ExecAuxRowMark;
     pub fn EvalPlanQual(
         epqstate: *mut EPQState,
         relation: Relation,
@@ -38611,6 +38681,8 @@ unsafe extern "C-unwind" {
     pub fn pg_set_timing_clock_source(source: TimingClockSourceType::Type) -> bool;
     pub static mut timing_tsc_enabled: bool;
     pub static mut timing_tsc_frequency_khz: int32;
+    pub fn pg_initialize_timing_tsc();
+    pub fn pg_timing_tsc_clock_source_info() -> *const TscClockSourceInfo;
     #[link_name = "pg_current_timing_clock_source__pgrx_cshim"]
     pub fn pg_current_timing_clock_source() -> TimingClockSourceType::Type;
     #[link_name = "pg_get_ticks_system__pgrx_cshim"]
@@ -38619,6 +38691,10 @@ unsafe extern "C-unwind" {
     pub fn pg_ticks_to_ns(ticks: int64) -> int64;
     #[link_name = "pg_ns_to_ticks__pgrx_cshim"]
     pub fn pg_ns_to_ticks(ns: int64) -> int64;
+    #[link_name = "pg_rdtsc__pgrx_cshim"]
+    pub fn pg_rdtsc() -> int64;
+    #[link_name = "pg_rdtscp__pgrx_cshim"]
+    pub fn pg_rdtscp() -> int64;
     #[link_name = "pg_get_ticks__pgrx_cshim"]
     pub fn pg_get_ticks() -> instr_time;
     #[link_name = "pg_get_ticks_fast__pgrx_cshim"]
@@ -39311,7 +39387,7 @@ unsafe extern "C-unwind" {
     pub fn get_backup_status() -> SessionBackupState::Type;
     #[link_name = "FullTransactionIdFromEpochAndXid__pgrx_cshim"]
     pub fn FullTransactionIdFromEpochAndXid(epoch: uint32, xid: TransactionId)
-    -> FullTransactionId;
+        -> FullTransactionId;
     #[link_name = "FullTransactionIdFromU64__pgrx_cshim"]
     pub fn FullTransactionIdFromU64(value: uint64) -> FullTransactionId;
     #[link_name = "FullTransactionIdRetreat__pgrx_cshim"]
@@ -39372,6 +39448,11 @@ unsafe extern "C-unwind" {
     pub fn RmgrIdIsBuiltin(rmid: ::core::ffi::c_int) -> bool;
     #[link_name = "RmgrIdIsCustom__pgrx_cshim"]
     pub fn RmgrIdIsCustom(rmid: ::core::ffi::c_int) -> bool;
+    pub fn pg_comp_crc32c_sb8(
+        crc: pg_crc32c,
+        data: *const ::core::ffi::c_void,
+        len: usize,
+    ) -> pg_crc32c;
     pub static mut pg_comp_crc32c: ::core::option::Option<
         unsafe extern "C-unwind" fn(
             crc: pg_crc32c,
@@ -39379,12 +39460,12 @@ unsafe extern "C-unwind" {
             len: usize,
         ) -> pg_crc32c,
     >;
-    pub fn pg_comp_crc32c_armv8(
+    pub fn pg_comp_crc32c_sse42(
         crc: pg_crc32c,
         data: *const ::core::ffi::c_void,
         len: usize,
     ) -> pg_crc32c;
-    pub fn pg_comp_crc32c_pmull(
+    pub fn pg_comp_crc32c_avx512(
         crc: pg_crc32c,
         data: *const ::core::ffi::c_void,
         len: usize,
@@ -40361,7 +40442,7 @@ unsafe extern "C-unwind" {
         bit: *mut uint8,
     );
     pub fn heap_attisnull(tup: HeapTuple, attnum: ::core::ffi::c_int, tupleDesc: TupleDesc)
-    -> bool;
+        -> bool;
     pub fn nocachegetattr(
         tup: HeapTuple,
         attnum: ::core::ffi::c_int,
@@ -40458,7 +40539,7 @@ unsafe extern "C-unwind" {
     pub fn tbm_end_private_iterate(iterator: *mut TBMPrivateIterator);
     pub fn tbm_end_shared_iterate(iterator: *mut TBMSharedIterator);
     pub fn tbm_attach_shared_iterate(dsa: *mut dsa_area, dp: dsa_pointer)
-    -> *mut TBMSharedIterator;
+        -> *mut TBMSharedIterator;
     pub fn tbm_calculate_entries(maxbytes: Size) -> ::core::ffi::c_int;
     pub fn tbm_begin_iterate(
         tbm: *mut TIDBitmap,
@@ -40481,7 +40562,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn set_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int);
     pub fn update_spins_per_delay(shared_spins_per_delay: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     #[link_name = "init_spin_delay__pgrx_cshim"]
     pub fn init_spin_delay(
         status: *mut SpinDelayStatus,
@@ -41327,7 +41408,7 @@ unsafe extern "C-unwind" {
     );
     pub fn table_block_parallelscan_estimate(rel: Relation) -> Size;
     pub fn table_block_parallelscan_initialize(rel: Relation, pscan: ParallelTableScanDesc)
-    -> Size;
+        -> Size;
     pub fn table_block_parallelscan_reinitialize(rel: Relation, pscan: ParallelTableScanDesc);
     pub fn table_block_parallelscan_nextpage(
         rel: Relation,
@@ -42276,7 +42357,7 @@ unsafe extern "C-unwind" {
     pub static mut replorigin_xact_state: ReplOriginXactState;
     pub static mut max_active_replication_origins: ::core::ffi::c_int;
     pub fn replorigin_by_name(roname: *const ::core::ffi::c_char, missing_ok: bool)
-    -> ReplOriginId;
+        -> ReplOriginId;
     pub fn replorigin_create(roname: *const ::core::ffi::c_char) -> ReplOriginId;
     pub fn replorigin_drop_by_name(
         name: *const ::core::ffi::c_char,
@@ -43363,7 +43444,7 @@ unsafe extern "C-unwind" {
     pub fn AlterDatabaseRefreshColl(stmt: *mut AlterDatabaseRefreshCollStmt) -> ObjectAddress;
     pub fn AlterDatabaseSet(stmt: *mut AlterDatabaseSetStmt) -> Oid;
     pub fn AlterDatabaseOwner(dbname: *const ::core::ffi::c_char, newOwnerId: Oid)
-    -> ObjectAddress;
+        -> ObjectAddress;
     pub fn have_createdb_privilege() -> bool;
     pub fn check_encoding_locale_matches(
         encoding: ::core::ffi::c_int,
@@ -45196,6 +45277,22 @@ unsafe extern "C-unwind" {
         ControlFile: *mut ControlFileData,
         do_sync: bool,
     );
+    pub static PGLZ_strategy_default: *const PGLZ_Strategy;
+    pub static PGLZ_strategy_always: *const PGLZ_Strategy;
+    pub fn pglz_compress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        strategy: *const PGLZ_Strategy,
+    ) -> int32;
+    pub fn pglz_decompress(
+        source: *const ::core::ffi::c_char,
+        slen: int32,
+        dest: *mut ::core::ffi::c_char,
+        rawsize: int32,
+        check_complete: bool,
+    ) -> int32;
+    pub fn pglz_maximum_compressed_size(rawsize: int32, total_compressed_size: int32) -> int32;
     pub fn ExecInitAgg(
         node: *mut Agg,
         estate: *mut EState,
@@ -45528,7 +45625,7 @@ unsafe extern "C-unwind" {
         Nulls: *const ::core::ffi::c_char,
     ) -> HeapTuple;
     pub fn SPI_fnumber(tupdesc: TupleDesc, fname: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn SPI_fname(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> *mut ::core::ffi::c_char;
     pub fn SPI_getvalue(
         tuple: HeapTuple,
@@ -45542,7 +45639,7 @@ unsafe extern "C-unwind" {
         isnull: *mut bool,
     ) -> Datum;
     pub fn SPI_gettype(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn SPI_gettypeid(tupdesc: TupleDesc, fnumber: ::core::ffi::c_int) -> Oid;
     pub fn SPI_getrelname(rel: Relation) -> *mut ::core::ffi::c_char;
     pub fn SPI_getnspname(rel: Relation) -> *mut ::core::ffi::c_char;
@@ -45708,11 +45805,11 @@ unsafe extern "C-unwind" {
     pub fn pg_encoding_max_length(encoding: ::core::ffi::c_int) -> ::core::ffi::c_int;
     pub fn pg_valid_client_encoding(name: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
     pub fn pg_valid_server_encoding_private(name: *const ::core::ffi::c_char)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn is_encoding_supported_by_icu(encoding: ::core::ffi::c_int) -> bool;
     pub fn get_encoding_name_for_icu(encoding: ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn pg_utf8_islegal(source: *const ::core::ffi::c_uchar, length: ::core::ffi::c_int)
-    -> bool;
+        -> bool;
     pub fn pg_utf_mblen_private(s: *const ::core::ffi::c_uchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar(from: *const ::core::ffi::c_char, to: *mut pg_wchar) -> ::core::ffi::c_int;
     pub fn pg_mb2wchar_with_len(
@@ -45839,7 +45936,7 @@ unsafe extern "C-unwind" {
         lc: *mut ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_ushort;
     pub fn CNStoBIG5(cns: ::core::ffi::c_ushort, lc: ::core::ffi::c_uchar)
-    -> ::core::ffi::c_ushort;
+        -> ::core::ffi::c_ushort;
     pub fn UtfToLocal(
         utf: *const ::core::ffi::c_uchar,
         len: ::core::ffi::c_int,
@@ -46832,7 +46929,7 @@ unsafe extern "C-unwind" {
     pub fn contain_vars_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn contain_vars_returning_old_or_new(node: *mut Node) -> bool;
     pub fn locate_var_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn pull_var_clause(node: *mut Node, flags: ::core::ffi::c_int) -> *mut List;
     pub fn flatten_join_alias_vars(
         root: *mut PlannerInfo,
@@ -47083,7 +47180,7 @@ unsafe extern "C-unwind" {
         inner_paramrels: Relids,
     ) -> Relids;
     pub fn calc_non_nestloop_required_outer(outer_path: *mut Path, inner_path: *mut Path)
-    -> Relids;
+        -> Relids;
     pub fn create_nestloop_path(
         root: *mut PlannerInfo,
         joinrel: *mut RelOptInfo,
@@ -47350,7 +47447,7 @@ unsafe extern "C-unwind" {
         required_outer: Relids,
     ) -> *mut ParamPathInfo;
     pub fn find_param_path_info(rel: *mut RelOptInfo, required_outer: Relids)
-    -> *mut ParamPathInfo;
+        -> *mut ParamPathInfo;
     pub fn get_param_path_clause_serials(path: *mut Path) -> *mut Bitmapset;
     pub fn build_child_join_rel(
         root: *mut PlannerInfo,
@@ -48082,9 +48179,9 @@ unsafe extern "C-unwind" {
         pushedDown: bool,
     );
     pub fn BuildOnConflictExcludedTargetlist(targetrel: Relation, exclRelIndex: Index)
-    -> *mut List;
+        -> *mut List;
     pub fn makeSortGroupClauseForSetOp(rescoltype: Oid, require_hash: bool)
-    -> *mut SortGroupClause;
+        -> *mut SortGroupClause;
     pub fn constructSetOpTargetlist(
         pstate: *mut ParseState,
         op: *mut SetOperationStmt,
@@ -48098,7 +48195,7 @@ unsafe extern "C-unwind" {
     pub fn assign_list_collations(pstate: *mut ParseState, exprs: *mut List);
     pub fn assign_expr_collations(pstate: *mut ParseState, expr: *mut Node);
     pub fn select_common_collation(pstate: *mut ParseState, exprs: *mut List, none_ok: bool)
-    -> Oid;
+        -> Oid;
     pub static mut Transform_null_equals: bool;
     pub fn transformExpr(
         pstate: *mut ParseState,
@@ -48768,7 +48865,7 @@ unsafe extern "C-unwind" {
     );
     pub fn RelationGetPartitionDesc(rel: Relation, omit_detached: bool) -> PartitionDesc;
     pub fn CreatePartitionDirectory(mcxt: MemoryContext, omit_detached: bool)
-    -> PartitionDirectory;
+        -> PartitionDirectory;
     pub fn PartitionDirectoryLookup(arg1: PartitionDirectory, arg2: Relation) -> PartitionDesc;
     pub fn DestroyPartitionDirectory(pdir: PartitionDirectory);
     pub fn get_default_oid_from_partdesc(partdesc: PartitionDesc) -> Oid;
@@ -48993,7 +49090,7 @@ unsafe extern "C-unwind" {
     pub fn plpgsql_ns_find_nearest_loop(ns_cur: *mut PLpgSQL_nsitem) -> *mut PLpgSQL_nsitem;
     pub fn plpgsql_stmt_typename(stmt: *mut PLpgSQL_stmt) -> *const ::core::ffi::c_char;
     pub fn plpgsql_getdiag_kindname(kind: PLpgSQL_getdiag_kind::Type)
-    -> *const ::core::ffi::c_char;
+        -> *const ::core::ffi::c_char;
     pub fn plpgsql_mark_local_assignment_targets(func: *mut PLpgSQL_function);
     pub fn plpgsql_free_function_memory(func: *mut PLpgSQL_function);
     pub fn plpgsql_delete_callback(cfunc: *mut CachedFunction);
@@ -49440,7 +49537,7 @@ unsafe extern "C-unwind" {
     pub fn logicalrep_read_typ(in_: StringInfo, ltyp: *mut LogicalRepTyp);
     pub fn logicalrep_write_stream_start(out: StringInfo, xid: TransactionId, first_segment: bool);
     pub fn logicalrep_read_stream_start(in_: StringInfo, first_segment: *mut bool)
-    -> TransactionId;
+        -> TransactionId;
     pub fn logicalrep_write_stream_stop(out: StringInfo);
     pub fn logicalrep_write_stream_commit(
         out: StringInfo,
@@ -49763,7 +49860,7 @@ unsafe extern "C-unwind" {
         yyscanner: yyscan_t,
     ) -> ::core::ffi::c_int;
     pub fn replication_yylex(yylval_param: *mut YYSTYPE, yyscanner: yyscan_t)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn replication_yyerror(
         replication_parse_result_p: *mut *mut Node,
         yyscanner: yyscan_t,
@@ -49859,7 +49956,7 @@ unsafe extern "C-unwind" {
     pub fn AddInvertedQual(parsetree: *mut Query, qual: *mut Node);
     pub fn contain_aggs_of_level(node: *mut Node, levelsup: ::core::ffi::c_int) -> bool;
     pub fn locate_agg_of_level(node: *mut Node, levelsup: ::core::ffi::c_int)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn contain_windowfuncs(node: *mut Node) -> bool;
     pub fn locate_windowfunc(node: *mut Node) -> ::core::ffi::c_int;
     pub fn checkExprHasSubLink(node: *mut Node) -> bool;
@@ -50151,7 +50248,7 @@ unsafe extern "C-unwind" {
     ) -> ::core::ffi::c_int;
     pub fn FileSize(file: File) -> pgoff_t;
     pub fn FileTruncate(file: File, offset: pgoff_t, wait_event_info: uint32)
-    -> ::core::ffi::c_int;
+        -> ::core::ffi::c_int;
     pub fn FileWriteback(file: File, offset: pgoff_t, nbytes: pgoff_t, wait_event_info: uint32);
     pub fn FilePathName(file: File) -> *mut ::core::ffi::c_char;
     pub fn FileGetRawDesc(file: File) -> ::core::ffi::c_int;
@@ -54733,7 +54830,7 @@ unsafe extern "C-unwind" {
     pub fn get_ordering_op_for_equality_op(opno: Oid, use_lhs_type: bool) -> Oid;
     pub fn get_mergejoin_opfamilies(opno: Oid) -> *mut List;
     pub fn get_compatible_hash_operators(opno: Oid, lhs_opno: *mut Oid, rhs_opno: *mut Oid)
-    -> bool;
+        -> bool;
     pub fn get_op_hash_functions(
         opno: Oid,
         lhs_procno: *mut RegProcedure,
@@ -54912,7 +55009,7 @@ unsafe extern "C-unwind" {
     pub fn set_ps_display(activity: *const ::core::ffi::c_char);
     pub fn get_ps_display(displen: *mut ::core::ffi::c_int) -> *const ::core::ffi::c_char;
     pub fn format_procedure_extended(procedure_oid: Oid, flags: uint16)
-    -> *mut ::core::ffi::c_char;
+        -> *mut ::core::ffi::c_char;
     pub fn format_operator_extended(operator_oid: Oid, flags: uint16) -> *mut ::core::ffi::c_char;
     pub fn stringToQualifiedNameList(
         string: *const ::core::ffi::c_char,

--- a/pgrx-sql-entity-graph/Cargo.toml
+++ b/pgrx-sql-entity-graph/Cargo.toml
@@ -10,7 +10,7 @@
  
 [package]
 name = "pgrx-sql-entity-graph"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "Sql Entity Graph for `pgrx`"

--- a/pgrx-tests/Cargo.toml
+++ b/pgrx-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-tests"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "Test framework for 'pgrx'-based Postgres extensions"
@@ -66,7 +66,7 @@ rand = "0.10.1"
 [dependencies.pgrx] # Not unified in workspace due to default-features key
 path = "../pgrx"
 default-features = false
-version = "=0.18.1"
+version = "=0.19.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = [

--- a/pgrx-unit-tests/Cargo.toml
+++ b/pgrx-unit-tests/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx-unit-tests"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "Internal pgrx test extension"
@@ -60,11 +60,11 @@ rand = "0.10.1"
 [dependencies.pgrx]
 path = "../pgrx"
 default-features = false
-version = "=0.18.1"
+version = "=0.19.0"
 
 [dependencies.pgrx-tests]
 path = "../pgrx-tests"
-version = "=0.18.1"
+version = "=0.19.0"
 
 [dev-dependencies]
 trybuild = "1.0.116"

--- a/pgrx/Cargo.toml
+++ b/pgrx/Cargo.toml
@@ -10,7 +10,7 @@
 
 [package]
 name = "pgrx"
-version = "0.18.1"
+version = "0.19.0"
 authors.workspace = true
 license.workspace = true
 description = "pgrx:  A Rust framework for creating Postgres extensions"

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -47,6 +47,8 @@ INCLUDE_FOR_DEP_UPDATES=(
 # versions bumped at release time.
 EXCLUDE_FROM_VERSION_BUMP=(
   'cargo-pgrx/src/templates/cargo_toml'
+  'cargo-pgrx/tests/fixtures/workspace/Cargo.toml'
+  'cargo-pgrx/tests/fixtures/workspace/hello/Cargo.toml'
   'tools/version-updater/Cargo.toml'
 )
 


### PR DESCRIPTION
Welcome to pgrx v0.19.0.  Among other things, this brings support for Postgres v19beta1.

As usual, install cargo-pgrx with `cargo install cargo-pgrx --version 0.19.0 --locked`, and if you want Postgres 19beta1 support you'll also need to run `cargo pgrx init`.  And make sure to update your crate dependencies with `cargo pgrx upgrade`.


## What's Changed

* add pg19beta1 support by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2303

The headline item.  As more betas are released we'll release new pgrx point releases supporting them.

* upgrade dependencies and rust edition to 2024 by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2312

Notably, pgrx wants to use the Rust 2024 edition now.

### cargo-pgrx

* fix(cargo-pgrx): preserve cargo rustflags for cdylib builds by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2304

Prior to this fix, RUSTFLAGS changes in `.cargo/config.toml` would have been ignored.

* Retry Postgres downloads during init by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2314
* fix: `cargo pgrx schema named_sql_entity` should export schema-qualified by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2310
* Replace cargo-edit with crates-index and toml_edit by @cbandy in https://github.com/pgcentralfoundation/pgrx/pull/2305
* feat(cargo-pgrx): accept Cargo VersionReq syntax for upgrade --to by @isdaniel in https://github.com/pgcentralfoundation/pgrx/pull/2321


### New Features

* Add #[pg_guc_hook] macro for simple GUC hooks by @cbandy in https://github.com/pgcentralfoundation/pgrx/pull/2323



### Postgres Bindings and Wrappers

* feat: expose PGLZ compression bindings + add pglz_inspect example  by @isdaniel in https://github.com/pgcentralfoundation/pgrx/pull/2326
* fix: bridge buffer page helpers via cshim on PG16+ by @mrdrivingduck in https://github.com/pgcentralfoundation/pgrx/pull/2331
* Fix binding of `struct Port` on pg17 by @cbandy in https://github.com/pgcentralfoundation/pgrx/pull/2302
* feat: add Bytea<'fcx> argument type with zero-copy return by @isdaniel in https://github.com/pgcentralfoundation/pgrx/pull/2301
* Add wrappers for postgres geometric types. by @hamiltop in https://github.com/pgcentralfoundation/pgrx/pull/1332


### Bugfixes and Cleanup

* Guard pgrx docs.rs release builds by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2315
* Fix docs.rs build by localizing docsrs cfg by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2299
* remove redundant casts and improve safety in varlena functions by @isdaniel in https://github.com/pgcentralfoundation/pgrx/pull/2298
* Update trybuild to 1.0.116 by @cbandy in https://github.com/pgcentralfoundation/pgrx/pull/2306
* Quiet two errors from rust-analyzer by @cbandy in https://github.com/pgcentralfoundation/pgrx/pull/2307
* fix dependabot security warnings by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2313
* refactor: unify #[pg_extern] attribute parsing via syn by @isdaniel in https://github.com/pgcentralfoundation/pgrx/pull/2317
* chore: add examples PostgresType in/out variants and memory-context patterns by @isdaniel in https://github.com/pgcentralfoundation/pgrx/pull/2318
* docs(spi): clarify SpiClient::select vs update for read-only vs writable SPI by @uded in https://github.com/pgcentralfoundation/pgrx/pull/2328
* fix pg19 drift by @eeeebbbbrrrr in https://github.com/pgcentralfoundation/pgrx/pull/2330

## New Contributors

* @hamiltop made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/1332
* @uded made their first contribution in https://github.com/pgcentralfoundation/pgrx/pull/2328

**Full Changelog**: https://github.com/pgcentralfoundation/pgrx/compare/v0.18.1...v0.19.0