### PR TITLE
Refactor dedup BoxRet + SqlTranslatable boilerplate via existing macros

### DIFF
--- a/pgrx/src/callconv.rs
+++ b/pgrx/src/callconv.rs
@@ -529,47 +529,18 @@ unsafe impl BoxRet for f64 {
     }
 }
 
-unsafe impl BoxRet for &[u8] {
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
-    }
-}
-
-unsafe impl BoxRet for &str {
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
-    }
-}
-
-unsafe impl BoxRet for &CStr {
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
-    }
-}
-
 macro_rules! impl_repackage_into_datum {
     ($($boxable:ty),*) => {
         $(  unsafe impl BoxRet for $boxable {
                 unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-                    match self.into_datum() {
-                        Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-                        None => fcinfo.return_null(),
-                    }
+                    unsafe { fcinfo.return_optional_datum(self.into_datum()) }
                 }
           })*
     };
 }
 
 impl_repackage_into_datum! {
+    &[u8], &str, &CStr,
     String, CString, Vec<u8>, char,
     Json, JsonB, Inet, Uuid, AnyNumeric, AnyArray, AnyElement, Internal,
     Date, Interval, Time, TimeWithTimeZone, Timestamp, TimestampWithTimeZone,
@@ -580,10 +551,7 @@ impl_repackage_into_datum! {
 
 unsafe impl<const P: u32, const S: u32> BoxRet for Numeric<P, S> {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
+        unsafe { fcinfo.return_optional_datum(self.into_datum()) }
     }
 }
 
@@ -592,10 +560,7 @@ where
     T: IntoDatum + RangeSubType,
 {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
+        unsafe { fcinfo.return_optional_datum(self.into_datum()) }
     }
 }
 
@@ -604,19 +569,13 @@ where
     T: IntoDatum,
 {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
+        unsafe { fcinfo.return_optional_datum(self.into_datum()) }
     }
 }
 
 unsafe impl<T: Copy> BoxRet for PgVarlena<T> {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
+        unsafe { fcinfo.return_optional_datum(self.into_datum()) }
     }
 }
 
@@ -625,10 +584,7 @@ where
     A: WhoAllocated,
 {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
+        unsafe { fcinfo.return_optional_datum(self.into_datum()) }
     }
 }
 
@@ -637,10 +593,7 @@ where
     A: WhoAllocated,
 {
     unsafe fn box_into<'fcx>(self, fcinfo: &mut FcInfo<'fcx>) -> Datum<'fcx> {
-        match self.into_datum() {
-            Some(datum) => unsafe { fcinfo.return_raw_datum(datum) },
-            None => fcinfo.return_null(),
-        }
+        unsafe { fcinfo.return_optional_datum(self.into_datum()) }
     }
 }
 
@@ -745,6 +698,20 @@ impl<'fcx> FcInfo<'fcx> {
         unsafe {
             *self.set_return_is_null() = false;
             mem::transmute(datum)
+        }
+    }
+
+    /// Return an optional raw Datum: the Datum if `Some`, SQL null if `None`.
+    ///
+    /// Convenience for the ubiquitous "repackage an `IntoDatum` result" pattern.
+    ///
+    /// # Safety
+    /// Same as [`FcInfo::return_raw_datum`] for the `Some` case; the `None` case is always safe.
+    #[inline]
+    pub unsafe fn return_optional_datum(&mut self, datum: Option<pg_sys::Datum>) -> Datum<'fcx> {
+        match datum {
+            Some(datum) => unsafe { self.return_raw_datum(datum) },
+            None => self.return_null(),
         }
     }
 

--- a/pgrx/src/datetime/date.rs
+++ b/pgrx/src/datetime/date.rs
@@ -10,9 +10,6 @@
 use core::num::TryFromIntError;
 use pgrx_pg_sys::PgTryBuilder;
 use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 
 use super::datetime_support::{DateTimeParts, HasExtractableParts};
 use super::{
@@ -281,11 +278,4 @@ impl<'de> serde::Deserialize<'de> for Date {
     }
 }
 
