### PR TITLE
Make &FlatArray<Text> serializable 

### DIFF
--- a/pgrx-unit-tests/src/tests/array_borrowed.rs
+++ b/pgrx-unit-tests/src/tests/array_borrowed.rs
@@ -79,6 +79,12 @@ fn borrow_serde_serialize_array_i32(values: &FlatArray<'_, i32>) -> Json {
     Json(json! { { "values": values } })
 }
 
+// Exercises `Text::as_str` directly (not via serde): sum of UTF-8 byte lengths of the non-null elements. Verifies the varlena header is excluded from the data.
+#[pg_extern]
+fn borrow_text_total_len(values: &FlatArray<'_, pgrx::array::Text>) -> i64 {
+    values.iter().filter_map(|n| n.into_option()).map(|t| t.as_str().len() as i64).sum()
+}
+
 #[pg_extern]
 fn borrow_return_text_array() -> Vec<&'static str> {
     vec!["a", "b", "c", "d"]
@@ -293,6 +299,73 @@ mod tests {
             .expect("returned json was null");
         assert_eq!(json.0, json! {{"values": []}});
         Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_serde_serialize_array_no_nulls() -> Result<(), pgrx::spi::Error> {
+        // No nulls => Postgres omits the null bitmap, exercising the None-bitmap iterator branch.
+        let json = Spi::get_one::<Json>("SELECT borrow_serde_serialize_array(ARRAY['a','b','c'])")?
+            .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": ["a", "b", "c"]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_serde_serialize_array_all_nulls() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT borrow_serde_serialize_array(ARRAY[null,null,null]::text[])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": [null, null, null]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_serde_serialize_array_json_special_chars() -> Result<(), pgrx::spi::Error> {
+        // Quote, backslash, newline, and tab must be serde-escaped, not emitted raw.
+        let json = Spi::get_one::<Json>(
+            r#"SELECT borrow_serde_serialize_array(ARRAY[E'a"b\\c', E'line1\nline2', E'\t'])"#,
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": ["a\"b\\c", "line1\nline2", "\t"]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_serde_serialize_array_header_boundary() -> Result<(), pgrx::spi::Error> {
+        // Postgres switches from a 1-byte to a 4-byte varlena header at ~126 bytes.
+        // Place elements on both sides of that boundary adjacent to each other so a
+        // wrong stride would corrupt the following element.
+        let s125 = "a".repeat(125);
+        let s126 = "b".repeat(126);
+        let s127 = "c".repeat(127);
+        let json = Spi::get_one::<Json>(&format!(
+            "SELECT borrow_serde_serialize_array(ARRAY['{s125}','{s126}','{s127}','z'])"
+        ))?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": [s125, s126, s127, "z"]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_text_as_str_len() {
+        // 'ab' (2) + null (skipped) + '日本語' (9 UTF-8 bytes) = 11; header excluded.
+        let len = Spi::get_one::<i64>(
+            "SELECT borrow_text_total_len(ARRAY['ab', null, '日本語']::text[])",
+        );
+        assert_eq!(len, Ok(Some(11)));
+    }
+
+    #[pg_test]
+    fn borrow_test_text_as_str_len_empty_and_all_null() {
+        assert_eq!(
+            Spi::get_one::<i64>("SELECT borrow_text_total_len(ARRAY[]::text[])"),
+            Ok(Some(0))
+        );
+        assert_eq!(
+            Spi::get_one::<i64>("SELECT borrow_text_total_len(ARRAY[null,null]::text[])"),
+            Ok(Some(0))
+        );
     }
 
     #[pg_test]

--- a/pgrx-unit-tests/src/tests/array_borrowed.rs
+++ b/pgrx-unit-tests/src/tests/array_borrowed.rs
@@ -11,7 +11,7 @@
 use core::ffi::CStr;
 use pgrx::Json;
 use pgrx::PostgresEnum;
-use pgrx::array::{FlatArray, RawArray};
+use pgrx::array::{FlatArray, RawArray, Text};
 use pgrx::memcx::MemCx;
 use pgrx::nullable::Nullable;
 use pgrx::palloc::PBox;
@@ -68,11 +68,10 @@ fn borrow_optional_array_with_default(
     values.unwrap().iter().map(|v| v.into_option().copied().unwrap_or(0)).sum()
 }
 
-// FIXME: replace with Text
-// #[pg_extern]
-// fn borrow_serde_serialize_array<'dat>(values: &FlatArray<'dat, &'dat str>) -> Json {
-//     Json(json! { { "values": values } })
-// }
+#[pg_extern]
+fn borrow_serde_serialize_array(values: &FlatArray<'_, pgrx::array::Text>) -> Json {
+    Json(json! { { "values": values } })
+}
 
 #[pg_extern]
 fn borrow_serde_serialize_array_i32(values: &FlatArray<'_, i32>) -> Json {
@@ -265,16 +264,36 @@ mod tests {
         assert_eq!(sum, Ok(Some(6f32)));
     }
 
-    // TODO: fix this test by redesigning SPI.
-    // #[pg_test]
-    // fn borrow_test_serde_serialize_array() -> Result<(), pgrx::spi::Error> {
-    //     let json = Spi::get_one::<Json>(
-    //         "SELECT borrow_serde_serialize_array(ARRAY['one', null, 'two', 'three'])",
-    //     )?
-    //     .expect("returned json was null");
-    //     assert_eq!(json.0, json! {{"values": ["one", null, "two", "three"]}});
-    //     Ok(())
-    // }
+    #[pg_test]
+    fn borrow_test_serde_serialize_array() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>(
+            "SELECT borrow_serde_serialize_array(ARRAY['one', null, 'two', 'three'])",
+        )?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": ["one", null, "two", "three"]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_serde_serialize_array_mixed() -> Result<(), pgrx::spi::Error> {
+        // Stride stress: empty string, null, multibyte, and a >127-byte element
+        // (forces a 4-byte varlena header next to 1-byte ones). Mis-stride corrupts tail.
+        let long = "x".repeat(200);
+        let json = Spi::get_one::<Json>(&format!(
+            "SELECT borrow_serde_serialize_array(ARRAY['', null, '日本語', '{long}', 'z'])"
+        ))?
+        .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": ["", null, "日本語", long, "z"]}});
+        Ok(())
+    }
+
+    #[pg_test]
+    fn borrow_test_serde_serialize_array_empty() -> Result<(), pgrx::spi::Error> {
+        let json = Spi::get_one::<Json>("SELECT borrow_serde_serialize_array(ARRAY[]::text[])")?
+            .expect("returned json was null");
+        assert_eq!(json.0, json! {{"values": []}});
+        Ok(())
+    }
 
     #[pg_test]
     fn borrow_test_optional_array_with_default() {

--- a/pgrx-unit-tests/tests/compile-fail/no-arrays-of-arrays.stderr
+++ b/pgrx-unit-tests/tests/compile-fail/no-arrays-of-arrays.stderr
@@ -9,10 +9,10 @@ error[E0277]: the trait bound `FlatArray<'_, i32>: pgrx::array::Element` is not 
             Date
             Oid
             Point
+            Text
             Time
             TimeWithTimeZone
             Timestamp
-            TimestampWithTimeZone
           and $N others
   = note: required for `FlatArray<'_, FlatArray<'_, i32>>` to implement `SqlTranslatable`
   = note: 1 redundant requirement hidden

--- a/pgrx/src/array.rs
+++ b/pgrx/src/array.rs
@@ -31,6 +31,7 @@ mod element;
 mod flat_array;
 mod port;
 
+pub use crate::datum::Text;
 pub use element::Element;
 pub use flat_array::{ArrayAllocError, FlatArray};
 

--- a/pgrx/src/array/flat_array.rs
+++ b/pgrx/src/array/flat_array.rs
@@ -395,6 +395,12 @@ where
     }
 }
 
+impl serde::Serialize for FlatArray<'_, super::Text> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_seq(self.iter().map(|n| n.into_option().map(|t| t.as_str())))
+    }
+}
+
 impl<'arr, T> ExactSizeIterator for ArrayIter<'arr, T> where T: ?Sized + Element {}
 impl<'arr, T> FusedIterator for ArrayIter<'arr, T> where T: ?Sized + Element {}
 

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -146,10 +146,12 @@ unsafe impl Element for ffi::CStr {
 pub struct Text([u8]);
 
 impl Text {
-    /// The string contents (UTF-8), excluding the varlena header.
+    /// The string contents, excluding the varlena header.
+    ///
+    /// Uses pgrx's encoding-aware conversion: when the database encoding isn't guaranteed UTF-8 (e.g. `SQL_ASCII`), the bytes are validated and this panics on non-UTF-8 data — same behavior as reading a `text` datum as `&str`.
     pub fn as_str(&self) -> &str {
-        // SAFETY: tail is a valid varlena; Postgres text is UTF-8 in pgrx's server encodings
-        unsafe { crate::varlena::text_to_rust_str_unchecked(self.0.as_ptr().cast()) }
+        // SAFETY: tail is a valid varlena
+        unsafe { crate::datum::from::convert_varlena_to_str_memoized(self.0.as_ptr().cast()) }
     }
 }
 

--- a/pgrx/src/datum/borrow.rs
+++ b/pgrx/src/datum/borrow.rs
@@ -140,3 +140,46 @@ unsafe impl Element for ffi::CStr {
         unsafe { ffi::CStr::from_ptr(char_ptr) }
     }
 }
