### PR TITLE
Restore ERROR detail preservation through error handling

### DIFF
--- a/pgrx-examples/hooks/src/lib.rs
+++ b/pgrx-examples/hooks/src/lib.rs
@@ -38,6 +38,48 @@ fn only_superusers_can_truncate(pstmt: PgBox<pg_sys::PlannedStmt>) {
 
 unsafe fn register_hooks() {
     //
+    // Executor Run Hook
+    //
+    static mut PREV_EXECUTOR_RUN_HOOK: pg_sys::ExecutorRun_hook_type = None;
+    PREV_EXECUTOR_RUN_HOOK = pg_sys::ExecutorRun_hook;
+    pg_sys::ExecutorRun_hook = Some(executor_run_hook);
+
+    #[cfg(any(
+        feature = "pg13",
+        feature = "pg14",
+        feature = "pg15",
+        feature = "pg16",
+        feature = "pg17"
+    ))]
+    #[pg_guard]
+    unsafe extern "C-unwind" fn executor_run_hook(
+        query_desc: *mut pg_sys::QueryDesc,
+        direction: pg_sys::ScanDirection::Type,
+        count: pg_sys::uint64,
+        execute_once: bool,
+    ) {
+        if let Some(prev_hook) = PREV_EXECUTOR_RUN_HOOK {
+            pg_guard_ffi_boundary(|| prev_hook(query_desc, direction, count, execute_once));
+        } else {
+            pg_sys::standard_ExecutorRun(query_desc, direction, count, execute_once)
+        }
+    }
+
+    #[cfg(any(feature = "pg18", feature = "pg19"))]
+    #[pg_guard]
+    unsafe extern "C-unwind" fn executor_run_hook(
+        query_desc: *mut pg_sys::QueryDesc,
+        direction: pg_sys::ScanDirection::Type,
+        count: pg_sys::uint64,
+    ) {
+        if let Some(prev_hook) = PREV_EXECUTOR_RUN_HOOK {
+            pg_guard_ffi_boundary(|| prev_hook(query_desc, direction, count));
+        } else {
+            pg_sys::standard_ExecutorRun(query_desc, direction, count)
+        }
+    }
+
+    //
     // Client Authentication hook
     //
     static mut PREV_CLIENTAUTHENTICATION_HOOK: pg_sys::libpq::ClientAuthentication_hook_type = None;
@@ -251,6 +293,43 @@ mod tests {
             SET ROLE bob;
             TRUNCATE t;
             ",
+        )
+        .unwrap();
+    }
+
+    #[pg_test(
+        error = "DIAG_PROBE: constraint_name=[diag_probe_k_unique] table_name=[diag_probe] sqlerrm=[duplicate key value violates unique constraint \"diag_probe_k_unique\"]"
+    )]
+    /// Proves errors crossing a guarded executor hook retain their structured
+    /// constraint and table names, not just the human-readable message.
+    fn test_guarded_error_preserves_structured_diagnostics() {
+        Spi::run(
+            r#"
+            CREATE TEMP TABLE diag_probe (
+                k text CONSTRAINT diag_probe_k_unique UNIQUE
+            );
+            INSERT INTO diag_probe VALUES ('x');
+
+            DO $$
+            DECLARE
+                violated_constraint text;
+                violated_table text;
+            BEGIN
+                BEGIN
+                    INSERT INTO diag_probe VALUES ('x');
+                EXCEPTION WHEN unique_violation THEN
+                    GET STACKED DIAGNOSTICS
+                        violated_constraint = CONSTRAINT_NAME,
+                        violated_table = TABLE_NAME;
+                    RAISE EXCEPTION 'DIAG_PROBE: constraint_name=[%] table_name=[%] sqlerrm=[%]',
+                        coalesce(violated_constraint, '<NULL>'),
+                        coalesce(violated_table, '<NULL>'),
+                        SQLERRM;
+                END;
+            END $$;
+
+            DROP TABLE diag_probe;
+            "#,
         )
         .unwrap();
     }