-unsafe impl SqlTranslatable for Date {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Date);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("date"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("date")));
-}
+crate::impl_sql_translatable!(Date, "date");

--- a/pgrx/src/datetime/interval.rs
+++ b/pgrx/src/datetime/interval.rs
@@ -11,9 +11,6 @@ use super::datetime_support::{IntervalConversionError, USECS_PER_DAY, USECS_PER_
 use super::{DateTimeParts, DateTimeTypeVisitor, Time, ToIsoString};
 use crate::datum::{FromDatum, IntoDatum};
 use crate::{direct_function_call, pg_sys};
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 
 /// From the PG docs <https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT>
 /// Internally interval values are stored as months, days, and microseconds. This is done because the number of days in a month varies,
@@ -309,12 +306,4 @@ impl<'de> serde::Deserialize<'de> for Interval {
         deserializer.deserialize_str(DateTimeTypeVisitor::<Self>::new())
     }
 }
-unsafe impl SqlTranslatable for Interval {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Interval);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("interval"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("interval")));
-}
+crate::impl_sql_translatable!(Interval, "interval");

--- a/pgrx/src/datetime/time.rs
+++ b/pgrx/src/datetime/time.rs
@@ -13,9 +13,6 @@ use crate::datum::{FromDatum, IntoDatum};
 use crate::{direct_function_call, pg_sys};
 use pgrx_pg_sys::PgTryBuilder;
 use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use std::num::TryFromIntError;
 
 /// A safe wrapper around Postgres `TIME` type, backed by a [`pg_sys::TimeADT`] integer value.
@@ -217,11 +214,4 @@ impl<'de> serde::Deserialize<'de> for Time {
     }
 }
 
-unsafe impl SqlTranslatable for Time {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Time);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("time"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("time")));
-}
+crate::impl_sql_translatable!(Time, "time");

--- a/pgrx/src/datetime/time_stamp.rs
+++ b/pgrx/src/datetime/time_stamp.rs
@@ -15,9 +15,6 @@ use crate::datum::{FromDatum, IntoDatum};
 use crate::{direct_function_call, pg_sys};
 use pgrx_pg_sys::PgTryBuilder;
 use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use std::num::TryFromIntError;
 
 /// A safe wrapper around Postgres `TIMESTAMP WITHOUT TIME ZONE` type, backed by a [`pg_sys::Timestamp`] integer value.
@@ -328,12 +325,4 @@ impl<'de> serde::Deserialize<'de> for Timestamp {
     }
 }
 
-unsafe impl SqlTranslatable for Timestamp {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Timestamp);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("timestamp"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("timestamp")));
-}
+crate::impl_sql_translatable!(Timestamp, "timestamp");

--- a/pgrx/src/datetime/time_stamp_with_timezone.rs
+++ b/pgrx/src/datetime/time_stamp_with_timezone.rs
@@ -15,9 +15,6 @@ use crate::datum::{FromDatum, IntoDatum};
 use crate::{direct_function_call, pg_sys};
 use pgrx_pg_sys::PgTryBuilder;
 use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 // taken from /include/datatype/timestamp.h
@@ -435,12 +432,4 @@ impl<'de> serde::Deserialize<'de> for TimestampWithTimeZone {
     }
 }
 
-unsafe impl SqlTranslatable for TimestampWithTimeZone {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(TimestampWithTimeZone);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("timestamp with time zone"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("timestamp with time zone")));
-}
+crate::impl_sql_translatable!(TimestampWithTimeZone, "timestamp with time zone");

--- a/pgrx/src/datetime/time_with_timezone.rs
+++ b/pgrx/src/datetime/time_with_timezone.rs
@@ -13,9 +13,6 @@ use crate::datum::{FromDatum, IntoDatum};
 use crate::{PgMemoryContexts, direct_function_call, direct_function_call_as_datum, pg_sys};
 use pgrx_pg_sys::PgTryBuilder;
 use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 /// A safe wrapper around Postgres `TIME WITH TIME ZONE` type, backed by a [`pg_sys::TimeTzADT`] integer value.