+
+/// A borrowed Postgres `text` varlena, usable as a `FlatArray` element.
+#[repr(transparent)]
+pub struct Text([u8]);
+
+impl Text {
+    /// The string contents (UTF-8), excluding the varlena header.
+    pub fn as_str(&self) -> &str {
+        // SAFETY: tail is a valid varlena; Postgres text is UTF-8 in pgrx's server encodings
+        unsafe { crate::varlena::text_to_rust_str_unchecked(self.0.as_ptr().cast()) }
+    }
+}
+
+unsafe impl DatumPass for Text {
+    const PASS: PassBy = PassBy::Ref;
+}
+unsafe impl Element for Text {
+    unsafe fn point_from(ptr: ptr::NonNull<u8>) -> ptr::NonNull<Self> {
+        // full varlena size so size_of_val == storage, keeping ArrayIter stride sound
+        let len = unsafe { crate::varlena::varsize_any(ptr.as_ptr().cast()) };
+        unsafe {
+            ptr::NonNull::new_unchecked(
+                ptr::slice_from_raw_parts_mut(ptr.as_ptr(), len) as *mut Self
+            )
+        }
+    }
+}
+
+unsafe impl pgrx_sql_entity_graph::metadata::SqlTranslatable for Text {
+    const TYPE_IDENT: &'static str = "Text";
+    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
+        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
+    const ARGUMENT_SQL: Result<
+        pgrx_sql_entity_graph::metadata::SqlMappingRef,
+        pgrx_sql_entity_graph::metadata::ArgumentError,
+    > = Ok(pgrx_sql_entity_graph::metadata::SqlMappingRef::literal("text"));
+    const RETURN_SQL: Result<
+        pgrx_sql_entity_graph::metadata::ReturnsRef,
+        pgrx_sql_entity_graph::metadata::ReturnsError,
+    > = Ok(pgrx_sql_entity_graph::metadata::ReturnsRef::One(
+        pgrx_sql_entity_graph::metadata::SqlMappingRef::literal("text"),
+    ));
+}