--- a/pgrx-examples/hooks/src/lib.rs
+++ b/pgrx-examples/hooks/src/lib.rs
@@ -298,10 +298,10 @@ mod tests {
     }
 
     #[pg_test(
-        error = "DIAG_PROBE: constraint_name=[diag_probe_k_unique] table_name=[diag_probe] sqlerrm=[duplicate key value violates unique constraint \"diag_probe_k_unique\"]"
+        error = "DIAG_PROBE: constraint_name=[diag_probe_k_unique] table_name=[diag_probe] detail=[Key (k)=(x) already exists.] sqlerrm=[duplicate key value violates unique constraint \"diag_probe_k_unique\"]"
     )]
     /// Proves errors crossing a guarded executor hook retain their structured
-    /// constraint and table names, not just the human-readable message.
+    /// diagnostics and original detail, not just the primary message.
     fn test_guarded_error_preserves_structured_diagnostics() {
         Spi::run(
             r#"
@@ -314,16 +314,19 @@ mod tests {
             DECLARE
                 violated_constraint text;
                 violated_table text;
+                violated_detail text;
             BEGIN
                 BEGIN
                     INSERT INTO diag_probe VALUES ('x');
                 EXCEPTION WHEN unique_violation THEN
                     GET STACKED DIAGNOSTICS
                         violated_constraint = CONSTRAINT_NAME,
-                        violated_table = TABLE_NAME;
-                    RAISE EXCEPTION 'DIAG_PROBE: constraint_name=[%] table_name=[%] sqlerrm=[%]',
+                        violated_table = TABLE_NAME,
+                        violated_detail = PG_EXCEPTION_DETAIL;
+                    RAISE EXCEPTION 'DIAG_PROBE: constraint_name=[%] table_name=[%] detail=[%] sqlerrm=[%]',
                         coalesce(violated_constraint, '<NULL>'),
                         coalesce(violated_table, '<NULL>'),
+                        coalesce(violated_detail, '<NULL>'),
                         SQLERRM;
                 END;
             END $$;

--- a/pgrx-pg-sys/src/submodules/ffi.rs
+++ b/pgrx-pg-sys/src/submodules/ffi.rs
@@ -240,12 +240,10 @@ unsafe fn pg_guard_ffi_boundary_impl<T, F: FnOnce() -> T>(f: F) -> T {
             };
             let line = errdata.lineno as _;
 
-            // clean up after ourselves by freeing the result of [CopyErrorData], flushing the
-            // Postgres error state (so the original error no longer occupies a slot on Postgres'
-            // fixed-size errordata[] stack), and restoring Postgres' understanding of where its
-            // next longjmp should go
+            // clean up after ourselves by freeing the result of [CopyErrorData] and restoring
+            // Postgres' understanding of where its next longjmp should go.  Keep the original
+            // error on Postgres' error stack so it can later be rethrown without losing fields.
             pg_sys::FreeErrorData(errdata_ptr);
-            pg_sys::FlushErrorState();
             pg_sys::PG_exception_stack = prev_exception_stack;
             pg_sys::error_context_stack = prev_error_context_stack;
 

--- a/pgrx-pg-sys/src/submodules/panic.rs
+++ b/pgrx-pg-sys/src/submodules/panic.rs
@@ -390,6 +390,7 @@ impl CaughtError {
 #[derive(Debug)]
 enum GuardAction<R> {
     Return(R),
+    ReThrow,
     Report(ErrorReportWithLevel),
 }
 
@@ -431,6 +432,16 @@ where
 {
     match unsafe { run_guarded(AssertUnwindSafe(f)) } {
         GuardAction::Return(r) => r,
+        GuardAction::ReThrow => {
+            #[cfg_attr(target_os = "windows", link(name = "postgres"))]
+            unsafe extern "C-unwind" {
+                fn pg_re_throw() -> !;
+            }
+            unsafe {
+                crate::CurrentMemoryContext = crate::ErrorContext;
+                pg_re_throw()
+            }
+        }
         GuardAction::Report(ereport) => {
             do_ereport(ereport);
             unreachable!("pgrx reported a CaughtError that wasn't raised at ERROR or above");
@@ -447,11 +458,10 @@ where
     match catch_unwind(f) {
         Ok(v) => GuardAction::Return(v),
         Err(e) => match downcast_panic_payload(e) {
-            CaughtError::PostgresError(ereport) => {
-                // Postgres raised this error via longjmp, which pg_guard_ffi_boundary caught
-                // and converted into a Rust panic.  downcast_panic_payload already attached the
-                // Rust backtrace from the panic hook, so just report it through do_ereport.
-                GuardAction::Report(ereport)
+            CaughtError::PostgresError(_) => {
+                // Return to the caller to rethrow the original Postgres ErrorData unchanged.  We
+                // can't do it here because this function has non-POF frames.
+                GuardAction::ReThrow
             }
             CaughtError::ErrorReport(ereport) | CaughtError::RustPanic { ereport, .. } => {
                 GuardAction::Report(ereport)
@@ -468,8 +478,8 @@ pub(crate) fn downcast_panic_payload(e: Box<dyn Any + Send>) -> CaughtError {
 
         // For PostgresErrors (originating from a pg_sys FFI longjmp caught by
         // pg_guard_ffi_boundary), the panic hook captured a Rust backtrace into
-        // PANIC_LOCATION.  Attach it now so callers (PgTryBuilder, run_guarded,
-        // etc.) can include it in the ERROR's DETAIL line.
+        // PANIC_LOCATION.  Attach it now so PgTryBuilder catch handlers can inspect it without
+        // changing the original Postgres error that will be rethrown.
         if let CaughtError::PostgresError(ref mut ereport) = caught {
             if ereport.inner.location.backtrace.is_none() {
                 let panic_location = take_panic_location();

--- a/pgrx-unit-tests/src/tests/pg_try_tests.rs
+++ b/pgrx-unit-tests/src/tests/pg_try_tests.rs
@@ -66,8 +66,8 @@ mod tests {
         Spi::get_one::<()>("SELECT crash()").map(|_| ())
     }
 
-    /// When a `pg_sys::` FFI call raises a Postgres ERROR (via longjmp), the error should
-    /// carry a Rust backtrace so that it appears in the ERROR's DETAIL line.
+    /// When a `pg_sys::` FFI call raises a Postgres ERROR (via longjmp), its `CaughtError`
+    /// should carry a Rust backtrace for catch handlers to inspect.
     #[pg_test]
     fn test_postgres_error_contains_backtrace() {
         use pgrx::pg_sys::panic::CaughtError;
@@ -88,8 +88,8 @@ mod tests {
         assert!(has_backtrace, "PostgresError from a pg_sys FFI call should contain a backtrace");
     }
 
-    /// When a Postgres ERROR propagates through Rust frames, destructors must run (via panic
-    /// unwinding) AND the resulting error should carry a Rust backtrace in its detail.
+    /// When a Postgres ERROR propagates through Rust frames, destructors must run via panic
+    /// unwinding and catch handlers should be able to inspect the captured Rust backtrace.
     #[pg_test]
     fn test_postgres_error_runs_drop_and_has_backtrace() {
         use pgrx::pg_sys::panic::CaughtError;


### PR DESCRIPTION
#2262 was intended to smuggle Rust backtraces into Postgres' ERROR detail line, but the implementation had the unintended side effect of wiping out user/postgres-provided ERROR detail lines, including those generated from pl/pgsql statements.

PR brings our use of `pg_re_throw()` back, preserving the actual Postgres ERROR as given, doesn't sneak a backtrace into caught Postgres ERRORs, adds a test around this (now known to be expected) behavior, and tidies up a few comments.