@@ -325,12 +322,4 @@ impl<'de> serde::Deserialize<'de> for TimeWithTimeZone {
     }
 }
 
-unsafe impl SqlTranslatable for TimeWithTimeZone {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(TimeWithTimeZone);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("time with time zone"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("time with time zone")));
-}
+crate::impl_sql_translatable!(TimeWithTimeZone, "time with time zone");

--- a/pgrx/src/datum/anyarray.rs
+++ b/pgrx/src/datum/anyarray.rs
@@ -9,9 +9,6 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use super::ArrayIntoIterator;
 use crate::{AnyElement, Array, FromDatum, IntoDatum, pg_sys};
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use std::iter::FusedIterator;
 
 /// The [`anyarray` polymorphic pseudo-type][anyarray].
@@ -76,15 +73,7 @@ impl IntoDatum for AnyArray {
     }
 }
 
-unsafe impl SqlTranslatable for AnyArray {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(AnyArray);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("anyarray"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("anyarray")));
-}
+crate::impl_sql_translatable!(AnyArray, "anyarray");
 
 impl<'a> IntoIterator for &'a AnyArray
 where

--- a/pgrx/src/datum/anyelement.rs
+++ b/pgrx/src/datum/anyelement.rs
@@ -8,9 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::{FromDatum, IntoDatum, pg_sys};
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 
 /// The [`anyelement` polymorphic pseudo-type][anyelement].
 ///
@@ -80,12 +77,4 @@ impl IntoDatum for AnyElement {
     }
 }
 
-unsafe impl SqlTranslatable for AnyElement {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(AnyElement);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("anyelement"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("anyelement")));
-}
+crate::impl_sql_translatable!(AnyElement, "anyelement");

--- a/pgrx/src/datum/geo.rs
+++ b/pgrx/src/datum/geo.rs
@@ -18,10 +18,6 @@
 //! more information on the geometric types.
 use std::{mem, ptr};
 
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
-};
-
 use crate::{FromDatum, IntoDatum, PgMemoryContexts, pg_sys, set_varsize_4b};
 
 // Copy types
@@ -269,13 +265,7 @@ impl FromDatum for Path {
     }
 }
 
-unsafe impl SqlTranslatable for Path {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Path);
-    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("path"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("path")));
-}
+crate::impl_sql_translatable!(Path, "path");
 
 /// An owned Postgres `polygon` type.
 #[derive(Debug, Clone, Default)]
@@ -284,14 +274,7 @@ pub struct Polygon {
     boundbox: Box,
 }
 
-unsafe impl SqlTranslatable for Polygon {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Polygon);
-    const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("polygon"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("polygon")));
-}
+crate::impl_sql_translatable!(Polygon, "polygon");
 
 impl Polygon {
     pub fn new(points: Vec<pg_sys::Point>) -> Self {

--- a/pgrx/src/datum/inet.rs
+++ b/pgrx/src/datum/inet.rs
@@ -11,9 +11,6 @@ use crate::{FromDatum, IntoDatum, direct_function_call, direct_function_call_as_
 use core::ffi::CStr;
 use pgrx_pg_sys::PgTryBuilder;
 use pgrx_pg_sys::errcodes::PgSqlErrorCode;
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -123,11 +120,4 @@ impl From<String> for Inet {
     }
 }
 
-unsafe impl SqlTranslatable for Inet {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Inet);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("inet"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("inet")));
-}
+crate::impl_sql_translatable!(Inet, "inet");

--- a/pgrx/src/datum/internal.rs
+++ b/pgrx/src/datum/internal.rs
@@ -8,9 +8,6 @@
 //LICENSE
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::{FromDatum, IntoDatum, PgMemoryContexts, pg_sys};
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 
 /// Represents Postgres' `internal` data type, which is documented as:
 ///
@@ -181,12 +178,4 @@ impl IntoDatum for Internal {
     }
 }
 
-unsafe impl SqlTranslatable for crate::datum::Internal {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Internal);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("internal"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("internal")));
-}
+crate::impl_sql_translatable!(Internal, "internal");