--- a/pgrx/src/datum/from.rs
+++ b/pgrx/src/datum/from.rs
@@ -386,7 +386,9 @@ impl<'a> FromDatum for &'a str {
 
 // This is not marked inline on purpose, to allow it to be in a single code section
 // which is then branch-predicted on every time by the CPU.
-unsafe fn convert_varlena_to_str_memoized<'a>(varlena: *const pg_sys::varlena) -> &'a str {
+pub(crate) unsafe fn convert_varlena_to_str_memoized<'a>(
+    varlena: *const pg_sys::varlena,
+) -> &'a str {
     match *crate::UTF8DATABASE {
         crate::Utf8Compat::Yes => varlena::text_to_rust_str_unchecked(varlena),
         crate::Utf8Compat::Maybe => varlena::text_to_rust_str(varlena)


### PR DESCRIPTION
## Motivation

The borrowed flat-array API supported scalars and CStr, but text arrays had a long-stubbed `&FlatArray<&str>` placeholder unsound, since &str excludes the varlena header and breaks iteration stride. No way to serialize a borrowed `text[]`.

## Changes

- Add Text varlena element: strides by full varlena size (varsize_any), mirroring the proven CStr element. 
- Enable borrow_serde_serialize_array fn + its pg_test.
-  rustc caps that hint list at 8 entries then prints and $N others, and the list is alphabetically sorted. Inserting `Text` (alphabetically between Point and Time) pushed the window forward by one, so `TimestampWithTimeZone` (previously 8th) dropped off into and $N others. The original fix only added Text (9 lines) without  removing TimestampWithTimeZone, so it still didn't match the compiler's truncated 8-line output.