### PR TITLE
Fix docs.rs rustdoc emit flag

### DIFF
--- a/tools/docsrs-check.sh
+++ b/tools/docsrs-check.sh
@@ -68,6 +68,6 @@ if [[ -n "${docsrs_target}" ]]; then
 fi
 
 docsrs_rustdocflags="${RUSTDOCFLAGS:-}"
-docsrs_rustdocflags="${docsrs_rustdocflags:+${docsrs_rustdocflags} }--cfg docsrs -Z unstable-options --emit=invocation-specific --cap-lints warn"
+docsrs_rustdocflags="${docsrs_rustdocflags:+${docsrs_rustdocflags} }--cfg docsrs -Z unstable-options --emit=html-non-static-files --cap-lints warn"
 
 DOCS_RS=1 RUSTDOCFLAGS="${docsrs_rustdocflags}" "${rustdoc_cmd[@]}"


### PR DESCRIPTION
`docsrs-check.sh` mirrors docs.rs' rustdoc invocation. Rust renamed the nightly-only `--emit=invocation-specific` option to `--emit=html-non-static-files` in [rust-lang/rust@c6b7f63](https://github.com/rust-lang/rust/commit/c6b7f630a5365ccfe2d4f24c7f5a4cc8499c5a55), temporarily retaining the old spelling to let Cargo and docs.rs migrate. That compatibility alias has now been removed from nightly, so CI fails before documenting pgrx.

Use [rustdoc's current spelling](https://doc.rust-lang.org/rustdoc/command-line-arguments.html#--emit-control-the-types-of-output-for-rustdoc-to-emit), preserving the same behavior: emit crate-specific HTML without shared toolchain assets.
