### PR TITLE
Avoid unsafe intermediate slice construction in varlena functions

### DIFF
--- a/pgrx/src/varlena.rs
+++ b/pgrx/src/varlena.rs
@@ -367,7 +367,7 @@ pub unsafe fn varsize_any_exhdr(ptr: *const pg_sys::varlena) -> usize {
 #[inline]
 pub unsafe fn vardata_1b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
     let va1b = ptr as *const pg_sys::varattrib_1b;
-    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
+    (*va1b).va_data.as_ptr()
 }
 
 /// ```c
@@ -376,8 +376,8 @@ pub unsafe fn vardata_1b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_
 #[allow(clippy::cast_ptr_alignment)]
 #[inline]
 pub unsafe fn vardata_4b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
-    let va1b = ptr as *const pg_sys::varattrib_4b__bindgen_ty_1; // 4byte
-    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
+    let va4b = ptr as *const pg_sys::varattrib_4b__bindgen_ty_1; // 4byte
+    (*va4b).va_data.as_ptr()
 }
 
 /// ```c
@@ -386,8 +386,8 @@ pub unsafe fn vardata_4b(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_
 #[allow(clippy::cast_ptr_alignment)]
 #[inline]
 pub unsafe fn vardata_4b_c(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
-    let va1b = ptr as *const pg_sys::varattrib_4b__bindgen_ty_2; // compressed
-    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
+    let va4bc = ptr as *const pg_sys::varattrib_4b__bindgen_ty_2; // compressed
+    (*va4bc).va_data.as_ptr()
 }
 
 /// ```c
@@ -396,8 +396,8 @@ pub unsafe fn vardata_4b_c(ptr: *const pg_sys::varlena) -> *const std::os::raw::
 #[allow(clippy::cast_ptr_alignment)]
 #[inline]
 pub unsafe fn vardata_1b_e(ptr: *const pg_sys::varlena) -> *const std::os::raw::c_char {
-    let va1b = ptr as *const pg_sys::varattrib_1b_e;
-    (*va1b).va_data.as_slice(varsize_1b(ptr)).as_ptr() as *const std::os::raw::c_char
+    let va1be = ptr as *const pg_sys::varattrib_1b_e;
+    (*va1be).va_data.as_ptr()
 }
 
 /// ```c


### PR DESCRIPTION
`unsafe __IncompleteArrayField<T>::as_slice` calls `unsafe
::core::slice::from_raw_parts`, which [is UB](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety) if the slice memory range is invalid.

But the length we pass in the `varlena_4b*` cases is `varsize_1b(ptr)` which  is a garbage value
potentially larger than the real length. Therefore the slice memory range can indeed be invalid.

I don't think this is a practical concern today because we immediately do `.as_ptr` on
the intermediate slice, but still looks like technically UB.