### PR TITLE
Fix `semicolon_in_expressions_from_macros` errors on nightly

### DIFF
--- a/cargo-pgrx/src/command/install.rs
+++ b/cargo-pgrx/src/command/install.rs
@@ -264,7 +264,7 @@ fn copy_file(
 ) -> eyre::Result<()> {
     let Some(dest_dir) = dest.parent() else {
         // what fresh hell could ever cause such an error?
-        eyre::bail!("no directory to copy to: {}", dest.display())
+        eyre::bail!("no directory to copy to: {}", dest.display());
     };
     match dest_dir.try_exists() {
         Ok(false) => fs::create_dir_all(dest_dir).wrap_err_with(|| {

--- a/cargo-pgrx/src/object_utils.rs
+++ b/cargo-pgrx/src/object_utils.rs
@@ -172,7 +172,9 @@ fn parse_macho_header(data: &[u8]) -> eyre::Result<(MachBits, MachEndian, usize)
         object::macho::MH_MAGIC => Ok((MachBits::Bits32, MachEndian::Big, 28)),
         object::macho::MH_CIGAM_64 => Ok((MachBits::Bits64, MachEndian::Little, 32)),
         object::macho::MH_MAGIC_64 => Ok((MachBits::Bits64, MachEndian::Big, 32)),
-        _ => bail!("invalid Mach-O magic"),
+        _ => {
+            bail!("invalid Mach-O magic");
+        }
     }
 }
 

--- a/pgrx-sql-entity-graph/src/section.rs
+++ b/pgrx-sql-entity-graph/src/section.rs
@@ -822,7 +822,7 @@ impl<'a> EntryReader<'a> {
                 let sql = match self.read_argument_sql_owned()? {
                     Ok(crate::metadata::SqlMapping::As(sql)) => sql,
                     Ok(other) => {
-                        bail!("invalid SQL declaration mapping in schema entry: {other:?}")
+                        bail!("invalid SQL declaration mapping in schema entry: {other:?}");
                     }
                     Err(err) => return Err(err.into()),
                 };


### PR DESCRIPTION
## Summary

Newer Rust toolchains promote the `semicolon_in_expressions_from_macros` future-incompatibility lint ([rust-lang/rust#79813](https://github.com/rust-lang/rust/issues/79813)) to a hard, deny-by-default error. This breaks `bail!(...)` invocations used in expression position (the tail of a block or match arm).

The `verify package can build` workflow (`.github/workflows/package-test.yaml`) builds with nightly (`rustup.sh nightly`, `cargo +nightly install --path cargo-pgrx`, `cargo +nightly package`), so it fails on this on current `develop`, independent of any feature work.

## Fix

Add trailing semicolons so the macro invocations are statements rather than tail expressions:

- `pgrx-sql-entity-graph/src/section.rs` (match-arm block)
- `cargo-pgrx/src/command/install.rs` (`let ... else` block)
- `cargo-pgrx/src/object_utils.rs` (bare match arm, wrapped in a block)

No behavior change: `bail!` diverges in all three cases.

## Testing

- Reproduced on nightly (`rustc 1.99.0-nightly`): `cargo +nightly build -p cargo-pgrx --locked` failed with the lint; after the fix it builds clean.
- Full nightly check across every crate the package workflow builds is clean:
  `cargo +nightly check -p pgrx-pg-config -p pgrx-bindgen -p pgrx-sql-entity-graph -p pgrx-macros -p pgrx-pg-sys -p pgrx -p pgrx-bench -p pgrx-tests -p cargo-pgrx --features pg18 --no-default-features`.
- No regression on the pinned toolchain (1.96.0): `cargo build -p cargo-pgrx` and `cargo test -p pgrx-sql-entity-graph` pass; `cargo fmt --all --check` and `cargo clippy -p pgrx-sql-entity-graph -- -Dwarnings` are clean.
