### PR TITLE
Add commands/async.h (LISTEN/NOTIFY) bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1896,6 +1896,15 @@ dependencies = [
  "pgrx",
  "pgrx-tests",
  "serde",
+]
+
+[[package]]
+name = "notify"
+version = "0.0.0"
+dependencies = [
+ "pgrx",
+ "pgrx-tests",
+ "postgres",
 ]
 
 [[package]]
@@ -2436,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.13"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacf632d0554ff75f58183694f41dc8999c8a3a43a386994d0ec2d034f1dfbe1"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2450,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -2468,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3482,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/pgrx-examples/notify/.gitignore
+++ b/pgrx-examples/notify/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.idea/
+/target
+*.iml
+**/*.rs.bk
+Cargo.lock
+sql/notify-1.0.sql

--- a/pgrx-examples/notify/Cargo.toml
+++ b/pgrx-examples/notify/Cargo.toml
@@ -1,0 +1,38 @@
+#LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+#LICENSE
+#LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+#LICENSE
+#LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+#LICENSE
+#LICENSE All rights reserved.
+#LICENSE
+#LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+[package]
+name = "notify"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+default = ["pg13"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
+pg19 = ["pgrx/pg19", "pgrx-tests/pg19"]
+pg_test = ["dep:postgres"]
+
+[dependencies]
+pgrx = { path = "../../pgrx" }
+postgres = { version = "0.19.14", optional = true }
+
+[dev-dependencies]
+pgrx-tests = { path = "../../pgrx-tests" }
+postgres = "0.19.14"

--- a/pgrx-examples/notify/README.md
+++ b/pgrx-examples/notify/README.md
@@ -1,0 +1,50 @@
+# notify — LISTEN/NOTIFY cache invalidation example
+
+Demonstrates safe `NOTIFY` / `LISTEN` / `UNLISTEN` wrappers (in `src/notify.rs`, over the `commands/async.h` bindings) driving a real-world cache-invalidation broadcast. An `AFTER INSERT OR UPDATE OR DELETE` trigger on `products` emits a `NOTIFY cache_invalidation, '<id>'` whenever a row changes. An external application that `LISTEN`s on that channel can drop the matching cache entry in real time instead of polling.
+
+## Try it
+
+```sql
+-- session 1: subscribe
+LISTEN cache_invalidation;
+
+-- session 2: change data
+INSERT INTO products (name) VALUES ('widget');   -- id 1
+UPDATE products SET name = 'gadget' WHERE id = 1;
+DELETE FROM products WHERE id = 1;
+```
+
+Session 1 receives three asynchronous notifications, each with the changed row's id as the payload:
+
+```
+Asynchronous notification "cache_invalidation" with payload "1" received from server process ...
+Asynchronous notification "cache_invalidation" with payload "1" received from server process ...
+Asynchronous notification "cache_invalidation" with payload "1" received from server process ...
+```
+
+The same wrappers are exposed for direct use via the `pgrx_notify(channel, payload)` function.
+
+## The hard case: coalesced invalidation 
+
+The per-row trigger above is fine for single-row changes, but a bulk `UPDATE products SET ... WHERE category = 5` touching a million rows would try to queue a million notifications and overrun the async queue (`max_notify_queue_pages`). Notifying once per row is the wrong granularity.
+
+`src/coalesced.rs` shows the correct pattern on an `inventory(id, sku,category)`
+table:
+
+1. A row-level trigger does **not** notify. It only accumulates the affected `category` into a per-transaction set in backend-local memory.
+2. A single `PreCommit` transaction callback (registered via pgrx's safe `register_xact_callback`) emits **one** `NOTIFY category_invalidation, '<category>'`per distinct dirtied category, just before commit.
+3. An `Abort` callback discards the set if the transaction rolls back.
+
+A million row changes in one category collapse into a single notification:
+
+```sql
+-- session 1: subscribe
+LISTEN category_invalidation;
+
+-- session 2: one statement, 500 rows across 2 categories
+INSERT INTO inventory (sku, category)
+SELECT 'sku' || g, g % 2 FROM generate_series(1, 500) g;
+```
+
+Session 1 receives exactly **two** notifications (payloads `0` and `1`), not 500.This needs Rust/C-level access hooking the transaction lifecycle and holding state across trigger invocations is impossible from a plain SQL trigger.
+

--- a/pgrx-examples/notify/notify.control
+++ b/pgrx-examples/notify/notify.control
@@ -1,0 +1,5 @@
+comment = 'notify:  Created by pgrx'
+default_version = '@CARGO_VERSION@'
+module_pathname = 'notify'
+relocatable = false
+superuser = false

--- a/pgrx-examples/notify/src/coalesced.rs
+++ b/pgrx-examples/notify/src/coalesced.rs
@@ -1,0 +1,101 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+//! Coalesced cache invalidation.
+//!
+//! The naive approach — `NOTIFY` once per changed row — falls apart on a bulk
+//! `UPDATE`/`DELETE`: a statement touching a million rows would try to queue a
+//! million notifications and overrun the async queue (`max_notify_queue_pages`).
+//!
+//! This module shows the correct pattern. A row-level trigger only *accumulates*
+//! the affected coarse key (here, `category`) into a per-transaction set held in
+//! backend-local memory. A single `PreCommit` transaction callback then emits one
+//! `NOTIFY` per distinct key, just before the transaction commits. A million row
+//! changes in one category collapse into a single notification. A matching
+//! `Abort` callback drops the accumulated keys if the transaction rolls back, so
+//! nothing leaks into the next transaction on this backend.
+//!
+//! This requires Rust/C-level access: hooking the transaction lifecycle and
+//! holding state across trigger invocations is impossible from a plain SQL
+//! trigger. `register_xact_callback` is pgrx's safe wrapper over
+//! `RegisterXactCallback`; the callbacks it registers live only for the current
+//! transaction, which is exactly the lifetime we want.
+
+use pgrx::prelude::*;
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeSet;
+
+thread_local! {
+    /// Distinct coarse keys dirtied by the current transaction. A Postgres backend is single-threaded, so a `thread_local` is effectively transaction/backend-local state. It is drained on commit and cleared on abort, so it never grows beyond the distinct keys of one transaction.
+    static DIRTY: RefCell<BTreeSet<i64>> = RefCell::new(BTreeSet::new());
+    /// Whether this transaction has already registered its end-of-transaction callbacks. Reset when either callback fires, so the next transaction on this backend re-arms.
+    static ARMED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Record that `category` was touched, arming the end-of-transaction flush on  first call within a transaction.
+fn mark_dirty(category: i64) {
+    DIRTY.with(|d| d.borrow_mut().insert(category));
+
+    if !ARMED.with(Cell::get) {
+        ARMED.with(|a| a.set(true));
+        // Emit the coalesced notifications immediately before commit...
+        pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::PreCommit, flush_dirty);
+        // ...or throw the accumulated keys away if the transaction aborts.
+        pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::Abort, discard_dirty);
+    }
+}
+
+/// `PreCommit`: emit exactly one `NOTIFY` per distinct dirtied key. Runs while the transaction is still open, which is required for `NOTIFY`.
+fn flush_dirty() {
+    ARMED.with(|a| a.set(false));
+    // `take` drains and clears the set in one step.
+    let categories = DIRTY.with(|d| std::mem::take(&mut *d.borrow_mut()));
+    for category in categories {
+        // One compact payload per key — the coalescing win — not one per row.
+        let _ = crate::notify::notify("category_invalidation", &category.to_string());
+    }
+}
+
+/// `Abort`: discard the accumulated keys so a rolled-back transaction does not leak dirty state into the next transaction on this backend.
+fn discard_dirty() {
+    ARMED.with(|a| a.set(false));
+    DIRTY.with(|d| d.borrow_mut().clear());
+}
+
+/// Row trigger: accumulate the affected `category` from the new row (INSERT / UPDATE) and the old row (UPDATE / DELETE). An UPDATE that moves a row between categories dirties both. No `NOTIFY` happens here — that is deferred to commit.
+#[pg_trigger]
+fn inventory_coalesce<'a>(
+    trigger: &'a pgrx::PgTrigger<'a>,
+) -> Result<Option<PgHeapTuple<'a, impl WhoAllocated>>, Box<dyn std::error::Error>> {
+    for tuple in [trigger.new(), trigger.old()] {
+        if let Some(tuple) = tuple {
+            if let Some(category) = tuple.get_by_name::<i64>("category")? {
+                mark_dirty(category);
+            }
+        }
+    }
+    // AFTER row triggers ignore the return value.
+    Ok(None::<PgHeapTuple<'a, pgrx::AllocatedByPostgres>>)
+}
+
+extension_sql!(
+    r#"
+CREATE TABLE inventory (
+    id        bigserial NOT NULL PRIMARY KEY,
+    sku       text NOT NULL,
+    category  bigint NOT NULL
+);
+
+CREATE TRIGGER inventory_coalesce
+    AFTER INSERT OR UPDATE OR DELETE ON inventory
+    FOR EACH ROW EXECUTE PROCEDURE inventory_coalesce();
+"#,
+    name = "create_inventory_trigger",
+    requires = [inventory_coalesce]
+);

--- a/pgrx-examples/notify/src/lib.rs
+++ b/pgrx-examples/notify/src/lib.rs
@@ -1,0 +1,195 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+use pgrx::prelude::*;
+
+mod coalesced;
+mod notify;
+
+pgrx::pg_module_magic!(name, version);
+
+/// Thin SQL-callable wrapper over [`notify::notify`], used to demonstrate (and test) error handling on over-length payloads.
+#[pg_extern]
+fn pgrx_notify(channel: &str, payload: &str) -> Result<(), String> {
+    notify::notify(channel, payload).map_err(|e| e.to_string())
+}
+
+/// SQL-callable `LISTEN <channel>` (server-side subscription).
+#[pg_extern]
+fn pgrx_listen(channel: &str) -> Result<(), String> {
+    notify::listen(channel).map_err(|e| e.to_string())
+}
+
+/// SQL-callable `UNLISTEN <channel>`.
+#[pg_extern]
+fn pgrx_unlisten(channel: &str) -> Result<(), String> {
+    notify::unlisten(channel).map_err(|e| e.to_string())
+}
+
+/// SQL-callable `UNLISTEN *`.
+#[pg_extern]
+fn pgrx_unlisten_all() {
+    notify::unlisten_all()
+}
+
+/// whenever a row in `products` changes,  broadcast its id on the `cache_invalidation` channel so external listeners can drop the corresponding cache entry.
+#[pg_trigger]
+fn products_notify<'a>(
+    trigger: &'a pgrx::PgTrigger<'a>,
+) -> Result<Option<PgHeapTuple<'a, impl WhoAllocated>>, Box<dyn std::error::Error>> {
+    // On DELETE the changed row is `old`; otherwise it is `new`.
+    let row = match trigger.new().or_else(|| trigger.old()) {
+        Some(r) => r.into_owned(),
+        None => return Ok(None),
+    };
+    let id: Option<i64> = row.get_by_name("id")?;
+    if let Some(id) = id {
+        notify::notify("cache_invalidation", &id.to_string())?;
+    }
+    Ok(Some(row))
+}
+
+extension_sql!(
+    r#"
+CREATE TABLE products (
+    id    bigserial NOT NULL PRIMARY KEY,
+    name  text NOT NULL
+);
+
+CREATE TRIGGER products_notify
+    AFTER INSERT OR UPDATE OR DELETE ON products
+    FOR EACH ROW EXECUTE PROCEDURE products_notify();
+"#,
+    name = "create_products_trigger",
+    requires = [products_notify]
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgrx::prelude::*;
+    use std::time::Duration;
+
+    /// Open a fresh client connection (a separate backend) to the running test server. `pgrx_tests::client()` can't be used from inside a `#[pg_test]` body — its `TEST_PORT` cell is unset there — so discover the live address from the server's own GUCs and connect directly.
+    fn open_client() -> postgres::Client {
+        let port: String = Spi::get_one("SHOW port").expect("SHOW port").expect("port set");
+        let host = if cfg!(windows) {
+            "127.0.0.1".to_string()
+        } else {
+            let host: String =
+                Spi::get_one("SHOW unix_socket_directories").expect("SHOW usd").expect("usd set");
+            let host = host.split(',').next().unwrap_or("").trim();
+            if host.is_empty() { "127.0.0.1".to_string() } else { host.to_string() }
+        };
+        let user = Spi::get_one::<String>("SELECT current_user::text")
+            .expect("current_user")
+            .expect("user");
+        let dbname = Spi::get_one::<String>("SELECT current_database()::text")
+            .expect("current_database")
+            .expect("db");
+        postgres::Config::new()
+            .host(&host)
+            .port(port.parse().expect("port"))
+            .user(&user)
+            .dbname(&dbname)
+            .connect(postgres::NoTls)
+            .expect("client connect")
+    }
+
+    #[pg_test]
+    fn notify_rejects_interior_nul() {
+        assert!(crate::notify::notify("chan\0nul", "payload").is_err());
+        assert!(crate::notify::notify("chan", "pay\0load").is_err());
+    }
+
+    #[pg_test]
+    fn listen_rejects_interior_nul() {
+        assert!(crate::notify::listen("chan\0nul").is_err());
+    }
+
+    /// End-to-end: a row change fires the trigger, which NOTIFYs, and a separate listening connection receives the payload after the writer commits.
+    #[pg_test]
+    fn trigger_delivers_cache_invalidation() {
+        // Connection A: subscribe.
+        let mut listener = open_client();
+        listener.batch_execute("LISTEN cache_invalidation").expect("LISTEN");
+
+        // Connection B: autocommit write that fires the trigger and commits.  Use RETURNING so the assertion is robust to the table's current serial.
+        let mut writer = open_client();
+        let row = writer
+            .query_one("INSERT INTO products (name) VALUES ('widget') RETURNING id", &[])
+            .expect("INSERT");
+        let id: i64 = row.get(0);
+
+        // Pump the protocol on A so libpq surfaces the async notification.
+        listener.batch_execute("SELECT 1").expect("pump");
+        let mut notifications = listener.notifications();
+        let got = {
+            use postgres::fallible_iterator::FallibleIterator;
+            notifications
+                .timeout_iter(Duration::from_secs(5))
+                .next()
+                .expect("notification iter")
+                .expect("a notification within 5s")
+        };
+
+        assert_eq!(got.channel(), "cache_invalidation");
+        assert_eq!(got.payload(), id.to_string());
+    }
+
+    /// Coalescing: a single statement touching 500 rows across 2 categories must
+    /// produce exactly 2 notifications (one per category), not 500.
+    #[pg_test]
+    fn bulk_change_coalesces_to_one_per_category() {
+        use postgres::fallible_iterator::FallibleIterator;
+
+        let mut listener = open_client();
+        listener.batch_execute("LISTEN category_invalidation").expect("LISTEN");
+
+        // 500 row changes across exactly two categories, in one autocommitted statement.
+        let mut writer = open_client();
+        writer
+            .batch_execute(
+                "INSERT INTO inventory (sku, category) \
+                 SELECT 'sku' || g, g % 2 FROM generate_series(1, 500) g",
+            )
+            .expect("bulk INSERT");
+
+        // Drain every notification that arrives within the window.
+        listener.batch_execute("SELECT 1").expect("pump");
+        let mut payloads = std::collections::BTreeSet::new();
+        let mut count = 0usize;
+        let mut notifications = listener.notifications();
+        let mut iter = notifications.timeout_iter(Duration::from_secs(2));
+        while let Some(n) = iter.next().expect("notification iter") {
+            count += 1;
+            payloads.insert(n.payload().to_string());
+        }
+
+        assert_eq!(count, 2, "expected 2 coalesced notifications, got {count}");
+        let expected: std::collections::BTreeSet<String> =
+            ["0".to_string(), "1".to_string()].into_iter().collect();
+        assert_eq!(payloads, expected);
+    }
+
+    /// Over-length payloads are reported by PostgreSQL as an error.
+    #[pg_test(error = "payload string too long")]
+    fn oversize_payload_errors() {
+        let big = "x".repeat(9000);
+        Spi::run(&format!("SELECT pgrx_notify('chan', '{big}')")).unwrap();
+    }
+}
+
+#[cfg(test)]
+pub mod pg_test {
+    pub fn setup(_options: Vec<&str>) {}
+    pub fn postgresql_conf_options() -> Vec<&'static str> {
+        vec![]
+    }
+}

--- a/pgrx-examples/notify/src/notify.rs
+++ b/pgrx-examples/notify/src/notify.rs
@@ -1,0 +1,50 @@
+//LICENSE Portions Copyright 2019-2021 ZomboDB, LLC.
+//LICENSE
+//LICENSE Portions Copyright 2021-2023 Technology Concepts & Design, Inc.
+//LICENSE
+//LICENSE Portions Copyright 2023-2023 PgCentral Foundation, Inc. <contact@pgcentral.org>
+//LICENSE
+//LICENSE All rights reserved.
+//LICENSE
+//LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+//! Safe wrappers around PostgreSQL's asynchronous notification interface
+//! (`commands/async.h`): `NOTIFY` / `LISTEN` / `UNLISTEN`.
+//!
+//! All of these must be called inside a transaction; notifications are
+//! delivered to listening sessions when the transaction commits.
+
+use std::ffi::{CString, NulError};
+
+/// Emit a `NOTIFY` on `channel` with `payload`.
+///
+/// Must be called inside a transaction. The notification is delivered to listening sessions at commit. Returns `Err` if either argument contains an interior NUL byte. Over-length arguments (channel name > 63 bytes, payload beyond `NOTIFY_PAYLOAD_MAX_LENGTH`) or being called outside a transaction are reported by PostgreSQL as an `ERROR`.
+pub fn notify(channel: &str, payload: &str) -> Result<(), NulError> {
+    let channel = CString::new(channel)?;
+    let payload = CString::new(payload)?;
+    // SAFETY: both pointers are valid, NUL-terminated C strings that stay alive for the duration of the call. On the success path `Async_Notify` copies them into Postgres-managed memory, so dropping the CStrings afterwards is fine. If `Async_Notify` raises a Postgres ERROR it does so via `longjmp`, which is sound across this `extern "C-unwind"` boundary but — like every  pg_sys call in pgrx — skips this frame's Rust destructors; the only thing that leaks is these two transient CString allocations, on an already aborting transaction. That is bounded and matches pgrx's memory model.
+    unsafe { pgrx::pg_sys::Async_Notify(channel.as_ptr(), payload.as_ptr()) };
+    Ok(())
+}
+
+/// Begin listening on `channel` (server-side `LISTEN`). Must be in a transaction.
+pub fn listen(channel: &str) -> Result<(), NulError> {
+    let channel = CString::new(channel)?;
+    // SAFETY: see `notify` — valid NUL-terminated pointer alive for the call.
+    unsafe { pgrx::pg_sys::Async_Listen(channel.as_ptr()) };
+    Ok(())
+}
+
+/// Stop listening on `channel` (server-side `UNLISTEN`). Must be in a transaction.
+pub fn unlisten(channel: &str) -> Result<(), NulError> {
+    let channel = CString::new(channel)?;
+    // SAFETY: see `notify` — valid NUL-terminated pointer alive for the call.
+    unsafe { pgrx::pg_sys::Async_Unlisten(channel.as_ptr()) };
+    Ok(())
+}
+
+/// Stop listening on all channels (`UNLISTEN *`). Must be in a transaction.
+pub fn unlisten_all() {
+    // SAFETY: takes no arguments; any Postgres ERROR propagates as a longjmp,
+    // see `notify`.
+    unsafe { pgrx::pg_sys::Async_UnlistenAll() };
+}

--- a/pgrx-pg-sys/include/pg13.h
+++ b/pgrx-pg-sys/include/pg13.h
@@ -73,6 +73,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
 #include "catalog/storage.h"
+#include "commands/async.h"
 #include "commands/comment.h"
 #include "commands/copy.h"
 #include "commands/dbcommands.h"

--- a/pgrx-pg-sys/include/pg14.h
+++ b/pgrx-pg-sys/include/pg14.h
@@ -73,6 +73,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
 #include "catalog/storage.h"
+#include "commands/async.h"
 #include "commands/comment.h"
 #include "commands/copy.h"
 #include "commands/dbcommands.h"

--- a/pgrx-pg-sys/include/pg15.h
+++ b/pgrx-pg-sys/include/pg15.h
@@ -74,6 +74,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
 #include "catalog/storage.h"
+#include "commands/async.h"
 #include "commands/comment.h"
 #include "commands/copy.h"
 #include "commands/dbcommands.h"

--- a/pgrx-pg-sys/include/pg16.h
+++ b/pgrx-pg-sys/include/pg16.h
@@ -75,6 +75,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
 #include "catalog/storage.h"
+#include "commands/async.h"
 #include "commands/comment.h"
 #include "commands/copy.h"
 #include "commands/dbcommands.h"

--- a/pgrx-pg-sys/include/pg17.h
+++ b/pgrx-pg-sys/include/pg17.h
@@ -75,6 +75,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
 #include "catalog/storage.h"
+#include "commands/async.h"
 #include "commands/comment.h"
 #include "commands/copy.h"
 #include "commands/dbcommands.h"

--- a/pgrx-pg-sys/include/pg18.h
+++ b/pgrx-pg-sys/include/pg18.h
@@ -75,6 +75,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
 #include "catalog/storage.h"
+#include "commands/async.h"
 #include "commands/comment.h"
 #include "commands/copy.h"
 #include "commands/dbcommands.h"

--- a/pgrx-pg-sys/include/pg19.h
+++ b/pgrx-pg-sys/include/pg19.h
@@ -75,6 +75,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
 #include "catalog/storage.h"
+#include "commands/async.h"
 #include "commands/comment.h"
 #include "commands/copy.h"
 #include "commands/dbcommands.h"


### PR DESCRIPTION
## What

- Bind `commands/async.h` in pgrx-pg-sys for pg13–pg19, exposing `Async_Notify` / `Async_Listen` / `Async_Unlisten` / `Async_UnlistenAll`.
- Add a `notify` example: safe `&str` wrappers over those externs plus a real-world cache-invalidation trigger that `NOTIFY`s a changed row's id on `cache_invalidation`.

## Why

LISTEN/NOTIFY is the only in-core mechanism for inter-process signalling substitute — delivery goes through Postgres's async queue. Server-side  `LISTEN` in particular has no SQL-function equivalent.
