### PR TITLE
fix: reduce the amount of useless allocations for errors on hot paths

### DIFF
--- a/cargo-pgrx/src/command/bench.rs
+++ b/cargo-pgrx/src/command/bench.rs
@@ -110,7 +110,7 @@ impl CommandExecute for Bench {
         )?;
 
         let extname = get_property(&package_manifest_path, "extname")?
-            .ok_or(eyre!("could not determine extension name"))?;
+            .ok_or_else(|| eyre!("could not determine extension name"))?;
         let dbname = self.dbname.clone().unwrap_or_else(|| format!("{extname}_benches"));
         if self.report {
             return self.execute_report(&pg_config, &dbname, &extname, bench_filter.as_deref());

--- a/cargo-pgrx/src/command/connect.rs
+++ b/cargo-pgrx/src/command/connect.rs
@@ -77,7 +77,7 @@ impl CommandExecute for Connect {
                 // We should infer from package
                 get_property(&package_manifest_path, "extname")
                     .wrap_err("could not determine extension name")?
-                    .ok_or(eyre!("extname not found in control file"))?
+                    .ok_or_else(|| eyre!("extname not found in control file"))?
             }
         };
 

--- a/cargo-pgrx/src/command/info.rs
+++ b/cargo-pgrx/src/command/info.rs
@@ -56,7 +56,7 @@ impl CommandExecute for Info {
                         .get(&version(pg_ver))?
                         .parent_path()
                         .parent()
-                        .ok_or(eyre::Error::msg("can't get path"))?
+                        .ok_or_else(|| eyre::Error::msg("can't get path"))?
                         .display()
                 );
             }
@@ -66,7 +66,7 @@ impl CommandExecute for Info {
                     config
                         .get(&version(pg_ver))?
                         .path()
-                        .ok_or(eyre::Error::msg("can't get path"))?
+                        .ok_or_else(|| eyre::Error::msg("can't get path"))?
                         .display()
                 );
             }

--- a/cargo-pgrx/src/command/init.rs
+++ b/cargo-pgrx/src/command/init.rs
@@ -659,7 +659,7 @@ fn validate_pg_config(pg_config: &PgConfig) -> eyre::Result<()> {
     Ok(())
 }
 