--- a/pgrx/src/datum/json.rs
+++ b/pgrx/src/datum/json.rs
@@ -11,9 +11,6 @@ use crate::{
     FromDatum, IntoDatum, direct_function_call, direct_function_call_as_datum, pg_sys, vardata_any,
     varsize_any_exhdr, void_mut_ptr,
 };
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use serde::{Serialize, Serializer};
 use serde_json::Value;
 
@@ -187,20 +184,6 @@ impl Serialize for JsonString {
     }
 }
 
-unsafe impl SqlTranslatable for Json {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Json);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("json"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("json")));
-}
+crate::impl_sql_translatable!(Json, "json");
 
-unsafe impl SqlTranslatable for JsonB {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(JsonB);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("jsonb"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("jsonb")));
-}
+crate::impl_sql_translatable!(JsonB, "jsonb");

--- a/pgrx/src/datum/range.rs
+++ b/pgrx/src/datum/range.rs
@@ -535,35 +535,11 @@ unsafe impl RangeSubType for TimestampWithTimeZone {
     }
 }
 
-unsafe impl SqlTranslatable for Range<i32> {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Range<i32>);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("int4range"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("int4range")));
-}
+crate::impl_sql_translatable!(Range<i32>, "int4range");
 
-unsafe impl SqlTranslatable for Range<i64> {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Range<i64>);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("int8range"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("int8range")));
-}
+crate::impl_sql_translatable!(Range<i64>, "int8range");
 
-unsafe impl SqlTranslatable for Range<AnyNumeric> {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Range<AnyNumeric>);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("numrange"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("numrange")));
-}
+crate::impl_sql_translatable!(Range<AnyNumeric>, "numrange");
 
 unsafe impl<const P: u32, const S: u32> SqlTranslatable for Range<Numeric<P, S>> {
     const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Range<Numeric<P, S>>);
@@ -575,32 +551,8 @@ unsafe impl<const P: u32, const S: u32> SqlTranslatable for Range<Numeric<P, S>>
         Ok(ReturnsRef::One(SqlMappingRef::literal("numrange")));
 }
 
-unsafe impl SqlTranslatable for Range<Date> {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Range<Date>);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("daterange"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("daterange")));
-}
+crate::impl_sql_translatable!(Range<Date>, "daterange");
 
-unsafe impl SqlTranslatable for Range<TimestampWithTimeZone> {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Range<TimestampWithTimeZone>);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("tstzrange"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("tstzrange")));
-}
+crate::impl_sql_translatable!(Range<TimestampWithTimeZone>, "tstzrange");
 
-unsafe impl SqlTranslatable for Range<Timestamp> {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Range<Timestamp>);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-        Ok(SqlMappingRef::literal("tsrange"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("tsrange")));
-}
+crate::impl_sql_translatable!(Range<Timestamp>, "tsrange");

--- a/pgrx/src/datum/uuid.rs
+++ b/pgrx/src/datum/uuid.rs
@@ -9,9 +9,6 @@
 //LICENSE Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 use crate::{FromDatum, IntoDatum, PgMemoryContexts, pg_sys};
 use core::fmt::Write;
-use pgrx_sql_entity_graph::metadata::{
-    ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable,
-};
 use std::ops::{Deref, DerefMut};
 
 const UUID_BYTES_LEN: usize = 16;
@@ -130,11 +127,4 @@ impl std::fmt::UpperHex for Uuid {
     }
 }
 
-unsafe impl SqlTranslatable for Uuid {
-    const TYPE_IDENT: &'static str = crate::pgrx_resolved_type!(Uuid);
-    const TYPE_ORIGIN: pgrx_sql_entity_graph::metadata::TypeOrigin =
-        pgrx_sql_entity_graph::metadata::TypeOrigin::External;
-    const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> = Ok(SqlMappingRef::literal("uuid"));
-    const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-        Ok(ReturnsRef::One(SqlMappingRef::literal("uuid")));
-}
+crate::impl_sql_translatable!(Uuid, "uuid");


### PR DESCRIPTION
- Refactor BoxRet implementations to use return_optional_datum for cleaner code
- Refactor SQL translatable implementations for various types to use macro for cleaner code