-fn write_config(pg_configs: &Vec<PgConfig>, init: &Init) -> eyre::Result<()> {
+fn write_config(pg_configs: &[PgConfig], init: &Init) -> eyre::Result<()> {
     let config_path = Pgrx::config_toml()?;
     let mut config = match std::fs::read_to_string(&config_path) {
         Ok(file) => toml::from_str::<ConfigToml>(&file)?,
@@ -675,9 +675,10 @@ fn write_config(pg_configs: &Vec<PgConfig>, init: &Init) -> eyre::Result<()> {
     config.base_port = init.base_port;
     config.base_testing_port = init.base_testing_port;
     for pg_config in pg_configs {
-        config
-            .configs
-            .insert(pg_config.label()?, pg_config.path().ok_or(eyre!("no path for pg_config"))?);
+        config.configs.insert(
+            pg_config.label()?,
+            pg_config.path().ok_or_else(|| eyre!("no path for pg_config"))?,
+        );
     }
 
     let mut file = File::create(&config_path)?;

--- a/cargo-pgrx/src/command/package.rs
+++ b/cargo-pgrx/src/command/package.rs
@@ -156,7 +156,7 @@ pub(crate) fn build_base_path(
     let mut target_dir = get_target_dir()?;
     let pgver = pg_config.major_version()?;
     let extname = get_property(manifest_path, "extname")?
-        .ok_or(eyre!("could not determine extension name"))?;
+        .ok_or_else(|| eyre!("could not determine extension name"))?;
     if let Some(target) = target {
         target_dir.push(target);
     }

--- a/cargo-pgrx/src/command/regress.rs
+++ b/cargo-pgrx/src/command/regress.rs
@@ -226,7 +226,7 @@ impl Regress {
         test_file: &DirEntry,
     ) -> eyre::Result<()> {
         let test_name = make_test_name(test_file);
-        let verbosity = &self.psql_verbosity.clone().unwrap_or("terse".into());
+        let verbosity = &self.psql_verbosity.clone().unwrap_or_else(|| "terse".into());
 
         println!("{} new test `{}`", "Bootstrapping".bold().green(), test_name.bold().cyan());
 
@@ -291,7 +291,7 @@ impl Regress {
 
         // The default verbosity is terse in order to avoid verbose log output
         // being enshrined in expected test output
-        let verbosity = &self.psql_verbosity.clone().unwrap_or("terse".into());
+        let verbosity = &self.psql_verbosity.clone().unwrap_or_else(|| "terse".into());
 
         // Run all tests that have expected output
         let success =
@@ -579,7 +579,7 @@ impl Regress {
                 )?;
             } else {
                 // Run setup.sql normally to establish schema/data
-                let verbosity = &self.psql_verbosity.clone().unwrap_or("terse".into());
+                let verbosity = &self.psql_verbosity.clone().unwrap_or_else(|| "terse".into());
                 run_tests(pg_config, pgregress_path, dbname, &[setup_entry], verbosity, 0)?;
             }
         }

--- a/cargo-pgrx/src/command/run.rs
+++ b/cargo-pgrx/src/command/run.rs
@@ -110,7 +110,7 @@ impl Run {
         let dbname = match &self.dbname {
             Some(dbname) => dbname.clone(),
             None => get_property(&package_manifest_path, "extname")?
-                .ok_or(eyre!("could not determine extension name"))?,
+                .ok_or_else(|| eyre!("could not determine extension name"))?,
         };
         let profile = CargoProfile::from_flags(
             self.profile.as_deref(),

--- a/pgrx-bindgen/src/build.rs
+++ b/pgrx-bindgen/src/build.rs
@@ -340,7 +340,7 @@ fn generate_bindings(
     let lib_dir = pg_config.lib_dir()?;
     println!(
         "cargo:rustc-link-search={}",
-        lib_dir.to_str().ok_or(eyre!("{lib_dir:?} is not valid UTF-8 string"))?
+        lib_dir.to_str().ok_or_else(|| eyre!("{lib_dir:?} is not valid UTF-8 string"))?
     );
     Ok(())
 }
@@ -1253,7 +1253,7 @@ fn rust_fmt(path: &Path) -> eyre::Result<()> {
         }
         Err(e)
             if e.downcast_ref::<std::io::Error>()
-                .ok_or(eyre!("Couldn't downcast error ref"))?
+                .ok_or_else(|| eyre!("Couldn't downcast error ref"))?
                 .kind()
                 == std::io::ErrorKind::NotFound =>
         {

--- a/pgrx-macros/src/lib.rs
+++ b/pgrx-macros/src/lib.rs
@@ -1375,7 +1375,7 @@ fn impl_aggregate_name(ast: DeriveInput) -> syn::Result<proc_macro2::TokenStream
         }
     }
 
-    let name_str = custom_name_value.unwrap_or(name.to_string());
+    let name_str = custom_name_value.unwrap_or_else(|| name.to_string());
 
     let expanded = quote! {
         impl ::pgrx::aggregate::ToAggregateName for #name {

--- a/pgrx-sql-entity-graph/src/pgrx_sql.rs
+++ b/pgrx-sql-entity-graph/src/pgrx_sql.rs
@@ -1721,7 +1721,7 @@ fn initialize_aggregates<'a>(
             )?;
         }
 
-        for arg in item.direct_args.as_ref().unwrap_or(&vec![]) {
+        for arg in item.direct_args.as_deref().unwrap_or(&[]) {
             if !arg.used_ty.needs_type_resolution() {
                 continue;
             }
@@ -1829,7 +1829,7 @@ fn connect_aggregate<'a>(
         )?;
     }
 
-    for arg in item.direct_args.as_ref().unwrap_or(&vec![]) {
+    for arg in item.direct_args.as_deref().unwrap_or(&[]) {
         if !arg.used_ty.needs_type_resolution() {
             continue;
         }

--- a/pgrx-sql-entity-graph/src/used_type.rs
+++ b/pgrx-sql-entity-graph/src/used_type.rs
@@ -95,10 +95,9 @@ impl UsedType {
             }
             syn::Type::Path(path) => {
                 let segments = &path.path;
-                let last = segments
-                    .segments
-                    .last()
-                    .ok_or(syn::Error::new(path.span(), "Could not read last segment of path"))?;
+                let last = segments.segments.last().ok_or_else(|| {
+                    syn::Error::new(path.span(), "Could not read last segment of path")
+                })?;
 
                 match last.ident.to_string().as_str() {
                     // Option<composite_type!(..)>
@@ -132,30 +131,32 @@ impl UsedType {
         let (resolved_ty, variadic, optional, result) = match resolved_ty {
             syn::Type::Path(type_path) => {
                 let path = &type_path.path;
-                let last_segment = path.segments.last().ok_or(syn::Error::new(
-                    path.span(),
-                    "No last segment found while scanning path",
-                ))?;
+                let last_segment = path.segments.last().ok_or_else(|| {
+                    syn::Error::new(path.span(), "No last segment found while scanning path")
+                })?;
                 let ident_string = last_segment.ident.to_string();
                 match ident_string.as_str() {
                     "Result" => {
                         if let syn::PathArguments::AngleBracketed(angles) = &last_segment.arguments
                             && let syn::GenericArgument::Type(inner_ty) =
-                                angles.args.first().ok_or(syn::Error::new(
-                                    angles.span(),
-                                    "No inner arg for Result<T, E> found",
-                                ))?
+                                angles.args.first().ok_or_else(|| {
+                                    syn::Error::new(
+                                        angles.span(),
+                                        "No inner arg for Result<T, E> found",
+                                    )
+                                })?
                         {
                             match inner_ty {
                                 // Result<$Type<T>>
                                 syn::Type::Path(inner_type_path) => {
                                     let path = &inner_type_path.path;
-                                    let last_segment = inner_type_path.path.segments.last().ok_or(
-                                        syn::Error::new(
-                                            path.span(),
-                                            "No last segment found while scanning path",
-                                        ),
-                                    )?;
+                                    let last_segment =
+                                        inner_type_path.path.segments.last().ok_or_else(|| {
+                                            syn::Error::new(
+                                                path.span(),
+                                                "No last segment found while scanning path",
+                                            )
+                                        })?;
                                     let ident_string = last_segment.ident.to_string();
                                     match ident_string.as_str() {
                                         "VariadicArray" => {
@@ -186,20 +187,23 @@ impl UsedType {
                         // Option<VariadicArray<T>>
                         if let syn::PathArguments::AngleBracketed(angles) = &last_segment.arguments
                             && let syn::GenericArgument::Type(inner_ty) =
-                                angles.args.first().ok_or(syn::Error::new(
-                                    angles.span(),
-                                    "No inner arg for Option<T> found",
-                                ))?
+                                angles.args.first().ok_or_else(|| {
+                                    syn::Error::new(
+                                        angles.span(),
+                                        "No inner arg for Option<T> found",
+                                    )
+                                })?
                         {
                             match inner_ty {
                                 // Option<VariadicArray<T>>
                                 syn::Type::Path(inner_type_path) => {
                                     let path = &inner_type_path.path;
-                                    let last_segment =
-                                        path.segments.last().ok_or(syn::Error::new(
+                                    let last_segment = path.segments.last().ok_or_else(|| {
+                                        syn::Error::new(
                                             path.span(),
                                             "No last segment found while scanning path",
-                                        ))?;
+                                        )
+                                    })?;
                                     let ident_string = last_segment.ident.to_string();
                                     match ident_string.as_str() {
                                         // Option<VariadicArray<T>>
@@ -257,7 +261,8 @@ impl UsedType {
 
     pub fn entity_tokens(&self) -> syn::Expr {
         let mut resolved_ty = self.resolved_ty.clone();
-        let mut resolved_ty_inner = self.resolved_ty_inner.clone().unwrap_or(resolved_ty.clone());
+        let mut resolved_ty_inner =
+            self.resolved_ty_inner.clone().unwrap_or_else(|| resolved_ty.clone());
         // The lifetimes of these are not relevant. Previously, we solved this by staticizing them
         // but we want to avoid staticizing in this codebase going forward. Anonymization makes it
         // easier to name the lifetime-bounded objects without the context for those lifetimes,
@@ -454,7 +459,7 @@ fn resolve_vec_inner(
     let last = segments
         .segments
         .last()
-        .ok_or(syn::Error::new(original.span(), "Could not read last segment of path"))?;
+        .ok_or_else(|| syn::Error::new(original.span(), "Could not read last segment of path"))?;
 
     if let syn::PathArguments::AngleBracketed(path_arg) = &last.arguments
         && let Some(syn::GenericArgument::Type(ty)) = path_arg.args.last()
@@ -481,11 +486,9 @@ fn resolve_vec_inner(
                 }
             }
             syn::Type::Path(arg_type_path) => {
-                let last = arg_type_path
-                    .path
-                    .segments
-                    .last()
-                    .ok_or(syn::Error::new(arg_type_path.span(), "No last segment in type path"))?;
+                let last = arg_type_path.path.segments.last().ok_or_else(|| {
+                    syn::Error::new(arg_type_path.span(), "No last segment in type path")
+                })?;
                 if last.ident == "Option" {
                     let (inner_ty, expr) = resolve_option_inner(arg_type_path)?;
                     let wrapped_ty = syn::parse_quote! {
@@ -534,7 +537,7 @@ fn resolve_variadic_array_inner(
         .path
         .segments
         .last_mut()
-        .ok_or(syn::Error::new(original_span, "Could not read last segment of path"))?;
+        .ok_or_else(|| syn::Error::new(original_span, "Could not read last segment of path"))?;
 
     if let syn::PathArguments::AngleBracketed(ref mut path_arg) = last.arguments
         // TODO: Lifetime????
@@ -562,11 +565,9 @@ fn resolve_variadic_array_inner(
                 }
             }
             syn::Type::Path(arg_type_path) => {
-                let last = arg_type_path
-                    .path
-                    .segments
-                    .last()
-                    .ok_or(syn::Error::new(arg_type_path.span(), "No last segment in type path"))?;
+                let last = arg_type_path.path.segments.last().ok_or_else(|| {
+                    syn::Error::new(arg_type_path.span(), "No last segment in type path")
+                })?;
                 if last.ident == "Option" {
                     let (inner_ty, expr) = resolve_option_inner(arg_type_path)?;
                     let wrapped_ty = syn::parse_quote! {
@@ -592,7 +593,7 @@ fn resolve_array_inner(
         .path
         .segments
         .last_mut()
-        .ok_or(syn::Error::new(original_span, "Could not read last segment of path"))?;
+        .ok_or_else(|| syn::Error::new(original_span, "Could not read last segment of path"))?;
 
     if let syn::PathArguments::AngleBracketed(ref mut path_arg) = last.arguments
         && let Some(syn::GenericArgument::Type(ty)) = path_arg.args.last()
@@ -619,11 +620,9 @@ fn resolve_array_inner(
                 }
             }
             syn::Type::Path(arg_type_path) => {
-                let last = arg_type_path
-                    .path
-                    .segments
-                    .last()
-                    .ok_or(syn::Error::new(arg_type_path.span(), "No last segment in type path"))?;
+                let last = arg_type_path.path.segments.last().ok_or_else(|| {
+                    syn::Error::new(arg_type_path.span(), "No last segment in type path")
+                })?;
                 match last.ident.to_string().as_str() {
                     "Option" => {
                         let (inner_ty, expr) = resolve_option_inner(arg_type_path)?;
@@ -649,7 +648,7 @@ fn resolve_option_inner(
     let last = segments
         .segments
         .last()
-        .ok_or(syn::Error::new(original.span(), "Could not read last segment of path"))?;
+        .ok_or_else(|| syn::Error::new(original.span(), "Could not read last segment of path"))?;
 
     if let syn::PathArguments::AngleBracketed(path_arg) = &last.arguments
         && let Some(syn::GenericArgument::Type(ty)) = path_arg.args.first()
@@ -678,11 +677,9 @@ fn resolve_option_inner(
                 }
             }
             syn::Type::Path(arg_type_path) => {
-                let last = arg_type_path
-                    .path
-                    .segments
-                    .last()
-                    .ok_or(syn::Error::new(arg_type_path.span(), "No last segment in type path"))?;
+                let last = arg_type_path.path.segments.last().ok_or_else(|| {
+                    syn::Error::new(arg_type_path.span(), "No last segment in type path")
+                })?;
                 match last.ident.to_string().as_str() {
                     // Option<Vec<composite_type!(..)>>
                     // Option<Vec<Option<composite_type!(..)>>>
@@ -729,7 +726,7 @@ fn resolve_result_inner(
     let last = segments
         .segments
         .last()
-        .ok_or(syn::Error::new(original.span(), "Could not read last segment of path"))?;
+        .ok_or_else(|| syn::Error::new(original.span(), "Could not read last segment of path"))?;
 
     // Get the path of our Result type, to handle crate::module::Result pattern
     let mut without_type_args = original.path.clone();
@@ -810,11 +807,9 @@ fn resolve_result_inner(
                 }
             }
             syn::Type::Path(arg_type_path) => {
-                let last = arg_type_path
-                    .path
-                    .segments
-                    .last()
-                    .ok_or(syn::Error::new(arg_type_path.span(), "No last segment in type path"))?;
+                let last = arg_type_path.path.segments.last().ok_or_else(|| {
+                    syn::Error::new(arg_type_path.span(), "No last segment in type path")
+                })?;
                 match last.ident.to_string().as_str() {
                     // Result<Option<composite_type!(..)>>
                     // Result<Option<Vec<composite_type!(..)>>>>

--- a/pgrx-tests/src/framework.rs
+++ b/pgrx-tests/src/framework.rs
@@ -318,8 +318,8 @@ pub fn client() -> eyre::Result<(postgres::Client, String)> {
 }
 
 fn install_extension() -> eyre::Result<()> {
-    let profile = std::env::var("PGRX_BUILD_PROFILE").unwrap_or("debug".into());
-    let no_schema = std::env::var("PGRX_NO_SCHEMA").unwrap_or("false".into()) == "true";
+    let profile = std::env::var("PGRX_BUILD_PROFILE").unwrap_or_else(|_| "debug".into());
+    let no_schema = std::env::var("PGRX_NO_SCHEMA").is_ok_and(|v| v == "true");
     let mut features = std::env::var("PGRX_FEATURES")
         .unwrap_or("".to_string())
         .split_ascii_whitespace()
@@ -327,9 +327,8 @@ fn install_extension() -> eyre::Result<()> {
         .collect::<HashSet<_>>();
     features.insert("pg_test".into());
 
-    let no_default_features =
-        std::env::var("PGRX_NO_DEFAULT_FEATURES").unwrap_or("false".to_string()) == "true";
-    let all_features = std::env::var("PGRX_ALL_FEATURES").unwrap_or("false".to_string()) == "true";
+    let no_default_features = std::env::var("PGRX_NO_DEFAULT_FEATURES").is_ok_and(|v| v == "true");
+    let all_features = std::env::var("PGRX_ALL_FEATURES").is_ok_and(|v| v == "true");
 
     let pg_version = format!("pg{}", pg_sys::get_pg_major_version_string());
     let pgrx = Pgrx::from_config()?;
@@ -343,7 +342,7 @@ fn install_extension() -> eyre::Result<()> {
         .arg("install")
         .arg("--test")
         .arg("--pg-config")
-        .arg(pg_config.path().ok_or(eyre!("No pg_config found"))?)
+        .arg(pg_config.path().ok_or_else(|| eyre!("No pg_config found"))?)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .env("CARGO_TARGET_DIR", get_target_dir()?);
@@ -1033,9 +1032,11 @@ fn get_cargo_test_features() -> eyre::Result<clap_cargo::Features> {
         match part.as_str() {
             "--no-default-features" => features.no_default_features = true,
             "--features" => {
-                let configured_features = iter.next().ok_or(eyre!(
-                    "no `--features` specified in the cargo argument list: {cargo_user_args:?}"
-                ))?;
+                let configured_features = iter.next().ok_or_else(|| {
+                    eyre!(
+                        "no `--features` specified in the cargo argument list: {cargo_user_args:?}"
+                    )
+                })?;
                 features.features = configured_features
                     .split(|c: char| c.is_ascii_whitespace() || c == ',')
                     .map(|s| s.to_string())

--- a/pgrx/src/spi/client.rs
+++ b/pgrx/src/spi/client.rs
@@ -194,7 +194,7 @@ impl<'conn> SpiClient<'conn> {
         use pgrx_pg_sys::AsPgCStr;
 
         let ptr = NonNull::new(unsafe { pg_sys::SPI_cursor_find(name.as_pg_cstr()) })
-            .ok_or(SpiError::CursorNotFound(name.to_string()))?;
+            .ok_or_else(|| SpiError::CursorNotFound(name.to_string()))?;
         Ok(SpiCursor { ptr, __marker: PhantomData })
     }
 }

--- a/tools/version-updater/src/main.rs
+++ b/tools/version-updater/src/main.rs
@@ -106,9 +106,8 @@ fn query_toml(query_args: &QueryCargoVersionArgs) {
     // default to <cwd>/pgrx-version-updater/Cargo.toml where <cwd> is assumed to be
     // the root of a PGRX checkout directory
     let filepath = match &query_args.file_path {
-        Some(path) => {
-            fullpath(path).expect(format!("Could not get full path for file: {path}").as_str())
-        }
+        Some(path) => fullpath(path)
+            .unwrap_or_else(|e| panic!("Could not get full path for file: {path}: {e:?}")),
         None => {
             let mut current_dir = env::current_dir().expect("Could not get current_dir!");
             current_dir.push("pgrx-version-updater/Cargo.toml");
@@ -118,11 +117,11 @@ fn query_toml(query_args: &QueryCargoVersionArgs) {
 
     // Open the Cargo.toml via toml_edit and parse it out.
     let data = fs::read_to_string(&filepath)
-        .expect(format!("Unable to open file at {}", filepath.display()).as_str());
+        .unwrap_or_else(|e| panic!("Unable to open file at {}: {e:?}", filepath.display()));
 
-    let doc = data.parse::<DocumentMut>().expect(
-        format!("File at location {} is an invalid Cargo.toml file", filepath.display()).as_str(),
-    );
+    let doc = data.parse::<DocumentMut>().unwrap_or_else(|e| {
+        panic!("File at location {} is an invalid Cargo.toml file: {e:?}", filepath.display())
+    });
 
     if let Some(package_version) = doc.get("package").and_then(|p| p.get("version")) {
         println!("{}", package_version.as_str().expect("Could not turn package version into str"));
@@ -179,7 +178,8 @@ fn update_files(args: &UpdateFilesArgs) {
     let mut exclude_version_files = HashSet::default();
     for file in &args.exclude_from_version_change {
         exclude_version_files.insert(
-            fullpath(file).expect(format!("Could not get full path for file: {file}").as_str()),
+            fullpath(file)
+                .unwrap_or_else(|e| panic!("Could not get full path for file: {file}: {e:?}")),
         );
     }
 
@@ -190,9 +190,9 @@ fn update_files(args: &UpdateFilesArgs) {
         .filter_map(|v| v.ok())
     {
         if is_cargo_toml_file(&entry) {
-            let filepath = fullpath(entry.path()).expect(
-                format!("Could not get full path for file {}", entry.path().display()).as_str(),
-            );
+            let filepath = fullpath(entry.path()).unwrap_or_else(|e| {
+                panic!("Could not get full path for file {}: {e:?}", entry.path().display())
+            });
 
             let output = format!(
                 "{} Cargo.toml file at {}",
@@ -210,8 +210,8 @@ fn update_files(args: &UpdateFilesArgs) {
 
     // Loop through all files that are included for dependency updates via CLI params
     for file in &args.include_for_dep_updates {
-        let filepath =
-            fullpath(file).expect(format!("Could not get full path for file {file}").as_str());
+        let filepath = fullpath(file)
+            .unwrap_or_else(|e| panic!("Could not get full path for file {file}: {e:?}"));
 
         let output = format!(
             "{} Cargo.toml file at {} for processing",
@@ -247,12 +247,11 @@ fn update_files(args: &UpdateFilesArgs) {
         );
 
         let data = fs::read_to_string(&filepath)
-            .expect(format!("Unable to open file at {}", filepath.display()).as_str());
+            .unwrap_or_else(|e| panic!("Unable to open file at {}: {e:?}", filepath.display()));
 
-        let mut doc = data.parse::<DocumentMut>().expect(
-            format!("File at location {} is an invalid Cargo.toml file", filepath.display())
-                .as_str(),
-        );
+        let mut doc = data.parse::<DocumentMut>().unwrap_or_else(|e| {
+            panic!("File at location {} is an invalid Cargo.toml file: {e:?}", filepath.display())
+        });
 
         if exclude_version_files.contains(&filepath) {
             output.push_str(
@@ -435,9 +434,9 @@ fn fullpath<P: AsRef<Path>>(test_path: P) -> Result<PathBuf, std::io::Error> {
 // Walkdir filter, ensure we don't traverse down a directory that should be ignored
 // e.g. .git/ and target/ directories should never be traversed.
 fn is_not_excluded_dir(entry: &DirEntry) -> bool {
-    let metadata = entry.metadata().expect(
-        format!("Could not get metadata for: {}", entry.file_name().to_string_lossy()).as_str(),
-    );
+    let metadata = entry.metadata().unwrap_or_else(|e| {
+        panic!("Could not get metadata for: {}: {e:?}", entry.file_name().to_string_lossy())
+    });
 
     if metadata.is_dir() {
         return !IGNORE_DIRS.contains(&entry.file_name().to_string_lossy().as_ref());
@@ -448,9 +447,9 @@ fn is_not_excluded_dir(entry: &DirEntry) -> bool {
 
 // Check if a specific DirEntry is named "Cargo.toml"
 fn is_cargo_toml_file(entry: &DirEntry) -> bool {
-    let metadata = entry.metadata().expect(
-        format!("Could not get metadata for: {}", entry.file_name().to_string_lossy()).as_str(),
-    );
+    let metadata = entry.metadata().unwrap_or_else(|e| {
+        panic!("Could not get metadata for: {}: {e:?}", entry.file_name().to_string_lossy())
+    });
 
     if metadata.is_file() {
         return entry.file_name().eq_ignore_ascii_case("Cargo.toml");


### PR DESCRIPTION
Hi, I noticed a bunch of strange allocations on my hot path and it turned out to be some `.ok_or(SpiError::CursorNotFound(name.to_string()))?` at `pgrx/src/spi/client.rs:159`, which was immediately dropped. I became upset and told claude to find all similar places there and make them like they should be, in `ok_or_else` and similar. I reviewed the code and I believe it is fine - and the changes are trivial.